### PR TITLE
Sprint 11: Model A frame capture pipeline

### DIFF
--- a/docs/cognitive-frames.md
+++ b/docs/cognitive-frames.md
@@ -1,0 +1,90 @@
+# Cognitive mode A — frame pipeline
+
+Cognitive mode A (`ModelA_ConsciousCapture`) needs short-range, cross-turn
+context to actually contribute to the next response. Sprint 11 added the
+missing piece: a bounded in-process ring of **frames** that turn-runtime
+populates after every completed turn and that mode A dispatch reads at prepare
+time.
+
+## What a frame looks like
+
+```ts
+interface Frame {
+  ts: number;                  // ms since epoch, turn completion time
+  surface: string;             // 'tui' | 'telegram' | 'http' | other audit surface
+  turnId: string;              // uuid generated at the start of the turn
+  lastNTurns: Array<{ role: 'user' | 'assistant' | string; text: string }>;
+  activeFilePaths: string[];   // optional — surface-provided, empty by default
+  activeToolCalls: string[];   // tool names invoked during the turn
+}
+```
+
+Frames are text-only and cheap. No screenshots, no binary payloads.
+
+## Ring buffer (`src/cognitive/frame-buffer.ts`)
+
+- `pushFrame(frame)` — append; evicts the oldest if the buffer is full.
+- `getRecentFrames(count = 5)` — return at most `count` most-recent frames
+  (each returned frame is a deep copy; safe to mutate).
+- `resetFrameBuffer()` — clear and re-apply the configured capacity
+  (test-only).
+- Capacity: `MEMPHIS_FRAME_BUFFER_SIZE` (default `128`, clamped to `[1, 4096]`).
+
+The ring is a singleton — one in-process buffer shared across every surface in
+the same Node process, matching the cross-surface presence registry landed in
+Sprint 5.
+
+## Dispatch into mode A
+
+`src/cognitive/mode-dispatch.ts` learned a new input field:
+
+```ts
+interface CognitiveModeDispatchInput {
+  blocks?: Block[];
+  inferred?: InferredDecision[];
+  predictions?: Prediction[];
+  frames?: Frame[];          // ← Sprint 11
+}
+```
+
+When the active cognitive mode is `A`, `computeCognitiveModeContribution`
+(`src/gateway/turn-runtime.ts`) pulls `getRecentFrames()` and passes them in.
+Mode B/C/D/E ignore frames entirely.
+
+`buildModeAFragment` emits a compact text block — one line per frame, trailing
+five frames max:
+
+```
+[mode_A:recent_captures]
+- note: earlier Model A capture…
+[mode_A:recent_frames]
+- t=2026-04-13T12:00:05.000Z surface=tui tools=memphis_exec files=/srv/app/deploy.sh user="deploy staging"
+- t=2026-04-13T12:00:21.000Z surface=telegram user="status?"
+```
+
+Captures (`source === 'model-a'`) and frames are independent sections; either
+can be empty.
+
+## Post-turn capture (`src/gateway/turn-runtime.ts`)
+
+At turn start the runtime generates a `turnId` via `crypto.randomUUID()`.
+After `runPostResponseCognitivePass` completes, the runtime builds a frame:
+
+- `lastNTurns` is extracted from the tail of the message list plus the
+  original user text + guarded assistant reply. Each field is truncated to
+  280 chars.
+- `activeToolCalls` is the de-duplicated set of `tool_calls[].name` across the
+  assistant messages in this turn.
+- `activeFilePaths` is empty by default — surfaces can set it in future
+  sprints; not wired to any heuristic today.
+
+A frame-push failure is logged and swallowed; it never fails the turn.
+
+## Tests
+
+- `tests/unit/frame-buffer.test.ts` — capacity, FIFO eviction, clone
+  semantics, env-driven resize, reset.
+- `tests/unit/mode-dispatch.test.ts` — `buildModeAFragment` renders and
+  truncates frames; other modes ignore them.
+- `tests/integration/mode-a-frame-dispatch.test.ts` — three prior turns
+  feed turn four's mode A prompt fragment.

