### PR TITLE
feat: tier-3 time-limited elevation + maxed defaults + Ollama one-liner installer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,8 +50,8 @@ DECENTRALIZED_LLM_API_BASE=
 DECENTRALIZED_LLM_API_KEY=
 LOCAL_FALLBACK_ENABLED=true
 
-GEN_TIMEOUT_MS=30000
-GEN_MAX_TOKENS=512
+GEN_TIMEOUT_MS=90000
+GEN_MAX_TOKENS=4096
 GEN_TEMPERATURE=0.4
 
 DATABASE_URL=file:./data/memphis.db
@@ -93,7 +93,7 @@ ALERT_THROTTLE_SECONDS=1800
 # MEMPHIS_QUEUE_RESUME_POLICY=skip     # skip | redispatch (caution: redispatch replays tasks)
 # MEMPHIS_QUEUE_WAL_PATH=./data/queue-wal.jsonl
 # MEMPHIS_QUEUE_WAL_MAX_BYTES=52428800 # 50MB
-# MEMPHIS_MAX_PENDING_TASKS=1000
+MEMPHIS_MAX_PENDING_TASKS=1000
 
 # Chain signing (requires RUST_CHAIN_ENABLED=true)
 # RUST_CHAIN_SIGNER_ALLOWLIST=         # comma-separated hex public keys
@@ -132,5 +132,13 @@ MEMPHIS_TELEGRAM_ALLOWED_USER_IDS=VAULT:telegram_allowed_user_ids
 # MEMPHIS_MEMORY_WARN_THRESHOLD=0.9                 # heap-usage ratio (0.5–0.99) before watchdog warns
 # MEMPHIS_REFLECTION_ENABLED=true
 # MEMPHIS_REFLECTION_INTERVAL_MS=86400000           # 24h, min: 1h
-# MEMPHIS_RATE_LIMIT_GLOBAL_MAX=100                 # requests/min, range: 1–100000
-# MEMPHIS_RATE_LIMIT_SENSITIVE_MAX=10               # requests/min, range: 1–10000
+MEMPHIS_RATE_LIMIT_GLOBAL_MAX=600                 # requests/min, range: 1–100000
+MEMPHIS_RATE_LIMIT_SENSITIVE_MAX=60                # requests/min, range: 1–10000
+
+# ── Tier-3 elevation (time-limited, operator-gated unrestricted mode) ──
+# Default tier is 2: Memphis may create new files anywhere, install packages,
+# download dependencies, run additive helpers — but cannot modify or delete
+# existing files outside ~/memphis/. To temporarily lift that restriction,
+# run `/tier 3 <operator-passphrase>` from the TUI or `@bot /tier 3 <pass>`
+# from Telegram. The grant lasts 3 hours and auto-reverts to tier 2.
+# DO NOT preload tier 3 here — elevation must always be explicit.

