### PR TITLE
fix: block system-prompt echo and auto-read .tier2-passphrase

### DIFF
--- a/src/gateway/conversation-context-service.ts
+++ b/src/gateway/conversation-context-service.ts
@@ -28,8 +28,28 @@ const MAX_COMPACTION_TOOL_RESULT_LINES = 3;
 const MAX_FALLBACK_HIGHLIGHT_LINES = 3;
 const MAX_FRAGMENT_LENGTH = 240;
 const MIN_FRAGMENT_LENGTH = 8;
-const REMAINING_CONTEXT_TOKENS_MEDIUM = 4096;
-const REMAINING_CONTEXT_TOKENS_HIGH = 2048;
+const REMAINING_CONTEXT_TOKENS_MEDIUM=4096;
+const REMAINING_CONTEXT_TOKENS_HIGH=2048;
+
+// Fragments matching these patterns are excluded from session_memory and compactions
+// to prevent system-prompt echo loops (e.g. "Fallback response: SYSTEM: <soul_manifest>")
+const BLOCKED_FRAGMENT_PATTERNS = [
+  /<soul_manifest>/i,
+  /<\/soul_manifest>/i,
+  /Fallback response: SYSTEM:/i,
+  /Fallback response: \{/i,
+  /\[filtered: protected system prompt\]/i,
+  /<session_memory>/i,
+  /<\/session_memory>/i,
+  /<conversation_compaction/i,
+  /<\/conversation_compaction>/i,
+  /<soul_boot>/i,
+  /<\/soul_boot>/i,
+];
+
+function isFragmentBlocked(value: string): boolean {
+  return BLOCKED_FRAGMENT_PATTERNS.some((pat) => pat.test(value));
+}
 
 const PREFERENCE_PATTERN =
   /\b(prefer|preference|avoid|without|local-first|local first|fail closed|fail-closed|never|always|required|must|should|do not|don't|cannot|can't|full control|override|tiered|constraint)\b/i;
@@ -148,7 +168,7 @@ function dedupeKey(value: string): string {
 function uniqueLines(values: string[], limit: number): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
-  for (const value of values.map(normalizeLine).filter(isUsefulLine)) {
+  for (const value of values.map(normalizeLine).filter(isUsefulLine).filter((v) => !isFragmentBlocked(v))) {
     const key = dedupeKey(value);
     if (seen.has(key)) continue;
     seen.add(key);

--- a/src/infra/auth/operator-gate.ts
+++ b/src/infra/auth/operator-gate.ts
@@ -11,6 +11,7 @@ import * as readline from 'node:readline/promises';
 
 import { getDataDir } from '../../config/paths.js';
 import { secureCompare } from '../../security/constant-time.js';
+import { readTier2PassphraseFromFile } from '../../security/tier2-passphrase-file.js';
 import type { CliArgs } from '../cli/types.js';
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -202,6 +203,19 @@ export async function requireOperatorAuth(
     const valid = validateOperatorPassphrase(inlinePassphrase, rawEnv);
     if (valid) authorizeSession();
     return valid;
+  }
+
+  // Auto-read from .tier2-passphrase file (enables self-auth without TTY)
+  const autoPassphrase = readTier2PassphraseFromFile(rawEnv);
+  if (autoPassphrase) {
+    const valid = validateOperatorPassphrase(autoPassphrase, rawEnv);
+    if (valid) {
+      authorizeSession();
+      return true;
+    }
+    // File exists but passphrase doesn't match — don't fall through to prompt
+    // (fail closed: if file is present but wrong, keep failing until operator fixes it)
+    return false;
   }
 
   // Interactive: prompt


### PR DESCRIPTION
## Summary

Fixes two issues:

**#65 — Fallback response loop**: `uniqueLines()` now filters out fragments matching `BLOCKED_FRAGMENT_PATTERNS` — `<soul_manifest>`, `<session_memory>`, `<conversation_compaction>`, `[filtered: protected system prompt]`, etc. This prevents the "Fallback response: SYSTEM: <soul_manifest>" echo loop from polluting session snapshots and compactions.

**#66 — Tier 2 passphrase auto-read**: `requireOperatorAuth()` now auto-reads `~/.memphis/.tier2-passphrase` when available, enabling self-auth without a TTY. Fails closed if the file exists but passphrase doesn't match operator.json.

## Changes
- `src/gateway/conversation-context-service.ts`: `BLOCKED_FRAGMENT_PATTERNS` + `isFragmentBlocked()` + filter in `uniqueLines()`
- `src/infra/auth/operator-gate.ts`: `readTier2PassphraseFromFile()` auto-read before interactive prompt

Closes #65, Closes #66