--- a/src/cognitive/frame-buffer.ts
+++ b/src/cognitive/frame-buffer.ts
@@ -1,0 +1,121 @@
+/**
+ * Frame buffer — bounded in-memory FIFO ring of recent turn "frames" used by
+ * cognitive mode A (`ModelA_ConsciousCapture`) to inject short-range context
+ * into the next turn's system prompt.
+ *
+ * A frame is a compact, text-only snapshot of one completed turn:
+ *   { ts, surface, turnId, lastNTurns, activeFilePaths, activeToolCalls }
+ *
+ * Frames are pushed post-turn from `src/gateway/turn-runtime.ts` and read at
+ * prepare time by `src/cognitive/mode-dispatch.ts` → `buildModeAFragment`.
+ */
+
+export interface FrameTurn {
+  role: 'user' | 'assistant' | 'system' | 'tool' | string;
+  text: string;
+}
+
+export interface Frame {
+  ts: number;
+  surface: string;
+  turnId: string;
+  lastNTurns: FrameTurn[];
+  activeFilePaths: string[];
+  activeToolCalls: string[];
+}
+
+export const DEFAULT_FRAME_BUFFER_SIZE = 128;
+export const DEFAULT_RECENT_FRAME_COUNT = 5;
+
+function readConfiguredSize(rawEnv: NodeJS.ProcessEnv): number {
+  const raw = rawEnv.MEMPHIS_FRAME_BUFFER_SIZE;
+  if (!raw) return DEFAULT_FRAME_BUFFER_SIZE;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_FRAME_BUFFER_SIZE;
+  return Math.min(parsed, 4096);
+}
+
+class FrameRingBuffer {
+  private buffer: Frame[] = [];
+  private capacity: number;
+
+  constructor(capacity: number) {
+    this.capacity = Math.max(1, capacity);
+  }
+
+  setCapacity(capacity: number): void {
+    this.capacity = Math.max(1, capacity);
+    if (this.buffer.length > this.capacity) {
+      this.buffer.splice(0, this.buffer.length - this.capacity);
+    }
+  }
+
+  push(frame: Frame): void {
+    this.buffer.push(frame);
+    if (this.buffer.length > this.capacity) {
+      this.buffer.splice(0, this.buffer.length - this.capacity);
+    }
+  }
+
+  recent(count: number): Frame[] {
+    if (count <= 0) return [];
+    return this.buffer.slice(-count).map(cloneFrame);
+  }
+
+  all(): Frame[] {
+    return this.buffer.map(cloneFrame);
+  }
+
+  size(): number {
+    return this.buffer.length;
+  }
+
+  getCapacity(): number {
+    return this.capacity;
+  }
+
+  clear(): void {
+    this.buffer.length = 0;
+  }
+}
+
+function cloneFrame(frame: Frame): Frame {
+  return {
+    ts: frame.ts,
+    surface: frame.surface,
+    turnId: frame.turnId,
+    lastNTurns: frame.lastNTurns.map((turn) => ({ role: turn.role, text: turn.text })),
+    activeFilePaths: [...frame.activeFilePaths],
+    activeToolCalls: [...frame.activeToolCalls],
+  };
+}
+
+let ringBuffer: FrameRingBuffer = new FrameRingBuffer(
+  readConfiguredSize(process.env),
+);
+
+export function pushFrame(frame: Frame): void {
+  ringBuffer.setCapacity(readConfiguredSize(process.env));
+  ringBuffer.push(cloneFrame(frame));
+}
+
+export function getRecentFrames(count: number = DEFAULT_RECENT_FRAME_COUNT): Frame[] {
+  return ringBuffer.recent(count);
+}
+
+export function getAllFrames(): Frame[] {
+  return ringBuffer.all();
+}
+
+export function getFrameBufferSize(): number {
+  return ringBuffer.size();
+}
+
+export function getFrameBufferCapacity(): number {
+  return ringBuffer.getCapacity();
+}
+
+/** Test-only reset. */
+export function resetFrameBuffer(): void {
+  ringBuffer = new FrameRingBuffer(readConfiguredSize(process.env));
+}

