### PR TITLE
Sprint 2: tier-3 hardening — unit coverage + env-overlay plumbing + runbook

### DIFF
--- a/docs/tier3-runbook.md
+++ b/docs/tier3-runbook.md
@@ -1,0 +1,271 @@
+# Tier-3 Elevation — Operator Runbook
+
+Tier-3 is Memphis's time-limited, passphrase-gated "full access" mode.
+It is opt-in, audited, and auto-expires after **3 hours**. Use it only when
+you need Memphis to do things that cross the tier-2 boundary (modify existing
+files outside `~/memphis/`, run unrestricted commands, or bump the surface
+`MAX_TOOL_TIER` to `3`).
+
+This runbook covers the entire lifecycle: what tier-3 unlocks, how to grant it
+on each surface, how to check status, how to revoke, what gets audited, and
+what to do when something fails.
+
+---
+
+## What tier-3 unlocks
+
+When a tier-3 session is active for `(surface, actorId)` Memphis merges these
+into that turn's `rawEnv`:
+
+| Env var | Value | Effect |
+|---|---|---|
+| `MEMPHIS_SURFACE_<SLUG>_MAX_TOOL_TIER` | `3` | Surface may call tier-3 tools |
+| `MEMPHIS_AUTONOMY_MODE` | `full` | Drops `GATEWAY_EXEC_RESTRICTED_MODE` (unrestricted exec allowlist) |
+| `MEMPHIS_TIER3_FS_UNRESTRICTED` | `true` | Drops the "create-new only outside sandbox" rule for fs-write / fs-ops |
+
+Outside the sandbox (`~/memphis/`), **without** tier-3:
+
+- `create-new`, `copy-dest`, `move-dest`, `mkdir`, `stat` — allowed
+- `append`, `overwrite`, `delete` on existing paths — **denied** (AppError 403)
+
+**With** tier-3: all of the above are allowed *except* always-blocked paths.
+
+## What tier-3 never unlocks (always-blocked)
+
+These are blocked at every tier, including tier-3 — no exceptions, no override:
+
+- `.env`, `.env.*` (any depth)
+- `vault-state.json`, `vault-entries.json`
+- `.git/` directories
+- `node_modules/` directories
+
+Rationale: vault recoverability and source-of-truth protection. If you need to
+touch `.env` or `.git/`, do it with shell tools outside Memphis.
+
+---
+
+## Grant a tier-3 session
+
+The operator passphrase you set during `memphis init` is what unlocks tier-3.
+Tier-3 is **per surface + per actor** — a TUI grant does not elevate Telegram.
+
+### TUI
+
+```
+/tier 3
+```
+
+TUI prompts for the operator passphrase on stderr (hidden). On success:
+
+```
+✅ Tier 3 granted for 3h (expires 2026-04-13T16:00:00Z)
+```
+
+On failure you'll see one of:
+
+- `❌ Invalid operator passphrase.` — retry (5 attempts / 15 min window)
+- `❌ Rate limited. Try again in Ns` — too many bad attempts; wait
+- `❌ Operator passphrase not configured. Run "memphis init" first.`
+
+### Telegram
+
+```
+/tier 3 <operator-passphrase>
+```
+
+Telegram requires the passphrase inline because chats have no secure prompt.
+The reply confirms the grant or denial. Treat the command message as sensitive
+and delete it if the channel is shared.
+
+### CLI
+
+```
+memphis operator elevate --surface cli
+```
+
+Prompts for the operator passphrase via hidden TTY. The session is bound to
+the CLI actor (`local`).
+
+---
+
+## Check tier-3 status
+
+### Any surface
+
+```
+/status
+```
+
+On TUI and Telegram, `/status` shows active tier-3 sessions, the surface they
+were granted for, and how many minutes remain. Expired sessions are hidden
+automatically (they are evicted on first check after the deadline and an
+`tier3-expire` audit event is written).
+
+### From the shell
+
+```
+memphis operator tier3-status
+```
+
+JSON output (operator-friendly, machine-readable):
+
+```json
+{
+  "active": true,
+  "sessions": [
+    {
+      "surface": "tui",
+      "actorId": "local",
+      "grantedAt": "2026-04-13T13:00:00Z",
+      "expiresAt": "2026-04-13T16:00:00Z",
+      "remainingMs": 10800000
+    }
+  ]
+}
+```
+
+---
+
+## Revoke a tier-3 session
+
+### TUI
+
+```
+/tier 2
+```
+
+Reverts to default tier-2. Writes a `tier3-revoke` audit event.
+
+### Telegram
+
+```
+/tier 2
+```
+
+Same behaviour. No passphrase required to revoke — anyone with access to the
+surface can lock it back down.
+
+### Kill every active session (kill-switch)
+
+```
+memphis operator tier3-revoke-all
+```
+
+Writes one `tier3-revoke` event per killed session with `reason=kill-switch`.
+Use this when you think a surface is compromised.
+
+---
+
+## Auto-expiry
+
+Every tier-3 session expires exactly `TIER_3_TTL_MS = 3 * 60 * 60 * 1000` (3h)
+after it was granted. Expiry is checked lazily:
+
+- On every `getActiveTier3Session()` call — if past `expiresAt`, the session
+  is deleted and a `tier3-expire` audit event is written.
+- On `hasAnyActiveTier3Session()` — walks all sessions and evicts any that
+  are past their deadline, auditing each.
+
+There is no background timer. A session that is granted and then never
+checked will linger in memory until the next check — but its *effects* are
+gated by `expiresAt`, so no privilege leak occurs. A process restart clears
+all sessions unconditionally.
+
+---
+
+## Audit trail
+
+All tier-3 state changes write to `MEMPHIS_SECURITY_AUDIT_LOG_PATH`
+(defaults to `data/security-audit.jsonl`):
+
+| Action | Status | Written when |
+|---|---|---|
+| `tier3-grant` | `allowed` | Operator passphrase accepted, session created |
+| `tier3-deny` | `blocked` | `reason: 'bad-passphrase' \| 'rate-limited' \| 'not-configured'` |
+| `tier3-revoke` | `allowed` | Manual revoke (reason recorded: `operator-request`, `ui-click`, `kill-switch`, ...) |
+| `tier3-expire` | `allowed` | Auto-expiry on first post-deadline check |
+
+Each event has `details: { surface, actorId, ...timestamps }`. Search with:
+
+```
+memphis audit search --action tier3- --since 2026-04-13
+memphis audit search --action tier3-grant --status allowed --json
+```
+
+---
+
+## Troubleshooting
+
+### "Invalid operator passphrase"
+
+You either mistyped or the passphrase was changed after init. If forgotten:
+
+```
+memphis vault recovery-unlock
+```
+
+Uses the recovery Q/A you set at `memphis init` time to reset the operator
+passphrase. Does **not** require the current passphrase.
+
+### "Operator passphrase not configured"
+
+You haven't run `memphis init` or the operator config at
+`<data-dir>/config/operator.json` has been deleted. Run:
+
+```
+memphis init
+```
+
+and set a passphrase + recovery Q/A.
+
+### "Rate limited. Try again in Ns"
+
+5 wrong attempts in 15 minutes triggers a window lock. Wait it out — there
+is no bypass. The rate limit is keyed to the operator config salt, so it
+survives across surfaces but not across a fresh `memphis init`.
+
+### Tier-3 "active" but tool still denied
+
+Tier-3 grants are per `(surface, actorId)`. If `/status` says you have a TUI
+session but a Telegram command is still denied, that's correct — grant
+explicitly on each surface.
+
+The surface's `auditSurface` must also match — if you invoked from an
+unrecognized surface label, the overlay falls back to no-op (see
+`applyTier3EnvOverride` in `src/gateway/turn-runtime.ts`).
+
+### Tier-3 session "active" but fs-permission says `create-new`-only
+
+Check that `MEMPHIS_TIER3_FS_UNRESTRICTED=true` is actually present in the
+tool's rawEnv. The overlay is applied in `turn-runtime.ts` and threaded
+through the in-process tool executor via `deps.rawEnv`. If you wrote a new
+tool that calls `assertFsPermission` with `tier3Active: false` regardless,
+update the call site to pass `isTier3FsBypassActive(rawEnv)`.
+
+### ".env is blocked even at tier 3"
+
+Correct. `.env` and vault files are in `ALWAYS_BLOCKED_PATTERNS` — tier 3
+does not override this. Modify those files from the shell.
+
+---
+
+## Manual smoke checklist (post-deploy)
+
+Run this after any change that touches tier-3 code paths:
+
+1. Grant on TUI — `/tier 3` with correct passphrase → green, `/status` shows
+   the session.
+2. Try overwriting `/tmp/test-tier3.txt` (create it first) via a tool call
+   → succeeds at tier 3, fails at tier 2 after `/tier 2`.
+3. Grant on Telegram with wrong passphrase — denied with `bad-passphrase`
+   reason in `security-audit.jsonl`.
+4. Grant, then restart Memphis — session is gone (in-memory state).
+5. Grant, leave for 3h, reopen — first `/status` check writes
+   `tier3-expire` event.
+6. Grant on TUI, verify Telegram still at tier 2 — cross-surface isolation.
+7. Hammer with 6 wrong passphrases — 6th attempt returns `rate-limited`
+   with a visible retry window.
+8. Revoke via `/tier 2` — `tier3-revoke` event with `reason: operator-request`.
+
+Anything that deviates from the above → open an issue and attach the
+relevant audit log lines.

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -660,7 +660,7 @@ function createRuntimeTools(
       },
       execute(input) {
         try {
-          return runMemphisExec(input);
+          return runMemphisExec(input, deps.rawEnv);
         } catch (err) {
           return { error: err instanceof Error ? err.message : String(err) };
         }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -603,7 +603,7 @@ export function createMemphisMcpServer(
       },
       withApprovalGate('memphis_exec', execPolicy, approvals, async ({ command }) => {
         try {
-          const result = runMemphisExec({ command });
+          const result = runMemphisExec({ command }, rawEnv);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
             structuredContent: result as Record<string, unknown>,

--- a/src/mcp/tools/exec.ts
+++ b/src/mcp/tools/exec.ts
@@ -21,9 +21,17 @@ export type MemphisExecOutput = {
 /**
  * Execute a safe command via the gateway exec policy.
  * Only allowlisted commands with validated arguments pass through.
+ *
+ * The rawEnv parameter is load-bearing for tier-3 elevation: when a tier-3
+ * session is active the caller will have merged `MEMPHIS_AUTONOMY_MODE=full`
+ * into rawEnv, which `loadGatewayExecPolicy` reads to drop restricted mode.
+ * Passing process.env here bypasses that overlay.
  */
-export function runMemphisExec(input: MemphisExecInput): MemphisExecOutput {
-  const policy = loadGatewayExecPolicy();
+export function runMemphisExec(
+  input: MemphisExecInput,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): MemphisExecOutput {
+  const policy = loadGatewayExecPolicy(rawEnv);
 
   // Enforce allowlist + metachar + argument validation
   enforceGatewayExecPolicy(input.command, policy);
@@ -32,7 +40,7 @@ export function runMemphisExec(input: MemphisExecInput): MemphisExecOutput {
     encoding: 'utf8',
     timeout: EXEC_TIMEOUT_MS,
     stdio: 'pipe',
-    env: { ...process.env },
+    env: { ...rawEnv },
   });
 
   if (result.error) {

--- a/src/mcp/tools/fs-permission.ts
+++ b/src/mcp/tools/fs-permission.ts
@@ -135,5 +135,5 @@ export function isTier3FsBypassActive(rawEnv: NodeJS.ProcessEnv = process.env): 
   // elevation whose env override hasn't been threaded to the tool executor's
   // rawEnv), respect it. Surface policy is the primary tier gate, so this
   // cannot escalate a non-elevated surface past its declared maxToolTier.
-  return hasAnyActiveTier3Session();
+  return hasAnyActiveTier3Session(rawEnv);
 }

--- a/src/security/tier3-session.ts
+++ b/src/security/tier3-session.ts
@@ -46,19 +46,26 @@ function now(): number {
   return Date.now();
 }
 
-function expireIfStale(session: Tier3Session, key: string): Tier3Session | null {
+function expireIfStale(
+  session: Tier3Session,
+  key: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): Tier3Session | null {
   if (session.expiresAt <= now()) {
     sessions.delete(key);
-    writeSecurityAudit({
-      action: 'tier3-expire',
-      status: 'allowed',
-      details: {
-        surface: session.surface,
-        actorId: session.actorId,
-        grantedAt: new Date(session.grantedAt).toISOString(),
-        expiredAt: new Date(session.expiresAt).toISOString(),
+    writeSecurityAudit(
+      {
+        action: 'tier3-expire',
+        status: 'allowed',
+        details: {
+          surface: session.surface,
+          actorId: session.actorId,
+          grantedAt: new Date(session.grantedAt).toISOString(),
+          expiredAt: new Date(session.expiresAt).toISOString(),
+        },
       },
-    });
+      rawEnv,
+    );
     return null;
   }
   return session;
@@ -142,11 +149,12 @@ export function requestTier3Elevation(request: Tier3ElevationRequest): Tier3Elev
 export function getActiveTier3Session(
   surface: Tier3Surface,
   actorId: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
 ): Tier3Session | null {
   const key = sessionKey(surface, actorId);
   const session = sessions.get(key);
   if (!session) return null;
-  return expireIfStale(session, key);
+  return expireIfStale(session, key, rawEnv);
 }
 
 /**
@@ -194,11 +202,24 @@ export function __resetTier3SessionsForTests(): void {
  * still need to respect the bypass. Surface-level policy enforcement is the
  * primary gate; this is an in-process fallback.
  */
-export function hasAnyActiveTier3Session(): boolean {
+export function hasAnyActiveTier3Session(rawEnv: NodeJS.ProcessEnv = process.env): boolean {
   const current = now();
   for (const [key, session] of sessions) {
     if (session.expiresAt > current) return true;
     sessions.delete(key);
+    writeSecurityAudit(
+      {
+        action: 'tier3-expire',
+        status: 'allowed',
+        details: {
+          surface: session.surface,
+          actorId: session.actorId,
+          grantedAt: new Date(session.grantedAt).toISOString(),
+          expiredAt: new Date(session.expiresAt).toISOString(),
+        },
+      },
+      rawEnv,
+    );
   }
   return false;
 }
@@ -216,8 +237,9 @@ export function hasAnyActiveTier3Session(): boolean {
 export function buildTier3EnvOverride(
   surface: Tier3Surface,
   actorId: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
 ): Record<string, string> {
-  const session = getActiveTier3Session(surface, actorId);
+  const session = getActiveTier3Session(surface, actorId, rawEnv);
   if (!session) return {};
   const slug = surface.toUpperCase();
   return {
@@ -230,8 +252,12 @@ export function buildTier3EnvOverride(
 /**
  * Minutes remaining until tier-3 session expires (0 if not active).
  */
-export function getTier3RemainingMs(surface: Tier3Surface, actorId: string): number {
-  const session = getActiveTier3Session(surface, actorId);
+export function getTier3RemainingMs(
+  surface: Tier3Surface,
+  actorId: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): number {
+  const session = getActiveTier3Session(surface, actorId, rawEnv);
   if (!session) return 0;
   return Math.max(0, session.expiresAt - now());
 }

--- a/tests/unit/fs-permission.test.ts
+++ b/tests/unit/fs-permission.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for fs-permission (memphis_fs_write / memphis_fs_ops guard).
+ *
+ * Matrix:
+ *   - Inside ~/memphis/ sandbox: all ops allowed regardless of tier
+ *   - Outside sandbox, nonexistent target: create-new/copy-dest/move-dest/mkdir allowed
+ *   - Outside sandbox, existing target: overwrite/append/delete denied at tier 2, allowed at tier 3
+ *   - ALWAYS_BLOCKED paths (.env, vault-*, .git/, node_modules/): denied at every tier
+ *   - stat: always allowed (except always-blocked)
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import os, { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AppError } from '../../src/core/errors.js';
+import {
+  assertFsPermission,
+  isInsideMemphisSandbox,
+  isTier3FsBypassActive,
+  resolveFsPath,
+  type FsPermissionOperation,
+} from '../../src/mcp/tools/fs-permission.js';
+
+let testDir: string;
+let existingFile: string;
+let nonexistentFile: string;
+const sandboxRoot = join(os.homedir(), 'memphis');
+
+function check(path: string, op: FsPermissionOperation, tier3Active = false): void {
+  assertFsPermission(path, { operation: op, tier3Active });
+}
+
+function expectDenied(path: string, op: FsPermissionOperation, tier3Active = false): void {
+  try {
+    check(path, op, tier3Active);
+    throw new Error(`expected assertFsPermission to throw for ${op} on ${path}`);
+  } catch (err) {
+    expect(err).toBeInstanceOf(AppError);
+    if (err instanceof AppError) {
+      expect(err.statusCode).toBe(403);
+    }
+  }
+}
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `memphis-fs-perm-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+  existingFile = join(testDir, 'existing.txt');
+  writeFileSync(existingFile, 'seed');
+  nonexistentFile = join(testDir, 'does-not-exist.txt');
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('isInsideMemphisSandbox', () => {
+  it('recognizes the sandbox root and subpaths', () => {
+    expect(isInsideMemphisSandbox(sandboxRoot)).toBe(true);
+    expect(isInsideMemphisSandbox(join(sandboxRoot, 'a', 'b', 'c.txt'))).toBe(true);
+  });
+
+  it('rejects paths outside the sandbox', () => {
+    expect(isInsideMemphisSandbox('/tmp/something')).toBe(false);
+    expect(isInsideMemphisSandbox('/etc/passwd')).toBe(false);
+  });
+
+  it('rejects sibling directories that merely share a prefix', () => {
+    expect(isInsideMemphisSandbox(`${sandboxRoot}-evil`)).toBe(false);
+    expect(isInsideMemphisSandbox(`${sandboxRoot}2`)).toBe(false);
+  });
+});
+
+describe('resolveFsPath', () => {
+  it('expands ~/ to the home directory', () => {
+    expect(resolveFsPath('~/foo/bar')).toBe(join(os.homedir(), 'foo', 'bar'));
+  });
+
+  it('resolves relative paths against cwd', () => {
+    const resolved = resolveFsPath('./relative');
+    expect(resolved.startsWith('/')).toBe(true);
+  });
+});
+
+describe('assertFsPermission — inside sandbox', () => {
+  const inside = join(sandboxRoot, 'any', 'deep', 'path.txt');
+
+  it.each<FsPermissionOperation>([
+    'create-new',
+    'append',
+    'overwrite',
+    'copy-dest',
+    'move-dest',
+    'delete',
+    'mkdir',
+    'stat',
+  ])('allows %s inside the sandbox at tier 2', (op) => {
+    expect(() => check(inside, op)).not.toThrow();
+  });
+});
+
+describe('assertFsPermission — outside sandbox, additive operations', () => {
+  it('allows create-new on a nonexistent target', () => {
+    expect(() => check(nonexistentFile, 'create-new')).not.toThrow();
+  });
+
+  it('denies create-new on an existing target at tier 2', () => {
+    expectDenied(existingFile, 'create-new');
+  });
+
+  it('allows copy-dest / move-dest on nonexistent targets', () => {
+    expect(() => check(nonexistentFile, 'copy-dest')).not.toThrow();
+    expect(() => check(nonexistentFile, 'move-dest')).not.toThrow();
+  });
+
+  it('denies copy-dest / move-dest on existing targets at tier 2', () => {
+    expectDenied(existingFile, 'copy-dest');
+    expectDenied(existingFile, 'move-dest');
+  });
+
+  it('allows mkdir outside sandbox (idempotent additive)', () => {
+    expect(() => check(join(testDir, 'new-dir'), 'mkdir')).not.toThrow();
+    expect(() => check(testDir, 'mkdir')).not.toThrow();
+  });
+});
+
+describe('assertFsPermission — outside sandbox, destructive operations', () => {
+  it('denies overwrite at tier 2', () => {
+    expectDenied(existingFile, 'overwrite');
+  });
+
+  it('denies append at tier 2', () => {
+    expectDenied(existingFile, 'append');
+  });
+
+  it('denies delete at tier 2', () => {
+    expectDenied(existingFile, 'delete');
+  });
+
+  it('allows overwrite / append / delete when tier-3 is active', () => {
+    expect(() => check(existingFile, 'overwrite', true)).not.toThrow();
+    expect(() => check(existingFile, 'append', true)).not.toThrow();
+    expect(() => check(existingFile, 'delete', true)).not.toThrow();
+  });
+
+  it('includes a clear tier-3 elevation hint in the denial message', () => {
+    try {
+      check(existingFile, 'overwrite');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppError);
+      if (err instanceof AppError) {
+        expect(err.message).toContain('/tier 3');
+        expect(err.message).toContain(existingFile);
+      }
+    }
+  });
+});
+
+describe('assertFsPermission — ALWAYS_BLOCKED patterns', () => {
+  const base = '/tmp/memphis-fs-blocked-samples';
+  const blockedSamples: Array<[string, string]> = [
+    ['.env in cwd', join(base, '.env')],
+    ['.env.local', join(base, '.env.local')],
+    ['.env.production', join(base, 'nested', '.env.production')],
+    ['vault-state.json', join(base, 'vault-state.json')],
+    ['vault-entries.json', join(base, 'some', 'path', 'vault-entries.json')],
+    ['.git directory itself', join(base, '.git')],
+    ['file inside .git', join(base, '.git', 'HEAD')],
+    ['file inside node_modules', join(base, 'node_modules', 'pkg', 'index.js')],
+  ];
+
+  it.each(blockedSamples)('blocks %s at tier 2 (overwrite)', (_label, p) => {
+    expectDenied(p, 'overwrite');
+  });
+
+  it.each(blockedSamples)('blocks %s at tier 3 too (overwrite)', (_label, p) => {
+    expectDenied(p, 'overwrite', true);
+  });
+
+  it.each(blockedSamples)('blocks %s even for create-new at tier 2', (_label, p) => {
+    expectDenied(p, 'create-new');
+  });
+
+  it('blocks .env inside the sandbox too', () => {
+    expectDenied(join(sandboxRoot, '.env'), 'overwrite');
+  });
+
+  it('blocks .git/ inside the sandbox too', () => {
+    expectDenied(join(sandboxRoot, '.git', 'HEAD'), 'delete');
+  });
+
+  it('blocks even stat on an always-blocked path', () => {
+    expectDenied(join(base, '.env'), 'stat');
+  });
+});
+
+describe('assertFsPermission — stat', () => {
+  it('is allowed outside sandbox on nonexistent paths', () => {
+    expect(() => check(nonexistentFile, 'stat')).not.toThrow();
+  });
+
+  it('is allowed outside sandbox on existing paths', () => {
+    expect(() => check(existingFile, 'stat')).not.toThrow();
+  });
+});
+
+describe('isTier3FsBypassActive', () => {
+  it('returns true when MEMPHIS_TIER3_FS_UNRESTRICTED=true', () => {
+    expect(isTier3FsBypassActive({ MEMPHIS_TIER3_FS_UNRESTRICTED: 'true' })).toBe(true);
+  });
+
+  it('is case-insensitive on the value', () => {
+    expect(isTier3FsBypassActive({ MEMPHIS_TIER3_FS_UNRESTRICTED: 'TRUE' })).toBe(true);
+  });
+
+  it('returns false when the env var is unset or not "true"', () => {
+    expect(isTier3FsBypassActive({})).toBe(false);
+    expect(isTier3FsBypassActive({ MEMPHIS_TIER3_FS_UNRESTRICTED: 'false' })).toBe(false);
+    expect(isTier3FsBypassActive({ MEMPHIS_TIER3_FS_UNRESTRICTED: '1' })).toBe(false);
+  });
+});

--- a/tests/unit/gateway-exec-policy.test.ts
+++ b/tests/unit/gateway-exec-policy.test.ts
@@ -33,6 +33,18 @@ describe('gateway exec-policy', () => {
       expect(policy.restrictedMode).toBe(false);
     });
 
+    it('drops restricted mode when MEMPHIS_AUTONOMY_MODE=full (tier-3 overlay)', () => {
+      const policy = loadGatewayExecPolicy({ MEMPHIS_AUTONOMY_MODE: 'full' });
+      expect(policy.restrictedMode).toBe(false);
+    });
+
+    it('stays restricted when MEMPHIS_AUTONOMY_MODE is any other value', () => {
+      for (const mode of ['balanced', 'quiet', 'paranoid']) {
+        const policy = loadGatewayExecPolicy({ MEMPHIS_AUTONOMY_MODE: mode });
+        expect(policy.restrictedMode).toBe(true);
+      }
+    });
+
     it('respects custom GATEWAY_EXEC_ALLOWLIST', () => {
       const policy = loadGatewayExecPolicy({ GATEWAY_EXEC_ALLOWLIST: 'cat,grep' });
       expect(policy.allowlist.has('cat')).toBe(true);

--- a/tests/unit/tier3-session.test.ts
+++ b/tests/unit/tier3-session.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Unit tests for tier-3 elevation sessions.
+ *
+ * Covers: passphrase validation paths (grant, bad-passphrase, rate-limited),
+ * TTL auto-expiry, manual revoke, cross-surface isolation, env overlay shape,
+ * and audit events for every outcome.
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearSessionAuth,
+  generateSalt,
+  hashWithSalt,
+  saveOperatorConfig,
+  type OperatorConfig,
+} from '../../src/infra/auth/operator-gate.js';
+import {
+  __resetTier3SessionsForTests,
+  TIER_3_TTL_MS,
+  buildTier3EnvOverride,
+  getActiveTier3Session,
+  getTier3RemainingMs,
+  hasAnyActiveTier3Session,
+  requestTier3Elevation,
+  revokeTier3Session,
+} from '../../src/security/tier3-session.js';
+
+interface AuditLine {
+  ts: string;
+  action: string;
+  status: 'allowed' | 'blocked' | 'error';
+  details?: Record<string, unknown>;
+}
+
+let testDir: string;
+let auditPath: string;
+let testEnv: NodeJS.ProcessEnv;
+
+function readAuditLines(): AuditLine[] {
+  if (!existsSync(auditPath)) return [];
+  const raw = readFileSync(auditPath, 'utf8').trim();
+  if (!raw) return [];
+  return raw.split('\n').map((line) => JSON.parse(line) as AuditLine);
+}
+
+function provisionOperator(passphrase: string): void {
+  const salt = generateSalt();
+  const config: OperatorConfig = {
+    schemaVersion: 1,
+    passphraseHash: hashWithSalt(passphrase, salt),
+    salt,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    recoveryQuestionHint: 'Test?',
+    recoveryHash: hashWithSalt('answer', salt),
+  };
+  saveOperatorConfig(config, testEnv);
+}
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `memphis-tier3-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+  auditPath = join(testDir, 'security-audit.jsonl');
+  testEnv = {
+    MEMPHIS_DATA_DIR: testDir,
+    MEMPHIS_SECURITY_AUDIT_LOG_PATH: auditPath,
+  };
+  __resetTier3SessionsForTests();
+  clearSessionAuth();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  __resetTier3SessionsForTests();
+  clearSessionAuth();
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('requestTier3Elevation', () => {
+  it('grants a tier-3 session when passphrase is correct', () => {
+    provisionOperator('correct-horse');
+
+    const result = requestTier3Elevation({
+      surface: 'tui',
+      actorId: 'operator',
+      passphrase: 'correct-horse',
+      rawEnv: testEnv,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.session.tier).toBe(3);
+    expect(result.session.surface).toBe('tui');
+    expect(result.session.actorId).toBe('operator');
+    expect(result.session.expiresAt - result.session.grantedAt).toBe(TIER_3_TTL_MS);
+
+    const events = readAuditLines();
+    expect(events).toHaveLength(1);
+    expect(events[0].action).toBe('tier3-grant');
+    expect(events[0].status).toBe('allowed');
+    expect(events[0].details?.surface).toBe('tui');
+    expect(events[0].details?.actorId).toBe('operator');
+    expect(events[0].details?.ttlMs).toBe(TIER_3_TTL_MS);
+  });
+
+  it('denies with bad-passphrase reason when passphrase is wrong', () => {
+    provisionOperator('correct-horse');
+
+    const result = requestTier3Elevation({
+      surface: 'telegram',
+      actorId: '12345',
+      passphrase: 'not-it',
+      rawEnv: testEnv,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('bad-passphrase');
+    expect(result.message).toContain('Invalid operator passphrase');
+
+    const events = readAuditLines();
+    expect(events).toHaveLength(1);
+    expect(events[0].action).toBe('tier3-deny');
+    expect(events[0].status).toBe('blocked');
+    expect(events[0].details?.reason).toBe('bad-passphrase');
+    expect(events[0].details?.surface).toBe('telegram');
+    expect(events[0].details?.actorId).toBe('12345');
+  });
+
+  it('denies with rate-limited reason after 5 wrong attempts', () => {
+    provisionOperator('correct-horse');
+
+    for (let i = 0; i < 5; i += 1) {
+      const r = requestTier3Elevation({
+        surface: 'tui',
+        actorId: 'operator',
+        passphrase: `wrong-${i}`,
+        rawEnv: testEnv,
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe('bad-passphrase');
+    }
+
+    const result = requestTier3Elevation({
+      surface: 'tui',
+      actorId: 'operator',
+      passphrase: 'wrong-6',
+      rawEnv: testEnv,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('rate-limited');
+
+    const events = readAuditLines();
+    const rateLimitedEvent = events[events.length - 1];
+    expect(rateLimitedEvent.action).toBe('tier3-deny');
+    expect(rateLimitedEvent.status).toBe('blocked');
+    expect(rateLimitedEvent.details?.reason).toBe('rate-limited');
+  });
+
+  it('fails even when no operator is configured', () => {
+    const result = requestTier3Elevation({
+      surface: 'tui',
+      actorId: 'operator',
+      passphrase: 'anything',
+      rawEnv: testEnv,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('bad-passphrase');
+  });
+});
+
+describe('TTL auto-expiry', () => {
+  it('keeps the session active right before expiresAt', () => {
+    vi.useFakeTimers();
+    const start = new Date('2026-04-13T10:00:00Z').getTime();
+    vi.setSystemTime(start);
+
+    provisionOperator('good-pass');
+
+    const grant = requestTier3Elevation({
+      surface: 'tui',
+      actorId: 'operator',
+      passphrase: 'good-pass',
+      rawEnv: testEnv,
+    });
+    expect(grant.ok).toBe(true);
+
+    vi.setSystemTime(start + TIER_3_TTL_MS - 1);
+    expect(getActiveTier3Session('tui', 'operator', testEnv)).not.toBeNull();
+    expect(hasAnyActiveTier3Session(testEnv)).toBe(true);
+  });
+
+  it('auto-evicts and audits tier3-expire on first check past deadline', () => {
+    vi.useFakeTimers();
+    const start = new Date('2026-04-13T10:00:00Z').getTime();
+    vi.setSystemTime(start);
+
+    provisionOperator('good-pass');
+
+    requestTier3Elevation({
+      surface: 'tui',
+      actorId: 'operator',
+      passphrase: 'good-pass',
+      rawEnv: testEnv,
+    });
+
+    vi.setSystemTime(start + TIER_3_TTL_MS + 1);
+    expect(getActiveTier3Session('tui', 'operator', testEnv)).toBeNull();
+    expect(hasAnyActiveTier3Session(testEnv)).toBe(false);
+
+    const expireEvents = readAuditLines().filter((e) => e.action === 'tier3-expire');
+    expect(expireEvents).toHaveLength(1);
+    expect(expireEvents[0].status).toBe('allowed');
+    expect(expireEvents[0].details?.surface).toBe('tui');
+    expect(expireEvents[0].details?.actorId).toBe('operator');
+  });
+
+  it('getTier3RemainingMs counts down toward zero', () => {
+    vi.useFakeTimers();
+    const start = new Date('2026-04-13T10:00:00Z').getTime();
+    vi.setSystemTime(start);
+
+    provisionOperator('good-pass');
+    requestTier3Elevation({
+      surface: 'tui',
+      actorId: 'operator',
+      passphrase: 'good-pass',
+      rawEnv: testEnv,
+    });
+
+    expect(getTier3RemainingMs('tui', 'operator', testEnv)).toBe(TIER_3_TTL_MS);
+
+    vi.setSystemTime(start + 60_000);
+    expect(getTier3RemainingMs('tui', 'operator', testEnv)).toBe(TIER_3_TTL_MS - 60_000);
+
+    vi.setSystemTime(start + TIER_3_TTL_MS + 1);
+    expect(getTier3RemainingMs('tui', 'operator', testEnv)).toBe(0);
+  });
+});
+
+describe('revokeTier3Session', () => {
+  it('returns true and audits when a session was active', () => {
+    provisionOperator('good-pass');
+    requestTier3Elevation({
+      surface: 'tui',
+      actorId: 'operator',
+      passphrase: 'good-pass',
+      rawEnv: testEnv,
+    });
+
+    const revoked = revokeTier3Session('tui', 'operator', 'ui-click', testEnv);
+    expect(revoked).toBe(true);
+    expect(getActiveTier3Session('tui', 'operator', testEnv)).toBeNull();
+
+    const revokeEvents = readAuditLines().filter((e) => e.action === 'tier3-revoke');
+    expect(revokeEvents).toHaveLength(1);
+    expect(revokeEvents[0].details?.reason).toBe('ui-click');
+    expect(revokeEvents[0].details?.surface).toBe('tui');
+  });
+
+  it('returns false and does not audit when no session exists', () => {
+    const revoked = revokeTier3Session('tui', 'ghost', 'ui-click', testEnv);
+    expect(revoked).toBe(false);
+    expect(readAuditLines().filter((e) => e.action === 'tier3-revoke')).toHaveLength(0);
+  });
+});
+
+describe('cross-surface isolation', () => {
+  it('grants independent sessions per (surface, actorId) pair', () => {
+    provisionOperator('good-pass');
+
+    requestTier3Elevation({
+      surface: 'tui',
+      actorId: 'alice',
+      passphrase: 'good-pass',
+      rawEnv: testEnv,
+    });
+
+    expect(getActiveTier3Session('tui', 'alice', testEnv)).not.toBeNull();
+    expect(getActiveTier3Session('telegram', 'alice', testEnv)).toBeNull();
+    expect(getActiveTier3Session('tui', 'bob', testEnv)).toBeNull();
+
+    requestTier3Elevation({
+      surface: 'telegram',
+      actorId: 'alice',
+      passphrase: 'good-pass',
+      rawEnv: testEnv,
+    });
+    expect(getActiveTier3Session('telegram', 'alice', testEnv)).not.toBeNull();
+
+    revokeTier3Session('tui', 'alice', 'test', testEnv);
+    expect(getActiveTier3Session('tui', 'alice', testEnv)).toBeNull();
+    expect(getActiveTier3Session('telegram', 'alice', testEnv)).not.toBeNull();
+  });
+});
+
+describe('buildTier3EnvOverride', () => {
+  it('returns an empty object when no session is active', () => {
+    expect(buildTier3EnvOverride('tui', 'operator', testEnv)).toEqual({});
+  });
+
+  it('returns surface-specific max-tier + unrestricted flags when active', () => {
+    provisionOperator('good-pass');
+    requestTier3Elevation({
+      surface: 'telegram',
+      actorId: 'operator',
+      passphrase: 'good-pass',
+      rawEnv: testEnv,
+    });
+
+    const overrides = buildTier3EnvOverride('telegram', 'operator', testEnv);
+    expect(overrides).toEqual({
+      MEMPHIS_SURFACE_TELEGRAM_MAX_TOOL_TIER: '3',
+      MEMPHIS_AUTONOMY_MODE: 'full',
+      MEMPHIS_TIER3_FS_UNRESTRICTED: 'true',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Locks in the tier-3 elevation work from PR #77 with dedicated tests, closes three env-overlay gaps that would have let a tier-3 session silently fail to unlock its intended privileges when reached via specific tool paths, and ships the operator runbook.

## What changed

### New unit coverage
- **`tests/unit/tier3-session.test.ts`** (12 tests) — passphrase grant / bad-passphrase / rate-limited, TTL auto-expiry via `vi.setSystemTime`, manual revoke (true + false paths), cross-surface isolation, env-overlay shape, and audit-event verification for every outcome (`tier3-grant`, `tier3-deny`, `tier3-revoke`, `tier3-expire`).
- **`tests/unit/fs-permission.test.ts`** (55 tests) — inside-sandbox full access, outside-sandbox additive vs destructive at tier 2 vs tier 3, `ALWAYS_BLOCKED_PATTERNS` (`.env`, `vault-*`, `.git/`, `node_modules/`) honored at all tiers, stat always allowed except on blocked paths, `isTier3FsBypassActive` env parsing (case-insensitive).
- **`tests/unit/gateway-exec-policy.test.ts`** — new regression cases asserting `MEMPHIS_AUTONOMY_MODE=full` drops restricted mode (and only `full`, not `balanced`/`quiet`/`paranoid`).

### Env-overlay plumbing fixes
- **`src/security/tier3-session.ts`** — thread `rawEnv` through `getActiveTier3Session`, `hasAnyActiveTier3Session`, `buildTier3EnvOverride`, `getTier3RemainingMs`, and the internal `expireIfStale`, so the `tier3-expire` audit lands on the caller's audit-log path. Also audit from `hasAnyActiveTier3Session` when evicting stale entries.
- **`src/mcp/tools/exec.ts`** + **`src/gateway/tool-executor.ts`** + **`src/mcp/server.ts`** — `runMemphisExec(input, rawEnv)`. Without this the tool was calling `loadGatewayExecPolicy()` against bare `process.env`, silently ignoring the tier-3 `MEMPHIS_AUTONOMY_MODE=full` overlay merged into the turn's `rawEnv` by `turn-runtime.ts`.
- **`src/mcp/tools/fs-permission.ts`** — pass `rawEnv` to the `hasAnyActiveTier3Session` fallback inside `isTier3FsBypassActive` so expire audits land on the right path.

### Docs
- **`docs/tier3-runbook.md`** — per-surface grant/status/revoke flow (TUI, Telegram, CLI), what tier-3 unlocks vs `ALWAYS_BLOCKED` list, troubleshooting decision tree, and a manual smoke checklist for post-deploy verification.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Full `npx vitest run` — **1500 tests / 332 files green**
- [x] New tier3-session + fs-permission test files drive the specific scenarios the runbook promises (grant, deny, TTL expiry, revoke, always-blocked, tier-2 vs tier-3 gating).
- [ ] Manual smoke on TUI + Telegram (grant/status/revoke/auto-expire) — operator to verify on their box per the runbook checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)