### PR TITLE
Sprint 4: cognitive modes A/B/C/D/E operationalized

### DIFF
--- a/crates/memphis-operator/src/runtime.rs
+++ b/crates/memphis-operator/src/runtime.rs
@@ -58,6 +58,11 @@ pub struct OverviewSummary {
     pub default_provider: String,
     pub embed_mode: String,
     pub cognitive_mode: String,
+    pub cognitive_mode_name: Option<String>,
+    pub cognitive_mode_temperature: Option<f64>,
+    pub cognitive_mode_style: Option<String>,
+    pub cognitive_mode_pattern: Option<String>,
+    pub cognitive_mode_last_modified: Option<String>,
     pub pulse_health: String,
     pub chains: usize,
     pub blocks: usize,
@@ -260,6 +265,10 @@ impl OperatorRuntime {
             Err(error) => snapshot.system_error = Some(error.to_string()),
         }
 
+        let (cognitive_mode_code, cognitive_mode_last_modified) =
+            read_cognitive_mode_summary(&self.config.data_dir);
+        let (mode_name, mode_temp, mode_style, mode_pattern) =
+            cognitive_mode_config(&cognitive_mode_code);
         let overview = OverviewSummary {
             data_dir: format_path(&self.config.data_dir),
             default_provider: self.config.default_provider.clone(),
@@ -267,7 +276,12 @@ impl OperatorRuntime {
                 memphis_embed::EmbedMode::LocalDeterministic => "local".to_string(),
                 memphis_embed::EmbedMode::Provider(name) => name.clone(),
             },
-            cognitive_mode: read_cognitive_mode(&self.config.data_dir),
+            cognitive_mode: cognitive_mode_code.clone(),
+            cognitive_mode_name: Some(mode_name.to_string()),
+            cognitive_mode_temperature: Some(mode_temp),
+            cognitive_mode_style: Some(mode_style.to_string()),
+            cognitive_mode_pattern: Some(mode_pattern.to_string()),
+            cognitive_mode_last_modified,
             pulse_health: read_pulse_health(&self.config.data_dir),
             chains: list_chain_names(&self.config.data_dir).len(),
             blocks: count_chain_blocks(&self.config.data_dir),
@@ -711,20 +725,41 @@ fn count_chain_blocks(data_dir: &Path) -> usize {
         .sum()
 }
 
-fn read_cognitive_mode(data_dir: &Path) -> String {
+fn read_cognitive_mode_summary(data_dir: &Path) -> (String, Option<String>) {
     // soul-manifest.json is in the parent of data_dir (project root .memphis/)
     // or relative to the config path. Try common locations.
     let config_dir = data_dir.parent().unwrap_or(data_dir).join(".memphis");
     let manifest_path = config_dir.join("soul-manifest.json");
     if let Ok(content) = fs::read_to_string(&manifest_path) {
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(mode) = value.get("cognitiveMode").and_then(|v| v.as_str()) {
-                return mode.to_string();
+            let mode = value
+                .get("cognitiveMode")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let updated = value
+                .get("cognitiveModeUpdatedAt")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            if let Some(mode) = mode {
+                return (mode, updated);
             }
         }
     }
-    // Fallback: check env
-    std::env::var("MEMPHIS_COGNITIVE_MODE").unwrap_or_else(|_| "A".to_string())
+    (
+        std::env::var("MEMPHIS_COGNITIVE_MODE").unwrap_or_else(|_| "A".to_string()),
+        None,
+    )
+}
+
+fn cognitive_mode_config(mode: &str) -> (&'static str, f64, &'static str, &'static str) {
+    match mode {
+        "A" => ("ConsciousCapture", 0.3, "fast", "concise"),
+        "B" => ("InferredDecisions", 0.5, "deliberate", "detailed"),
+        "C" => ("PredictivePatterns", 0.7, "reflective", "analogical"),
+        "D" => ("CollectiveCoord", 0.4, "collaborative", "socratic"),
+        "E" => ("MetaCognitiveRef", 0.2, "meta", "concise"),
+        _ => ("ConsciousCapture", 0.3, "fast", "concise"),
+    }
 }
 
 fn read_pulse_health(data_dir: &Path) -> String {

--- a/crates/memphis-tui/src/app.rs
+++ b/crates/memphis-tui/src/app.rs
@@ -2813,10 +2813,38 @@ impl AppState {
                 overview.default_provider
             )));
             lines.push(plain(format!("Embed mode: {}", overview.embed_mode)));
+            let mode_label = match overview.cognitive_mode_name.as_deref() {
+                Some(name) if !name.is_empty() => {
+                    format!("{} ({})", overview.cognitive_mode, name)
+                }
+                _ => overview.cognitive_mode.clone(),
+            };
             lines.push(plain(format!(
                 "Cognitive mode: {}  PULSE: {}",
-                overview.cognitive_mode, overview.pulse_health
+                mode_label, overview.pulse_health
             )));
+            let mut tune_parts: Vec<String> = Vec::new();
+            if let Some(temp) = overview.cognitive_mode_temperature {
+                tune_parts.push(format!("temp {:.1}", temp));
+            }
+            if let Some(style) = overview.cognitive_mode_style.as_ref() {
+                if !style.is_empty() {
+                    tune_parts.push(format!("style {}", style));
+                }
+            }
+            if let Some(pattern) = overview.cognitive_mode_pattern.as_ref() {
+                if !pattern.is_empty() {
+                    tune_parts.push(format!("pattern {}", pattern));
+                }
+            }
+            if !tune_parts.is_empty() {
+                lines.push(dim(format!("  {}", tune_parts.join("  ·  "))));
+            }
+            if let Some(last_modified) = overview.cognitive_mode_last_modified.as_ref() {
+                if !last_modified.is_empty() {
+                    lines.push(dim(format!("  last changed: {}", last_modified)));
+                }
+            }
             lines.push(blank());
             lines.push(info("Inventory"));
             lines.push(plain(format!(
@@ -4603,6 +4631,11 @@ mod tests {
                 default_provider: "ollama".to_string(),
                 embed_mode: "local".to_string(),
                 cognitive_mode: "A".to_string(),
+                cognitive_mode_name: Some("ConsciousCapture".to_string()),
+                cognitive_mode_temperature: Some(0.3),
+                cognitive_mode_style: Some("fast".to_string()),
+                cognitive_mode_pattern: Some("concise".to_string()),
+                cognitive_mode_last_modified: None,
                 pulse_health: "healthy".to_string(),
                 chains: 1,
                 blocks: 1,
@@ -4685,6 +4718,11 @@ mod tests {
                 default_provider: "ollama".to_string(),
                 embed_mode: "local".to_string(),
                 cognitive_mode: "A".to_string(),
+                cognitive_mode_name: Some("ConsciousCapture".to_string()),
+                cognitive_mode_temperature: Some(0.3),
+                cognitive_mode_style: Some("fast".to_string()),
+                cognitive_mode_pattern: Some("concise".to_string()),
+                cognitive_mode_last_modified: None,
                 pulse_health: "healthy".to_string(),
                 chains: 1,
                 blocks: 1,
@@ -4744,6 +4782,11 @@ mod tests {
                 default_provider: "ollama".to_string(),
                 embed_mode: "local".to_string(),
                 cognitive_mode: "A".to_string(),
+                cognitive_mode_name: Some("ConsciousCapture".to_string()),
+                cognitive_mode_temperature: Some(0.3),
+                cognitive_mode_style: Some("fast".to_string()),
+                cognitive_mode_pattern: Some("concise".to_string()),
+                cognitive_mode_last_modified: None,
                 pulse_health: "healthy".to_string(),
                 chains: 5,
                 blocks: 42,

--- a/docs/cognitive-modes.md
+++ b/docs/cognitive-modes.md
@@ -1,0 +1,97 @@
+# Cognitive Modes A/B/C/D/E
+
+Memphis exposes five cognitive modes. Each mode shapes a turn in three ways:
+
+1. **Temperature** passed to the LLM.
+2. **Max-tokens ceiling** derived from the mode's style.
+3. **Prompt fragment** prepended to the cognitive context — unique per mode.
+
+The active mode is stored in `~/.memphis/soul-manifest.json` (`cognitiveMode`) with a
+last-modified timestamp (`cognitiveModeUpdatedAt`). Read via `/v1/cognitive/status`.
+
+## Matrix
+
+| Mode | Name              | Temp | Style         | Max tokens | What it attaches to the turn                                         |
+|------|-------------------|------|---------------|-----------:|----------------------------------------------------------------------|
+| A    | ConsciousCapture  | 0.3  | fast          |      1024  | last ≤5 Model A captures (notes/decisions/milestones)                |
+| B    | InferredDecisions | 0.5  | deliberate    |      4096  | top-3 Model B inferred decisions with category + confidence          |
+| C    | PredictivePatterns| 0.7  | reflective    |      4096  | top-3 Model C pattern predictions with confidence                    |
+| D    | CollectiveCoord   | 0.4  | collaborative |      4096  | peer roster (`MEMPHIS_COGNITIVE_PEERS`) or pass-through marker       |
+| E    | MetaCognitiveRef  | 0.2  | meta          |      2048  | latest persisted reflection (`chain: reflections`, `kind: reflection`)|
+
+Style → max tokens map (`resolveMaxTokensForStyle`):
+
+```
+fast=1024  deliberate=4096  reflective=4096  collaborative=4096  meta=2048
+```
+
+## Switching modes
+
+- **TUI**: `/cognitive set-mode <A..E>` (tier 1).
+- **Telegram**: `/mode <A..E>` (tier 1).
+- **HTTP**: `POST /v1/cognitive/mode { "mode": "B" }`.
+
+Each switch appends a `mode_change` block to the system chain and emits a PULSE
+event. The `cognitiveModeUpdatedAt` timestamp is refreshed on every change and
+surfaces in the TUI overview + `/v1/cognitive/status` response.
+
+## When to pick which mode
+
+- **A — ConsciousCapture**: short, fact-oriented turns. You want speed and low
+  variance. Decisions you will later codify to the chain.
+- **B — InferredDecisions**: a task that benefits from "what have we decided
+  recently?" context. Refactors, follow-ups, anything branching from prior work.
+- **C — PredictivePatterns**: exploratory or planning turns. You want the model
+  to see "what usually happens next?" inferred from the Model C registry.
+- **D — CollectiveCoord**: multi-agent consensus. Only meaningful when
+  `MEMPHIS_COGNITIVE_PEERS` is set; otherwise falls through to single-agent.
+- **E — MetaCognitiveRef**: retros, SLO reviews, post-mortems. Turn prepends the
+  most recent daily/weekly reflection from Model E.
+
+## How modes are dispatched
+
+Every turn goes through `src/gateway/turn-runtime.ts`:
+
+1. Load mode from `getCognitiveMode(rawEnv)`.
+2. Run cognitive prelude (Model B + C) to collect blocks/inferred/predictions.
+3. Call `applyCognitiveMode(mode, { blocks, inferred, predictions }, rawEnv)`.
+4. Merge the mode's `promptFragment` into the cognitive context.
+5. Pass the mode's `temperature` + `maxTokens` into the provider call.
+
+The per-mode fragment is deterministic and pure — the dispatch function does
+not read from disk or the network. Tests: `tests/unit/mode-dispatch.test.ts`.
+
+## Reflection loop (Mode E source)
+
+`startReflectionLoop` is invoked in `src/app/bootstrap.ts` at process boot.
+Period: `MEMPHIS_REFLECTION_INTERVAL_MS` (default 24 h, minimum 1 h). Persists
+to the `reflections` chain; those blocks are exactly what Mode E pulls.
+
+Disable the loop with `MEMPHIS_REFLECTION_ENABLED=false`.
+
+## Status endpoint
+
+`GET /v1/cognitive/status` returns:
+
+```json
+{
+  "cognitiveMode": {
+    "active": "B",
+    "config": {
+      "name": "InferredDecisions",
+      "description": "Deep analysis with evidence chains — detailed reasoning",
+      "temperature": 0.5,
+      "style": "deliberate",
+      "pattern": "detailed",
+      "maxTokens": 4096
+    },
+    "lastModified": "2026-04-13T12:34:00.000Z"
+  },
+  "availableModes": ["A", "B", "C", "D", "E"],
+  ...
+}
+```
+
+The TUI overview surfaces this information on the first screen. Field names in
+Rust: `cognitive_mode`, `cognitive_mode_name`, `cognitive_mode_temperature`,
+`cognitive_mode_style`, `cognitive_mode_pattern`, `cognitive_mode_last_modified`.

--- a/src/cognitive/mode-dispatch.ts
+++ b/src/cognitive/mode-dispatch.ts
@@ -1,0 +1,155 @@
+import type { InferredDecision } from './model-b.js';
+import {
+  COGNITIVE_MODES,
+  getCognitiveModeConfig,
+  type CognitiveMode,
+  type CognitiveModeConfig,
+} from './modes.js';
+import type { Prediction } from './types.js';
+import type { Block } from '../memory/chain.js';
+
+export interface CognitiveModeDispatchInput {
+  blocks?: Block[];
+  inferred?: InferredDecision[];
+  predictions?: Prediction[];
+}
+
+export interface CognitiveModeContribution {
+  mode: CognitiveMode;
+  config: CognitiveModeConfig;
+  temperature: number;
+  maxTokens: number;
+  promptFragment: string;
+}
+
+const STYLE_TO_MAX_TOKENS: Record<string, number> = {
+  fast: 1024,
+  deliberate: 4096,
+  reflective: 4096,
+  collaborative: 4096,
+  meta: 2048,
+};
+
+const DEFAULT_MAX_TOKENS = 2048;
+
+export function resolveMaxTokensForStyle(style: string): number {
+  return STYLE_TO_MAX_TOKENS[style] ?? DEFAULT_MAX_TOKENS;
+}
+
+function isReflectionBlock(block: Block): boolean {
+  if (block.chain !== 'reflections') return false;
+  const kind = (block.data as { kind?: unknown })?.kind;
+  return kind === 'reflection';
+}
+
+function isModelACaptureBlock(block: Block): boolean {
+  const source = (block.data as { source?: unknown })?.source;
+  return source === 'model-a';
+}
+
+function truncate(value: string, max: number): string {
+  const flat = value.replace(/\s+/g, ' ').trim();
+  return flat.length <= max ? flat : `${flat.slice(0, max - 1)}…`;
+}
+
+function buildModeAFragment(blocks: Block[] | undefined): string {
+  if (!blocks || blocks.length === 0) return '';
+  const captures = blocks.filter(isModelACaptureBlock).slice(-5);
+  if (captures.length === 0) return '';
+  const lines = captures.map((block) => {
+    const data = block.data as { title?: string; content?: string; kind?: string };
+    const title = data.title ?? data.content ?? '(untitled)';
+    const kind = data.kind ?? 'note';
+    return `- ${kind}: ${truncate(title, 140)}`;
+  });
+  return ['[mode_A:recent_captures]', ...lines].join('\n');
+}
+
+function buildModeBFragment(inferred: InferredDecision[] | undefined): string {
+  if (!inferred || inferred.length === 0) return '';
+  const top = inferred.slice(0, 3);
+  const lines = top.map(
+    (item) =>
+      `- ${item.category} ${Math.round(item.confidence * 100)}% ${truncate(item.title, 120)} [${item.source}]`,
+  );
+  return ['[mode_B:inferred_decisions]', ...lines].join('\n');
+}
+
+function buildModeCFragment(predictions: Prediction[] | undefined): string {
+  if (!predictions || predictions.length === 0) return '';
+  const top = predictions.slice(0, 3);
+  const lines = top.map(
+    (item) => `- ${item.type} ${Math.round(item.confidence * 100)}% ${truncate(item.title, 120)}`,
+  );
+  return ['[mode_C:predicted_next_actions]', ...lines].join('\n');
+}
+
+function buildModeDFragment(rawEnv: NodeJS.ProcessEnv): string {
+  const peers = rawEnv.MEMPHIS_COGNITIVE_PEERS?.trim();
+  if (!peers) {
+    return '[mode_D:collective] single-agent pass-through (MEMPHIS_COGNITIVE_PEERS unset)';
+  }
+  const peerList = peers
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return `[mode_D:collective] coordinating with ${peerList.length} peer(s): ${peerList.join(', ')}`;
+}
+
+function buildModeEFragment(blocks: Block[] | undefined): string {
+  if (!blocks || blocks.length === 0) {
+    return '[mode_E:reflection] no prior reflection available';
+  }
+  const reflections = blocks.filter(isReflectionBlock);
+  if (reflections.length === 0) {
+    return '[mode_E:reflection] no prior reflection available';
+  }
+  const latest = reflections[reflections.length - 1];
+  const data = latest.data as { period?: string; content?: string; title?: string };
+  const period = data.period ?? 'daily';
+  const content = data.content ?? data.title ?? '';
+  return `[mode_E:reflection:${period}] ${truncate(content, 280)}`;
+}
+
+export function applyCognitiveMode(
+  mode: CognitiveMode,
+  input: CognitiveModeDispatchInput = {},
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): CognitiveModeContribution {
+  const config = getCognitiveModeConfig(mode);
+  const temperature = config.temperature;
+  const maxTokens = resolveMaxTokensForStyle(config.style);
+
+  let fragment = '';
+  switch (mode) {
+    case 'A':
+      fragment = buildModeAFragment(input.blocks);
+      break;
+    case 'B':
+      fragment = buildModeBFragment(input.inferred);
+      break;
+    case 'C':
+      fragment = buildModeCFragment(input.predictions);
+      break;
+    case 'D':
+      fragment = buildModeDFragment(rawEnv);
+      break;
+    case 'E':
+      fragment = buildModeEFragment(input.blocks);
+      break;
+    default:
+      fragment = '';
+  }
+
+  return {
+    mode,
+    config,
+    temperature,
+    maxTokens,
+    promptFragment: fragment,
+  };
+}
+
+export function listCognitiveModes(): CognitiveMode[] {
+  return Object.keys(COGNITIVE_MODES) as CognitiveMode[];
+}

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -3,6 +3,7 @@ import type { LlmClient, LoopLimits, MemoryClient, ToolExecutor } from './chat-t
 import {
   prepareCognitivePrelude,
   runPostResponseCognitivePass,
+  type CognitivePrelude,
 } from './cognitive-runtime.js';
 import type { ConversationContextService, ConversationPromptOverlay } from './conversation-context-service.js';
 import {
@@ -28,6 +29,10 @@ import {
   buildSessionMemoryFragment,
 } from './system-prompt.js';
 import { fetchUrlsFromMessage } from './url-extract.js';
+import {
+  applyCognitiveMode,
+  type CognitiveModeContribution,
+} from '../cognitive/mode-dispatch.js';
 import type { RuntimeTelemetry, TokenUsage } from '../core/types.js';
 import { metrics } from '../infra/logging/metrics.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
@@ -41,6 +46,7 @@ import {
   getActiveTier3Session,
   type Tier3Surface,
 } from '../security/tier3-session.js';
+import { getCognitiveMode } from '../soul/manifest.js';
 
 const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
 
@@ -145,6 +151,7 @@ type PreparedTurn = {
   memoryUserText: string;
   classification?: InputRiskClassification;
   blockedCapabilities: string[];
+  cognitiveModeContribution?: CognitiveModeContribution;
 };
 
 type SurfaceToolPolicyResult = {
@@ -412,16 +419,23 @@ async function prepareTextTurn(
     log.warn({ err: error, surface: options.surface }, 'turn url fetch failed');
   }
 
+  let cognitiveModeContribution: CognitiveModeContribution | undefined;
   if (options.cognitiveRuntimeEnabled !== false && !highRisk) {
     if (!surfacePolicy.allowCognitivePrelude) {
       blockedCapabilities.push('cognitive_prelude_surface_policy_blocked');
     } else {
+      let prelude: CognitivePrelude | undefined;
       try {
-        const prelude = await prepareCognitivePrelude(input);
+        prelude = await prepareCognitivePrelude(input);
         cognitiveContext = prelude.promptFragment;
       } catch (error) {
         log.warn({ err: error, surface: options.surface }, 'turn cognitive prelude failed');
       }
+      cognitiveModeContribution = computeCognitiveModeContribution(
+        options.rawEnv ?? process.env,
+        prelude,
+      );
+      cognitiveContext = mergeModeFragment(cognitiveContext, cognitiveModeContribution);
     }
   } else if (highRisk) {
     blockedCapabilities.push('cognitive_prelude');
@@ -454,6 +468,7 @@ async function prepareTextTurn(
     memoryUserText: highRisk ? '' : input,
     classification,
     blockedCapabilities,
+    cognitiveModeContribution,
   };
 }
 
@@ -469,6 +484,7 @@ async function prepareMessagesTurn(
   let memoryUserText = originalUserText;
   let recalledMemory: Array<{ content: string; score: number }> = [];
   let cognitiveContext = '';
+  let cognitiveModeContribution: CognitiveModeContribution | undefined;
   const blockedCapabilities: string[] = [];
   const highRisk = classification?.risk === 'high';
 
@@ -515,12 +531,18 @@ async function prepareMessagesTurn(
       if (!surfacePolicy.allowCognitivePrelude) {
         blockedCapabilities.push('cognitive_prelude_surface_policy_blocked');
       } else {
+        let prelude: CognitivePrelude | undefined;
         try {
-          const prelude = await prepareCognitivePrelude(originalUserText);
+          prelude = await prepareCognitivePrelude(originalUserText);
           cognitiveContext = prelude.promptFragment;
         } catch (error) {
           log.warn({ err: error, surface: options.surface }, 'turn cognitive prelude failed');
         }
+        cognitiveModeContribution = computeCognitiveModeContribution(
+          options.rawEnv ?? process.env,
+          prelude,
+        );
+        cognitiveContext = mergeModeFragment(cognitiveContext, cognitiveModeContribution);
       }
     } else if (highRisk) {
       blockedCapabilities.push('cognitive_prelude');
@@ -545,7 +567,33 @@ async function prepareMessagesTurn(
     memoryUserText,
     classification,
     blockedCapabilities,
+    cognitiveModeContribution,
   };
+}
+
+function computeCognitiveModeContribution(
+  rawEnv: NodeJS.ProcessEnv,
+  prelude: CognitivePrelude | undefined,
+): CognitiveModeContribution {
+  const mode = getCognitiveMode(rawEnv);
+  return applyCognitiveMode(
+    mode,
+    {
+      blocks: prelude?.blocks,
+      inferred: prelude?.inferred,
+      predictions: prelude?.predictions,
+    },
+    rawEnv,
+  );
+}
+
+function mergeModeFragment(
+  existing: string,
+  contribution: CognitiveModeContribution | undefined,
+): string {
+  if (!contribution?.promptFragment) return existing;
+  if (!existing) return contribution.promptFragment;
+  return `${existing}\n${contribution.promptFragment}`;
 }
 
 function replaceLatestUserMessage(messages: ChatMessage[], content: string): ChatMessage[] {
@@ -584,14 +632,21 @@ async function resolveInputClassification(
   return classification;
 }
 
-function resolveLlm(options: TurnRuntimeInput): {
+function resolveLlm(
+  options: TurnRuntimeInput,
+  contribution?: CognitiveModeContribution,
+): {
   llm: LlmClient;
   provider: string;
   model: string;
 } {
   if (options.provider) {
     return {
-      llm: providerToLlmClient(options.provider, { model: options.model }),
+      llm: providerToLlmClient(options.provider, {
+        model: options.model,
+        temperature: contribution?.temperature,
+        maxTokens: contribution?.maxTokens,
+      }),
       provider: options.provider.name,
       model: options.model ?? options.provider.defaultModel(),
     };
@@ -663,7 +718,7 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
       },
     });
   }
-  const llm = resolveLlm(options);
+  const llm = resolveLlm(options, prepared.cognitiveModeContribution);
   let result: Awaited<ReturnType<typeof runAgentLoop>>;
   try {
     result = await runAgentLoop({

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -958,25 +958,41 @@ export function createHttpServer(
 
   // ── Cognitive & System Status (for TUI) ─────────────────────────
   app.get('/v1/cognitive/status', async () => {
-    const { getCognitiveMode } = await import('../../soul/manifest.js');
+    const { getCognitiveMode, getCognitiveModeLastModified } = await import(
+      '../../soul/manifest.js'
+    );
+    const { getCognitiveModeConfig } = await import('../../cognitive/modes.js');
+    const { resolveMaxTokensForStyle } = await import('../../cognitive/mode-dispatch.js');
     const { loadPulseEntries } = await import('../runtime/heartbeat-watchdog.js');
     const { resolveProviderKeyResult } = await import('../../providers/index.js');
 
     const mode = getCognitiveMode();
+    const modeConfig = getCognitiveModeConfig(mode);
+    const lastModified = getCognitiveModeLastModified();
     const pulseEntries = loadPulseEntries();
     const lastPulse = pulseEntries.at(-1);
     const chainStatus = getChainAdapterStatus(process.env);
     const vaultStatus = getRustVaultAdapterStatus(process.env);
     const embedStatus = getRustEmbedAdapterStatus(process.env);
 
-    // Provider key status
     const providerKeys = ['minimax', 'deepseek', 'glm'].map((name) => {
       const result = resolveProviderKeyResult(name);
       return { name, source: result.source };
     });
 
     return {
-      cognitiveMode: mode,
+      cognitiveMode: {
+        active: mode,
+        config: {
+          name: modeConfig.name,
+          description: modeConfig.description,
+          temperature: modeConfig.temperature,
+          style: modeConfig.style,
+          pattern: modeConfig.pattern,
+          maxTokens: resolveMaxTokensForStyle(modeConfig.style),
+        },
+        lastModified,
+      },
       availableModes: ['A', 'B', 'C', 'D', 'E'],
       pulse: lastPulse
         ? {

--- a/src/soul/manifest.ts
+++ b/src/soul/manifest.ts
@@ -141,6 +141,9 @@ export function ensureSoulManifest(rawEnv: NodeJS.ProcessEnv = process.env): Sou
   if (existing?.cognitiveMode) {
     fresh.cognitiveMode = existing.cognitiveMode;
   }
+  if (existing?.cognitiveModeUpdatedAt) {
+    fresh.cognitiveModeUpdatedAt = existing.cognitiveModeUpdatedAt;
+  }
 
   // Preserve evolution settings including passphraseHash (Tier 2 auth)
   if (existing?.evolution) {
@@ -156,6 +159,13 @@ export function getCognitiveMode(rawEnv: NodeJS.ProcessEnv = process.env): Cogni
   return manifest?.cognitiveMode ?? 'A';
 }
 
+export function getCognitiveModeLastModified(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const manifest = loadSoulManifest(rawEnv);
+  return manifest?.cognitiveModeUpdatedAt ?? null;
+}
+
 export function setCognitiveMode(
   mode: CognitiveMode,
   rawEnv: NodeJS.ProcessEnv = process.env,
@@ -165,6 +175,7 @@ export function setCognitiveMode(
 
   const previousMode = manifest.cognitiveMode ?? 'A';
   manifest.cognitiveMode = mode;
+  manifest.cognitiveModeUpdatedAt = new Date().toISOString();
   writeSoulManifest(manifest, rawEnv);
 
   // Write mode change to system chain and PULSE (non-blocking, non-fatal)

--- a/src/soul/types.ts
+++ b/src/soul/types.ts
@@ -64,6 +64,7 @@ export interface SoulManifest {
   evolution: SoulEvolutionPolicy;
   mode: AutonomyMode;
   cognitiveMode?: CognitiveMode;
+  cognitiveModeUpdatedAt?: string;
   trustRules: TrustRule[];
 }
 
@@ -150,6 +151,8 @@ export const soulManifestSchema = z.object({
     snapshotBeforeEvolution: z.boolean(),
   }),
   mode: autonomyModeSchema.default('balanced'),
+  cognitiveMode: z.enum(['A', 'B', 'C', 'D', 'E']).optional(),
+  cognitiveModeUpdatedAt: z.string().optional(),
   trustRules: z.array(trustRuleSchema).default([]),
 });
 

--- a/tests/unit/mode-dispatch.test.ts
+++ b/tests/unit/mode-dispatch.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyCognitiveMode,
+  listCognitiveModes,
+  resolveMaxTokensForStyle,
+} from '../../src/cognitive/mode-dispatch.js';
+import type { InferredDecision } from '../../src/cognitive/model-b.js';
+import type { Prediction } from '../../src/cognitive/types.js';
+import type { Block } from '../../src/memory/chain.js';
+
+function blockA(title: string, kind = 'note'): Block {
+  return {
+    chain: 'journal',
+    timestamp: new Date().toISOString(),
+    data: { type: 'journal', content: title, title, kind, source: 'model-a', tags: [] },
+  };
+}
+
+function blockReflection(content: string, period: 'daily' | 'weekly' = 'daily'): Block {
+  return {
+    chain: 'reflections',
+    timestamp: new Date().toISOString(),
+    data: { type: 'reflection', kind: 'reflection', period, content, source: 'model-e', tags: [] },
+  };
+}
+
+function inferred(title: string, confidence = 0.75): InferredDecision {
+  return {
+    id: `inf-${title}`,
+    source: 'git',
+    title,
+    reasoning: 'why',
+    confidence,
+    category: 'tactical',
+    evidence: [],
+    timestamp: new Date(),
+  };
+}
+
+function prediction(title: string, confidence = 0.6): Prediction {
+  return {
+    type: 'tactical',
+    title,
+    confidence,
+    basedOn: [],
+    evidence: [],
+  };
+}
+
+describe('resolveMaxTokensForStyle', () => {
+  it.each([
+    ['fast', 1024],
+    ['deliberate', 4096],
+    ['reflective', 4096],
+    ['collaborative', 4096],
+    ['meta', 2048],
+  ])('maps style %s to %d max tokens', (style, expected) => {
+    expect(resolveMaxTokensForStyle(style)).toBe(expected);
+  });
+
+  it('falls back to a safe default for unknown styles', () => {
+    expect(resolveMaxTokensForStyle('unknown')).toBe(2048);
+  });
+});
+
+describe('applyCognitiveMode', () => {
+  it('lists exactly the five documented modes', () => {
+    expect(listCognitiveModes()).toEqual(['A', 'B', 'C', 'D', 'E']);
+  });
+
+  it('returns mode A contribution with recent Model A captures', () => {
+    const blocks = [blockA('first capture'), blockA('second capture'), blockA('third capture')];
+    const c = applyCognitiveMode('A', { blocks }, {});
+    expect(c.mode).toBe('A');
+    expect(c.temperature).toBe(0.3);
+    expect(c.maxTokens).toBe(1024);
+    expect(c.promptFragment).toContain('[mode_A:recent_captures]');
+    expect(c.promptFragment).toContain('third capture');
+  });
+
+  it('returns mode B contribution with inferred decisions', () => {
+    const c = applyCognitiveMode(
+      'B',
+      { inferred: [inferred('rename util', 0.9), inferred('refactor', 0.6)] },
+      {},
+    );
+    expect(c.mode).toBe('B');
+    expect(c.temperature).toBe(0.5);
+    expect(c.maxTokens).toBe(4096);
+    expect(c.promptFragment).toContain('[mode_B:inferred_decisions]');
+    expect(c.promptFragment).toContain('rename util');
+    expect(c.promptFragment).toContain('90%');
+  });
+
+  it('returns mode C contribution with predictions', () => {
+    const c = applyCognitiveMode(
+      'C',
+      { predictions: [prediction('try provider cascade', 0.55)] },
+      {},
+    );
+    expect(c.mode).toBe('C');
+    expect(c.temperature).toBe(0.7);
+    expect(c.maxTokens).toBe(4096);
+    expect(c.promptFragment).toContain('[mode_C:predicted_next_actions]');
+    expect(c.promptFragment).toContain('try provider cascade');
+  });
+
+  it('mode D pass-through when MEMPHIS_COGNITIVE_PEERS is unset', () => {
+    const c = applyCognitiveMode('D', {}, {});
+    expect(c.mode).toBe('D');
+    expect(c.temperature).toBe(0.4);
+    expect(c.maxTokens).toBe(4096);
+    expect(c.promptFragment).toMatch(/single-agent pass-through/);
+  });
+
+  it('mode D lists peers when MEMPHIS_COGNITIVE_PEERS is set', () => {
+    const c = applyCognitiveMode('D', {}, { MEMPHIS_COGNITIVE_PEERS: 'peer-a, peer-b' });
+    expect(c.promptFragment).toContain('coordinating with 2 peer(s)');
+    expect(c.promptFragment).toContain('peer-a');
+  });
+
+  it('mode E attaches the latest reflection when present', () => {
+    const blocks = [blockReflection('old daily reflection'), blockReflection('newest daily reflection')];
+    const c = applyCognitiveMode('E', { blocks }, {});
+    expect(c.mode).toBe('E');
+    expect(c.temperature).toBe(0.2);
+    expect(c.maxTokens).toBe(2048);
+    expect(c.promptFragment).toContain('[mode_E:reflection:daily]');
+    expect(c.promptFragment).toContain('newest daily reflection');
+  });
+
+  it('mode E signals no prior reflection when none exist', () => {
+    const c = applyCognitiveMode('E', { blocks: [] }, {});
+    expect(c.promptFragment).toContain('no prior reflection available');
+  });
+
+  it('passes through config for the requested mode', () => {
+    for (const mode of listCognitiveModes()) {
+      const c = applyCognitiveMode(mode, {}, {});
+      expect(c.config.name).toBeTruthy();
+      expect(c.config.style).toBeTruthy();
+      expect(c.temperature).toBe(c.config.temperature);
+    }
+  });
+
+  it('truncates long titles so the fragment stays compact', () => {
+    const longTitle = 'x'.repeat(1000);
+    const c = applyCognitiveMode('B', { inferred: [inferred(longTitle, 0.9)] }, {});
+    expect(c.promptFragment.length).toBeLessThan(400);
+  });
+});

--- a/tests/unit/provider-adapter-defaults.test.ts
+++ b/tests/unit/provider-adapter-defaults.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { providerToLlmClient } from '../../src/gateway/provider-adapter.js';
+
+describe('providerToLlmClient', () => {
+  it('forwards temperature and maxTokens defaults into provider.chat', async () => {
+    const chat = vi.fn(async () => ({ content: 'hi', tool_calls: undefined }));
+    const llm = providerToLlmClient(
+      { chat } as never,
+      { temperature: 0.42, maxTokens: 2048, model: 'test-model' },
+    );
+
+    await llm.complete({ system: 'system', messages: [{ role: 'user', content: 'ping' }] });
+
+    expect(chat).toHaveBeenCalledTimes(1);
+    const [, options] = chat.mock.calls[0]!;
+    expect(options).toMatchObject({
+      temperature: 0.42,
+      maxTokens: 2048,
+      model: 'test-model',
+      systemPrompt: 'system',
+    });
+  });
+
+  it('omits temperature/maxTokens when defaults are not provided', async () => {
+    const chat = vi.fn(async () => ({ content: 'hi', tool_calls: undefined }));
+    const llm = providerToLlmClient({ chat } as never);
+
+    await llm.complete({ system: 'system', messages: [{ role: 'user', content: 'ping' }] });
+
+    const [, options] = chat.mock.calls[0]! as [unknown, Record<string, unknown>];
+    expect(options.temperature).toBeUndefined();
+    expect(options.maxTokens).toBeUndefined();
+  });
+});

--- a/tests/unit/turn-runtime.test.ts
+++ b/tests/unit/turn-runtime.test.ts
@@ -551,4 +551,52 @@ describe('turn runtime', () => {
     expect(result.persistence.degraded).toBe(true);
     expect(result.persistence.errors).toContain('memory_store_scanned_blocked');
   });
+
+  it('appends the active cognitive mode fragment to the system prompt', async () => {
+    prepareCognitivePrelude.mockImplementation(async () => ({
+      blocks: [],
+      exact: { query: 'write a spec', count: 0, hits: [] },
+      inferred: [
+        {
+          id: 'dec-1',
+          source: 'git',
+          title: 'adopt sqlite for queue',
+          reasoning: 'recent commits favor local-first',
+          confidence: 0.8,
+          category: 'tactical',
+          evidence: [],
+          timestamp: new Date(),
+        },
+      ],
+      predictions: [],
+      promptFragment: '',
+    }));
+
+    const soulManifest = await import('../../src/soul/manifest.js');
+    const getModeSpy = vi.spyOn(soulManifest, 'getCognitiveMode').mockReturnValue('B');
+
+    const { runTurnRuntime } = await import('../../src/gateway/turn-runtime.js');
+
+    await runTurnRuntime({
+      input: 'write a spec for the vault rotate flow',
+      messages: [],
+      provider: {
+        name: 'ollama',
+        isConfigured: () => true,
+        isAvailable: async () => true,
+        listModels: async () => ['qwen2.5-coder:3b'],
+        defaultModel: () => 'qwen2.5-coder:3b',
+        healthCheck: async () => ({ name: 'ollama', ok: true }),
+        chat: vi.fn(),
+        generate: vi.fn(),
+      },
+      surface: 'http.chat.generate',
+    });
+
+    const runCall = runAgentLoop.mock.calls[0]?.[0];
+    expect(runCall.systemPrompt).toContain('[mode_B:inferred_decisions]');
+    expect(runCall.systemPrompt).toContain('adopt sqlite for queue');
+
+    getModeSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

Sprint 4 of the post-PR-#77 roadmap. Cognitive modes A/B/C/D/E now shape each turn instead of just appearing in status text.

- **Dispatch**: `src/cognitive/mode-dispatch.ts` — pure `applyCognitiveMode(mode, prelude, env)` returning `{ mode, config, temperature, maxTokens, promptFragment }`. Style → maxTokens map: fast=1024, deliberate=4096, reflective=4096, collaborative=4096, meta=2048. Per-mode fragments: **A** last-5 Model A captures · **B** top-3 inferred decisions · **C** top-3 predictions · **D** peer roster (or single-agent pass-through when `MEMPHIS_COGNITIVE_PEERS` unset) · **E** latest persisted reflection.
- **Wiring**: `src/gateway/turn-runtime.ts` calls dispatch after the cognitive prelude, merges the fragment into the cognitive context, and pipes `temperature`/`maxTokens` through `resolveLlm` → `providerToLlmClient`.
- **Surfaced**: `/v1/cognitive/status` now returns `{ active, config, lastModified }`. `cognitiveModeUpdatedAt` added to `SoulManifest` + schema; `setCognitiveMode` stamps it on every change. Rust `OverviewSummary` gains `cognitive_mode_{name,temperature,style,pattern,last_modified}`; TUI overview renders the enriched block.
- **Reflection loop** (Sprint 4d): already wired in `bootstrap.ts` via `startReflectionLoop` — verified, no code change needed.
- **Tests**: 18 new unit tests (mode-dispatch×16, provider-adapter-defaults×2) + 1 turn-runtime fragment assertion. Full suite **1578 TS + 25 memphis-operator + 81 memphis-tui**, all green.
- **Docs**: `docs/cognitive-modes.md` documents the matrix, dispatch path, and `/v1/cognitive/status` payload.

## Test plan

- [x] `npm run typecheck && npm run lint && npm test` — green (1578 passed, 0 failed)
- [x] `cargo test --manifest-path crates/memphis-operator/Cargo.toml` — 25 passed
- [x] `cargo test --manifest-path crates/memphis-tui/Cargo.toml` — 81 passed
- [x] Smoke test (`npm run test:smoke`) — SMOKE_TEST_OK
- [ ] Manual: set `/mode B`, run a turn, verify provider receives `temperature: 0.5` + `maxTokens: 4096` and system prompt contains `[mode_B:inferred_decisions]`
- [ ] Manual: hit `GET /v1/cognitive/status`, confirm `{ cognitiveMode: { active, config, lastModified } }` shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)