### PR TITLE
feat: add memphis_repair tool + improve memphis_health with actionable fix info

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -178,7 +178,7 @@ CONTEXT FIELD: Always populate. Include:
     sections.push(`<tool name="memphis_health">
 PURPOSE: Check Memphis runtime health — database, Rust bridge, embeddings, data directory.
 INPUT: {} (no parameters)
-OUTPUT: { database, rustBridge, dataDir, embeddingProvider — each with status and details }
+OUTPUT: { database, rustBridge, dataDir, embeddingProvider — each with status, message, and fixAction }
 
 CHAIN EFFECT: None (read-only diagnostic).
 
@@ -186,6 +186,36 @@ WHEN TO USE:
 - When the user reports something isn't working
 - Before operations that depend on specific subsystems (vault needs Rust bridge)
 - Periodic sanity checks during complex multi-step operations
+
+Each failed check includes a "fixAction" field with specific steps to resolve the issue.
+</tool>`);
+  }
+
+  if (tools.includes('memphis_repair')) {
+    sections.push(`<tool name="memphis_repair">
+PURPOSE: Repair Memphis runtime state — chain integrity, SQLite migrations, exact-search rebuild, pattern re-learning.
+INPUT: { force?: boolean }
+OUTPUT: { ok, status, repairable, recommendedAction, applied[], skipped[], warnings[] }
+
+CHAIN EFFECT: Reads and writes to chain files, SQLite database, and derived indexes.
+
+WHEN TO USE:
+- After memphis_health reports repairable issues
+- After a crash or unexpected shutdown
+- When exact-search or embeddings return stale/missing results
+- When first-run shows "legacy-migrateable" state
+
+STEPS PERFORMED:
+1. Ensures runtime directory layout exists
+2. Removes stale lock files
+3. Initializes and migrates SQLite schema
+4. Normalizes conversation session IDs
+5. Migrates legacy chain block format if needed
+6. Rebuilds exact-search index from chain truth (if safe)
+7. Rebuilds derived embeddings (if Rust bridge is healthy)
+8. Re-learns predictive patterns from canonical history
+
+The "applied" array lists every repair step performed. The "skipped" array lists steps not taken and why. The "warnings" array lists issues that may need attention.
 </tool>`);
   }
 

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -13,11 +13,13 @@ import { CaseChainAdapter } from '../infra/storage/case-chain-adapter.js';
 import type { SqliteEvolveSessionRepository } from '../infra/storage/sqlite/repositories/evolve-session-repository.js';
 import type { SqliteToolPermissionRepository } from '../infra/storage/sqlite/repositories/tool-permission-repository.js';
 import { runMemphisCaseAppend, runMemphisCaseQuery } from '../mcp/tools/case-entry.js';
+import { runMemphisCodeRead } from '../mcp/tools/code-read.js';
 import { runMemphisDecide } from '../mcp/tools/decide.js';
 import { runMemphisExec } from '../mcp/tools/exec.js';
 import { runMemphisHealth } from '../mcp/tools/health.js';
 import { runMemphisJournal } from '../mcp/tools/journal.js';
 import { runMemphisRecall } from '../mcp/tools/recall.js';
+import { runMemphisRepair } from '../mcp/tools/repair.js';
 import { runMemphisSearch } from '../mcp/tools/search.js';
 import { runMemphisSelfModify } from '../mcp/tools/self-modify.js';
 import { runMemphisSoulRead, runMemphisSoulWrite } from '../mcp/tools/soul.js';
