### PR TITLE
Sprint 5: cross-surface presence registry and unified /status

### DIFF
--- a/crates/memphis-tui/src/app.rs
+++ b/crates/memphis-tui/src/app.rs
@@ -1583,6 +1583,7 @@ impl AppState {
             "guide.show" => self.append_guide_host_result(result.data),
             "pulse.status" => self.append_pulse_status_host_result(result.data),
             "cognitive.mode" => self.append_cognitive_mode_host_result(result.data),
+            "presence.snapshot" => self.append_presence_host_result(result.data),
             _ => self.append_generic_extension_host_result(result),
         }
     }
@@ -1800,6 +1801,60 @@ impl AppState {
             "Repair: {} -> {}",
             repair_status, repair_action
         )));
+
+        if let Some(lines) = data.get("surfaceStatus").and_then(Value::as_array) {
+            for line in lines {
+                if let Some(text) = line.as_str() {
+                    self.append_line(dim(text.to_string()));
+                }
+            }
+        }
+    }
+
+    fn append_presence_host_result(&mut self, data: Value) {
+        self.append_line(section("Active surfaces"));
+        let total = data.get("total").and_then(Value::as_u64).unwrap_or(0);
+        let active = data.get("active").and_then(Value::as_u64).unwrap_or(0);
+        self.append_line(info(format!("Surfaces: {active} active / {total} tracked")));
+
+        let Some(snapshots) = data.get("snapshots").and_then(Value::as_array) else {
+            self.append_line(dim("No presence snapshots."));
+            return;
+        };
+        if snapshots.is_empty() {
+            self.append_line(dim("No presence snapshots."));
+            return;
+        }
+        for snap in snapshots.iter().take(6) {
+            let surface = snap
+                .get("surface")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let age_ms = snap.get("ageMs").and_then(Value::as_u64).unwrap_or(0);
+            let stale = snap.get("stale").and_then(Value::as_bool).unwrap_or(false);
+            let tier = snap.get("tier").and_then(Value::as_u64);
+            let count = snap
+                .get("activityCount")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            let tone = if stale {
+                LineTone::Dim
+            } else {
+                LineTone::Success
+            };
+            let state = if stale {
+                "idle".to_string()
+            } else {
+                format!("last turn {}ms ago", age_ms)
+            };
+            let tier_text = tier
+                .map(|t| format!(" tier {t}"))
+                .unwrap_or_else(|| String::new());
+            self.append_line(styled(
+                format!("- {surface:<10} {state}{tier_text} ({count} events)"),
+                tone,
+            ));
+        }
     }
 
     fn append_agents_host_result(&mut self, data: Value) {

--- a/docs/surface-presence.md
+++ b/docs/surface-presence.md
@@ -1,0 +1,87 @@
+# Cross-surface presence
+
+Memphis runs several conversational surfaces in parallel — Telegram, the Rust
+TUI, and the HTTP gateway. Before Sprint 5, each surface tracked its own
+sessions and `/status` showed only local state: a Telegram `/status` had no
+idea whether the TUI had just executed a command, and vice versa.
+
+The `src/core/surface-presence.ts` module closes that gap with a single
+in-memory registry shared by every surface in the same Node process.
+
+## Registry API
+
+```ts
+recordSurfaceActivity({
+  surface: 'telegram' | 'tui' | 'http' | string,
+  actorId: string,                 // opaque — e.g. 'telegram:42' or 'local'
+  tier?: 0 | 1 | 2 | 3,            // current surface tier for this actor
+  tuiHostSessionId?: string,       // TUI host session, when applicable
+  telegramChatId?: number | string, // Telegram chat id, when applicable
+});
+
+const snapshots = getActiveSurfacesSnapshot({ staleMs = 5 * 60_000 });
+```
+
+Each entry is keyed by surface. Repeat calls for the same surface update
+`lastActivityMs`, merge actor ids into a set, and bump `activityCount`. Entries
+older than `staleMs` stay in the snapshot but are flagged `stale: true`.
+
+`formatSurfaceStatusLines(snapshots)` renders a human-readable block identical
+across surfaces:
+
+```
+Active surfaces:
+  telegram last turn 12s ago     tier 2   (chat 999)
+  tui      last turn 4m ago      tier 3   (local)
+  http     idle                  tier 2   (10.0.0.1)
+```
+
+## Call sites
+
+Activity is recorded at the inbound edge of every surface:
+
+| Surface  | Call site                                                        |
+|----------|------------------------------------------------------------------|
+| Telegram | `src/gateway/channels/telegram.ts` — `bot.on('message:text', …)` |
+| TUI      | `src/infra/tui-host/commands.ts` — top of `executeTuiHostCommand` |
+| HTTP     | `src/infra/http/server.ts` — `onRequest` hook, after auth passes |
+
+## Surfacing the snapshot
+
+Every `/status` path now renders the shared block:
+
+- **Telegram** — `bot.command('status')` → `options.onStatus()` in
+  `src/app/bootstrap.ts` composes version/LLM/bridge lines plus the output of
+  `formatSurfaceStatusLines(getActiveSurfacesSnapshot())`.
+- **TUI** — new `presence.snapshot` capability in
+  `src/infra/tui-host/protocol.ts`; `executePresenceSnapshot` returns
+  `{ snapshots, active, total }` and the Rust renderer
+  (`append_presence_host_result` in `crates/memphis-tui/src/app.rs`) prints a
+  per-surface line. The existing `health.status` also includes
+  `surfaceStatus: string[]` so the standard TUI overview carries the same
+  summary without an extra round-trip.
+- **HTTP** — `GET /v1/ops/status` payload gets two new top-level fields:
+  `activeSurfaces: SurfaceActivitySnapshot[]` and `surfaceStatus: string[]`.
+  `buildHealthPayload` (consumed by both HTTP and TUI) also carries the same
+  two fields.
+
+## Durability across restarts
+
+Presence is in-process; a restart zeros the map. To give operators a warm view
+of who was active before a restart, the heartbeat watchdog snapshots active
+surface ids into each `PulseEntry`:
+
+```
+- 2026-04-13T12:34:56.000Z HEARTBEAT health=healthy uptime=42s mode=A surfaces=telegram,tui
+```
+
+`loadPulseEntries()` parses that `surfaces=…` field back into
+`PulseEntry.activeSurfaces?: string[]`. The field is optional so existing PULSE
+logs keep parsing.
+
+## Tests
+
+- `tests/unit/surface-presence.test.ts` — registry semantics (TTL, multi-actor,
+  tier updates, formatter output).
+- `tests/integration/surface-presence-cross-surface.test.ts` — drive activity
+  on one surface and assert another surface's capability sees it.

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -5,6 +5,10 @@ import { createAppContainer } from './container.js';
 import { getCognitiveModeConfig } from '../cognitive/modes.js';
 import { getAppVersion } from '../config/paths.js';
 import { AppError, errorTemplates } from '../core/errors.js';
+import {
+  formatSurfaceStatusLines,
+  getActiveSurfacesSnapshot,
+} from '../core/surface-presence.js';
 import type { GenerateInput, GenerateOptions, ProviderName } from '../core/types.js';
 import {
   channelGatewayEnabled as resolveTelegramGatewayEnabled,
@@ -340,12 +344,17 @@ async function startChannelGateway(container?: {
         const allowlistCount = parseTelegramAllowedUserIds(process.env).length;
         const embedStatus = getRustEmbedAdapterStatus(process.env);
         const rustBridge = embedStatus.bridgeLoaded ? 'rust-napi' : 'ts-legacy';
+        const mode = getCognitiveMode();
+        const modeConfig = getCognitiveModeConfig(mode);
+        const surfaceLines = formatSurfaceStatusLines(getActiveSurfacesSnapshot());
         return [
           `Memphis v${getAppVersion()}`,
           `LLM: ${provider.name} (${provider.defaultModel()})`,
           `Bridge: ${rustBridge}${embedStatus.embedApiAvailable ? ' + embed' : ''}`,
           `Tools: ${toolExecutor.listTools().length} tools`,
           `Allowlist: ${allowlistCount > 0 ? `${allowlistCount} ids` : 'open'}`,
+          `Cognitive mode: ${mode} (${modeConfig.name})`,
+          ...surfaceLines,
         ].join('\n');
       },
       onRecall: async (userId) => {

--- a/src/core/surface-presence.ts
+++ b/src/core/surface-presence.ts
@@ -1,0 +1,158 @@
+/**
+ * Cross-surface presence registry.
+ *
+ * In-memory map of { surface → recent activity } shared by every surface
+ * (Telegram, TUI host, HTTP). Each inbound event calls recordSurfaceActivity;
+ * /status on any surface can call getActiveSurfacesSnapshot to render a unified
+ * view of who is active where.
+ *
+ * Entries older than staleMs (default 5 minutes) are marked stale in the
+ * snapshot but not evicted — a restart would zero the map anyway, and we want
+ * operators to see "Telegram idle 12m" rather than "Telegram — no history."
+ */
+
+export const DEFAULT_STALE_MS = 5 * 60 * 1000;
+
+/** Known surface identifiers. Extensible — any string is accepted. */
+export type SurfaceId = 'tui' | 'telegram' | 'http' | (string & {});
+
+export type SurfaceTier = 0 | 1 | 2 | 3;
+
+export interface RecordSurfaceActivityInput {
+  surface: SurfaceId;
+  actorId: string;
+  tier?: SurfaceTier;
+  tuiHostSessionId?: string;
+  telegramChatId?: number | string;
+  now?: number;
+}
+
+export interface SurfaceActivitySnapshot {
+  surface: SurfaceId;
+  lastActivityMs: number;
+  ageMs: number;
+  stale: boolean;
+  tier: SurfaceTier | null;
+  actorIds: string[];
+  tuiHostSessionIds: string[];
+  telegramChatIds: string[];
+  activityCount: number;
+}
+
+export interface GetActiveSurfacesOptions {
+  staleMs?: number;
+  now?: number;
+}
+
+interface SurfaceActivityEntry {
+  surface: SurfaceId;
+  lastActivityMs: number;
+  tier: SurfaceTier | null;
+  actorIds: Set<string>;
+  tuiHostSessionIds: Set<string>;
+  telegramChatIds: Set<string>;
+  activityCount: number;
+}
+
+const registry = new Map<SurfaceId, SurfaceActivityEntry>();
+
+export function recordSurfaceActivity(input: RecordSurfaceActivityInput): void {
+  const now = input.now ?? Date.now();
+  const existing = registry.get(input.surface);
+  const entry: SurfaceActivityEntry = existing ?? {
+    surface: input.surface,
+    lastActivityMs: now,
+    tier: input.tier ?? null,
+    actorIds: new Set<string>(),
+    tuiHostSessionIds: new Set<string>(),
+    telegramChatIds: new Set<string>(),
+    activityCount: 0,
+  };
+
+  entry.lastActivityMs = now;
+  if (input.tier !== undefined) entry.tier = input.tier;
+  if (input.actorId) entry.actorIds.add(input.actorId);
+  if (input.tuiHostSessionId) entry.tuiHostSessionIds.add(input.tuiHostSessionId);
+  if (input.telegramChatId !== undefined) {
+    entry.telegramChatIds.add(String(input.telegramChatId));
+  }
+  entry.activityCount += 1;
+
+  registry.set(input.surface, entry);
+}
+
+export function getActiveSurfacesSnapshot(
+  options: GetActiveSurfacesOptions = {},
+): SurfaceActivitySnapshot[] {
+  const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+  const now = options.now ?? Date.now();
+
+  const snapshots: SurfaceActivitySnapshot[] = [];
+  for (const entry of registry.values()) {
+    const ageMs = Math.max(0, now - entry.lastActivityMs);
+    snapshots.push({
+      surface: entry.surface,
+      lastActivityMs: entry.lastActivityMs,
+      ageMs,
+      stale: ageMs > staleMs,
+      tier: entry.tier,
+      actorIds: Array.from(entry.actorIds),
+      tuiHostSessionIds: Array.from(entry.tuiHostSessionIds),
+      telegramChatIds: Array.from(entry.telegramChatIds),
+      activityCount: entry.activityCount,
+    });
+  }
+
+  return snapshots.sort((a, b) => b.lastActivityMs - a.lastActivityMs);
+}
+
+/** For tests and deterministic fixtures. Never call from production paths. */
+export function resetSurfacePresence(): void {
+  registry.clear();
+}
+
+// ── Formatter ────────────────────────────────────────────────────────────────
+
+/**
+ * Render a human-readable "Active surfaces:" block. Same output shape across
+ * TUI, Telegram, and HTTP so operators see identical wording everywhere.
+ */
+export function formatSurfaceStatusLines(
+  snapshots: SurfaceActivitySnapshot[],
+): string[] {
+  if (snapshots.length === 0) {
+    return ['Active surfaces: (none)'];
+  }
+  const lines = ['Active surfaces:'];
+  for (const s of snapshots) {
+    const ageLabel = s.stale ? 'idle' : `last turn ${formatAgeShort(s.ageMs)} ago`;
+    const tierLabel = s.tier !== null ? `tier ${s.tier}` : 'tier ?';
+    const actor = formatActorLabel(s);
+    const parts = [`  ${s.surface.padEnd(8)}`, ageLabel.padEnd(22), tierLabel.padEnd(8), actor];
+    lines.push(parts.filter((p) => p.trim().length > 0).join(' '));
+  }
+  return lines;
+}
+
+function formatActorLabel(s: SurfaceActivitySnapshot): string {
+  if (s.surface === 'telegram' && s.telegramChatIds.length > 0) {
+    const primary = s.telegramChatIds[0];
+    const more = s.telegramChatIds.length - 1;
+    return more > 0 ? `(chat ${primary} +${more})` : `(chat ${primary})`;
+  }
+  if (s.actorIds.length === 0) return '';
+  const primary = s.actorIds[0];
+  const more = s.actorIds.length - 1;
+  return more > 0 ? `(${primary} +${more})` : `(${primary})`;
+}
+
+function formatAgeShort(ms: number): string {
+  if (ms < 1000) return '<1s';
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remMin = minutes % 60;
+  return `${hours}h${remMin}m`;
+}

--- a/src/gateway/channels/telegram.ts
+++ b/src/gateway/channels/telegram.ts
@@ -3,6 +3,7 @@ import { Bot, InputFile } from 'grammy';
 import { parseTelegramAllowedUserIds } from './telegram-readiness.js';
 import { splitText } from './utils.js';
 import { getCognitiveModeConfig, isValidCognitiveMode } from '../../cognitive/modes.js';
+import { recordSurfaceActivity } from '../../core/surface-presence.js';
 import { validateOperatorPassphrase } from '../../infra/auth/operator-gate.js';
 import { renderSurfaceDesignGuideText } from '../../infra/operator-guide.js';
 import {
@@ -396,6 +397,13 @@ export function createTelegramAdapter(
         const userId = `telegram:${String(msg.from?.id ?? 'unknown')}`;
         const sessionTier = getSessionTier(chatId);
         const rawEnvOverride = buildTierEnvOverride(chatId, sessionTier);
+
+        recordSurfaceActivity({
+          surface: 'telegram',
+          actorId: userId,
+          tier: sessionTier,
+          telegramChatId: chatId,
+        });
 
         // Startup context: injected once per chatId per bot session
         let systemPromptAppend: string | undefined;

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -2,6 +2,11 @@ import { accessSync, constants, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 import { getAppVersion } from '../../config/paths.js';
+import {
+  formatSurfaceStatusLines,
+  getActiveSurfacesSnapshot,
+  type SurfaceActivitySnapshot,
+} from '../../core/surface-presence.js';
 import { buildSurfacePolicySnapshot, type SurfacePolicy } from '../../gateway/surface-policy.js';
 import type { AppConfig } from '../config/schema.js';
 import {
@@ -45,6 +50,8 @@ export type HealthPayload = {
   };
   runtime: RuntimeHealthSnapshot;
   surfacePolicies: SurfacePolicy[];
+  activeSurfaces: SurfaceActivitySnapshot[];
+  surfaceStatus: string[];
   workPolling?: WorkPollingSnapshot | null;
   localWorker?: LocalWorkerRuntimeStatus | null;
   scheduler?: SchedulerRuntimeStatus | null;
@@ -213,6 +220,7 @@ export async function buildHealthPayload(
   const requiredHealthy = checks.database.status === 'ok' && checks.data_dir.status === 'ok';
   const runtimeHealthy = runtimeIsOperational(runtime);
 
+  const activeSurfaces = getActiveSurfacesSnapshot();
   return {
     status: requiredHealthy && runtimeHealthy ? 'healthy' : 'unhealthy',
     repairable: runtime.repair.repairable,
@@ -220,6 +228,8 @@ export async function buildHealthPayload(
     checks,
     runtime,
     surfacePolicies: buildSurfacePolicySnapshot(rawEnv),
+    activeSurfaces,
+    surfaceStatus: formatSurfaceStatusLines(activeSurfaces),
     workPolling: options?.workPolling ?? null,
     localWorker: getLocalWorkerRuntimeStatus(),
     scheduler: getSchedulerRuntimeStatus(rawEnv, {

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -21,6 +21,11 @@ import type {
   SessionRepository,
 } from '../../core/contracts/repository.js';
 import { AppError } from '../../core/errors.js';
+import {
+  formatSurfaceStatusLines,
+  getActiveSurfacesSnapshot,
+  recordSurfaceActivity,
+} from '../../core/surface-presence.js';
 import type { ConversationContextService } from '../../gateway/conversation-context-service.js';
 import { createInProcessMemoryClient } from '../../gateway/memory-client.js';
 import { buildSurfacePolicySnapshot } from '../../gateway/surface-policy.js';
@@ -311,6 +316,12 @@ export function createHttpServer(
 
     // Auth passed → allow under fail-closed semantics
     allow('authorized');
+
+    recordSurfaceActivity({
+      surface: 'http',
+      actorId: request.ip ?? 'unknown',
+      tier: 2,
+    });
   });
 
   app.addHook('onResponse', async (request, reply) => {
@@ -616,6 +627,8 @@ export function createHttpServer(
         warnings: bootstrapWarnings,
       },
       dualApproval,
+      activeSurfaces: getActiveSurfacesSnapshot(),
+      surfaceStatus: formatSurfaceStatusLines(getActiveSurfacesSnapshot()),
       timestamp: new Date().toISOString(),
     };
   });

--- a/src/infra/runtime/heartbeat-watchdog.ts
+++ b/src/infra/runtime/heartbeat-watchdog.ts
@@ -10,6 +10,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from '
 import path from 'node:path';
 
 import { getConfigPath } from '../../config/paths.js';
+import { getActiveSurfacesSnapshot } from '../../core/surface-presence.js';
 import type { PulseEntry, PulseEventType } from '../../soul/types.js';
 import { getChainAdapterStatus } from '../storage/chain-adapter.js';
 import { getRustEmbedAdapterStatus } from '../storage/rust-embed-adapter.js';
@@ -232,6 +233,9 @@ export function writePulseEvent(entry: PulseEntry): void {
     parts.push(`health=${e.health}`);
     parts.push(`uptime=${e.uptimeSeconds}s`);
     if (e.cognitiveMode) parts.push(`mode=${e.cognitiveMode}`);
+    if (e.activeSurfaces && e.activeSurfaces.length > 0) {
+      parts.push(`surfaces=${e.activeSurfaces.join(',')}`);
+    }
     if (e.detail) parts.push(e.detail);
     return parts.join(' ');
   });
@@ -257,12 +261,17 @@ export function loadPulseEntries(): PulseEntry[] {
         /^- (\S+) (BOOT|HEARTBEAT|IDENTITY-ASSERT|ADAPTATION|MODE-CHANGE) health=(\S+) uptime=(\d+)s/,
       );
       if (match) {
-        entries.push({
+        const entry: PulseEntry = {
           timestamp: match[1]!,
           event: match[2]!.toLowerCase().replace(/-/g, '-') as PulseEventType,
           health: match[3] as PulseEntry['health'],
           uptimeSeconds: parseInt(match[4]!, 10),
-        });
+        };
+        const surfaces = line.match(/surfaces=(\S+)/);
+        if (surfaces) {
+          entry.activeSurfaces = surfaces[1]!.split(',').filter(Boolean);
+        }
+        entries.push(entry);
       }
     }
     return entries;
@@ -282,10 +291,14 @@ export function writeBootPulse(): void {
 }
 
 function writeHeartbeatPulse(heartbeat: WatchdogHeartbeat): void {
+  const surfaces = getActiveSurfacesSnapshot()
+    .filter((snapshot) => !snapshot.stale)
+    .map((snapshot) => snapshot.surface);
   writePulseEvent({
     timestamp: heartbeat.timestamp,
     event: 'heartbeat',
     health: heartbeat.health,
     uptimeSeconds: heartbeat.uptimeSeconds,
+    activeSurfaces: surfaces.length > 0 ? surfaces : undefined,
   });
 }

--- a/src/infra/tui-host/commands.ts
+++ b/src/infra/tui-host/commands.ts
@@ -1,6 +1,11 @@
 import type { TuiHostCapability } from './protocol.js';
 import { createAppContainer } from '../../app/container.js';
 import { getCognitiveModeConfig, isValidCognitiveMode } from '../../cognitive/modes.js';
+import {
+  getActiveSurfacesSnapshot,
+  recordSurfaceActivity,
+  type SurfaceActivitySnapshot,
+} from '../../core/surface-presence.js';
 import { sendTelegramMessage } from '../../gateway/channels/telegram-send.js';
 import {
   buildSurfacePolicySnapshot,
@@ -57,6 +62,15 @@ export async function executeTuiHostCommand(
 ): Promise<unknown> {
   assertNotAborted(context.signal);
   await maybeApplyTestDelay(args, context.signal);
+
+  const tuiSessionId = optionalStringArg(args, 'hostSessionId') ?? 'tui-local';
+  const activeTier3 = getActiveTier3Session(TUI_TIER_SURFACE, TUI_TIER_ACTOR_ID);
+  recordSurfaceActivity({
+    surface: 'tui',
+    actorId: TUI_TIER_ACTOR_ID,
+    tier: activeTier3 ? 3 : 2,
+    tuiHostSessionId: tuiSessionId,
+  });
 
   switch (command) {
     case 'guide.show':
@@ -123,9 +137,25 @@ export async function executeTuiHostCommand(
       return executeSecurityTierElevate(args, context);
     case 'security.tier.revoke':
       return executeSecurityTierRevoke(context);
+    case 'presence.snapshot':
+      return executePresenceSnapshot(context);
     default:
       return exhaustiveCapability(command);
   }
+}
+
+async function executePresenceSnapshot(
+  context: TuiHostCommandContext,
+): Promise<unknown> {
+  context.emitLine('info', 'Loading cross-surface presence snapshot...');
+  const snapshots = getActiveSurfacesSnapshot();
+  assertNotAborted(context.signal);
+  const activeCount = snapshots.filter((s: SurfaceActivitySnapshot) => !s.stale).length;
+  context.emitLine(
+    activeCount === 0 ? 'warning' : 'info',
+    `Surfaces: ${snapshots.length} tracked, ${activeCount} active`,
+  );
+  return { snapshots, active: activeCount, total: snapshots.length };
 }
 
 async function executeGuideShow(context: TuiHostCommandContext): Promise<unknown> {

--- a/src/infra/tui-host/protocol.ts
+++ b/src/infra/tui-host/protocol.ts
@@ -29,6 +29,7 @@ export const TUI_HOST_CAPABILITIES = [
   'security.tier.status',
   'security.tier.elevate',
   'security.tier.revoke',
+  'presence.snapshot',
 ] as const;
 
 export type TuiHostCapability = (typeof TUI_HOST_CAPABILITIES)[number];

--- a/src/soul/types.ts
+++ b/src/soul/types.ts
@@ -204,6 +204,7 @@ export interface PulseEntry {
   uptimeSeconds: number;
   cognitiveMode?: string;
   detail?: string;
+  activeSurfaces?: string[];
 }
 
 // ── Interaction Memory (Burn-After-Action) ──────────────────────────────────

--- a/tests/integration/surface-presence-cross-surface.test.ts
+++ b/tests/integration/surface-presence-cross-surface.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getActiveSurfacesSnapshot,
+  recordSurfaceActivity,
+  resetSurfacePresence,
+} from '../../src/core/surface-presence.js';
+import { executeTuiHostCommand } from '../../src/infra/tui-host/commands.js';
+
+function makeCtx() {
+  const lines: Array<{ level: string; text: string }> = [];
+  return {
+    lines,
+    ctx: {
+      emitLine: (level: 'info' | 'warning' | 'error', text: string) => {
+        lines.push({ level, text });
+      },
+      signal: new AbortController().signal,
+    },
+  };
+}
+
+describe('cross-surface presence visibility', () => {
+  beforeEach(() => {
+    resetSurfacePresence();
+  });
+
+  it('TUI presence.snapshot capability sees Telegram activity after a Telegram message', async () => {
+    recordSurfaceActivity({
+      surface: 'telegram',
+      actorId: 'telegram:1001',
+      tier: 2,
+      telegramChatId: 42,
+    });
+
+    const { ctx, lines } = makeCtx();
+    const result = (await executeTuiHostCommand('presence.snapshot', undefined, ctx)) as {
+      snapshots: Array<{ surface: string; telegramChatIds: string[] }>;
+      active: number;
+      total: number;
+    };
+
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    const telegramSnap = result.snapshots.find((s) => s.surface === 'telegram');
+    expect(telegramSnap).toBeDefined();
+    expect(telegramSnap?.telegramChatIds).toContain('42');
+    expect(lines.some((l) => l.text.includes('Surfaces:'))).toBe(true);
+  });
+
+  it('invoking a TUI host command records TUI presence visible to any /status consumer', async () => {
+    const { ctx } = makeCtx();
+
+    try {
+      await executeTuiHostCommand('pulse.status', undefined, ctx);
+    } catch {
+      // pulse.status runs loadPulseEntries() against the local filesystem; we
+      // don't care whether it finds a pulse file, only that the top-of-function
+      // recordSurfaceActivity call ran before any downstream error.
+    }
+
+    const snaps = getActiveSurfacesSnapshot();
+    const tui = snaps.find((s) => s.surface === 'tui');
+    expect(tui).toBeDefined();
+    expect(tui?.tier).toBeGreaterThanOrEqual(2);
+    expect(tui?.activityCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('snapshot ordering reflects most-recent-first activity across surfaces', () => {
+    recordSurfaceActivity({ surface: 'tui', actorId: 'local', tier: 2, now: 100 });
+    recordSurfaceActivity({ surface: 'telegram', actorId: 't:1', tier: 2, now: 200 });
+    recordSurfaceActivity({ surface: 'http', actorId: '10.0.0.1', tier: 2, now: 300 });
+
+    const snaps = getActiveSurfacesSnapshot({ now: 300 });
+    expect(snaps.map((s) => s.surface)).toEqual(['http', 'telegram', 'tui']);
+  });
+});

--- a/tests/unit/surface-presence.test.ts
+++ b/tests/unit/surface-presence.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_STALE_MS,
+  formatSurfaceStatusLines,
+  getActiveSurfacesSnapshot,
+  recordSurfaceActivity,
+  resetSurfacePresence,
+} from '../../src/core/surface-presence.js';
+
+beforeEach(() => {
+  resetSurfacePresence();
+});
+
+describe('surface-presence registry', () => {
+  it('starts empty', () => {
+    expect(getActiveSurfacesSnapshot()).toEqual([]);
+  });
+
+  it('records a single surface activity', () => {
+    recordSurfaceActivity({
+      surface: 'telegram',
+      actorId: 'telegram:42',
+      tier: 2,
+      telegramChatId: 123,
+      now: 1_000_000,
+    });
+    const [snap] = getActiveSurfacesSnapshot({ now: 1_000_000 });
+    expect(snap?.surface).toBe('telegram');
+    expect(snap?.tier).toBe(2);
+    expect(snap?.stale).toBe(false);
+    expect(snap?.actorIds).toEqual(['telegram:42']);
+    expect(snap?.telegramChatIds).toEqual(['123']);
+    expect(snap?.activityCount).toBe(1);
+  });
+
+  it('aggregates multiple actors on the same surface', () => {
+    recordSurfaceActivity({
+      surface: 'telegram',
+      actorId: 'telegram:1',
+      tier: 2,
+      telegramChatId: 100,
+      now: 1_000,
+    });
+    recordSurfaceActivity({
+      surface: 'telegram',
+      actorId: 'telegram:2',
+      tier: 2,
+      telegramChatId: 200,
+      now: 2_000,
+    });
+    const [snap] = getActiveSurfacesSnapshot({ now: 2_000 });
+    expect(snap?.actorIds.sort()).toEqual(['telegram:1', 'telegram:2']);
+    expect(snap?.telegramChatIds.sort()).toEqual(['100', '200']);
+    expect(snap?.activityCount).toBe(2);
+    expect(snap?.lastActivityMs).toBe(2_000);
+  });
+
+  it('tracks multiple surfaces independently', () => {
+    recordSurfaceActivity({ surface: 'tui', actorId: 'local', tier: 2, now: 1_000 });
+    recordSurfaceActivity({ surface: 'telegram', actorId: 't:1', tier: 2, now: 2_000 });
+    recordSurfaceActivity({ surface: 'http', actorId: '127.0.0.1', tier: 2, now: 3_000 });
+    const snaps = getActiveSurfacesSnapshot({ now: 3_000 });
+    expect(snaps.map((s) => s.surface)).toEqual(['http', 'telegram', 'tui']);
+    expect(snaps[0]?.lastActivityMs).toBe(3_000);
+  });
+
+  it('marks entries older than staleMs as stale', () => {
+    recordSurfaceActivity({ surface: 'telegram', actorId: 't:1', tier: 2, now: 0 });
+    const snaps = getActiveSurfacesSnapshot({
+      now: DEFAULT_STALE_MS + 1,
+      staleMs: DEFAULT_STALE_MS,
+    });
+    expect(snaps[0]?.stale).toBe(true);
+  });
+
+  it('honors the tier update on subsequent recordings', () => {
+    recordSurfaceActivity({ surface: 'tui', actorId: 'local', tier: 2, now: 1_000 });
+    recordSurfaceActivity({ surface: 'tui', actorId: 'local', tier: 3, now: 2_000 });
+    const [snap] = getActiveSurfacesSnapshot({ now: 2_000 });
+    expect(snap?.tier).toBe(3);
+  });
+
+  it('collects tuiHostSessionIds into a set', () => {
+    recordSurfaceActivity({
+      surface: 'tui',
+      actorId: 'local',
+      tier: 2,
+      tuiHostSessionId: 'tui-host-1',
+      now: 1,
+    });
+    recordSurfaceActivity({
+      surface: 'tui',
+      actorId: 'local',
+      tier: 2,
+      tuiHostSessionId: 'tui-host-1',
+      now: 2,
+    });
+    recordSurfaceActivity({
+      surface: 'tui',
+      actorId: 'local',
+      tier: 2,
+      tuiHostSessionId: 'tui-host-2',
+      now: 3,
+    });
+    const [snap] = getActiveSurfacesSnapshot({ now: 3 });
+    expect(snap?.tuiHostSessionIds.sort()).toEqual(['tui-host-1', 'tui-host-2']);
+  });
+});
+
+describe('formatSurfaceStatusLines', () => {
+  it('returns a "(none)" line when the snapshot is empty', () => {
+    expect(formatSurfaceStatusLines([])).toEqual(['Active surfaces: (none)']);
+  });
+
+  it('renders a line per surface with age, tier, and actor', () => {
+    recordSurfaceActivity({
+      surface: 'telegram',
+      actorId: 'telegram:42',
+      tier: 2,
+      telegramChatId: 999,
+      now: 1_000_000,
+    });
+    const snaps = getActiveSurfacesSnapshot({ now: 1_005_000 });
+    const lines = formatSurfaceStatusLines(snaps);
+    expect(lines[0]).toBe('Active surfaces:');
+    expect(lines[1]).toMatch(/telegram/);
+    expect(lines[1]).toMatch(/last turn 5s ago/);
+    expect(lines[1]).toMatch(/tier 2/);
+    expect(lines[1]).toMatch(/\(chat 999\)/);
+  });
+
+  it('renders "idle" for stale surfaces', () => {
+    recordSurfaceActivity({ surface: 'http', actorId: '10.0.0.1', tier: 2, now: 0 });
+    const snaps = getActiveSurfacesSnapshot({
+      now: DEFAULT_STALE_MS + 60_000,
+      staleMs: DEFAULT_STALE_MS,
+    });
+    const lines = formatSurfaceStatusLines(snaps);
+    expect(lines[1]).toMatch(/http/);
+    expect(lines[1]).toMatch(/idle/);
+  });
+
+  it('renders +N suffix when multiple actors share a surface', () => {
+    recordSurfaceActivity({ surface: 'telegram', actorId: 'a', telegramChatId: 1, now: 1 });
+    recordSurfaceActivity({ surface: 'telegram', actorId: 'b', telegramChatId: 2, now: 2 });
+    recordSurfaceActivity({ surface: 'telegram', actorId: 'c', telegramChatId: 3, now: 3 });
+    const snaps = getActiveSurfacesSnapshot({ now: 3 });
+    const lines = formatSurfaceStatusLines(snaps);
+    expect(lines[1]).toMatch(/\+2/);
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/core/surface-presence.ts` registry: in-memory map of which surface (Telegram / TUI / HTTP) saw activity, with actor ids, tier, and a 5-minute stale threshold. Shared `formatSurfaceStatusLines` renders an identical block across every surface.
- Activity is recorded at the inbound edge of each surface: Telegram `message:text` handler, TUI `executeTuiHostCommand`, HTTP `onRequest` after auth.
- `/status` now renders a unified view: Telegram's `/status` includes the active-surfaces block; a new TUI host capability `presence.snapshot` returns the full JSON snapshot; `HealthPayload` (served by HTTP `/v1/ops/status` and TUI `health.status`) gains `activeSurfaces` and `surfaceStatus`.
- `PulseEntry` gains optional `activeSurfaces?: string[]`; the heartbeat watchdog stamps active surface ids into every heartbeat line so a post-restart recovery has a warm view.

## Why this order

Sprint plan's hard-ordering rule: Sprint 5 must precede Sprint 6 — on-the-fly config can't meaningfully display diffs unless `/status` already shows provider + cognitive mode + presence state. This PR closes that precondition.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 1592 passed / 346 files (was 1578 pre-sprint; delta 11 unit + 3 integration new)
- [x] `cargo test -p memphis-tui` — 81 passed
- [x] `cargo test -p memphis-operator` — 25 passed
- [x] Registry unit coverage: TTL staleness, multi-surface ordering, multi-actor aggregation, tier updates, tuiHostSessionIds set
- [x] Formatter unit coverage: empty snapshot, fresh/stale labels, +N suffix for multi-actor telegram
- [x] Cross-surface integration: record a Telegram message → `presence.snapshot` on the TUI host sees it; invoke a TUI host command → `getActiveSurfacesSnapshot` sees `surface=tui` with the tier recorded

## Docs

`docs/surface-presence.md` — API, call-site table, durability story, and test locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)