### PR TITLE
feat: Sprint 3 — provider cascade anthropic→minimax→ollama + Ollama tuning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,13 +10,29 @@ MEMPHIS_OWNER_NAME=local operator
 # Runtime API protection (required in production)
 MEMPHIS_API_TOKEN=
 
-# Optional. If omitted, Memphis defaults to Ollama-first setup and gracefully falls back to local-fallback.
-# Supported values: ollama | local-fallback | shared-llm | decentralized-llm
-DEFAULT_PROVIDER=ollama
+# Default provider when `auto` is requested. Operator-preferred order:
+# anthropic → minimax → ollama → local-fallback (override via MEMPHIS_PROVIDER_CASCADE).
+# Supported values: anthropic | minimax | ollama | shared-llm | decentralized-llm | glm | deepseek | local-fallback
+DEFAULT_PROVIDER=anthropic
 
-# Ollama local model (used when DEFAULT_PROVIDER=ollama)
+# Cascade order (comma-separated). Omit to use the default above.
+# Every name must match a known provider — typos fail loud at startup.
+# Example: MEMPHIS_PROVIDER_CASCADE=anthropic,minimax,ollama,local-fallback
+# MEMPHIS_PROVIDER_CASCADE=
+
+# Ollama local model — used when anthropic/minimax are unreachable (offline third fallback).
 OLLAMA_URL=http://127.0.0.1:11434
 OLLAMA_MODEL=cogito:3b
+
+# Ollama tuning (used when the cascade reaches Ollama; all optional).
+# Rationale: offline/triage mode prefers deterministic + bounded-long answers over quick-but-hallucinated ones.
+# OLLAMA_NUM_CTX=8192            # context window; raise for long prompts, lower if RAM-bound
+# OLLAMA_TEMPERATURE=0.2         # determinism-leaning
+# OLLAMA_TOP_P=0.85              # focus the tail
+# OLLAMA_TOP_K=40                # optional; undefined lets Ollama pick
+# OLLAMA_REPEAT_PENALTY=1.15     # avoid local-loop stuck
+# OLLAMA_NUM_PREDICT_OFFLINE=4096 # long-form cap when Ollama is last resort
+# OLLAMA_REQUEST_TIMEOUT_MS=300000 # 5-minute hard ceiling per request
 
 # ── Provider vault keys ─────────────────────────────────────────────
 # Add providers via: memphis provider add <name> --api-key <key>

--- a/src/app/container.ts
+++ b/src/app/container.ts
@@ -20,7 +20,7 @@ import { TaskQueueService } from '../infra/storage/task-queue-service.js';
 import { CapacityWake } from '../infra/work/capacity-wake.js';
 import { SessionTokenService } from '../infra/work/session-token-service.js';
 import { WorkPollingService } from '../infra/work/work-polling-service.js';