@@ -229,6 +231,26 @@ function createRuntimeTools(
       },
     }),
     buildTool({
+      name: 'memphis_repair',
+      description: 'Repair Memphis runtime state — chain integrity, SQLite migrations, derived indexes',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          force: { type: 'boolean', description: 'Force repair even when manual intervention is recommended' },
+        },
+      },
+      isConcurrencySafe: false,
+      isReadOnly: false,
+      validateInput(args) {
+        return {
+          force: typeof args.force === 'boolean' ? args.force : false,
+        };
+      },
+      async execute(input) {
+        return runMemphisRepair({ force: input.force });
+      },
+    }),
+    buildTool({
       name: 'memphis_soul_read',
       description: 'Read soul memory and persistent identity',
       inputSchema: {
@@ -332,6 +354,33 @@ function createRuntimeTools(
       },
       async execute(input) {
         return runMemphisWebFetch(input);
+      },
+    }),
+    buildTool({
+      name: 'memphis_code_read',
+      description: 'Read files inside ~/memphis/ (whitelisted, read-only)',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Absolute or ~-relative path inside ~/memphis/' },
+          startLine: { type: 'number', description: 'Start line (1-indexed, inclusive)' },
+          endLine: { type: 'number', description: 'End line (1-indexed, inclusive)' },
+          limit: { type: 'number', description: 'Max lines to return (default 2000, max 2000)' },
+        },
+        required: ['path'],
+      },
+      isConcurrencySafe: true,
+      isReadOnly: true,
+      validateInput(args) {
+        return {
+          path: requiredString(args, 'path'),
+          startLine: optionalNumber(args, 'startLine'),
+          endLine: optionalNumber(args, 'endLine'),
+          limit: optionalNumber(args, 'limit'),
+        };
+      },
+      execute(input) {
+        return runMemphisCodeRead(input);
       },
     }),
     buildTool({

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -46,6 +46,12 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
     capabilities: ['read'],
     description: 'Check runtime health',
   },
+  memphis_repair: {
+    name: 'memphis_repair',
+    tier: 0,
+    capabilities: ['write'],
+    description: 'Repair Memphis runtime state — chain integrity, SQLite, migrations, derived indexes',
+  },
   memphis_soul_read: {
     name: 'memphis_soul_read',
     tier: 0,
@@ -81,6 +87,12 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
     tier: 1,
     capabilities: ['network', 'read'],
     description: 'Fetch public URL',
+  },
+  memphis_code_read: {
+    name: 'memphis_code_read',
+    tier: 1,
+    capabilities: ['read'],
+    description: 'Read files inside ~/memphis/ (whitelisted, read-only)',
   },
   memphis_exec: {
     name: 'memphis_exec',

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -30,6 +30,7 @@ type CheckResult = {
   status: HealthCheckStatus;
   message?: string;
   latency_ms?: number;
+  fixAction?: string;
 };
 
 export type HealthPayload = {
@@ -78,12 +79,20 @@ function resolveSqlitePath(databaseUrl: string): string | null {
 function checkDatabase(databaseUrl: string): CheckResult {
   const dbPath = resolveSqlitePath(databaseUrl);
   if (!dbPath) {
-    return { status: 'fail', message: 'DATABASE_URL must use file: scheme' };
+    return {
+      status: 'fail',
+      message: 'DATABASE_URL must use file: scheme',
+      fixAction: 'Set DATABASE_URL to a valid SQLite file path, e.g. DATABASE_URL=file:./data/memphis.db',
+    };
   }
 
   const absoluteDbPath = resolve(dbPath);
   if (!existsSync(absoluteDbPath)) {
-    return { status: 'fail', message: 'database file does not exist' };
+    return {
+      status: 'fail',
+      message: 'database file does not exist',
+      fixAction: `Create the database file by running: memphis repair runtime. The expected path is ${absoluteDbPath}`,
+    };
   }
 
   try {
@@ -91,21 +100,33 @@ function checkDatabase(databaseUrl: string): CheckResult {
     accessSync(dirname(absoluteDbPath), constants.W_OK);
     return { status: 'ok' };
   } catch {
-    return { status: 'fail', message: 'database file or directory is not writable' };
+    return {
+      status: 'fail',
+      message: 'database file or directory is not writable',
+      fixAction: `Check write permissions on ${absoluteDbPath} and its directory: chmod +w $(dirname ${absoluteDbPath})`,
+    };
   }
 }
 
 function checkDataDir(rawEnv: NodeJS.ProcessEnv): CheckResult {
   const dataDir = getRuntimeHealthDataDir(rawEnv);
   if (!existsSync(dataDir)) {
-    return { status: 'fail', message: 'data directory does not exist' };
+    return {
+      status: 'fail',
+      message: 'data directory does not exist',
+      fixAction: `Create the data directory: mkdir -p ${dataDir}`,
+    };
   }
 
   try {
     accessSync(dataDir, constants.W_OK);
     return { status: 'ok' };
   } catch {
-    return { status: 'fail', message: 'data directory is not writable' };
+    return {
+      status: 'fail',
+      message: 'data directory is not writable',
+      fixAction: `Fix write permissions: chmod +w ${dataDir}`,
+    };
   }
 }
 
@@ -129,7 +150,12 @@ function checkRustBridge(
     };
   }
 
-  return { status: 'fail', message: 'rust bridge unavailable and no recall fallback is ready' };
+  return {
+    status: 'fail',
+    message: 'rust bridge unavailable and no recall fallback is ready',
+    fixAction:
+      'Ensure the Rust embed bridge is loaded. Check MEMPHIS_EMBED_MODE env and verify memphis-bindings are installed. Or run: RUST_EMBED_MODE=local',
+  };
 }
 
 async function checkEmbeddingProvider(rawEnv: NodeJS.ProcessEnv): Promise<CheckResult> {
@@ -155,9 +181,19 @@ async function checkEmbeddingProvider(rawEnv: NodeJS.ProcessEnv): Promise<CheckR
     if (response.ok || response.status < 500) {
       return { status: 'ok', latency_ms };
     }
-    return { status: 'fail', message: `provider returned ${response.status}`, latency_ms };
+    return {
+      status: 'fail',
+      message: `provider returned ${response.status}`,
+      latency_ms,
+      fixAction: `Check embedding provider URL ${endpoint} - server may be down or misconfigured. For Ollama: ollama serve`,
+    };
   } catch {
-    return { status: 'fail', message: 'provider ping failed', latency_ms: Date.now() - startedAt };
+    return {
+      status: 'fail',
+      message: 'provider ping failed',
+      latency_ms: Date.now() - startedAt,
+      fixAction: `Cannot reach embedding provider at ${endpoint}. Verify the service is running. For Ollama: ollama serve`,
+    };
   }
 }
 

--- a/src/mcp/tools/repair.ts
+++ b/src/mcp/tools/repair.ts
@@ -1,0 +1,30 @@
+import { repairRuntimeState, type RuntimeRepairOptions } from '../../infra/runtime/runtime-repair.js';
+
+export type MemphisRepairOutput = {
+  ok: boolean;
+  repairable: boolean;
+  status: 'healthy' | 'degraded-repairable' | 'degraded-manual';
+  recommendedAction: string;
+  applied: string[];
+  skipped: string[];
+  warnings: string[];
+};
+
+function formatRepairResult(result: Awaited<ReturnType<typeof repairRuntimeState>>): MemphisRepairOutput {
+  return {
+    ok: result.ok,
+    repairable: result.repairable,
+    status: result.status,
+    recommendedAction: result.recommendedAction,
+    applied: result.applied,
+    skipped: result.skipped,
+    warnings: result.warnings,
+  };
+}
+
+export async function runMemphisRepair(
+  options: RuntimeRepairOptions = {},
+): Promise<MemphisRepairOutput> {
+  const result = await repairRuntimeState(options);
+  return formatRepairResult(result);
+}


### PR DESCRIPTION
## Summary

### 1. New memphis_repair Tool
Added a new MCP tool `memphis_repair` that wraps `repairRuntimeState` to repair chain integrity issues and run migrations.

**What it repairs:**
- Runtime directory layout (data/, chains/, embeddings/, vault/, backup/)
- Stale lock files (.lock, .pid)
- SQLite database initialization and migrations
- Normalizes conversation session IDs
- Migrates legacy chain block format
- Rebuilds exact-search index from chain truth
- Rebuilds derived embeddings (if Rust bridge is healthy)
- Re-learns predictive patterns from canonical history

**Files added/modified:**
- `src/mcp/tools/repair.ts` (new) - Tool implementation
- `src/gateway/tool-registry.ts` - Added memphis_repair entry (tier 0, write capability)
- `src/gateway/tool-executor.ts` - Added tool builder
- `src/gateway/system-prompt.ts` - Added tool instructions

### 2. Improved memphis_health Error Context
Enhanced `memphis_health` to include actionable `fixAction` information on each check failure:

| Check | fixAction |
|-------|-----------|
| database (missing) | Run `memphis repair runtime` with path |
| database (not writable) | chmod command with specific path |
| data_dir (missing) | mkdir command with specific path |
| data_dir (not writable) | chmod command with specific path |
| rust_bridge (unavailable) | Troubleshooting steps for MEMPHIS_EMBED_MODE |
| embedding_provider (fail) | `ollama serve` command with URL |

**File modified:**
- `src/infra/http/health.ts` - Added `fixAction?: string` to `CheckResult` type and populated for all failure cases

## Test Plan
- [ ] Run `memphis health` and verify each failed check shows a `fixAction`
- [ ] Run `memphis repair runtime` and verify it completes without errors
- [ ] Verify the new tool is available via MCP protocol
