### PR TITLE
fix: NAPI binary copy after build + vault secrets propagation

### DIFF
--- a/scripts/run-rust.sh
+++ b/scripts/run-rust.sh
@@ -6,18 +6,36 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 LOCAL_WRAPPER="${REPO_ROOT}/scripts/with-local-rust.sh"
 CARGO_HOME_CANDIDATE="${CARGO_HOME:-$HOME/.cargo}"
 
-if [[ -x "${LOCAL_WRAPPER}" ]]; then
-  exec "${LOCAL_WRAPPER}" cargo "$@"
-fi
+run_cargo() {
+  if [[ -x "${LOCAL_WRAPPER}" ]]; then
+    "${LOCAL_WRAPPER}" cargo "$@"
+  elif command -v cargo >/dev/null 2>&1; then
+    cargo "$@"
+  elif [[ -x "${CARGO_HOME_CANDIDATE}/bin/cargo" ]]; then
+    export PATH="${CARGO_HOME_CANDIDATE}/bin:${PATH}"
+    cargo "$@"
+  else
+    echo "error: cargo not found. Install Rust via rustup or provide scripts/with-local-rust.sh." >&2
+    exit 1
+  fi
+}
 
-if command -v cargo >/dev/null 2>&1; then
-  exec cargo "$@"
-fi
+run_cargo "$@"
 
-if [[ -x "${CARGO_HOME_CANDIDATE}/bin/cargo" ]]; then
-  export PATH="${CARGO_HOME_CANDIDATE}/bin:${PATH}"
-  exec cargo "$@"
-fi
+# After a build, copy the NAPI shared library to the location Node expects.
+if [[ "${1:-}" == "build" ]]; then
+  PROFILE="debug"
+  for arg in "$@"; do
+    if [[ "$arg" == "--release" ]]; then PROFILE="release"; fi
+  done
 
-echo "error: cargo not found. Install Rust via rustup or provide scripts/with-local-rust.sh." >&2
-exit 1
+  NAPI_SO="${REPO_ROOT}/target/${PROFILE}/libmemphis_napi.so"
+  NAPI_DYLIB="${REPO_ROOT}/target/${PROFILE}/libmemphis_napi.dylib"
+  NAPI_DEST="${REPO_ROOT}/crates/memphis-napi/index.node"
+
+  if [[ -f "${NAPI_SO}" ]]; then
+    cp "${NAPI_SO}" "${NAPI_DEST}"
+  elif [[ -f "${NAPI_DYLIB}" ]]; then
+    cp "${NAPI_DYLIB}" "${NAPI_DEST}"
+  fi
+fi

--- a/src/infra/config/env.ts
+++ b/src/infra/config/env.ts
@@ -84,6 +84,14 @@ export function loadConfig(rawEnv: NodeJS.ProcessEnv = process.env): AppConfig {
   const envCopy = normalizeConfigAliases(rawEnv);
   const vaultResolved = resolveVaultSecrets(envCopy);
   if (vaultResolved.length > 0) {
+    // Propagate resolved vault secrets back to process.env so that
+    // downstream code reading process.env directly (e.g. Telegram adapter)
+    // sees the plaintext values instead of the VAULT: prefix.
+    for (const key of vaultResolved) {
+      if (envCopy[key] !== undefined) {
+        rawEnv[key] = envCopy[key];
+      }
+    }
     emitConfigInfo(
       `[memphis-config] Resolved ${vaultResolved.length} secret(s) from vault: ${vaultResolved.join(', ')}`,
     );


### PR DESCRIPTION
## Summary

- **NAPI binary copy**: `scripts/run-rust.sh` now copies `libmemphis_napi.so` → `crates/memphis-napi/index.node` after `cargo build`. Previously the .so was built but never placed where Node's `require()` looks for it, causing vault, embeddings, and case-index to be unavailable on fresh installs.
- **Vault secret propagation**: `loadConfig()` resolved `VAULT:` prefixed secrets into a shallow env copy but never wrote them back to `process.env`. Telegram adapter (and any downstream code reading `process.env` directly) received the literal `VAULT:key_name` string instead of the decrypted value, crashing grammY on `deleteWebhook` (404).

## Test plan

- [ ] Fresh install: `rm -rf node_modules dist target crates/memphis-napi/index.node && npm install && npm run build` — verify `index.node` exists after build
- [ ] Vault init + Telegram: configure `VAULT:telegram_bot_token` in `.env`, run `memphis serve` — verify no crash, gateway starts
- [ ] `npm run test:ts` passes
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)