-import { OrchestrationService } from '../modules/orchestration/service.js';
+import { OrchestrationService, parseCascadeOrder } from '../modules/orchestration/service.js';
 import { createConfiguredRuntimeProviders } from '../providers/runtime-registry.js';
 
 function defaultWalPath(databaseUrl: string): string {
@@ -78,6 +78,7 @@ export function createAppContainer(
     maxRetries: 2,
     providerCooldownMs: 15_000,
     providers,
+    cascadeOrder: parseCascadeOrder(config.MEMPHIS_PROVIDER_CASCADE),
   });
   const sessionTokenService = new SessionTokenService(
     process.env.MEMPHIS_SESSION_TOKEN_SECRET ??

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -119,7 +119,8 @@ export type SearchResult = {
 export type ProviderCascadeResult = {
   provider: RuntimeProvider;
   degraded: boolean;
-  tier: 1 | 2 | 3 | 4 | 5;
+  /** 1-indexed position in the cascade walk. Tier 1 = first try (requested or head of cascade). */
+  tier: number;
   originalRequested: string;
   actualProvider: string;
   reason?: string;
@@ -127,7 +128,7 @@ export type ProviderCascadeResult = {
 
 export type DegradationInfo = {
   degraded: boolean;
-  tier?: 1 | 2 | 3 | 4 | 5;
+  tier?: number;
   originalProvider?: string;
   actualProvider: string;
   reason?: string;

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -43,7 +43,15 @@ export const envSchema = z.object({
   MEMPHIS_AGENT_NAME: z.string().default('Memphis Agent'),
   MEMPHIS_OWNER_NAME: z.string().default('local operator'),
 
-  DEFAULT_PROVIDER: z.enum(PROVIDER_NAMES).optional().default('ollama'),
+  DEFAULT_PROVIDER: z.enum(PROVIDER_NAMES).optional().default('anthropic'),
+
+  /**
+   * Comma-separated cascade order for provider fallback.
+   * Example: `anthropic,minimax,ollama,local-fallback`
+   * Each name must match PROVIDER_NAMES; unknown names throw at startup.
+   * Omit to use DEFAULT_PROVIDER_CASCADE (anthropic → minimax → ollama → local-fallback).
+   */
+  MEMPHIS_PROVIDER_CASCADE: z.string().optional(),
 
   ANTHROPIC_API_KEY: z.string().optional(),
   ANTHROPIC_MODEL: z.string().optional(),
@@ -64,6 +72,19 @@ export const envSchema = z.object({
   DECENTRALIZED_LLM_MODEL: z.string().optional(),
   OLLAMA_URL: z.string().optional(),
   OLLAMA_MODEL: z.string().optional(),
+
+  // ── Ollama tuning (slow-but-eventual offline answers) ───────────────────
+  // Rationale: when the cascade reaches Ollama we're already offline or in
+  // triage mode. Remove hidden short timeouts, set deterministic defaults so
+  // the model doesn't wander, and give it a long-but-finite ceiling so the
+  // cascade never hangs forever.
+  OLLAMA_NUM_CTX: z.coerce.number().int().min(512).max(131072).optional(),
+  OLLAMA_TEMPERATURE: z.coerce.number().min(0).max(2).optional(),
+  OLLAMA_TOP_P: z.coerce.number().min(0).max(1).optional(),
+  OLLAMA_TOP_K: z.coerce.number().int().min(1).max(1000).optional(),
+  OLLAMA_REPEAT_PENALTY: z.coerce.number().min(0.5).max(5).optional(),
+  OLLAMA_NUM_PREDICT_OFFLINE: z.coerce.number().int().min(64).max(32768).optional(),
+  OLLAMA_REQUEST_TIMEOUT_MS: z.coerce.number().int().min(1000).max(3_600_000).optional(),
   MINIMAX_API_KEY: z.string().optional(),
   MINIMAX_MODEL: z.string().optional(),
   MINIMAX_BASE_URL: z.string().optional(),

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -347,6 +347,15 @@ export function createHttpServer(
     };
   });
 
+  app.get('/v1/providers/models', async () => {
+    const models = await orchestration.providersModels();
+    return {
+      defaultProvider: config.DEFAULT_PROVIDER,
+      cascade: orchestration.getCascadeOrder(),
+      models,
+    };
+  });
+
   app.get('/metrics', async (_request, reply) => {
     if (!metrics.metricsEnabled(process.env)) {
       return reply.status(404).send({

--- a/src/modules/orchestration/service.ts
+++ b/src/modules/orchestration/service.ts
@@ -1,12 +1,13 @@
 import { ProviderPolicy } from './provider-policy.js';
 import type { LLMProvider } from '../../core/contracts/llm-provider.js';
 import { AppError } from '../../core/errors.js';
-import type {
-  GenerateInput,
-  GenerateResult,
-  ProviderName,
-  ProviderTraceAttempt,
-  ProviderCascadeResult,
+import {
+  PROVIDER_NAMES,
+  type GenerateInput,
+  type GenerateResult,
+  type ProviderName,
+  type ProviderTraceAttempt,
+  type ProviderCascadeResult,
 } from '../../core/types.js';
 import { metrics } from '../../infra/logging/metrics.js';
 import {
@@ -19,12 +20,66 @@ import {
   type RuntimeProvider,
 } from '../../providers/runtime.js';
 
+/**
+ * Operator-preferred default cascade order. Anthropic primary, Minimax second
+ * fallback, Ollama offline third, local-fallback always-succeeds safety net.
+ * Override with MEMPHIS_PROVIDER_CASCADE=comma,separated,list.
+ */
+export const DEFAULT_PROVIDER_CASCADE: ProviderName[] = [
+  'anthropic',
+  'minimax',
+  'ollama',
+  'local-fallback',
+];
+
+/**
+ * Parse MEMPHIS_PROVIDER_CASCADE env value into a validated list. Every entry
+ * must match a known PROVIDER_NAMES value — we fail loud on typos rather than
+ * silently skipping, because a wrong cascade means the operator thought they
+ * had a fallback they don't actually have.
+ */
+export function parseCascadeOrder(
+  rawValue: string | undefined,
+): ProviderName[] {
+  if (!rawValue || !rawValue.trim()) return [...DEFAULT_PROVIDER_CASCADE];
+  const parts = rawValue
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return [...DEFAULT_PROVIDER_CASCADE];
+
+  const seen = new Set<ProviderName>();
+  const result: ProviderName[] = [];
+  for (const part of parts) {
+    if (!(PROVIDER_NAMES as readonly string[]).includes(part)) {
+      throw new AppError(
+        'VALIDATION_ERROR',
+        `MEMPHIS_PROVIDER_CASCADE contains unknown provider '${part}'. ` +
+          `Valid names: ${PROVIDER_NAMES.join(', ')}`,
+        400,
+      );
+    }
+    const name = part as ProviderName;
+    if (!seen.has(name)) {
+      seen.add(name);
+      result.push(name);
+    }
+  }
+  // Always guarantee local-fallback terminates the cascade. Without it, a
+  // fully-degraded state throws — that's worse than falling through to safe
+  // canned output.
+  if (!seen.has('local-fallback')) result.push('local-fallback');
+  return result;
+}
+
 export type OrchestratorDeps = {
   defaultProvider: ProviderName;
   providers: Array<RuntimeProvider | LLMProvider>;
   fallbackProvider?: ProviderName;
   maxRetries?: number;
   providerCooldownMs?: number;
+  /** Ordered cascade of providers to try after the requested one. Defaults to DEFAULT_PROVIDER_CASCADE. */
+  cascadeOrder?: ProviderName[];
 };
 
 function sleep(ms: number): Promise<void> {
@@ -44,6 +99,7 @@ export class OrchestrationService {
   private readonly providers = new Map<ProviderName, RuntimeProvider>();
   private readonly maxRetries: number;
   private readonly providerPolicy: ProviderPolicy;
+  private readonly cascadeOrder: ProviderName[];
 
   constructor(private readonly deps: OrchestratorDeps) {
     for (const provider of deps.providers) {
@@ -52,6 +108,15 @@ export class OrchestrationService {
     }
     this.maxRetries = deps.maxRetries ?? 2;
     this.providerPolicy = new ProviderPolicy(deps.providerCooldownMs ?? 30_000);
+    this.cascadeOrder =
+      deps.cascadeOrder && deps.cascadeOrder.length > 0
+        ? [...deps.cascadeOrder]
+        : [...DEFAULT_PROVIDER_CASCADE];
+  }
+
+  /** Read-only view of the configured cascade order (for /status + tests). */
+  public getCascadeOrder(): ProviderName[] {
+    return [...this.cascadeOrder];
   }
 
   private pickAutoProvider(strategy: 'default' | 'latency-aware'): ProviderName {
@@ -105,111 +170,87 @@ export class OrchestrationService {
   }
 
   /**
-   * Resolve provider with 5-tier cascade: requested → default → minimax → ollama → local-fallback
+   * Resolve provider via cascade walk: [requested, defaultProvider, ...cascadeOrder]
+   * deduped. Tier is the 1-indexed position in the walk. Tier 1 is the first
+   * slot (the requested provider if explicit, or the default otherwise). Later
+   * tiers are whichever position in the cascade actually served the request.
    *
-   * NOTE: The cascade order is: requested -> default -> minimax -> ollama -> local-fallback
-   * This ensures minimax is always tried before ollama when default (usually minimax) fails.
-   * TODO(#36): Make cascade order configurable via provider priority list.
-   * NEVER throws - always returns a provider
-   * Security: Validates provider names, sanitizes degradation reasons
+   * Operator default cascade: anthropic → minimax → ollama → local-fallback
+   * (see DEFAULT_PROVIDER_CASCADE). Override with MEMPHIS_PROVIDER_CASCADE.
+   *
+   * NEVER throws when local-fallback is registered (which parseCascadeOrder
+   * guarantees). Sanitizes all degradation reasons before returning.
    */
   private resolveProviderCascade(
     requested?: 'auto' | ProviderName,
     strategy: 'default' | 'latency-aware' = 'default',
   ): ProviderCascadeResult {
-    // Resolve requested provider name
-    let requestedName =
+    let resolvedRequested: ProviderName =
       requested && requested !== 'auto' ? requested : this.pickAutoProvider(strategy);
 
-    // SECURITY: Validate provider name before lookup
-    if (!validateProviderName(requestedName)) {
-      // Log suspicious provider name and fall back to safe default
-      requestedName = 'local-fallback';
+    // SECURITY: reject path-traversal/injection attempts in provider names.
+    if (!validateProviderName(resolvedRequested)) {
+      resolvedRequested = 'local-fallback';
     }
 
-    // Tier 1: Try requested provider
-    const requestedProvider = this.providers.get(requestedName);
-    if (requestedProvider && !this.providerPolicy.isInCooldown(requestedName)) {
-      return {
-        provider: requestedProvider,
-        degraded: false,
-        tier: 1,
-        originalRequested: requestedName,
-        actualProvider: requestedName,
-      };
-    }
-
-    // Tier 1 failed - build reason
-    const tier1Reason = requestedProvider
-      ? sanitizeDegradationReason(
-          `${requestedName} in cooldown (${this.providerPolicy.remainingCooldownMs(requestedName)}ms remaining)`,
-        )
-      : sanitizeDegradationReason(`${requestedName} unavailable`);
-
-    // Tier 2: Try default provider (if different from requested)
-    const defaultName = this.deps.defaultProvider;
-    if (defaultName !== requestedName) {
-      const defaultProvider = this.providers.get(defaultName);
-      if (defaultProvider && !this.providerPolicy.isInCooldown(defaultName)) {
-        return {
-          provider: defaultProvider,
-          degraded: true,
-          tier: 2,
-          originalRequested: requestedName,
-          actualProvider: defaultName,
-          reason: tier1Reason,
-        };
+    // Build the walk list: requested first (tier 1), then default provider
+    // as a safety net (preserves behaviour for operators whose default isn't
+    // in cascadeOrder), then the full cascade. Dedupe preserves first-seen
+    // position so tier numbers are stable.
+    const walk: ProviderName[] = [];
+    const seen = new Set<ProviderName>();
+    const push = (name: ProviderName): void => {
+      if (!seen.has(name)) {
+        seen.add(name);
+        walk.push(name);
       }
-    }
-
-    // Tier 3: Try minimax specifically (if not already tried as default)
-    // This ensures minimax is in the cascade before ollama
-    if (defaultName !== 'minimax' && requestedName !== 'minimax') {
-      const minimaxProvider = this.providers.get('minimax');
-      if (minimaxProvider && !this.providerPolicy.isInCooldown('minimax')) {
-        return {
-          provider: minimaxProvider,
-          degraded: true,
-          tier: 3,
-          originalRequested: requestedName,
-          actualProvider: 'minimax',
-          reason: sanitizeDegradationReason(`${requestedName} and ${defaultName} unavailable, trying minimax`),
-        };
-      }
-    }
-
-    // Tier 4: Try ollama (local)
-    const ollamaProvider = this.providers.get('ollama');
-    if (ollamaProvider && !this.providerPolicy.isInCooldown('ollama') && requestedName !== 'ollama') {
-      return {
-        provider: ollamaProvider,
-        degraded: true,
-        tier: 4,
-        originalRequested: requestedName,
-        actualProvider: 'ollama',
-        reason: sanitizeDegradationReason(`${requestedName} and ${defaultName} unavailable, using ollama`),
-      };
-    }
-
-    // Tier 5: local-fallback (always succeeds)
-    const fallbackProvider = this.providers.get('local-fallback');
-    if (!fallbackProvider) {
-      // This should never happen in production, but handle it defensively
-      throw new AppError(
-        'PROVIDER_UNAVAILABLE',
-        'Critical: local-fallback provider not configured',
-        503,
-      );
-    }
-
-    return {
-      provider: fallbackProvider,
-      degraded: true,
-      tier: 5,
-      originalRequested: requestedName,
-      actualProvider: 'local-fallback',
-      reason: sanitizeDegradationReason('all providers unavailable, using local-fallback'),
     };
+    push(resolvedRequested);
+    push(this.deps.defaultProvider);
+    for (const name of this.cascadeOrder) push(name);
+    // local-fallback is the always-succeeds terminator; make sure it's in the
+    // walk even if the operator omitted it from cascadeOrder and default.
+    push('local-fallback');
+
+    const skipReasons: string[] = [];
+    for (let i = 0; i < walk.length; i += 1) {
+      const name = walk[i];
+      const provider = this.providers.get(name);
+      if (!provider) {
+        skipReasons.push(`${name} unavailable`);
+        continue;
+      }
+      if (this.providerPolicy.isInCooldown(name)) {
+        skipReasons.push(
+          `${name} in cooldown (${this.providerPolicy.remainingCooldownMs(name)}ms remaining)`,
+        );
+        continue;
+      }
+      const tier = i + 1;
+      const degraded = tier > 1;
+      return {
+        provider,
+        degraded,
+        tier,
+        originalRequested: resolvedRequested,
+        actualProvider: name,
+        reason: degraded
+          ? sanitizeDegradationReason(
+              skipReasons.length > 0
+                ? skipReasons.join('; ')
+                : `all providers unavailable, using ${name}`,
+            )
+          : undefined,
+      };
+    }
+
+    // Only reachable if local-fallback isn't registered at all — treat as a
+    // runtime-misconfig rather than silently returning something invalid.
+    throw new AppError(
+      'PROVIDER_UNAVAILABLE',
+      'Critical: cascade exhausted — local-fallback not registered',
+      503,
+    );
   }
 
   /**
@@ -387,6 +428,25 @@ export class OrchestrationService {
         error: result.reason instanceof Error ? result.reason.message : 'Unknown provider error',
       };
     });
+  }
+
+  /**
+   * Per-provider model inventory. For live providers (ollama with /api/tags,
+   * anthropic with static list, etc.) returns whatever listModels() exposes.
+   * Providers that are unreachable return an empty array rather than throwing.
+   */
+  public async providersModels(): Promise<Record<string, string[]>> {
+    const entries = [...this.providers.entries()];
+    const results = await Promise.allSettled(
+      entries.map(async ([name, provider]) => [name, await provider.listModels()] as const),
+    );
+    const out: Record<string, string[]> = {};
+    for (let i = 0; i < results.length; i += 1) {
+      const result = results[i];
+      const [name] = entries[i];
+      out[name] = result.status === 'fulfilled' ? result.value[1] : [];
+    }
+    return out;
   }
 
   /**

--- a/src/providers/glm/adapter.ts
+++ b/src/providers/glm/adapter.ts
@@ -30,7 +30,7 @@ export class GlmProvider {
   }
 
   async listModels(): Promise<string[]> {
-    return ['glm-4-flash', 'glm-4', 'glm-4-plus', 'glm-3-turbo'];
+    return ['glm-4.6', 'glm-4.5-air', 'glm-4-flash', 'glm-4', 'glm-4-plus', 'glm-3-turbo'];
   }
 
   defaultModel() {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -50,6 +50,11 @@ export interface ChatOptions {
   maxTokens?: number;
   systemPrompt?: string;
   tools?: ChatToolDefinition[];
+  /** Ollama-only tuning (ignored by other providers). */
+  topP?: number;
+  topK?: number;
+  repeatPenalty?: number;
+  numCtx?: number;
 }
 
 export interface Provider {
@@ -65,14 +70,62 @@ export interface Provider {
 // OLLAMA (always available, local-first)
 // ═══════════════════════════════════════════
 
+function readOllamaEnvNumber(
+  rawEnv: NodeJS.ProcessEnv,
+  key: string,
+): number | undefined {
+  const value = rawEnv[key];
+  if (value === undefined || value === '') return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Resolve Ollama generation options with this precedence:
+ *   1. explicit ChatOptions from caller
+ *   2. OLLAMA_* env tuning knobs
+ *   3. offline-friendly defaults (low temp, bounded but generous context)
+ *
+ * Exported for tests.
+ */
+export function resolveOllamaOptions(
+  opts: ChatOptions | undefined,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): {
+  temperature: number;
+  num_predict: number;
+  top_p?: number;
+  top_k?: number;
+  repeat_penalty?: number;
+  num_ctx?: number;
+} {
+  const envTemp = readOllamaEnvNumber(rawEnv, 'OLLAMA_TEMPERATURE');
+  const envTopP = readOllamaEnvNumber(rawEnv, 'OLLAMA_TOP_P');
+  const envTopK = readOllamaEnvNumber(rawEnv, 'OLLAMA_TOP_K');
+  const envRepeatPenalty = readOllamaEnvNumber(rawEnv, 'OLLAMA_REPEAT_PENALTY');
+  const envNumCtx = readOllamaEnvNumber(rawEnv, 'OLLAMA_NUM_CTX');
+  const envNumPredict = readOllamaEnvNumber(rawEnv, 'OLLAMA_NUM_PREDICT_OFFLINE');
+
+  return {
+    temperature: opts?.temperature ?? envTemp ?? 0.2,
+    num_predict: opts?.maxTokens ?? envNumPredict ?? 4096,
+    top_p: opts?.topP ?? envTopP ?? 0.85,
+    top_k: opts?.topK ?? envTopK,
+    repeat_penalty: opts?.repeatPenalty ?? envRepeatPenalty ?? 1.15,
+    num_ctx: opts?.numCtx ?? envNumCtx ?? 8192,
+  };
+}
+
 export class OllamaProvider implements Provider {
   name = 'ollama';
   private baseUrl: string;
   private model: string;
+  private rawEnv: NodeJS.ProcessEnv;
 
-  constructor(opts?: { url?: string; model?: string }) {
-    this.baseUrl = opts?.url || process.env.OLLAMA_URL || 'http://127.0.0.1:11434';
-    this.model = opts?.model || process.env.OLLAMA_MODEL || 'qwen2.5-coder:3b';
+  constructor(opts?: { url?: string; model?: string; rawEnv?: NodeJS.ProcessEnv }) {
+    this.rawEnv = opts?.rawEnv ?? process.env;
+    this.baseUrl = opts?.url || this.rawEnv.OLLAMA_URL || 'http://127.0.0.1:11434';
+    this.model = opts?.model || this.rawEnv.OLLAMA_MODEL || 'qwen2.5-coder:3b';
   }
 
   isConfigured() {
@@ -127,24 +180,30 @@ export class OllamaProvider implements Provider {
       },
     }));
 
+    const ollamaOptions = resolveOllamaOptions(opts, this.rawEnv);
+    // Drop undefineds so we don't send noise keys to Ollama.
+    const optionsBody: Record<string, number> = {};
+    for (const [k, v] of Object.entries(ollamaOptions)) {
+      if (v !== undefined) optionsBody[k] = v;
+    }
+
     const body: Record<string, unknown> = {
       model,
       messages: allMessages,
       stream: false,
-      options: {
-        temperature: opts?.temperature ?? 0.7,
-        num_predict: opts?.maxTokens ?? 2048,
-      },
+      options: optionsBody,
     };
 
     if (ollamaTools?.length) {
       body.tools = ollamaTools;
     }
 
+    const timeoutMs = readOllamaEnvNumber(this.rawEnv, 'OLLAMA_REQUEST_TIMEOUT_MS') ?? 300_000;
     const r = await fetch(`${this.baseUrl}/api/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
     });
 
     if (!r.ok) throw new Error(`Ollama error: ${r.status} ${await r.text()}`);
@@ -214,7 +273,14 @@ export class MinimaxProvider implements Provider {
   }
 
   async listModels(): Promise<string[]> {
-    return ['MiniMax-M2.7', 'abab5.5-chat', 'abab6-chat', 'abab6.5s-chat'];
+    return [
+      'MiniMax-M2.7',
+      'MiniMax-M1',
+      'MiniMax-Text-01',
+      'abab6.5s-chat',
+      'abab6.5-chat',
+      'abab5.5-chat',
+    ];
   }
 
   defaultModel() {

--- a/src/providers/runtime-registry.ts
+++ b/src/providers/runtime-registry.ts
@@ -136,6 +136,7 @@ export function createConfiguredRuntimeProviders(
       new OllamaProvider({
         url: rawEnv.OLLAMA_URL,
         model: rawEnv.OLLAMA_MODEL,
+        rawEnv,
       }),
     ),
   );

--- a/tests/unit/cascade-order.test.ts
+++ b/tests/unit/cascade-order.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ProviderName } from '../../src/core/types.js';
+import {
+  DEFAULT_PROVIDER_CASCADE,
+  OrchestrationService,
+  parseCascadeOrder,
+} from '../../src/modules/orchestration/service.js';
+import type { RuntimeProvider } from '../../src/providers/runtime.js';
+
+function mock(name: ProviderName): RuntimeProvider {
+  return {
+    name,
+    isConfigured: () => true,
+    isAvailable: async () => true,
+    listModels: async () => [`${name}-model-a`, `${name}-model-b`],
+    defaultModel: () => `${name}-model-a`,
+    healthCheck: async () => ({ name, ok: true }),
+    chat: vi.fn(),
+    generate: vi.fn(async () => ({
+      id: 'x',
+      providerUsed: name,
+      output: 'ok',
+      timingMs: 1,
+    })),
+  };
+}
+
+describe('parseCascadeOrder', () => {
+  it('returns the default cascade when the env value is empty', () => {
+    expect(parseCascadeOrder(undefined)).toEqual(DEFAULT_PROVIDER_CASCADE);
+    expect(parseCascadeOrder('')).toEqual(DEFAULT_PROVIDER_CASCADE);
+    expect(parseCascadeOrder('   ')).toEqual(DEFAULT_PROVIDER_CASCADE);
+  });
+
+  it('parses a well-formed comma-separated list', () => {
+    expect(parseCascadeOrder('anthropic,minimax,ollama,local-fallback')).toEqual([
+      'anthropic',
+      'minimax',
+      'ollama',
+      'local-fallback',
+    ]);
+  });
+
+  it('trims whitespace and dedupes', () => {
+    expect(parseCascadeOrder(' anthropic , anthropic , minimax ,ollama, ollama , local-fallback ')).toEqual([
+      'anthropic',
+      'minimax',
+      'ollama',
+      'local-fallback',
+    ]);
+  });
+
+  it('always appends local-fallback if operator omits it (idiot-defensive)', () => {
+    expect(parseCascadeOrder('anthropic,minimax')).toEqual([
+      'anthropic',
+      'minimax',
+      'local-fallback',
+    ]);
+  });
+
+  it('fails loud on unknown provider names', () => {
+    expect(() => parseCascadeOrder('anthropic,typo-here,ollama')).toThrowError(
+      /MEMPHIS_PROVIDER_CASCADE contains unknown provider 'typo-here'/,
+    );
+  });
+});
+
+describe('OrchestrationService cascade walk', () => {
+  let anthropic: RuntimeProvider;
+  let minimax: RuntimeProvider;
+  let ollama: RuntimeProvider;
+  let fallback: RuntimeProvider;
+
+  beforeEach(() => {
+    anthropic = mock('anthropic');
+    minimax = mock('minimax');
+    ollama = mock('ollama');
+    fallback = mock('local-fallback');
+  });
+
+  function service(cascadeOrder?: ProviderName[]) {
+    return new OrchestrationService({
+      defaultProvider: 'anthropic',
+      providers: [anthropic, minimax, ollama, fallback],
+      providerCooldownMs: 5000,
+      cascadeOrder,
+    });
+  }
+
+  it('lands on anthropic when requested=auto and nothing is degraded', () => {
+    const result = service().getCascadeResult('auto');
+    expect(result.actualProvider).toBe('anthropic');
+    expect(result.tier).toBe(1);
+    expect(result.degraded).toBe(false);
+  });
+
+  it('cascades auto→minimax→ollama→local-fallback when each upstream fails', () => {
+    const orchestration = service();
+    const policy = (orchestration as unknown as { providerPolicy: { markFailure: (n: string) => void } }).providerPolicy;
+
+    policy.markFailure('anthropic');
+    let result = orchestration.getCascadeResult('auto');
+    expect(result.actualProvider).toBe('minimax');
+    expect(result.tier).toBe(2);
+    expect(result.degraded).toBe(true);
+
+    policy.markFailure('minimax');
+    result = orchestration.getCascadeResult('auto');
+    expect(result.actualProvider).toBe('ollama');
+    expect(result.tier).toBe(3);
+
+    policy.markFailure('ollama');
+    result = orchestration.getCascadeResult('auto');
+    expect(result.actualProvider).toBe('local-fallback');
+    expect(result.tier).toBe(4);
+  });
+
+  it('respects MEMPHIS_PROVIDER_CASCADE override — deepseek-first cascade', () => {
+    const deepseek = mock('deepseek');
+    const glm = mock('glm');
+    const orchestration = new OrchestrationService({
+      defaultProvider: 'deepseek',
+      providers: [deepseek, glm, anthropic, minimax, ollama, fallback],
+      cascadeOrder: parseCascadeOrder('deepseek,glm,anthropic,ollama,local-fallback'),
+    });
+
+    const result = orchestration.getCascadeResult('auto');
+    expect(result.actualProvider).toBe('deepseek');
+    expect(result.tier).toBe(1);
+    expect(orchestration.getCascadeOrder()).toEqual([
+      'deepseek',
+      'glm',
+      'anthropic',
+      'ollama',
+      'local-fallback',
+    ]);
+  });
+
+  it('prepends explicit requested provider to the walk (tier 1)', () => {
+    const orchestration = service();
+    const result = orchestration.getCascadeResult('minimax');
+    expect(result.actualProvider).toBe('minimax');
+    expect(result.tier).toBe(1);
+  });
+
+  it('degrades through cascade when explicit requested is in cooldown', () => {
+    const orchestration = service();
+    const policy = (orchestration as unknown as { providerPolicy: { markFailure: (n: string) => void } }).providerPolicy;
+    policy.markFailure('minimax');
+
+    const result = orchestration.getCascadeResult('minimax');
+    // tier 1 = minimax (cooldown → skip)
+    // tier 2 = defaultProvider anthropic
+    expect(result.actualProvider).toBe('anthropic');
+    expect(result.tier).toBe(2);
+    expect(result.degraded).toBe(true);
+    expect(result.reason).toContain('minimax in cooldown');
+  });
+
+  it('does not throw when cascade is exhausted — local-fallback always terminates', () => {
+    const orchestration = service();
+    const policy = (orchestration as unknown as { providerPolicy: { markFailure: (n: string) => void } }).providerPolicy;
+    policy.markFailure('anthropic');
+    policy.markFailure('minimax');
+    policy.markFailure('ollama');
+
+    const result = orchestration.getCascadeResult('auto');
+    expect(result.actualProvider).toBe('local-fallback');
+    expect(result.degraded).toBe(true);
+  });
+
+  it('exposes the configured cascade via getCascadeOrder()', () => {
+    expect(service().getCascadeOrder()).toEqual(DEFAULT_PROVIDER_CASCADE);
+  });
+});

--- a/tests/unit/ollama-tuning.test.ts
+++ b/tests/unit/ollama-tuning.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OllamaProvider, resolveOllamaOptions } from '../../src/providers/index.js';
+
+describe('resolveOllamaOptions', () => {
+  it('applies offline-friendly defaults when nothing is configured', () => {
+    const out = resolveOllamaOptions(undefined, {});
+    expect(out.temperature).toBe(0.2);
+    expect(out.num_predict).toBe(4096);
+    expect(out.top_p).toBe(0.85);
+    expect(out.repeat_penalty).toBe(1.15);
+    expect(out.num_ctx).toBe(8192);
+    // top_k is optional — unset by default.
+    expect(out.top_k).toBeUndefined();
+  });
+
+  it('reads env overrides', () => {
+    const out = resolveOllamaOptions(undefined, {
+      OLLAMA_TEMPERATURE: '0.5',
+      OLLAMA_NUM_CTX: '16384',
+      OLLAMA_TOP_P: '0.9',
+      OLLAMA_TOP_K: '64',
+      OLLAMA_REPEAT_PENALTY: '1.2',
+      OLLAMA_NUM_PREDICT_OFFLINE: '8192',
+    });
+    expect(out.temperature).toBe(0.5);
+    expect(out.num_ctx).toBe(16384);
+    expect(out.top_p).toBe(0.9);
+    expect(out.top_k).toBe(64);
+    expect(out.repeat_penalty).toBe(1.2);
+    expect(out.num_predict).toBe(8192);
+  });
+
+  it('ChatOptions override env (explicit > env > default)', () => {
+    const out = resolveOllamaOptions(
+      {
+        temperature: 0.1,
+        maxTokens: 2048,
+        topP: 0.7,
+        topK: 20,
+        repeatPenalty: 1.05,
+        numCtx: 4096,
+      },
+      {
+        OLLAMA_TEMPERATURE: '0.9',
+        OLLAMA_NUM_CTX: '32000',
+      },
+    );
+    expect(out.temperature).toBe(0.1);
+    expect(out.num_predict).toBe(2048);
+    expect(out.top_p).toBe(0.7);
+    expect(out.top_k).toBe(20);
+    expect(out.repeat_penalty).toBe(1.05);
+    expect(out.num_ctx).toBe(4096);
+  });
+
+  it('ignores non-numeric env values (falls back to default)', () => {
+    const out = resolveOllamaOptions(undefined, {
+      OLLAMA_TEMPERATURE: 'not-a-number',
+    });
+    expect(out.temperature).toBe(0.2);
+  });
+});
+
+describe('OllamaProvider.chat plumbs tuning into request body', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ message: { content: 'hi' }, eval_count: 1, prompt_eval_count: 1 }),
+    })) as ReturnType<typeof vi.fn>;
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('includes num_ctx/top_p/top_k/repeat_penalty/num_predict/temperature in options', async () => {
+    const provider = new OllamaProvider({
+      url: 'http://127.0.0.1:11434',
+      model: 'test-model',
+      rawEnv: {
+        OLLAMA_NUM_CTX: '8192',
+        OLLAMA_TOP_P: '0.85',
+        OLLAMA_TOP_K: '40',
+        OLLAMA_REPEAT_PENALTY: '1.15',
+        OLLAMA_TEMPERATURE: '0.2',
+        OLLAMA_NUM_PREDICT_OFFLINE: '4096',
+      },
+    });
+
+    await provider.chat([{ role: 'user', content: 'hello' }]);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.options).toMatchObject({
+      num_ctx: 8192,
+      top_p: 0.85,
+      top_k: 40,
+      repeat_penalty: 1.15,
+      temperature: 0.2,
+      num_predict: 4096,
+    });
+  });
+
+  it('uses OLLAMA_REQUEST_TIMEOUT_MS for the abort signal', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const provider = new OllamaProvider({
+      url: 'http://127.0.0.1:11434',
+      model: 'm',
+      rawEnv: { OLLAMA_REQUEST_TIMEOUT_MS: '120000' },
+    });
+    await provider.chat([{ role: 'user', content: 'hi' }]);
+    expect(timeoutSpy).toHaveBeenCalledWith(120000);
+    timeoutSpy.mockRestore();
+  });
+});

--- a/tests/unit/orchestration-cascade.test.ts
+++ b/tests/unit/orchestration-cascade.test.ts
@@ -116,7 +116,8 @@ describe('Provider Cascade', () => {
       expect(result.tier).toBe(5);
       expect(result.originalRequested).toBe('minimax');
       expect(result.actualProvider).toBe('local-fallback');
-      expect(result.reason).toContain('all providers unavailable');
+      // New cascade: reason lists the per-provider skip causes (more actionable).
+      expect(result.reason).toContain('cooldown');
     });
 
     it('always succeeds with local-fallback', () => {

--- a/tests/unit/provider-models.test.ts
+++ b/tests/unit/provider-models.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ProviderName } from '../../src/core/types.js';
+import { OrchestrationService } from '../../src/modules/orchestration/service.js';
+import { AnthropicProvider } from '../../src/providers/anthropic/adapter.js';
+import { GlmProvider } from '../../src/providers/glm/adapter.js';
+import { MinimaxProvider } from '../../src/providers/index.js';
+import type { RuntimeProvider } from '../../src/providers/runtime.js';
+import { adaptChatProvider } from '../../src/providers/runtime.js';
+
+function mock(
+  name: ProviderName,
+  models: string[],
+  opts: { throws?: boolean } = {},
+): RuntimeProvider {
+  return {
+    name,
+    isConfigured: () => true,
+    isAvailable: async () => true,
+    listModels: async () => {
+      if (opts.throws) throw new Error('provider unreachable');
+      return models;
+    },
+    defaultModel: () => models[0] ?? `${name}-default`,
+    healthCheck: async () => ({ name, ok: true }),
+    chat: vi.fn(),
+    generate: vi.fn(),
+  };
+}
+
+describe('per-provider listModels()', () => {
+  it('Anthropic exposes the current Claude 4 lineup', async () => {
+    const p = new AnthropicProvider({ apiKey: 'test' });
+    const models = await p.listModels();
+    expect(models).toEqual(
+      expect.arrayContaining(['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001']),
+    );
+  });
+
+  it('Minimax exposes M2.7 + M1 + Text-01 + abab legacy series', async () => {
+    const p = new MinimaxProvider({ apiKey: 'test' });
+    const models = await p.listModels();
+    expect(models).toEqual(
+      expect.arrayContaining([
+        'MiniMax-M2.7',
+        'MiniMax-M1',
+        'MiniMax-Text-01',
+        'abab6.5s-chat',
+        'abab6.5-chat',
+        'abab5.5-chat',
+      ]),
+    );
+  });
+
+  it('GLM exposes 4.6 + 4.5-air alongside legacy 4-flash', async () => {
+    const p = new GlmProvider({ apiKey: 'test' });
+    const models = await p.listModels();
+    expect(models).toEqual(expect.arrayContaining(['glm-4.6', 'glm-4.5-air', 'glm-4-flash']));
+  });
+});
+
+describe('OrchestrationService.providersModels()', () => {
+  it('aggregates models across configured providers', async () => {
+    const anthropic = mock('anthropic', ['claude-opus-4-6', 'claude-sonnet-4-6']);
+    const minimax = mock('minimax', ['MiniMax-M2.7', 'MiniMax-M1']);
+    const ollama = mock('ollama', ['cogito:3b', 'nomic-embed-text']);
+    const fallback = mock('local-fallback', ['local-fallback-v0']);
+
+    const orchestration = new OrchestrationService({
+      defaultProvider: 'anthropic',
+      providers: [anthropic, minimax, ollama, fallback],
+    });
+
+    const all = await orchestration.providersModels();
+    expect(all.anthropic).toEqual(['claude-opus-4-6', 'claude-sonnet-4-6']);
+    expect(all.minimax).toEqual(['MiniMax-M2.7', 'MiniMax-M1']);
+    expect(all.ollama).toEqual(['cogito:3b', 'nomic-embed-text']);
+    expect(all['local-fallback']).toEqual(['local-fallback-v0']);
+  });
+
+  it('returns empty array for providers that throw (unreachable endpoint)', async () => {
+    const anthropic = mock('anthropic', ['claude-sonnet-4-6']);
+    const ollama = mock('ollama', [], { throws: true });
+    const fallback = mock('local-fallback', ['local-fallback-v0']);
+
+    const orchestration = new OrchestrationService({
+      defaultProvider: 'anthropic',
+      providers: [anthropic, ollama, fallback],
+    });
+
+    const all = await orchestration.providersModels();
+    expect(all.anthropic).toEqual(['claude-sonnet-4-6']);
+    expect(all.ollama).toEqual([]);
+    expect(all['local-fallback']).toEqual(['local-fallback-v0']);
+  });
+
+  it('adaptChatProvider preserves the underlying listModels()', async () => {
+    const adapted = adaptChatProvider(new AnthropicProvider({ apiKey: 'test' }));
+    const models = await adapted.listModels();
+    expect(models).toEqual(
+      expect.arrayContaining(['claude-opus-4-6', 'claude-sonnet-4-6']),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Rewires the provider cascade to the operator-preferred order `anthropic → minimax → ollama → local-fallback` and makes it configurable via `MEMPHIS_PROVIDER_CASCADE` (comma-separated, validated at startup — typos fail loud).
- Flips `DEFAULT_PROVIDER` from `ollama` to `anthropic`; `.env.example` rewritten to reflect the new intent.
- Adds Ollama tuning knobs so the offline third-fallback can produce slow-but-eventual answers without hidden short timeouts or hallucinated output.
- Adds `GET /v1/providers/models` aggregating each provider's `listModels()` + the active cascade order.

## How it works

**Cascade walk.** `resolveProviderCascade` is now a single walk over `[requested, defaultProvider, ...cascadeOrder, local-fallback]` deduped. Tier = 1-indexed position; the first non-cooldown registered provider wins. The `tier` type is loosened from `1|2|3|4|5` to `number` so operators can have longer cascades.

**Fail-loud cascade validation.** `parseCascadeOrder()` rejects unknown provider names at startup rather than silently skipping — operators find typos immediately instead of discovering the cascade isn't what they thought at 3am.

**Idiot-defensive local-fallback.** If an operator forgets `local-fallback` in their cascade override, we append it automatically. The cascade never throws in production.

**Ollama tuning.** New `ChatOptions.{topP,topK,repeatPenalty,numCtx}` plumbed into the request body, with `OLLAMA_{NUM_CTX,TEMPERATURE,TOP_P,TOP_K,REPEAT_PENALTY,NUM_PREDICT_OFFLINE,REQUEST_TIMEOUT_MS}` env overrides. Precedence: explicit ChatOptions > env > offline-friendly default. 5-minute hard timeout via `AbortSignal.timeout(OLLAMA_REQUEST_TIMEOUT_MS)`.

**Model inventory.**
- Anthropic: `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001` (+ legacy 4-5).
- Minimax: `MiniMax-M2.7`, `MiniMax-M1`, `MiniMax-Text-01`, abab6.5s/6.5/5.5-chat.
- GLM: `glm-4.6`, `glm-4.5-air` + legacy.
- Ollama: dynamic via `/api/tags`.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npx vitest run` — **1455/1455 green** across 333 files.
- [x] New tests:
  - `tests/unit/cascade-order.test.ts` — 12 cases (parseCascadeOrder validation, default cascade, override, requested prepend, cooldown degradation, exhaustion safety, env override round-trip).
  - `tests/unit/ollama-tuning.test.ts` — 6 cases (option resolution precedence, request-body plumbing for every knob, timeout wiring, env-overrides-only, non-numeric env fallback).
  - `tests/unit/provider-models.test.ts` — 6 cases (per-provider `listModels()` for Anthropic/Minimax/GLM, aggregated `providersModels()`, unreachable-provider graceful empty).
- [x] Existing `tests/unit/orchestration-cascade.test.ts` still passes (one reason-message assertion updated for the new, more informative format).
- [ ] Manual smoke (to run post-merge): with only Anthropic configured → hits Anthropic; disable Anthropic endpoint → falls to Minimax; disable Minimax → falls to Ollama; all down → local-fallback.
- [ ] `GET /v1/providers/models` returns the expected shape against a live server.

## Plan reference

Sprint 3 from `/home/memphis/.claude/plans/prancy-launching-neumann.md`. Sprints 3e (OAuth+API-key paths per provider) and 3g (`memphis provider setup` interactive walk-through) are deliberately deferred to a follow-up — the code paths for OAuth already exist in `anthropic/adapter.ts`; the vault-key map rewire is documentation + `runtime-registry.ts` work, not a behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)