--- a/src/cognitive/mode-dispatch.ts
+++ b/src/cognitive/mode-dispatch.ts
@@ -1,3 +1,4 @@
+import type { Frame } from './frame-buffer.js';
 import type { InferredDecision } from './model-b.js';
 import {
   COGNITIVE_MODES,
@@ -12,6 +13,7 @@ export interface CognitiveModeDispatchInput {
   blocks?: Block[];
   inferred?: InferredDecision[];
   predictions?: Prediction[];
+  frames?: Frame[];
 }
 
 export interface CognitiveModeContribution {
@@ -52,17 +54,54 @@ function truncate(value: string, max: number): string {
   return flat.length <= max ? flat : `${flat.slice(0, max - 1)}…`;
 }
 
-function buildModeAFragment(blocks: Block[] | undefined): string {
-  if (!blocks || blocks.length === 0) return '';
-  const captures = blocks.filter(isModelACaptureBlock).slice(-5);
-  if (captures.length === 0) return '';
-  const lines = captures.map((block) => {
-    const data = block.data as { title?: string; content?: string; kind?: string };
-    const title = data.title ?? data.content ?? '(untitled)';
-    const kind = data.kind ?? 'note';
-    return `- ${kind}: ${truncate(title, 140)}`;
-  });
-  return ['[mode_A:recent_captures]', ...lines].join('\n');
+function formatFrameTimestamp(ts: number): string {
+  if (!Number.isFinite(ts) || ts <= 0) return 'unknown';
+  try {
+    return new Date(ts).toISOString();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function formatFrameLine(frame: Frame): string {
+  const parts: string[] = [`t=${formatFrameTimestamp(frame.ts)}`, `surface=${frame.surface}`];
+  if (frame.activeToolCalls.length > 0) {
+    parts.push(`tools=${frame.activeToolCalls.slice(0, 4).join(',')}`);
+  }
+  if (frame.activeFilePaths.length > 0) {
+    parts.push(`files=${frame.activeFilePaths.slice(0, 3).join(',')}`);
+  }
+  const lastUser = [...frame.lastNTurns].reverse().find((turn) => turn.role === 'user');
+  if (lastUser) {
+    parts.push(`user="${truncate(lastUser.text, 120)}"`);
+  }
+  return `- ${parts.join(' ')}`;
+}
+
+function buildModeAFragment(
+  blocks: Block[] | undefined,
+  frames: Frame[] | undefined,
+): string {
+  const sections: string[] = [];
+
+  const captures = (blocks ?? []).filter(isModelACaptureBlock).slice(-5);
+  if (captures.length > 0) {
+    const captureLines = captures.map((block) => {
+      const data = block.data as { title?: string; content?: string; kind?: string };
+      const title = data.title ?? data.content ?? '(untitled)';
+      const kind = data.kind ?? 'note';
+      return `- ${kind}: ${truncate(title, 140)}`;
+    });
+    sections.push(['[mode_A:recent_captures]', ...captureLines].join('\n'));
+  }
+
+  const recentFrames = (frames ?? []).slice(-5);
+  if (recentFrames.length > 0) {
+    const frameLines = recentFrames.map(formatFrameLine);
+    sections.push(['[mode_A:recent_frames]', ...frameLines].join('\n'));
+  }
+
+  return sections.join('\n');
 }
 
 function buildModeBFragment(inferred: InferredDecision[] | undefined): string {
@@ -123,7 +162,7 @@ export function applyCognitiveMode(
   let fragment = '';
   switch (mode) {
     case 'A':
-      fragment = buildModeAFragment(input.blocks);
+      fragment = buildModeAFragment(input.blocks, input.frames);
       break;
     case 'B':
       fragment = buildModeBFragment(input.inferred);

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -30,6 +30,12 @@ import {
 } from './system-prompt.js';
 import { fetchUrlsFromMessage } from './url-extract.js';
 import {
+  getRecentFrames,
+  pushFrame,
+  type Frame,
+  type FrameTurn,
+} from '../cognitive/frame-buffer.js';
+import {
   applyCognitiveMode,
   type CognitiveModeContribution,
 } from '../cognitive/mode-dispatch.js';
@@ -49,6 +55,66 @@ import {
 import { getCognitiveMode } from '../soul/manifest.js';
 
 const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+
+function generateTurnId(): string {
+  try {
+    if (typeof globalThis.crypto?.randomUUID === 'function') {
+      return globalThis.crypto.randomUUID();
+    }
+  } catch {
+    // fall through to random hex fallback
+  }
+  return `turn-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function extractFrameToolCalls(messages: ChatMessage[]): string[] {
+  const names = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== 'assistant') continue;
+    const toolCalls = msg.tool_calls;
+    if (Array.isArray(toolCalls)) {
+      for (const call of toolCalls) {
+        if (call?.name) names.add(call.name);
+      }
+    }
+  }
+  return Array.from(names);
+}
+
+function extractFrameLastNTurns(
+  messages: ChatMessage[],
+  originalUserText: string,
+  assistantReply: string,
+  limit: number = 4,
+): FrameTurn[] {
+  const turns: FrameTurn[] = [];
+  for (const msg of messages.slice(-limit * 2)) {
+    if (msg.role !== 'user' && msg.role !== 'assistant') continue;
+    const textValue = msg.content;
+    if (!textValue || !textValue.trim()) continue;
+    turns.push({ role: msg.role, text: truncateFrameText(textValue) });
+  }
+  const truncatedUserText = truncateFrameText(originalUserText);
+  if (truncatedUserText.length > 0) {
+    const alreadyPresent = turns.some(
+      (turn) => turn.role === 'user' && turn.text === truncatedUserText,
+    );
+    if (!alreadyPresent) {
+      turns.push({ role: 'user', text: truncatedUserText });
+    }
+  }
+  const truncatedAssistantReply = truncateFrameText(assistantReply);
+  if (truncatedAssistantReply.length > 0) {
+    turns.push({ role: 'assistant', text: truncatedAssistantReply });
+  }
+  return turns.slice(-limit);
+}
+
+function truncateFrameText(text: string, max: number = 280): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  if (flat.length <= max) return flat;
+  return `${flat.slice(0, max - 1)}…`;
+}
 
 function mapSurfaceToTier3Surface(surface: string): Tier3Surface | null {
   const normalized = surface.toLowerCase();
@@ -582,6 +648,7 @@ function computeCognitiveModeContribution(
       blocks: prelude?.blocks,
       inferred: prelude?.inferred,
       predictions: prelude?.predictions,
+      frames: mode === 'A' ? getRecentFrames() : undefined,
     },
     rawEnv,
   );
@@ -665,6 +732,7 @@ function resolveLlm(
 
 export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRuntimeResult> {
   const startedAt = Date.now();
+  const turnId = generateTurnId();
   const classification = await resolveInputClassification(options);
   const auditSurface = options.auditSurface ?? options.surface;
   const rawEnvWithTier3 = applyTier3EnvOverride(
@@ -868,6 +936,24 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     if (!postResponse.ok) {
       persistence.degraded = true;
       persistence.errors.push(postResponse.error);
+    }
+
+    try {
+      const frame: Frame = {
+        ts: Date.now(),
+        surface: auditSurface,
+        turnId,
+        lastNTurns: extractFrameLastNTurns(
+          messages,
+          prepared.originalUserText,
+          guarded.output,
+        ),
+        activeFilePaths: [],
+        activeToolCalls: extractFrameToolCalls(messages),
+      };
+      pushFrame(frame);
+    } catch (error) {
+      log.warn({ err: error, turnId }, 'frame push failed');
     }
   }
 

--- a/tests/integration/mode-a-frame-dispatch.test.ts
+++ b/tests/integration/mode-a-frame-dispatch.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getRecentFrames,
+  pushFrame,
+  resetFrameBuffer,
+  type Frame,
+} from '../../src/cognitive/frame-buffer.js';
+import { applyCognitiveMode } from '../../src/cognitive/mode-dispatch.js';
+
+function frameFromTurn(turnIdx: number, surface: string, userText: string, assistantText: string): Frame {
+  return {
+    ts: Date.parse('2026-04-13T12:00:00.000Z') + turnIdx * 1000,
+    surface,
+    turnId: `turn-${turnIdx}`,
+    lastNTurns: [
+      { role: 'user', text: userText },
+      { role: 'assistant', text: assistantText },
+    ],
+    activeFilePaths: [],
+    activeToolCalls: turnIdx % 2 === 0 ? ['memphis_fs_write'] : [],
+  };
+}
+
+describe('mode A frame dispatch (frame-buffer → applyCognitiveMode)', () => {
+  beforeEach(() => {
+    resetFrameBuffer();
+  });
+
+  it('exposes the three most-recent frames when turn 4 dispatches in mode A', () => {
+    pushFrame(frameFromTurn(1, 'tui', 'open the roadmap', 'opened'));
+    pushFrame(frameFromTurn(2, 'tui', 'summarize sprint 5', 'summary...'));
+    pushFrame(frameFromTurn(3, 'telegram', 'what next', 'sprint 11'));
+
+    const frames = getRecentFrames();
+    expect(frames.map((f) => f.turnId)).toEqual(['turn-1', 'turn-2', 'turn-3']);
+
+    const contribution = applyCognitiveMode('A', { frames }, {});
+    expect(contribution.promptFragment).toContain('[mode_A:recent_frames]');
+    expect(contribution.promptFragment).toContain('user="open the roadmap"');
+    expect(contribution.promptFragment).toContain('user="summarize sprint 5"');
+    expect(contribution.promptFragment).toContain('user="what next"');
+    expect(contribution.promptFragment).toContain('surface=telegram');
+  });
+
+  it('emits no frames block when the buffer is empty', () => {
+    const contribution = applyCognitiveMode('A', { frames: getRecentFrames() }, {});
+    expect(contribution.promptFragment).not.toContain('[mode_A:recent_frames]');
+  });
+
+  it('mode B/C/D/E ignore frames — they are only injected by mode A dispatch', () => {
+    pushFrame(frameFromTurn(1, 'tui', 'only mode-A sees me', 'ack'));
+    const frames = getRecentFrames();
+
+    for (const mode of ['B', 'C', 'D', 'E'] as const) {
+      const c = applyCognitiveMode(mode, { frames }, {});
+      expect(c.promptFragment).not.toContain('[mode_A:recent_frames]');
+      expect(c.promptFragment).not.toContain('only mode-A sees me');
+    }
+  });
+
+  it('frames push from different surfaces are all visible in a later mode-A turn', () => {
+    pushFrame(frameFromTurn(1, 'tui', 'tui command', 'tui reply'));
+    pushFrame(frameFromTurn(2, 'telegram', 'telegram question', 'telegram reply'));
+    pushFrame(frameFromTurn(3, 'http', 'http query', 'http reply'));
+
+    const contribution = applyCognitiveMode('A', { frames: getRecentFrames() }, {});
+    expect(contribution.promptFragment).toContain('surface=tui');
+    expect(contribution.promptFragment).toContain('surface=telegram');
+    expect(contribution.promptFragment).toContain('surface=http');
+  });
+});

--- a/tests/unit/frame-buffer.test.ts
+++ b/tests/unit/frame-buffer.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_FRAME_BUFFER_SIZE,
+  DEFAULT_RECENT_FRAME_COUNT,
+  getAllFrames,
+  getFrameBufferCapacity,
+  getFrameBufferSize,
+  getRecentFrames,
+  pushFrame,
+  resetFrameBuffer,
+  type Frame,
+} from '../../src/cognitive/frame-buffer.js';
+
+function makeFrame(index: number, surface: string = 'tui'): Frame {
+  return {
+    ts: 1_000_000_000 + index,
+    surface,
+    turnId: `turn-${index}`,
+    lastNTurns: [
+      { role: 'user', text: `user message ${index}` },
+      { role: 'assistant', text: `assistant reply ${index}` },
+    ],
+    activeFilePaths: [`/tmp/file-${index}.ts`],
+    activeToolCalls: index % 2 === 0 ? ['memphis_fs_ops'] : [],
+  };
+}
+
+describe('frame-buffer', () => {
+  const originalEnv = process.env.MEMPHIS_FRAME_BUFFER_SIZE;
+
+  beforeEach(() => {
+    process.env.MEMPHIS_FRAME_BUFFER_SIZE = originalEnv ?? '';
+    if (!process.env.MEMPHIS_FRAME_BUFFER_SIZE) {
+      delete process.env.MEMPHIS_FRAME_BUFFER_SIZE;
+    }
+    resetFrameBuffer();
+  });
+
+  it('starts empty', () => {
+    expect(getAllFrames()).toEqual([]);
+    expect(getFrameBufferSize()).toBe(0);
+    expect(getRecentFrames()).toEqual([]);
+  });
+
+  it('default capacity matches DEFAULT_FRAME_BUFFER_SIZE when env unset', () => {
+    delete process.env.MEMPHIS_FRAME_BUFFER_SIZE;
+    resetFrameBuffer();
+    expect(getFrameBufferCapacity()).toBe(DEFAULT_FRAME_BUFFER_SIZE);
+  });
+
+  it('honors MEMPHIS_FRAME_BUFFER_SIZE override', () => {
+    process.env.MEMPHIS_FRAME_BUFFER_SIZE = '16';
+    resetFrameBuffer();
+    expect(getFrameBufferCapacity()).toBe(16);
+  });
+
+  it('falls back to default on an invalid env value', () => {
+    process.env.MEMPHIS_FRAME_BUFFER_SIZE = 'banana';
+    resetFrameBuffer();
+    expect(getFrameBufferCapacity()).toBe(DEFAULT_FRAME_BUFFER_SIZE);
+  });
+
+  it('clamps excessively large configured sizes to 4096', () => {
+    process.env.MEMPHIS_FRAME_BUFFER_SIZE = '9999999';
+    resetFrameBuffer();
+    expect(getFrameBufferCapacity()).toBe(4096);
+  });
+
+  it('pushes frames in order and getRecentFrames returns the last N most-recent', () => {
+    for (let i = 0; i < 10; i += 1) {
+      pushFrame(makeFrame(i));
+    }
+    const recent = getRecentFrames(3);
+    expect(recent.map((f) => f.turnId)).toEqual(['turn-7', 'turn-8', 'turn-9']);
+  });
+
+  it('defaults to DEFAULT_RECENT_FRAME_COUNT when count omitted', () => {
+    for (let i = 0; i < DEFAULT_RECENT_FRAME_COUNT + 3; i += 1) {
+      pushFrame(makeFrame(i));
+    }
+    expect(getRecentFrames()).toHaveLength(DEFAULT_RECENT_FRAME_COUNT);
+  });
+
+  it('evicts oldest frames in FIFO order when exceeding capacity', () => {
+    process.env.MEMPHIS_FRAME_BUFFER_SIZE = '3';
+    resetFrameBuffer();
+
+    pushFrame(makeFrame(0));
+    pushFrame(makeFrame(1));
+    pushFrame(makeFrame(2));
+    pushFrame(makeFrame(3));
+    pushFrame(makeFrame(4));
+
+    const all = getAllFrames();
+    expect(all.map((f) => f.turnId)).toEqual(['turn-2', 'turn-3', 'turn-4']);
+    expect(getFrameBufferSize()).toBe(3);
+  });
+
+  it('returns zero frames when count is zero or negative', () => {
+    pushFrame(makeFrame(0));
+    expect(getRecentFrames(0)).toEqual([]);
+    expect(getRecentFrames(-5)).toEqual([]);
+  });
+
+  it('roundtrips all frame fields through getRecentFrames', () => {
+    const source = makeFrame(42, 'telegram');
+    pushFrame(source);
+    const [echoed] = getRecentFrames(1);
+    expect(echoed).toEqual(source);
+  });
+
+  it('returns independent copies from getRecentFrames (mutation-safe)', () => {
+    pushFrame(makeFrame(0));
+    const [first] = getRecentFrames(1);
+    if (!first) throw new Error('expected a frame');
+    first.lastNTurns.push({ role: 'user', text: 'injected' });
+    first.activeFilePaths.push('/tmp/evil');
+    first.activeToolCalls.push('bad');
+    const [second] = getRecentFrames(1);
+    expect(second?.lastNTurns).toHaveLength(2);
+    expect(second?.activeFilePaths).toEqual(['/tmp/file-0.ts']);
+    expect(second?.activeToolCalls).toEqual(['memphis_fs_ops']);
+  });
+
+  it('cloning frame input prevents post-push mutation from leaking into storage', () => {
+    const frame = makeFrame(1);
+    pushFrame(frame);
+    frame.lastNTurns.push({ role: 'user', text: 'after-push mutation' });
+    const [stored] = getRecentFrames(1);
+    expect(stored?.lastNTurns).toHaveLength(2);
+  });
+
+  it('resetFrameBuffer clears state and re-applies capacity from env', () => {
+    process.env.MEMPHIS_FRAME_BUFFER_SIZE = '2';
+    resetFrameBuffer();
+    pushFrame(makeFrame(0));
+    pushFrame(makeFrame(1));
+    resetFrameBuffer();
+    expect(getAllFrames()).toEqual([]);
+    expect(getFrameBufferCapacity()).toBe(2);
+  });
+
+  it('adopts a new capacity on push when env changes mid-session', () => {
+    process.env.MEMPHIS_FRAME_BUFFER_SIZE = '5';
+    resetFrameBuffer();
+    for (let i = 0; i < 5; i += 1) pushFrame(makeFrame(i));
+    expect(getFrameBufferSize()).toBe(5);
+
+    process.env.MEMPHIS_FRAME_BUFFER_SIZE = '2';
+    pushFrame(makeFrame(5));
+    expect(getFrameBufferSize()).toBe(2);
+    expect(getAllFrames().map((f) => f.turnId)).toEqual(['turn-4', 'turn-5']);
+  });
+});

--- a/tests/unit/mode-dispatch.test.ts
+++ b/tests/unit/mode-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { Frame } from '../../src/cognitive/frame-buffer.js';
 import {
   applyCognitiveMode,
   listCognitiveModes,
@@ -8,6 +9,21 @@ import {
 import type { InferredDecision } from '../../src/cognitive/model-b.js';
 import type { Prediction } from '../../src/cognitive/types.js';
 import type { Block } from '../../src/memory/chain.js';
+
+function makeFrame(overrides: Partial<Frame> = {}): Frame {
+  return {
+    ts: Date.parse('2026-04-13T12:00:00.000Z'),
+    surface: 'telegram',
+    turnId: 'turn-x',
+    lastNTurns: [
+      { role: 'user', text: 'hi there' },
+      { role: 'assistant', text: 'hello back' },
+    ],
+    activeFilePaths: [],
+    activeToolCalls: [],
+    ...overrides,
+  };
+}
 
 function blockA(title: string, kind = 'note'): Block {
   return {
@@ -148,5 +164,76 @@ describe('applyCognitiveMode', () => {
     const longTitle = 'x'.repeat(1000);
     const c = applyCognitiveMode('B', { inferred: [inferred(longTitle, 0.9)] }, {});
     expect(c.promptFragment.length).toBeLessThan(400);
+  });
+
+  it('mode A renders a recent-frames block when frames are supplied', () => {
+    const frames = [
+      makeFrame({
+        turnId: 'turn-1',
+        surface: 'tui',
+        lastNTurns: [
+          { role: 'user', text: 'deploy the staging service' },
+          { role: 'assistant', text: 'deploying…' },
+        ],
+        activeToolCalls: ['memphis_exec'],
+        activeFilePaths: ['/srv/app/deploy.sh'],
+      }),
+      makeFrame({
+        turnId: 'turn-2',
+        surface: 'telegram',
+        lastNTurns: [
+          { role: 'user', text: 'status?' },
+          { role: 'assistant', text: 'healthy' },
+        ],
+      }),
+    ];
+    const c = applyCognitiveMode('A', { frames }, {});
+    expect(c.promptFragment).toContain('[mode_A:recent_frames]');
+    expect(c.promptFragment).toContain('surface=tui');
+    expect(c.promptFragment).toContain('surface=telegram');
+    expect(c.promptFragment).toContain('tools=memphis_exec');
+    expect(c.promptFragment).toContain('files=/srv/app/deploy.sh');
+    expect(c.promptFragment).toContain('user="deploy the staging service"');
+    expect(c.promptFragment).toContain('user="status?"');
+  });
+
+  it('mode A merges captures and frames into a combined fragment', () => {
+    const blocks = [blockA('deliberate capture')];
+    const frames = [makeFrame({ turnId: 'turn-99' })];
+    const c = applyCognitiveMode('A', { blocks, frames }, {});
+    expect(c.promptFragment).toContain('[mode_A:recent_captures]');
+    expect(c.promptFragment).toContain('deliberate capture');
+    expect(c.promptFragment).toContain('[mode_A:recent_frames]');
+  });
+
+  it('mode A omits the frames block when the frames list is empty', () => {
+    const c = applyCognitiveMode('A', { frames: [] }, {});
+    expect(c.promptFragment).not.toContain('[mode_A:recent_frames]');
+  });
+
+  it('mode A keeps only the trailing 5 frames in the fragment', () => {
+    const frames = Array.from({ length: 8 }).map((_, idx) =>
+      makeFrame({ turnId: `turn-${idx}`, surface: `s${idx}` }),
+    );
+    const c = applyCognitiveMode('A', { frames }, {});
+    expect(c.promptFragment).not.toContain('surface=s0');
+    expect(c.promptFragment).not.toContain('surface=s2');
+    expect(c.promptFragment).toContain('surface=s3');
+    expect(c.promptFragment).toContain('surface=s7');
+  });
+
+  it('mode A truncates very long user text inside frame lines', () => {
+    const frames = [
+      makeFrame({
+        turnId: 'turn-long',
+        lastNTurns: [{ role: 'user', text: 'x'.repeat(500) }],
+      }),
+    ];
+    const c = applyCognitiveMode('A', { frames }, {});
+    const frameLine = c.promptFragment
+      .split('\n')
+      .find((line) => line.startsWith('- t='));
+    expect(frameLine).toBeDefined();
+    expect(frameLine!.length).toBeLessThan(300);
   });
 });


### PR DESCRIPTION
## Summary

Mode A was decorative before this sprint — `ModelA_ConsciousCapture` only emitted context when explicit capture blocks had been written to the chain, and nothing in turn-runtime was feeding the mode short-range cross-turn signal. Sprint 11 closes the loop with a bounded ring of per-turn frames.

- **New ring buffer** (`src/cognitive/frame-buffer.ts`) — default 128 frames, env-configurable via `MEMPHIS_FRAME_BUFFER_SIZE`, deep-cloning reads so callers can't mutate storage.
- **Mode A dispatch extension** — `CognitiveModeDispatchInput` gains `frames?: Frame[]`; `buildModeAFragment` now renders a compact `[mode_A:recent_frames]` block (trailing 5 frames) alongside the existing captures section.
- **Turn-runtime wiring** — each turn generates a UUID `turnId`, pushes a frame after `runPostResponseCognitivePass` (ts/surface/turnId/lastNTurns/activeFilePaths/activeToolCalls), and feeds `getRecentFrames()` into `applyCognitiveMode` only when the active mode is `A`. Push failures are logged and swallowed, never faulting the turn.
- **Modes B/C/D/E unchanged** — frames are mode-A-only.

## Verification

- `npm run typecheck && npm run lint` — green
- `npm test` — 1615 tests passing (+23 from this sprint), 348 files
- `cargo test --all-features` — 233 tests passing

## Test plan

- [x] Unit: frame-buffer capacity, FIFO eviction, env-driven resize, reset semantics, mutation safety
- [x] Unit: mode-dispatch renders `[mode_A:recent_frames]` with surface/tools/files/user extracts
- [x] Unit: mode-dispatch truncates long frame text, caps at trailing 5 frames
- [x] Unit: modes B/C/D/E ignore frames even when supplied
- [x] Integration: 3 prior turns → turn 4's mode A fragment sees all three
- [x] Integration: cross-surface (tui/telegram/http) frames all visible in a later mode-A turn
- [ ] Manual smoke on operator box after merge: set `MEMPHIS_COGNITIVE_MODE=A`, run a short chat, confirm turn N+1 prompt carries N's frame

## Docs

- `docs/cognitive-frames.md` — frame shape, buffer API, mode-A fragment format, post-turn capture flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)