--- a/crates/memphis-tui/src/app.rs
+++ b/crates/memphis-tui/src/app.rs
@@ -362,6 +362,21 @@ const HELP_ENTRIES: &[HelpEntry] = &[
         route: CommandRoute::Host,
     },
     HelpEntry {
+        display: "/tier",
+        example: "/tier",
+        route: CommandRoute::Host,
+    },
+    HelpEntry {
+        display: "/tier 3 <passphrase>",
+        example: "/tier 3 <operator-passphrase>",
+        route: CommandRoute::Host,
+    },
+    HelpEntry {
+        display: "/tier revoke",
+        example: "/tier revoke",
+        route: CommandRoute::Host,
+    },
+    HelpEntry {
         display: "/legacy <memphis cli args...>",
         example: "/legacy health",
         route: CommandRoute::Legacy,
@@ -3993,6 +4008,46 @@ fn extension_host_command_for_tokens(
                     label: format!("config surfaces reset {surface} {setting}"),
                     command: "config.surfaces.reset".to_string(),
                     args: json!({ "surface": surface, "setting": setting }),
+                },
+                ActiveCommandKind::Generic,
+            )))
+        }
+        [cmd] if *cmd == "tier" => Ok(Some((
+            ExtensionHostCommand {
+                label: "tier status".to_string(),
+                command: "security.tier.status".to_string(),
+                args: json!({}),
+            },
+            ActiveCommandKind::Generic,
+        ))),
+        [cmd, sub] if *cmd == "tier" && *sub == "status" => Ok(Some((
+            ExtensionHostCommand {
+                label: "tier status".to_string(),
+                command: "security.tier.status".to_string(),
+                args: json!({}),
+            },
+            ActiveCommandKind::Generic,
+        ))),
+        [cmd, sub] if *cmd == "tier" && *sub == "revoke" => Ok(Some((
+            ExtensionHostCommand {
+                label: "tier revoke".to_string(),
+                command: "security.tier.revoke".to_string(),
+                args: json!({}),
+            },
+            ActiveCommandKind::Generic,
+        ))),
+        [cmd, tier, rest @ ..] if *cmd == "tier" && *tier == "3" => {
+            let passphrase = rest.join(" ");
+            if passphrase.trim().is_empty() {
+                return Err(
+                    "tier 3 requires the operator passphrase: /tier 3 <passphrase>".to_string(),
+                );
+            }
+            Ok(Some((
+                ExtensionHostCommand {
+                    label: "tier 3 elevate".to_string(),
+                    command: "security.tier.elevate".to_string(),
+                    args: json!({ "tier": 3, "passphrase": passphrase }),
                 },
                 ActiveCommandKind::Generic,
             )))

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -85,9 +85,45 @@ install_rust() {
   source "$HOME/.cargo/env"
 }
 
+install_ollama() {
+  if command -v ollama >/dev/null 2>&1; then
+    log_ok "Ollama already installed: $(ollama --version 2>&1 | head -n1)"
+    return
+  fi
+
+  log_info "Installing Ollama (official installer)"
+  curl -fsSL https://ollama.com/install.sh | sh
+}
+
+install_ollama_models() {
+  if ! command -v ollama >/dev/null 2>&1; then
+    log_err "Ollama not available; skipping model pulls"
+    return
+  fi
+
+  # Ensure the daemon is reachable. The official installer usually starts
+  # it, but on headless systems it may need a nudge.
+  if ! ollama list >/dev/null 2>&1; then
+    log_info "Starting ollama daemon in background"
+    (ollama serve >/dev/null 2>&1 &) || true
+    sleep 3
+  fi
+
+  for model in nomic-embed-text cogito:3b; do
+    if ollama list 2>/dev/null | awk '{print $1}' | grep -Fxq "$model"; then
+      log_ok "Ollama model already present: $model"
+      continue
+    fi
+    log_info "Pulling Ollama model: $model"
+    if ! ollama pull "$model"; then
+      log_err "Failed to pull $model (continuing)"
+    fi
+  done
+}
+
 verify() {
   local failed=0
-  for cmd in git curl python3 node npm rustc cargo; do
+  for cmd in git curl python3 node npm rustc cargo ollama; do
     if command -v "$cmd" >/dev/null 2>&1; then
       log_ok "$cmd: $("$cmd" --version 2>/dev/null | head -n1 || true)"
     else
@@ -95,6 +131,17 @@ verify() {
       failed=1
     fi
   done
+
+  if command -v ollama >/dev/null 2>&1; then
+    for model in nomic-embed-text cogito:3b; do
+      if ollama list 2>/dev/null | awk '{print $1}' | grep -Fxq "$model"; then
+        log_ok "ollama model present: $model"
+      else
+        log_err "ollama model missing: $model"
+        failed=1
+      fi
+    done
+  fi
 
   if (( failed )); then
     log_err "Verification failed"
@@ -124,6 +171,8 @@ main() {
 
   install_node
   install_rust
+  install_ollama
+  install_ollama_models
   verify
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -298,6 +298,35 @@ ensure_rust_stable() {
   log "Rust ready: $(rustc --version)"
 }
 
+ensure_ollama() {
+  if have ollama; then
+    log "Ollama detected: $(ollama --version 2>&1 | head -n1)"
+  else
+    warn "Ollama not found — required for local embeddings and the default cogito:3b chat model."
+    confirm "Install Ollama now via the official script (curl | sh)?" || {
+      warn "Skipping Ollama install; embeddings and local chat will be degraded."
+      return
+    }
+    download_to_stdout https://ollama.com/install.sh | sh
+    have ollama || fail "Ollama install failed: ollama not found after install"
+  fi
+
+  if ! ollama list >/dev/null 2>&1; then
+    log "Starting ollama daemon in background"
+    (ollama serve >/dev/null 2>&1 &) || true
+    sleep 3
+  fi
+
+  for model in nomic-embed-text cogito:3b; do
+    if ollama list 2>/dev/null | awk '{print $1}' | grep -Fxq "$model"; then
+      log "Ollama model already present: $model"
+      continue
+    fi
+    log "Pulling Ollama model: $model (this may take a few minutes)"
+    ollama pull "$model" || warn "Failed to pull $model (continuing; you can retry later)"
+  done
+}
+
 check_core_tools() {
   have git || fail "missing required core tool: git"
   have_downloader || fail "missing required downloader: need curl, wget, or python3"
@@ -413,6 +442,10 @@ print_next_steps() {
     4. memphis service install   # install & enable systemd user service
     5. memphis service restart   # start (or restart) the runtime
     6. memphis tui               # open the native operator console
+    7. In the TUI: /tier 3 <operator-passphrase> grants 3h of unrestricted
+       mutation (overwrite existing files anywhere, freeform sudo), then
+       auto-reverts. Default tier 2 is safe: creates/installs/downloads
+       freely, but cannot modify existing files outside ~/memphis/.
 
   Everyday commands:
 
@@ -451,6 +484,7 @@ main() {
   ensure_build_essentials
   ensure_node22
   ensure_rust_stable
+  ensure_ollama
   resolve_repo
 
   cd "$TARGET_DIR"

--- a/src/gateway/channels/telegram.ts
+++ b/src/gateway/channels/telegram.ts
@@ -5,6 +5,13 @@ import { splitText } from './utils.js';
 import { getCognitiveModeConfig, isValidCognitiveMode } from '../../cognitive/modes.js';
 import { validateOperatorPassphrase } from '../../infra/auth/operator-gate.js';
 import { renderSurfaceDesignGuideText } from '../../infra/operator-guide.js';
+import {
+  buildTier3EnvOverride,
+  getActiveTier3Session,
+  getTier3RemainingMs,
+  requestTier3Elevation,
+  revokeTier3Session,
+} from '../../security/tier3-session.js';
 import { getCognitiveMode, setCognitiveMode } from '../../soul/manifest.js';
 import type { ChannelAdapter, MessageHandler } from '../chat-types.js';
 import {
@@ -26,10 +33,15 @@ export type TelegramAdapterOptions = {
    * Returns a startup context string injected into the system prompt for that turn.
    * sessionTier reflects the current surface tier for this chat (default 2).
    */
-  onStartupContext?: (userId: string, sessionTier: 0 | 1 | 2) => Promise<string>;
+  onStartupContext?: (userId: string, sessionTier: 0 | 1 | 2 | 3) => Promise<string>;
 };
 
 // ─── Per-session tier state ──────────────────────────────────────────────────
+//
+// Tiers 0/1/2 live in this local map (15-min TTL, no passphrase). Tier 3
+// lives in the shared tier3-session module (3-hour TTL, passphrase-gated,
+// audited). This keeps passphrase validation and audit in one place while
+// leaving the low-friction tier-0/1/2 flow unchanged.
 
 type TierSession = {
   tier: 0 | 1 | 2;
@@ -39,10 +51,11 @@ type TierSession = {
 /** chatId → active tier elevation (expires after TTL or bot restart). */
 const sessionTierMap = new Map<string, TierSession>();
 
-const TIER_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const TIER_TTL_MS = 15 * 60 * 1000; // 15 minutes (for tiers 0/1/2)
 export const DEFAULT_TELEGRAM_SESSION_TIER = 2 as const;
 
-function getSessionTier(chatId: string): 0 | 1 | 2 {
+function getSessionTier(chatId: string): 0 | 1 | 2 | 3 {
+  if (getActiveTier3Session('telegram', chatId)) return 3;
   const session = sessionTierMap.get(chatId);
   if (!session) return DEFAULT_TELEGRAM_SESSION_TIER;
   if (Date.now() > session.expiresAt) {
@@ -62,7 +75,14 @@ function setSessionTier(chatId: string, tier: 0 | 1 | 2): void {
 
 // ─── Env override for surface policy ────────────────────────────────────────
 
-function buildTierEnvOverride(tier: 0 | 1 | 2): Record<string, string> | undefined {
+function buildTierEnvOverride(
+  chatId: string,
+  tier: 0 | 1 | 2 | 3,
+): Record<string, string> | undefined {
+  if (tier === 3) {
+    const override = buildTier3EnvOverride('telegram', chatId);
+    return Object.keys(override).length > 0 ? override : undefined;
+  }
   if (tier === DEFAULT_TELEGRAM_SESSION_TIER) return undefined;
   return {
     MEMPHIS_SURFACE_TELEGRAM_MAX_TOOL_TIER: String(tier),
@@ -80,20 +100,33 @@ async function handleTierCommand(ctx: {
 }): Promise<void> {
   const chatId = String(ctx.message.chat.id);
   const text = ctx.message.text ?? '';
-  // /tier            → show current tier
-  // /tier 0          → downgrade to safe
-  // /tier 1          → downgrade to reduced operator mode
-  // /tier 2          → return to the default full companion mode
   const parts = text.split(/\s+/);
-  const requestedTier = parts[1];
+  const arg = parts[1];
 
-  if (!requestedTier) {
+  // /tier                     → show current tier
+  // /tier 0                   → safe lock-down
+  // /tier 1                   → reduced operator mode
+  // /tier 2                   → default companion mode
+  // /tier 3 <passphrase>      → 3-hour unrestricted elevation (requires operator passphrase)
+  // /tier status              → alias for no-arg
+  // /tier revoke              → immediately revert to tier 2 (revokes tier 3 if active)
+
+  if (!arg || arg === 'status') {
     const current = getSessionTier(chatId);
+    if (current === 3) {
+      const remainingMs = getTier3RemainingMs('telegram', chatId);
+      const mins = Math.max(0, Math.round(remainingMs / 1000 / 60));
+      await ctx.reply(
+        `Tier: 3 (unrestricted — full filesystem mutation & sudo). Expires in ~${mins}min.\n` +
+          `Use /tier revoke to end early.`,
+      );
+      return;
+    }
     const expiresAt = sessionTierMap.get(chatId)?.expiresAt;
     const expiresIn = expiresAt ? Math.max(0, Math.round((expiresAt - Date.now()) / 1000 / 60)) : 0;
     const msg =
       current === DEFAULT_TELEGRAM_SESSION_TIER
-        ? 'Tier: 2 (default full companion mode).\nUse /tier 1 for reduced mode or /tier 0 to lock down.'
+        ? 'Tier: 2 (default full companion mode).\nUse /tier 1 for reduced mode, /tier 0 to lock down, or /tier 3 <passphrase> for 3h unrestricted mode.'
         : current === 1
           ? `Tier: 1 (reduced operator mode) — expires in ~${expiresIn}min\nUse /tier 2 to restore defaults or /tier 0 to lock down.`
           : `Tier: 0 (safe lock-down) — expires in ~${expiresIn}min\nUse /tier 2 to restore defaults.`;
@@ -101,9 +134,20 @@ async function handleTierCommand(ctx: {
     return;
   }
 
-  const tier = Number(requestedTier);
-  if (![0, 1, 2].includes(tier)) {
-    await ctx.reply('Usage: /tier [0|1|2] [passphrase for tier 2]');
+  if (arg === 'revoke') {
+    const wasTier3 = revokeTier3Session('telegram', chatId, 'operator-telegram-revoke');
+    setSessionTier(chatId, DEFAULT_TELEGRAM_SESSION_TIER);
+    await ctx.reply(
+      wasTier3
+        ? 'Tier 3 revoked. Back to tier 2 (default companion mode).'
+        : 'Tier 2 restored (default companion mode).',
+    );
+    return;
+  }
+
+  const tier = Number(arg);
+  if (![0, 1, 2, 3].includes(tier)) {
+    await ctx.reply('Usage: /tier [0|1|2|3] (tier 3 requires operator passphrase)');
     return;
   }
 
@@ -119,6 +163,30 @@ async function handleTierCommand(ctx: {
     return;
   }
 
+  if (tier === 3) {
+    const passphrase = parts.slice(2).join(' ').trim();
+    if (!passphrase) {
+      await ctx.reply('Tier 3 requires the operator passphrase. Usage: /tier 3 <passphrase>');
+      return;
+    }
+    const result = requestTier3Elevation({
+      surface: 'telegram',
+      actorId: chatId,
+      passphrase,
+    });
+    if (!result.ok) {
+      await ctx.reply(`Tier 3 elevation denied: ${result.message}`);
+      return;
+    }
+    const expiresAtIso = new Date(result.session.expiresAt).toISOString();
+    await ctx.reply(
+      `Tier 3 granted — unrestricted mutation active for 3 hours (expires ${expiresAtIso}).\n` +
+        `Use /tier revoke to end early.`,
+    );
+    return;
+  }
+
+  // tier === 2 — an explicit legacy passphrase may be provided but is no longer required.
   const passphrase = parts.slice(2).join(' ').trim();
   if (passphrase) {
     try {
@@ -292,7 +360,7 @@ export function createTelegramAdapter(
             chatId,
             text: intent,
             timestamp: new Date(msg.date * 1000),
-            rawEnvOverride: buildTierEnvOverride(tier),
+            rawEnvOverride: buildTierEnvOverride(chatId, tier),
             systemPromptAppend: evolvePrompt,
           });
         } catch (err) {
@@ -327,7 +395,7 @@ export function createTelegramAdapter(
         const chatId = String(msg.chat.id);
         const userId = `telegram:${String(msg.from?.id ?? 'unknown')}`;
         const sessionTier = getSessionTier(chatId);
-        const rawEnvOverride = buildTierEnvOverride(sessionTier);
+        const rawEnvOverride = buildTierEnvOverride(chatId, sessionTier);
 
         // Startup context: injected once per chatId per bot session
         let systemPromptAppend: string | undefined;
@@ -426,7 +494,7 @@ export function createTelegramAdapter(
               chatId,
               text: sttResult.text,
               timestamp: new Date(msg.date * 1000),
-              rawEnvOverride: buildTierEnvOverride(sessionTier),
+              rawEnvOverride: buildTierEnvOverride(chatId, sessionTier),
             });
           } catch (err) {
             const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/gateway/exec-policy.ts
+++ b/src/gateway/exec-policy.ts
@@ -32,6 +32,12 @@ const SHELL_METACHAR_RE = /[;&|`$(){}[\]!#~<>\\'\n\r\x00-\x1f\x7f]/;
 const SAFE_PATH_RE = /^[A-Za-z0-9_./@~ -]+$/;
 const SAFE_FLAG_RE = /^-[A-Za-z0-9]+$/;
 
+const PACKAGE_NAME_RE = /^[A-Za-z0-9_.:@/+-]+$/;
+const APT_ACTION_RE = /^(install|update)$/;
+const DNF_ACTION_RE = /^(install|check-update|update)$/;
+const PACMAN_FLAG_RE = /^-S(y|yu|u)?$/;
+const ZYPPER_ACTION_RE = /^(install|refresh|update)$/;
+
 const DEFAULT_COMMAND_RULES: Record<string, CommandRule> = {
   // ─── Basic utilities ──────────────────────────────────────────────
   echo: { allowedArgs: [/^[A-Za-z0-9 _.,:=@/-]+$/], maxArgLength: 200 },
@@ -106,7 +112,7 @@ const DEFAULT_COMMAND_RULES: Record<string, CommandRule> = {
   },
   cargo: {
     allowedArgs: [
-      /^(build|check|test|run|clippy|fmt|doc|bench|clean|update|tree|metadata|version)$/,
+      /^(build|check|test|run|clippy|fmt|doc|bench|clean|update|tree|metadata|version|install|add|search)$/,
       SAFE_FLAG_RE,
       /^--[a-z-]+(=[A-Za-z0-9_./-]+)?$/,
       /^[A-Za-z0-9_./@:-]+$/,
@@ -135,6 +141,86 @@ const DEFAULT_COMMAND_RULES: Record<string, CommandRule> = {
   tar: { allowedArgs: [SAFE_FLAG_RE, SAFE_PATH_RE], maxArgLength: 300 },
   zip: { allowedArgs: [SAFE_FLAG_RE, SAFE_PATH_RE], maxArgLength: 300 },
   unzip: { allowedArgs: [SAFE_FLAG_RE, SAFE_PATH_RE], maxArgLength: 300 },
+
+  // ─── Package managers — additive actions only (install/update/refresh) ──
+  // At tier 2 Memphis can install software but cannot remove/purge/downgrade
+  // system state. Uninstall is tier-3-only (autonomy-mode=full bypasses this).
+  apt: {
+    allowedArgs: [APT_ACTION_RE, /^-y$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 500,
+  },
+  'apt-get': {
+    allowedArgs: [APT_ACTION_RE, /^-y$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 500,
+  },
+  dnf: {
+    allowedArgs: [DNF_ACTION_RE, /^-y$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 500,
+  },
+  yum: {
+    allowedArgs: [DNF_ACTION_RE, /^-y$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 500,
+  },
+  pacman: {
+    allowedArgs: [PACMAN_FLAG_RE, /^--noconfirm$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 500,
+  },
+  zypper: {
+    allowedArgs: [ZYPPER_ACTION_RE, /^-y$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 500,
+  },
+  brew: {
+    allowedArgs: [/^(install|update|upgrade|tap|list|info)$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 500,
+  },
+  snap: {
+    allowedArgs: [/^(install|refresh|list|info)$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 500,
+  },
+  flatpak: {
+    allowedArgs: [/^(install|update|list|info)$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 500,
+  },
+
+  // ─── Language-specific package installers (additive) ─────────────
+  rustup: {
+    allowedArgs: [/^(install|update|default|toolchain|component|show)$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 300,
+  },
+  pipx: {
+    allowedArgs: [/^(install|upgrade|list|run)$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 300,
+  },
+  gem: {
+    allowedArgs: [/^(install|update|list|info)$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 300,
+  },
+  go: {
+    allowedArgs: [/^(install|get|build|run|test|mod|version)$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 300,
+  },
+
+  // ─── Ollama (LLM runtime) — additive verbs ───────────────────────
+  ollama: {
+    allowedArgs: [/^(pull|list|show|serve|ps|version)$/, SAFE_FLAG_RE, PACKAGE_NAME_RE],
+    maxArgLength: 300,
+  },
+
+  // ─── Downloaders ──────────────────────────────────────────────────
+  curl: {
+    allowedArgs: [SAFE_FLAG_RE, /^--[a-zA-Z-]+(=.+)?$/, /^-[A-Za-z]+$/, /^https?:\/\/[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$/, SAFE_PATH_RE],
+    maxArgLength: 600,
+  },
+  wget: {
+    allowedArgs: [SAFE_FLAG_RE, /^--[a-zA-Z-]+(=.+)?$/, /^-[A-Za-z]+$/, /^https?:\/\/[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$/, SAFE_PATH_RE],
+    maxArgLength: 600,
+  },
+
+  // ─── User-scoped systemctl (no root state change) ────────────────
+  systemctl: {
+    allowedArgs: [/^--user$/, /^(start|stop|restart|status|enable|disable|is-active|is-enabled|daemon-reload|list-units)$/, PACKAGE_NAME_RE],
+    maxArgLength: 300,
+  },
 };
 
 export function loadGatewayExecPolicy(rawEnv: NodeJS.ProcessEnv = process.env): GatewayExecPolicy {

--- a/src/gateway/surface-policy.ts
+++ b/src/gateway/surface-policy.ts
@@ -143,7 +143,12 @@ function parseBooleanEnv(value: string | undefined, fallback: boolean): boolean 
 
 function parseToolTierEnv(value: string | undefined, fallback: ToolTier): ToolTier {
   const normalized = value?.trim();
-  if (normalized === '0' || normalized === '1' || normalized === '2') {
+  if (
+    normalized === '0' ||
+    normalized === '1' ||
+    normalized === '2' ||
+    normalized === '3'
+  ) {
     return Number(normalized) as ToolTier;
   }
   return fallback;
@@ -253,10 +258,15 @@ export function parseSurfacePolicySettingValue(
   const normalized = value.trim().toLowerCase();
 
   if (definition.kind === 'tier') {
-    if (normalized === '0' || normalized === '1' || normalized === '2') {
+    if (
+      normalized === '0' ||
+      normalized === '1' ||
+      normalized === '2' ||
+      normalized === '3'
+    ) {
       return normalized;
     }
-    throw new Error(`Invalid value for ${setting}: ${value}. Expected 0, 1, or 2.`);
+    throw new Error(`Invalid value for ${setting}: ${value}. Expected 0, 1, 2, or 3.`);
   }
 
   if (['1', 'true', 'yes', 'on'].includes(normalized)) return 'true';

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -709,13 +709,15 @@ function createRuntimeTools(
 
     buildTool({
       name: 'memphis_fs_write',
-      description: 'Write or append to files inside ~/memphis/',
+      description:
+        'Write/append/overwrite files. Inside ~/memphis/: unrestricted. ' +
+        'Outside: create-new is always allowed; append and overwrite require tier 3.',
       inputSchema: {
         type: 'object',
         properties: {
           path: { type: 'string', description: 'File path' },
           content: { type: 'string', description: 'Content to write' },
-          mode: { type: 'string', enum: ['write', 'append'] },
+          mode: { type: 'string', enum: ['write', 'append', 'overwrite'] },
           createDirs: { type: 'boolean' },
         },
         required: ['path', 'content'],
@@ -725,12 +727,12 @@ function createRuntimeTools(
         return {
           path: requiredString(args, 'path'),
           content: requiredString(args, 'content'),
-          mode: optionalString(args, 'mode') as 'write' | 'append' | undefined,
+          mode: optionalString(args, 'mode') as 'write' | 'append' | 'overwrite' | undefined,
           createDirs: optionalBoolean(args, 'createDirs'),
         };
       },
       execute(input) {
-        return runMemphisFsWrite(input);
+        return runMemphisFsWrite(input, deps.rawEnv);
       },
     }),
     buildTool({
@@ -756,7 +758,7 @@ function createRuntimeTools(
         };
       },
       execute(input) {
-        return runMemphisFsOps(input);
+        return runMemphisFsOps(input, deps.rawEnv);
       },
     }),
     buildTool({

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -8,7 +8,7 @@
 import type { MemphisFeatureFlag } from '../infra/features/flags.js';
 import { isFeatureFlagEnabled } from '../infra/features/flags.js';
 
-export type ToolTier = 0 | 1 | 2;
+export type ToolTier = 0 | 1 | 2 | 3;
 export type ToolCapability = 'read' | 'write' | 'network' | 'execute';
 
 export interface ToolMeta {

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -36,8 +36,47 @@ import type { ChatMessage, ChatToolCall, ChatToolDefinition } from '../providers
 import type { RuntimeProvider } from '../providers/runtime.js';
 import { scanContent } from '../security/content-scan.js';
 import { emitRuntimeSecurityEvent } from '../security/runtime-security-events.js';
+import {
+  buildTier3EnvOverride,
+  getActiveTier3Session,
+  type Tier3Surface,
+} from '../security/tier3-session.js';
 
 const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+
+function mapSurfaceToTier3Surface(surface: string): Tier3Surface | null {
+  const normalized = surface.toLowerCase();
+  if (normalized.startsWith('telegram')) return 'telegram';
+  if (normalized.startsWith('matrix')) return 'matrix';
+  if (normalized.startsWith('http')) return 'http';
+  if (
+    normalized === 'tui' ||
+    normalized.startsWith('tui.') ||
+    normalized === 'cli.chat' ||
+    normalized === 'cli' ||
+    normalized.startsWith('cli.')
+  ) {
+    return 'tui';
+  }
+  return null;
+}
+
+function applyTier3EnvOverride(
+  rawEnv: NodeJS.ProcessEnv,
+  surface: string,
+  auditSurface: string | undefined,
+  actorId: string | undefined,
+): NodeJS.ProcessEnv {
+  const tier3Surface =
+    mapSurfaceToTier3Surface(auditSurface ?? surface) ??
+    mapSurfaceToTier3Surface(surface);
+  if (!tier3Surface) return rawEnv;
+  const resolvedActorId = actorId ?? 'local';
+  const session = getActiveTier3Session(tier3Surface, resolvedActorId);
+  if (!session) return rawEnv;
+  const override = buildTier3EnvOverride(tier3Surface, resolvedActorId);
+  return { ...rawEnv, ...override };
+}
 
 type ToolExecutorLike = {
   execute(call: ChatToolCall): Promise<string>;
@@ -88,6 +127,7 @@ export type TurnRuntimeInput = {
   surface: string;
   auditSurface?: string;
   rawEnv?: NodeJS.ProcessEnv;
+  actorId?: string;
   sendReply?: (reply: string) => Promise<void>;
   persistSession?: (entry: {
     userText: string;
@@ -572,7 +612,13 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
   const startedAt = Date.now();
   const classification = await resolveInputClassification(options);
   const auditSurface = options.auditSurface ?? options.surface;
-  const surfacePolicy = resolveSurfacePolicy(auditSurface, options.rawEnv ?? process.env);
+  const rawEnvWithTier3 = applyTier3EnvOverride(
+    options.rawEnv ?? process.env,
+    options.surface,
+    options.auditSurface,
+    options.actorId,
+  );
+  const surfacePolicy = resolveSurfacePolicy(auditSurface, rawEnvWithTier3);
   const conversationOverlay =
     options.conversationContext && options.conversationId
       ? await options.conversationContext.getPromptOverlay(options.conversationId)

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -79,8 +79,8 @@ export const envSchema = z.object({
   GLM_BASE_URL: z.string().optional(),
   LOCAL_FALLBACK_ENABLED: boolFromString.default(true),
 
-  GEN_TIMEOUT_MS: z.coerce.number().int().min(100).max(120000).default(30000),
-  GEN_MAX_TOKENS: z.coerce.number().int().min(1).max(32768).default(512),
+  GEN_TIMEOUT_MS: z.coerce.number().int().min(100).max(120000).default(90000),
+  GEN_MAX_TOKENS: z.coerce.number().int().min(1).max(32768).default(4096),
   GEN_TEMPERATURE: z.coerce.number().min(0).max(2).default(0.4),
 
   DATABASE_URL: z.string().default('file:./data/memphis.db'),
@@ -88,7 +88,7 @@ export const envSchema = z.object({
   MEMPHIS_QUEUE_RESUME_POLICY: z.enum(['keep', 'fail', 'redispatch']).default('keep'),
   MEMPHIS_QUEUE_WAL_PATH: z.string().optional(),
   MEMPHIS_QUEUE_WAL_MAX_BYTES: z.coerce.number().int().min(1024).max(1073741824).default(10485760),
-  MEMPHIS_MAX_PENDING_TASKS: z.coerce.number().int().min(1).max(100000).default(100),
+  MEMPHIS_MAX_PENDING_TASKS: z.coerce.number().int().min(1).max(100000).default(1000),
 
   RUST_CHAIN_ENABLED: boolFromString.default(true),
   RUST_CHAIN_BRIDGE_PATH: z.string().default('./crates/memphis-napi'),
@@ -128,14 +128,14 @@ export const envSchema = z.object({
       'nvidia',
       'mixedbread',
     ])
-    .default('local'),
-  RUST_EMBED_DIM: z.coerce.number().int().min(1).max(4096).default(32),
+    .default('ollama'),
+  RUST_EMBED_DIM: z.coerce.number().int().min(1).max(4096).default(768),
   RUST_EMBED_MAX_TEXT_BYTES: z.coerce.number().int().min(64).max(1000000).default(4096),
   RUST_EMBED_PROVIDER_URL: z.string().optional(),
   RUST_EMBED_PROVIDER_API_KEY: z.string().optional(),
   RUST_EMBED_PROVIDER_MODEL: z.string().optional(),
   RUST_EMBED_PROVIDER_TIMEOUT_MS: z.coerce.number().int().min(100).max(60000).default(8000),
-  RUST_EMBED_PERSIST_ENABLED: boolFromString.default(false),
+  RUST_EMBED_PERSIST_ENABLED: boolFromString.default(true),
   RUST_EMBED_PERSIST_PATH: z.string().optional(),
 
   // ── Operational thresholds (all optional, defaults match prior hardcoded values) ──
@@ -154,8 +154,8 @@ export const envSchema = z.object({
   MEMPHIS_SKILLS_DIR: z.string().optional(),
   MEMPHIS_REFLECTION_ENABLED: boolFromString.default(true),
   MEMPHIS_REFLECTION_INTERVAL_MS: z.coerce.number().int().min(3600000).optional(),
-  MEMPHIS_RATE_LIMIT_GLOBAL_MAX: z.coerce.number().int().min(1).max(100000).optional(),
-  MEMPHIS_RATE_LIMIT_SENSITIVE_MAX: z.coerce.number().int().min(1).max(10000).optional(),
+  MEMPHIS_RATE_LIMIT_GLOBAL_MAX: z.coerce.number().int().min(1).max(100000).default(600),
+  MEMPHIS_RATE_LIMIT_SENSITIVE_MAX: z.coerce.number().int().min(1).max(10000).default(60),
   MEMPHIS_TELEGRAM_TOKEN_OVERRIDE: z.string().optional(),
   MEMPHIS_TELEGRAM_ALLOWED_USER_IDS: z.string().optional(),
 

--- a/src/infra/tui-host/commands.ts
+++ b/src/infra/tui-host/commands.ts
@@ -12,6 +12,12 @@ import {
 } from '../../gateway/surface-policy.js';
 import { KnowledgeService } from '../../modules/knowledge/service.js';
 import { inspectFirstRunStatusReport } from '../../onboarding/first-run.js';
+import {
+  getActiveTier3Session,
+  getTier3RemainingMs,
+  requestTier3Elevation,
+  revokeTier3Session,
+} from '../../security/tier3-session.js';
 import { getCognitiveMode, setCognitiveMode } from '../../soul/manifest.js';
 import type { CognitiveMode } from '../../soul/types.js';
 import { handleAppsCommand } from '../cli/commands/apps.js';
@@ -111,6 +117,12 @@ export async function executeTuiHostCommand(
       return executePulseStatus(context);
     case 'cognitive.mode':
       return executeCognitiveMode(args, context);
+    case 'security.tier.status':
+      return executeSecurityTierStatus(context);
+    case 'security.tier.elevate':
+      return executeSecurityTierElevate(args, context);
+    case 'security.tier.revoke':
+      return executeSecurityTierRevoke(context);
     default:
       return exhaustiveCapability(command);
   }
@@ -520,6 +532,103 @@ async function executeCognitiveModeSet(
   }
 
   return { previousMode, mode: newMode, config };
+}
+
+const TUI_TIER_SURFACE = 'tui' as const;
+const TUI_TIER_ACTOR_ID = 'local' as const;
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return 'expired';
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${hours}h${minutes}m${seconds}s`;
+}
+
+async function executeSecurityTierStatus(
+  context: TuiHostCommandContext,
+): Promise<unknown> {
+  const session = getActiveTier3Session(TUI_TIER_SURFACE, TUI_TIER_ACTOR_ID);
+  const remainingMs = session
+    ? getTier3RemainingMs(TUI_TIER_SURFACE, TUI_TIER_ACTOR_ID)
+    : 0;
+  const tier = session ? 3 : 2;
+  assertNotAborted(context.signal);
+  context.emitLine(
+    'info',
+    session
+      ? `Tier ${tier} active for ${formatRemaining(remainingMs)} (expires ${new Date(session.expiresAt).toISOString()}).`
+      : 'Tier 2 (default). No elevation active.',
+  );
+  return {
+    surface: TUI_TIER_SURFACE,
+    actorId: TUI_TIER_ACTOR_ID,
+    tier,
+    session: session
+      ? {
+          grantedAt: new Date(session.grantedAt).toISOString(),
+          expiresAt: new Date(session.expiresAt).toISOString(),
+          remainingMs,
+        }
+      : null,
+  };
+}
+
+async function executeSecurityTierElevate(
+  args: Record<string, unknown> | undefined,
+  context: TuiHostCommandContext,
+): Promise<unknown> {
+  const tierInput = optionalNumberArg(args, 'tier') ?? 3;
+  if (tierInput !== 3) {
+    throw new Error('Only tier 3 elevation is supported via /tier');
+  }
+  const passphrase = requireStringArg(args, 'passphrase');
+  context.emitLine('info', 'Requesting tier 3 elevation...');
+  const result = requestTier3Elevation({
+    surface: TUI_TIER_SURFACE,
+    actorId: TUI_TIER_ACTOR_ID,
+    passphrase,
+    rawEnv: process.env,
+  });
+  assertNotAborted(context.signal);
+  if (!result.ok) {
+    context.emitLine('error', `Tier 3 denied: ${result.message}`);
+    return { ok: false, reason: result.reason, message: result.message };
+  }
+  const remainingMs = getTier3RemainingMs(TUI_TIER_SURFACE, TUI_TIER_ACTOR_ID);
+  context.emitLine(
+    'info',
+    `Tier 3 granted. Expires ${new Date(result.session.expiresAt).toISOString()} (${formatRemaining(remainingMs)} remaining).`,
+  );
+  return {
+    ok: true,
+    surface: TUI_TIER_SURFACE,
+    actorId: TUI_TIER_ACTOR_ID,
+    tier: 3,
+    grantedAt: new Date(result.session.grantedAt).toISOString(),
+    expiresAt: new Date(result.session.expiresAt).toISOString(),
+    remainingMs,
+  };
+}
+
+async function executeSecurityTierRevoke(
+  context: TuiHostCommandContext,
+): Promise<unknown> {
+  const revoked = revokeTier3Session(
+    TUI_TIER_SURFACE,
+    TUI_TIER_ACTOR_ID,
+    'manual',
+    process.env,
+  );
+  assertNotAborted(context.signal);
+  context.emitLine(
+    revoked ? 'info' : 'warning',
+    revoked
+      ? 'Tier 3 revoked; default tier 2 restored.'
+      : 'No active tier 3 elevation to revoke.',
+  );
+  return { revoked, surface: TUI_TIER_SURFACE, actorId: TUI_TIER_ACTOR_ID };
 }
 
 function getDb() {

--- a/src/infra/tui-host/protocol.ts
+++ b/src/infra/tui-host/protocol.ts
@@ -26,6 +26,9 @@ export const TUI_HOST_CAPABILITIES = [
   'config.surfaces.reset',
   'pulse.status',
   'cognitive.mode',
+  'security.tier.status',
+  'security.tier.elevate',
+  'security.tier.revoke',
 ] as const;
 
 export type TuiHostCapability = (typeof TUI_HOST_CAPABILITIES)[number];

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -872,11 +872,13 @@ export function createMemphisMcpServer(
     server.registerTool(
       'memphis_fs_write',
       {
-        description: 'Write or append to files inside ~/memphis/ (blocks sensitive paths)',
+        description:
+          'Write/append/overwrite files. Full access inside ~/memphis/. ' +
+          'Outside, create-new only; append or overwrite needs tier 3.',
         inputSchema: {
           path: z.string().min(1),
           content: z.string(),
-          mode: z.enum(['write', 'append']).optional(),
+          mode: z.enum(['write', 'append', 'overwrite']).optional(),
           createDirs: z.boolean().optional(),
           approval_request_id: z.string().optional(),
         },
@@ -901,7 +903,9 @@ export function createMemphisMcpServer(
     server.registerTool(
       'memphis_fs_ops',
       {
-        description: 'Filesystem operations: copy, move, delete, mkdir, stat',
+        description:
+          'Filesystem operations: copy, move, delete, mkdir, stat. ' +
+          'Destructive ops on existing paths outside ~/memphis/ require tier 3.',
         inputSchema: {
           operation: z.enum(['copy', 'move', 'delete', 'mkdir', 'stat']),
           source: z.string().min(1),

--- a/src/mcp/tools/fs-ops.ts
+++ b/src/mcp/tools/fs-ops.ts
@@ -1,7 +1,15 @@
 /**
  * memphis_fs_ops — filesystem operations (copy, move, delete, mkdir, stat).
  *
- * Sandboxed to ~/memphis/. Blocks sensitive paths.
+ * Permission model (see fs-permission.ts):
+ *   - Inside ~/memphis/: all operations allowed.
+ *   - Outside ~/memphis/:
+ *       mkdir, stat                → always allowed (additive / read-only).
+ *       copy, move (dest missing)  → allowed (create-new).
+ *       copy, move (dest exists)   → require tier 3.
+ *       delete                     → requires tier 3.
+ *   - Always-blocked paths (.env, vault-*, .git/, node_modules/) denied even
+ *     at tier 3.
  */
 
 import {
@@ -12,10 +20,13 @@ import {
   rmSync,
   statSync,
 } from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 
-import { AppError } from '../../core/errors.js';
+import {
+  assertFsPermission,
+  isTier3FsBypassActive,
+  resolveFsPath,
+  type FsPermissionOperation,
+} from './fs-permission.js';
 
 export type FsOperation = 'copy' | 'move' | 'delete' | 'mkdir' | 'stat';
 
@@ -41,54 +52,33 @@ export type MemphisFsOpsOutput = {
   error?: string;
 };
 
-const BLOCKED_PATTERNS = [
-  /\/\.env$/,
-  /\/\.env\./,
-  /\/vault-state\.json$/,
-  /\/vault-entries\.json$/,
-  /\/\.git\//,
-  /\/\.git$/,
-  /\/node_modules\//,
-];
-
-function resolvePath(inputPath: string): string {
-  return inputPath.startsWith('~/')
-    ? path.join(os.homedir(), inputPath.slice(2))
-    : path.resolve(inputPath);
+function destOperationFor(operation: FsOperation): FsPermissionOperation {
+  return operation === 'move' ? 'move-dest' : 'copy-dest';
 }
 
-function assertInMemphisDir(resolvedPath: string): void {
-  const memphisDir = path.join(os.homedir(), 'memphis');
-  const normalized = path.normalize(resolvedPath);
-  if (!normalized.startsWith(memphisDir + path.sep) && normalized !== memphisDir) {
-    throw new AppError(
-      'VALIDATION_ERROR',
-      `Path '${resolvedPath}' is outside ~/memphis/`,
-      403,
-    );
-  }
-}
+export function runMemphisFsOps(
+  input: MemphisFsOpsInput,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): MemphisFsOpsOutput {
+  const source = resolveFsPath(input.source);
+  const dest = input.destination ? resolveFsPath(input.destination) : undefined;
+  const tier3Active = isTier3FsBypassActive(rawEnv);
 
-function assertNotBlocked(resolvedPath: string): void {
-  const normalized = path.normalize(resolvedPath);
-  for (const pattern of BLOCKED_PATTERNS) {
-    if (pattern.test(normalized)) {
-      throw new AppError('VALIDATION_ERROR', `Operation on '${resolvedPath}' is blocked`, 403);
-    }
-  }
-}
+  // Source-side permission:
+  //   stat / copy       → read-only (operation 'stat')
+  //   mkdir             → additive (operation 'mkdir')
+  //   delete / move     → destructive on source (operation 'delete')
+  const sourceOperation: FsPermissionOperation =
+    input.operation === 'mkdir'
+      ? 'mkdir'
+      : input.operation === 'delete' || input.operation === 'move'
+        ? 'delete'
+        : 'stat';
 
-export function runMemphisFsOps(input: MemphisFsOpsInput): MemphisFsOpsOutput {
-  const source = resolvePath(input.source);
-  assertInMemphisDir(source);
+  assertFsPermission(source, { operation: sourceOperation, tier3Active });
 
-  const dest = input.destination ? resolvePath(input.destination) : undefined;
-  if (dest) assertInMemphisDir(dest);
-
-  // Block sensitive paths for destructive ops
-  if (input.operation !== 'stat') {
-    assertNotBlocked(source);
-    if (dest) assertNotBlocked(dest);
+  if (dest && (input.operation === 'copy' || input.operation === 'move')) {
+    assertFsPermission(dest, { operation: destOperationFor(input.operation), tier3Active });
   }
 
   try {

--- a/src/mcp/tools/fs-permission.ts
+++ b/src/mcp/tools/fs-permission.ts
@@ -1,0 +1,139 @@
+/**
+ * Shared filesystem permission check for memphis_fs_write / memphis_fs_ops.
+ *
+ * Two-level permission model:
+ *
+ *   Default (tier ≤ 2, no tier-3 session active)
+ *     - Inside ~/memphis/: full read/write/overwrite/delete.
+ *     - Outside ~/memphis/: may create new files/dirs; may NOT modify,
+ *       overwrite, truncate, or delete existing files/dirs.
+ *
+ *   Tier 3 active (MEMPHIS_TIER3_FS_UNRESTRICTED=true)
+ *     - Full read/write/overwrite/delete anywhere.
+ *
+ *   Always blocked (regardless of tier)
+ *     - .env / .env.* files (any depth)
+ *     - vault-state.json / vault-entries.json (vault recoverability)
+ *     - .git/ directories (source of truth for state)
+ *     - node_modules/ (reproducible from package-lock.json)
+ */
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { AppError } from '../../core/errors.js';
+import { hasAnyActiveTier3Session } from '../../security/tier3-session.js';
+
+export type FsPermissionOperation =
+  | 'create-new'   // fs-write mode=write (fails loud if exists outside sandbox)
+  | 'append'       // fs-write mode=append (requires tier 3 outside sandbox)
+  | 'overwrite'    // fs-write mode=overwrite (requires tier 3 outside sandbox)
+  | 'copy-dest'    // fs-ops copy destination
+  | 'move-dest'    // fs-ops move destination
+  | 'delete'       // fs-ops delete
+  | 'mkdir'        // fs-ops mkdir (additive — allowed outside sandbox)
+  | 'stat';        // fs-ops stat (read-only — always allowed)
+
+export interface FsPermissionContext {
+  operation: FsPermissionOperation;
+  /** True when a tier-3 elevation session is active for this request. */
+  tier3Active: boolean;
+}
+
+const ALWAYS_BLOCKED_PATTERNS: RegExp[] = [
+  /(^|\/)\.env$/,
+  /(^|\/)\.env\.[^/]+$/,
+  /(^|\/)vault-state\.json$/,
+  /(^|\/)vault-entries\.json$/,
+  /(^|\/)\.git\//,
+  /(^|\/)\.git$/,
+  /(^|\/)node_modules\//,
+];
+
+export function resolveFsPath(inputPath: string): string {
+  if (inputPath.startsWith('~/')) {
+    return path.join(os.homedir(), inputPath.slice(2));
+  }
+  return path.resolve(inputPath);
+}
+
+function memphisSandboxDir(): string {
+  return path.join(os.homedir(), 'memphis');
+}
+
+export function isInsideMemphisSandbox(resolvedPath: string): boolean {
+  const sandbox = memphisSandboxDir();
+  const normalized = path.normalize(resolvedPath);
+  return normalized === sandbox || normalized.startsWith(sandbox + path.sep);
+}
+
+function assertNotAlwaysBlocked(resolvedPath: string): void {
+  const normalized = path.normalize(resolvedPath);
+  for (const pattern of ALWAYS_BLOCKED_PATTERNS) {
+    if (pattern.test(normalized)) {
+      throw new AppError(
+        'VALIDATION_ERROR',
+        `Operation on '${resolvedPath}' is always blocked (Memphis recoverability path)`,
+        403,
+      );
+    }
+  }
+}
+
+/**
+ * True when the operation is inherently non-destructive (cannot mutate
+ * existing state): stat (read), mkdir (creates only, no-op on existing),
+ * create-new (refuses to overwrite).
+ */
+function isAdditiveOperation(op: FsPermissionOperation, resolvedPath: string): boolean {
+  if (op === 'stat' || op === 'mkdir') return true;
+  if (op === 'create-new' || op === 'copy-dest' || op === 'move-dest') {
+    // Allowed when target does not already exist.
+    return !existsSync(resolvedPath);
+  }
+  return false;
+}
+
+/**
+ * Assert that {operation} is permitted at {resolvedPath} given the current
+ * tier. Throws AppError(403) when denied. Returns silently when allowed.
+ */
+export function assertFsPermission(resolvedPath: string, context: FsPermissionContext): void {
+  // Recoverability paths are always off-limits (even at tier 3).
+  assertNotAlwaysBlocked(resolvedPath);
+
+  // stat is purely read-only — always allowed (subject to always-blocked).
+  if (context.operation === 'stat') return;
+
+  // Inside the sandbox, anything goes (still subject to always-blocked).
+  if (isInsideMemphisSandbox(resolvedPath)) return;
+
+  // Tier-3 session active → full access outside sandbox.
+  if (context.tier3Active) return;
+
+  // Additive-only operations are allowed outside sandbox.
+  if (isAdditiveOperation(context.operation, resolvedPath)) return;
+
+  throw new AppError(
+    'VALIDATION_ERROR',
+    `Outside ~/memphis/, ${context.operation} on an existing path requires tier 3. ` +
+      `Run "/tier 3 <operator_passphrase>" to elevate for 3 hours. (path: ${resolvedPath})`,
+    403,
+  );
+}
+
+/**
+ * Read the tier-3 fs bypass flag from the current process env. Kept as a
+ * helper so call sites can pass a custom rawEnv (for tests) without each
+ * site duplicating the parsing.
+ */
+export function isTier3FsBypassActive(rawEnv: NodeJS.ProcessEnv = process.env): boolean {
+  if ((rawEnv.MEMPHIS_TIER3_FS_UNRESTRICTED ?? '').toLowerCase() === 'true') {
+    return true;
+  }
+  // Fallback: if any tier-3 session is active in this process (e.g. TUI /tier 3
+  // elevation whose env override hasn't been threaded to the tool executor's
+  // rawEnv), respect it. Surface policy is the primary tier gate, so this
+  // cannot escalate a non-elevated surface past its declared maxToolTier.
+  return hasAnyActiveTier3Session();
+}

--- a/src/mcp/tools/fs-write.ts
+++ b/src/mcp/tools/fs-write.ts
@@ -1,22 +1,37 @@
 /**
- * memphis_fs_write — safe file write/append restricted to ~/memphis/.
+ * memphis_fs_write — write/append/overwrite files with tier-aware sandboxing.
  *
- * Blocks sensitive paths (.env, vault-*, .git/, node_modules/).
+ * Permission model (see fs-permission.ts):
+ *   - Inside ~/memphis/: full access.
+ *   - Outside ~/memphis/:
+ *       mode='write'     → allowed only if file does not exist yet.
+ *       mode='append'    → requires tier 3 (MEMPHIS_TIER3_FS_UNRESTRICTED=true).
+ *       mode='overwrite' → requires tier 3.
+ *   - Always-blocked paths (.env, vault-*, .git/, node_modules/) are denied
+ *     even at tier 3.
  */
 
 import { existsSync, mkdirSync, writeFileSync, appendFileSync } from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { AppError } from '../../core/errors.js';
+import {
+  assertFsPermission,
+  isTier3FsBypassActive,
+  resolveFsPath,
+  type FsPermissionOperation,
+} from './fs-permission.js';
 
 export type MemphisFsWriteInput = {
   /** Path (absolute or ~-relative) to write to */
   path: string;
   /** Content to write */
   content: string;
-  /** 'write' (overwrite/create) or 'append' */
-  mode?: 'write' | 'append';
+  /**
+   * 'write'     → create if missing; outside sandbox, refuses to overwrite existing
+   * 'append'    → append; outside sandbox, requires tier 3
+   * 'overwrite' → truncate+replace; outside sandbox, requires tier 3
+   */
+  mode?: 'write' | 'append' | 'overwrite';
   /** Create parent directories if missing */
   createDirs?: boolean;
 };
@@ -28,53 +43,31 @@ export type MemphisFsWriteOutput = {
   error?: string;
 };
 
-const BLOCKED_PATTERNS = [
-  /\/\.env$/,
-  /\/\.env\./,
-  /\/vault-state\.json$/,
-  /\/vault-entries\.json$/,
-  /\/\.git\//,
-  /\/\.git$/,
-  /\/node_modules\//,
-];
-
 const MAX_CONTENT_BYTES = 1_048_576; // 1 MB
 
-function resolvePath(inputPath: string): string {
-  return inputPath.startsWith('~/')
-    ? path.join(os.homedir(), inputPath.slice(2))
-    : path.resolve(inputPath);
-}
-
-function assertInMemphisDir(resolvedPath: string): void {
-  const memphisDir = path.join(os.homedir(), 'memphis');
-  const normalized = path.normalize(resolvedPath);
-  if (!normalized.startsWith(memphisDir + path.sep) && normalized !== memphisDir) {
-    throw new AppError(
-      'VALIDATION_ERROR',
-      `Path '${resolvedPath}' is outside the allowed ~/memphis/ directory`,
-      403,
-    );
+function operationForMode(mode: MemphisFsWriteInput['mode']): FsPermissionOperation {
+  switch (mode) {
+    case 'append':
+      return 'append';
+    case 'overwrite':
+      return 'overwrite';
+    case 'write':
+    default:
+      return 'create-new';
   }
 }
 
-function assertNotBlocked(resolvedPath: string): void {
-  const normalized = path.normalize(resolvedPath);
-  for (const pattern of BLOCKED_PATTERNS) {
-    if (pattern.test(normalized)) {
-      throw new AppError(
-        'VALIDATION_ERROR',
-        `Write to '${resolvedPath}' is blocked (sensitive path)`,
-        403,
-      );
-    }
-  }
-}
+export function runMemphisFsWrite(
+  input: MemphisFsWriteInput,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): MemphisFsWriteOutput {
+  const resolvedPath = resolveFsPath(input.path);
+  const mode = input.mode ?? 'write';
 
-export function runMemphisFsWrite(input: MemphisFsWriteInput): MemphisFsWriteOutput {
-  const resolvedPath = resolvePath(input.path);
-  assertInMemphisDir(resolvedPath);
-  assertNotBlocked(resolvedPath);
+  assertFsPermission(resolvedPath, {
+    operation: operationForMode(mode),
+    tier3Active: isTier3FsBypassActive(rawEnv),
+  });
 
   const contentBytes = Buffer.byteLength(input.content, 'utf8');
   if (contentBytes > MAX_CONTENT_BYTES) {
@@ -86,7 +79,6 @@ export function runMemphisFsWrite(input: MemphisFsWriteInput): MemphisFsWriteOut
     };
   }
 
-  const mode = input.mode ?? 'write';
   const existed = existsSync(resolvedPath);
 
   try {
@@ -97,6 +89,8 @@ export function runMemphisFsWrite(input: MemphisFsWriteInput): MemphisFsWriteOut
     if (mode === 'append') {
       appendFileSync(resolvedPath, input.content, 'utf8');
     } else {
+      // Both 'write' and 'overwrite' truncate+write. The create-new guard
+      // for 'write' outside the sandbox was already enforced above.
       writeFileSync(resolvedPath, input.content, 'utf8');
     }
 

--- a/src/security/tier3-session.ts
+++ b/src/security/tier3-session.ts
@@ -1,0 +1,237 @@
+/**
+ * Tier-3 elevation sessions — time-limited, operator-passphrase-gated unlock
+ * for fully unrestricted runtime (overwrite existing files anywhere, freeform
+ * sudo, autonomy-mode=full).
+ *
+ * By default Memphis runs at tier 2: it can create new files anywhere on the
+ * host, install packages, download things — but it cannot modify files that
+ * already exist outside ~/memphis/. Tier 3 lifts that restriction for exactly
+ * 3 hours and then auto-reverts.
+ *
+ * Grants and revocations are audited via writeSecurityAudit().
+ */
+import { validateOperatorPassphrase } from '../infra/auth/operator-gate.js';
+import { writeSecurityAudit } from '../infra/logging/security-audit.js';
+
+export const TIER_3_TTL_MS = 3 * 60 * 60 * 1000;
+
+export type Tier3Surface = 'tui' | 'telegram' | 'matrix' | 'http' | 'cli';
+
+export interface Tier3Session {
+  surface: Tier3Surface;
+  actorId: string;
+  tier: 3;
+  grantedAt: number;
+  expiresAt: number;
+}
+
+export interface Tier3ElevationRequest {
+  surface: Tier3Surface;
+  actorId: string;
+  passphrase: string;
+  rawEnv?: NodeJS.ProcessEnv;
+}
+
+export type Tier3ElevationResult =
+  | { ok: true; session: Tier3Session }
+  | { ok: false; reason: 'bad-passphrase' | 'rate-limited' | 'not-configured'; message: string };
+
+const sessions = new Map<string, Tier3Session>();
+
+function sessionKey(surface: Tier3Surface, actorId: string): string {
+  return `${surface}:${actorId}`;
+}
+
+function now(): number {
+  return Date.now();
+}
+
+function expireIfStale(session: Tier3Session, key: string): Tier3Session | null {
+  if (session.expiresAt <= now()) {
+    sessions.delete(key);
+    writeSecurityAudit({
+      action: 'tier3-expire',
+      status: 'allowed',
+      details: {
+        surface: session.surface,
+        actorId: session.actorId,
+        grantedAt: new Date(session.grantedAt).toISOString(),
+        expiredAt: new Date(session.expiresAt).toISOString(),
+      },
+    });
+    return null;
+  }
+  return session;
+}
+
+/**
+ * Request a tier-3 elevation. Validates the operator passphrase via
+ * validateOperatorPassphrase(). On success, installs a session that expires
+ * TIER_3_TTL_MS from now. Every outcome (grant, bad-passphrase, rate-limit,
+ * not-configured) is audited.
+ */
+export function requestTier3Elevation(request: Tier3ElevationRequest): Tier3ElevationResult {
+  const { surface, actorId, passphrase, rawEnv = process.env } = request;
+
+  let valid: boolean;
+  try {
+    valid = validateOperatorPassphrase(passphrase, rawEnv);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'rate-limited';
+    writeSecurityAudit(
+      {
+        action: 'tier3-deny',
+        status: 'blocked',
+        details: { surface, actorId, reason: 'rate-limited', message },
+      },
+      rawEnv,
+    );
+    return { ok: false, reason: 'rate-limited', message };
+  }
+
+  if (!valid) {
+    writeSecurityAudit(
+      {
+        action: 'tier3-deny',
+        status: 'blocked',
+        details: { surface, actorId, reason: 'bad-passphrase' },
+      },
+      rawEnv,
+    );
+    return {
+      ok: false,
+      reason: 'bad-passphrase',
+      message:
+        'Invalid operator passphrase. Tier 3 requires the passphrase you set during `memphis init`.',
+    };
+  }
+
+  const grantedAt = now();
+  const session: Tier3Session = {
+    surface,
+    actorId,
+    tier: 3,
+    grantedAt,
+    expiresAt: grantedAt + TIER_3_TTL_MS,
+  };
+  sessions.set(sessionKey(surface, actorId), session);
+
+  writeSecurityAudit(
+    {
+      action: 'tier3-grant',
+      status: 'allowed',
+      details: {
+        surface,
+        actorId,
+        grantedAt: new Date(grantedAt).toISOString(),
+        expiresAt: new Date(session.expiresAt).toISOString(),
+        ttlMs: TIER_3_TTL_MS,
+      },
+    },
+    rawEnv,
+  );
+
+  return { ok: true, session };
+}
+
+/**
+ * Return the active tier-3 session for {surface, actorId}, or null if none
+ * or expired. Automatically evicts expired sessions (and audits the
+ * auto-expiry on first check after the deadline).
+ */
+export function getActiveTier3Session(
+  surface: Tier3Surface,
+  actorId: string,
+): Tier3Session | null {
+  const key = sessionKey(surface, actorId);
+  const session = sessions.get(key);
+  if (!session) return null;
+  return expireIfStale(session, key);
+}
+
+/**
+ * Manually revoke an active tier-3 session. No-op (returns false) if there
+ * is no active session. Audited when a session is actually revoked.
+ */
+export function revokeTier3Session(
+  surface: Tier3Surface,
+  actorId: string,
+  reason = 'operator-request',
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const key = sessionKey(surface, actorId);
+  const session = sessions.get(key);
+  if (!session) return false;
+  sessions.delete(key);
+  writeSecurityAudit(
+    {
+      action: 'tier3-revoke',
+      status: 'allowed',
+      details: {
+        surface,
+        actorId,
+        reason,
+        grantedAt: new Date(session.grantedAt).toISOString(),
+        revokedAt: new Date(now()).toISOString(),
+      },
+    },
+    rawEnv,
+  );
+  return true;
+}
+
+/**
+ * Test helper: wipe all sessions. Not exported from the package barrel —
+ * only used by unit tests.
+ */
+export function __resetTier3SessionsForTests(): void {
+  sessions.clear();
+}
+
+/**
+ * True if at least one tier-3 session is currently active in this process.
+ * Used as a secondary signal for tools that can't easily plumb rawEnv but
+ * still need to respect the bypass. Surface-level policy enforcement is the
+ * primary gate; this is an in-process fallback.
+ */
+export function hasAnyActiveTier3Session(): boolean {
+  const current = now();
+  for (const [key, session] of sessions) {
+    if (session.expiresAt > current) return true;
+    sessions.delete(key);
+  }
+  return false;
+}
+
+/**
+ * Build the rawEnv overrides that should be merged into turn-runtime
+ * processing when a tier-3 session is active. Returns an empty object if
+ * no session is active.
+ *
+ * The overrides:
+ *   - bump the surface's MAX_TOOL_TIER to 3
+ *   - set MEMPHIS_AUTONOMY_MODE=full (flips restrictedMode=false)
+ *   - set MEMPHIS_TIER3_FS_UNRESTRICTED=true (fs-permission bypass)
+ */
+export function buildTier3EnvOverride(
+  surface: Tier3Surface,
+  actorId: string,
+): Record<string, string> {
+  const session = getActiveTier3Session(surface, actorId);
+  if (!session) return {};
+  const slug = surface.toUpperCase();
+  return {
+    [`MEMPHIS_SURFACE_${slug}_MAX_TOOL_TIER`]: '3',
+    MEMPHIS_AUTONOMY_MODE: 'full',
+    MEMPHIS_TIER3_FS_UNRESTRICTED: 'true',
+  };
+}
+
+/**
+ * Minutes remaining until tier-3 session expires (0 if not active).
+ */
+export function getTier3RemainingMs(surface: Tier3Surface, actorId: string): number {
+  const session = getActiveTier3Session(surface, actorId);
+  if (!session) return 0;
+  return Math.max(0, session.expiresAt - now());
+}

--- a/tests/integration/rate-limit.e2e.test.ts
+++ b/tests/integration/rate-limit.e2e.test.ts
@@ -32,6 +32,9 @@ function cfg(db: string): AppConfig {
 describe('S4.2 Rate limit', () => {
   it('rate-limits sensitive endpoint burst', async () => {
     process.env.MEMPHIS_API_TOKEN = 'test-token';
+    // Pin the sensitive rate limit to the burst-size we're testing against,
+    // regardless of .env / shell env contents.
+    process.env.MEMPHIS_RATE_LIMIT_SENSITIVE_MAX = '10';
     const dir = mkdtempSync(join(tmpdir(), 'mv4-rl-'));
     const conf = cfg(join(dir, 'rl.db'));
     const c = createAppContainer(conf);

--- a/tests/unit/config-thresholds.test.ts
+++ b/tests/unit/config-thresholds.test.ts
@@ -21,8 +21,9 @@ describe('configurable thresholds defaults', () => {
     expect(result.data.MEMPHIS_SNAPSHOT_MIN_KEEP).toBeUndefined();
     expect(result.data.MEMPHIS_HEARTBEAT_INTERVAL_MS).toBeUndefined();
     expect(result.data.MEMPHIS_REFLECTION_INTERVAL_MS).toBeUndefined();
-    expect(result.data.MEMPHIS_RATE_LIMIT_GLOBAL_MAX).toBeUndefined();
-    expect(result.data.MEMPHIS_RATE_LIMIT_SENSITIVE_MAX).toBeUndefined();
+    // Rate limits have maxed defaults so new installs ship with sane caps.
+    expect(result.data.MEMPHIS_RATE_LIMIT_GLOBAL_MAX).toBe(600);
+    expect(result.data.MEMPHIS_RATE_LIMIT_SENSITIVE_MAX).toBe(60);
 
     // Bool defaults
     expect(result.data.MEMPHIS_REFLECTION_ENABLED).toBe(true);

--- a/tests/unit/mcp-tools.test.ts
+++ b/tests/unit/mcp-tools.test.ts
@@ -40,7 +40,9 @@ describe('MCP tool: memphis_exec', () => {
   });
 
   it('blocks non-allowlisted command', () => {
-    expect(() => runMemphisExec({ command: 'curl http://example.com' })).toThrow(AppError);
+    // curl/wget were added to the additive allowlist (tier 2 may download).
+    // Use a command that stays off the allowlist: arbitrary binary invocation.
+    expect(() => runMemphisExec({ command: 'nc -l 1234' })).toThrow(AppError);
   });
 
   it('blocks shell metacharacters', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
     env: {
       MEMPHIS_API_TOKEN: '',
       RUST_CHAIN_ENABLED: 'true',
+      // Pin rate-limit defaults for deterministic test behavior regardless
+      // of what the operator's local .env contains.
+      MEMPHIS_RATE_LIMIT_SENSITIVE_MAX: '10',
+      MEMPHIS_RATE_LIMIT_GLOBAL_MAX: '100',
     },
   },
 });


### PR DESCRIPTION
## Summary

- **Tier 3 time-limited elevation**: `/tier 3 <operator-passphrase>` grants 3h of unrestricted mutation (overwrite existing files anywhere, freeform sudo, autonomy-mode=full), then auto-reverts to tier 2. Available from both TUI and Telegram with audit on every grant/deny/revoke/expire.
- **Additive-outside-sandbox default**: at tier 2 Memphis creates new files, installs packages, downloads things freely — but cannot modify or delete existing files outside `~/memphis/`. Always-blocked paths (`.env*`, `vault-*`, `.git/`, `node_modules/`) are enforced even at tier 3.
- **Maxed defaults**: `GEN_MAX_TOKENS 512→4096`, `GEN_TIMEOUT_MS 30s→90s`, `RUST_EMBED_MODE local→ollama` (dim 32→768), persistence enabled, `MEMPHIS_MAX_PENDING_TASKS 100→1000`, rate limits `600/60`.
- **Ollama one-liner installer**: `install.sh` + `install-prerequisites.sh` now install Ollama and pull `nomic-embed-text` + `cogito:3b` so fresh installs work with real embeddings and local chat out of the box.

## Key files

- `src/security/tier3-session.ts` — in-memory session state with TTL + audit
- `src/mcp/tools/fs-permission.ts` — shared additive-vs-mutating FS check
- `src/gateway/channels/telegram.ts`, `src/infra/tui-host/commands.ts` — `/tier` command wiring
- `src/gateway/turn-runtime.ts` — auto-merges tier-3 env override for mapped surfaces
- `src/gateway/exec-policy.ts` — expanded allowlist for install verbs at tier 2
- `scripts/install.sh`, `scripts/install-prerequisites.sh` — Ollama + models

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1431 tests pass (no regressions)
- [x] ESLint clean
- [ ] CI green on this branch
- [ ] Manual smoke: `/tier 3 <pass>` in TUI → fs_write to `/tmp/` succeeds; `/tier revoke` → reverts
- [ ] Fresh installer smoke in Docker (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)