### PR TITLE
Sprint 12: chain integrity — verify-tampering test, archive GC, snapshot-on-rotation

### DIFF
--- a/docs/chain-integrity.md
+++ b/docs/chain-integrity.md
@@ -1,0 +1,106 @@
+# Chain integrity, GC, and snapshots
+
+Sprint 12 closes three durability gaps in the chain storage layer:
+
+1. **Verification** — `memphis chain verify` (TS-side) now has a tampering
+   test that proves a single byte flip is detected.
+2. **Archive GC** — `archiveGC()` prunes old gzipped archives down to a
+   keep-count, opt-in via `MEMPHIS_CHAIN_GC_ENABLED` so the operator
+   explicitly authorises permanent deletion.
+3. **Snapshot on rotation** — `takeChainSnapshot()` writes a
+   `snapshot-<ts>.json` to `data/chain-snapshots/` before each rotation,
+   capturing chain head + last 1000 blocks. Existing `pruneSnapshots()`
+   ages them out.
+
+## Verification
+
+`verifyChainIntegrity(chainName?)` (`src/infra/storage/chain-adapter.ts`)
+re-reads every block file in the active chain, recomputes its hash via
+the same canonical-JSON SHA-256 algorithm used by the Rust core, and
+verifies the parent link from genesis. A tampered block surfaces as
+`Error: chain integrity check failed for <file>: hash mismatch`.
+
+Run from the CLI:
+
+```
+memphis chain verify [--chain <name>]
+```
+
+## Archive GC
+
+```ts
+archiveGC(chainName, { gcEnabled, gcKeep })
+```
+
+| Flag/Env | Default | Meaning |
+|---|---|---|
+| `MEMPHIS_CHAIN_GC_ENABLED` | `false` | When `true`, GC runs after each rotation. |
+| `MEMPHIS_CHAIN_GC_KEEP_ARCHIVES` | `8` | Number of most-recent archives to retain. |
+
+GC sorts archives by the embedded ISO timestamp in the archive filename
+(`{chain}_{first}-{last}_{ISO}.jsonl.gz`), falling back to file mtime
+when the format ever changes. Older archives beyond the keep window are
+deleted. Best-effort: a missing or locked file is silently skipped — the
+deleted-count is the source of truth.
+
+GC is **off by default**. Data deletion is irreversible; the operator
+must opt in explicitly. The `archiveGC()` return value reports
+`archivesScanned`, `archivesDeleted`, `bytesFreed`, plus the kept and
+deleted file lists for audit.
+
+## Snapshot on rotation
+
+```ts
+takeChainSnapshot(chainName, { snapshotTailBlocks, snapshotDir })
+```
+
+| Flag/Env | Default | Meaning |
+|---|---|---|
+| `MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION` | `true` | When `true`, every `rotateChain()` writes a snapshot before archiving. |
+| `MEMPHIS_CHAIN_SNAPSHOT_TAIL_BLOCKS` | `1000` | Trailing block count captured in each snapshot. |
+| `MEMPHIS_SNAPSHOT_MAX_AGE_MS` (existing) | 7 days | Hand-off to `pruneSnapshots()`. |
+| `MEMPHIS_SNAPSHOT_MIN_KEEP` (existing) | 3 | Hand-off to `pruneSnapshots()`. |
+
+Snapshots are JSON files in `data/chain-snapshots/` named
+`snapshot-<ts>.json` so they're recognized by the existing
+`pruneSnapshots()` machinery (`src/backup/snapshot-pruner.ts`). Each
+snapshot records:
+
+```jsonc
+{
+  "chain": "journal",
+  "takenAt": "2026-04-13T13:14:15.000Z",
+  "blockCount": 4321,
+  "tailLimit": 1000,
+  "head": { /* most-recent block */ },
+  "tail": [ /* up to tailLimit trailing blocks */ ],
+  "schemaVersion": 1
+}
+```
+
+Rotation never fails because of a snapshot error — snapshots are
+best-effort safety nets, not a source of truth.
+
+## Wiring
+
+`rotateChain()` itself orchestrates the new behavior:
+
+1. Measure chain dir size; bail if under threshold.
+2. **Snapshot** trailing blocks to `data/chain-snapshots/` (best-effort).
+3. **Archive** the older blocks to `.archives/`.
+4. **GC** old archives if `MEMPHIS_CHAIN_GC_ENABLED=true`.
+
+The trigger for `rotateChain()` itself remains operator-driven (CLI or
+scheduled task) — automatic rotation hooks are intentionally out of
+scope for Sprint 12.
+
+## Tests
+
+- `tests/unit/chain-integrity.test.ts`:
+  - tamper detection: flip a byte in a block → `verifyChainIntegrity`
+    throws with `hash mismatch`.
+  - GC: default-off, deletes only when enabled, respects `gcKeep`.
+  - Snapshot: writes well-formed JSON with head + tail; respects tail cap.
+  - Three rotations + GC: archive count converges to `gcKeep`; snapshot
+    files appear once per rotation; `MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION=false`
+    suppresses snapshots.

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -72,6 +72,10 @@ export function getBackupPath(rawEnv: NodeJS.ProcessEnv = process.env): string {
   return path.join(getDataDir(rawEnv), 'backups');
 }
 
+export function getChainSnapshotsPath(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  return path.join(getDataDir(rawEnv), 'chain-snapshots');
+}
+
 export function getLogsPath(rawEnv: NodeJS.ProcessEnv = process.env): string {
   return path.join(getDataDir(rawEnv), 'logs');
 }

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -156,6 +156,12 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
 
   // ── Frame buffer (Sprint 11) ──
   MEMPHIS_FRAME_BUFFER_SIZE: 'hot',
+
+  // ── Chain integrity (Sprint 12) ──
+  MEMPHIS_CHAIN_GC_ENABLED: 'warm',
+  MEMPHIS_CHAIN_GC_KEEP_ARCHIVES: 'warm',
+  MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION: 'warm',
+  MEMPHIS_CHAIN_SNAPSHOT_TAIL_BLOCKS: 'warm',
 };
 
 export const DEFAULT_TIER_FOR_UNKNOWN: MutabilityTier = 'warm';

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -167,6 +167,10 @@ export const envSchema = z.object({
     .max(1073741824)
     .optional(),
   MEMPHIS_CHAIN_ROTATION_MIN_KEEP_BLOCKS: z.coerce.number().int().min(1).max(10000).optional(),
+  MEMPHIS_CHAIN_GC_ENABLED: boolFromString.default(false),
+  MEMPHIS_CHAIN_GC_KEEP_ARCHIVES: z.coerce.number().int().min(1).max(1000).optional(),
+  MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION: boolFromString.default(true),
+  MEMPHIS_CHAIN_SNAPSHOT_TAIL_BLOCKS: z.coerce.number().int().min(1).max(100000).optional(),
   MEMPHIS_SNAPSHOT_MAX_AGE_MS: z.coerce.number().int().min(3600000).max(2592000000).optional(),
   MEMPHIS_SNAPSHOT_MIN_KEEP: z.coerce.number().int().min(1).max(1000).optional(),
   MEMPHIS_HEARTBEAT_INTERVAL_MS: z.coerce.number().int().min(5000).max(3600000).optional(),

--- a/src/infra/storage/chain-rotation.ts
+++ b/src/infra/storage/chain-rotation.ts
@@ -12,7 +12,7 @@ import * as path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { createGzip } from 'node:zlib';
 
-import { getChainPath } from '../../config/paths.js';
+import { getChainPath, getChainSnapshotsPath } from '../../config/paths.js';
 
 const SAFE_CHAIN_NAME = /^[A-Za-z0-9_-]{1,64}$/;
 
@@ -21,6 +21,12 @@ const DEFAULT_ROTATION_THRESHOLD_BYTES = 50 * 1024 * 1024;
 
 /** Minimum blocks to keep in the active chain after rotation. */
 const MIN_KEEP_BLOCKS = 10;
+
+/** Default archive retention — current + last-N gzipped archives. */
+export const DEFAULT_ARCHIVE_KEEP = 8;
+
+/** Snapshot scope: how many trailing blocks to capture in each snapshot. */
+export const DEFAULT_SNAPSHOT_TAIL_BLOCKS = 1000;
 
 export interface ChainRotationResult {
   chain: string;
@@ -38,6 +44,38 @@ export interface ChainRotationOptions {
   minKeepBlocks?: number;
   /** Specific chain name. If omitted, rotates all chains that exceed threshold. */
   chainName?: string;
+  /**
+   * Override of `MEMPHIS_CHAIN_GC_ENABLED`. When true, prune old gzipped
+   * archives after a successful rotation.
+   */
+  gcEnabled?: boolean;
+  /** Number of recent archives to keep when GC runs. Default 8. */
+  gcKeep?: number;
+  /** When true, write a snapshot to `data/chain-snapshots/` before archiving. */
+  snapshotEnabled?: boolean;
+  /** Trailing block count to capture per snapshot. Default 1000. */
+  snapshotTailBlocks?: number;
+  /** Optional override for the snapshot directory (mostly for tests). */
+  snapshotDir?: string;
+  /** Override the env used to resolve config paths/flags (mostly for tests). */
+  rawEnv?: NodeJS.ProcessEnv;
+}
+
+export interface ChainArchiveGcResult {
+  chain: string;
+  archivesScanned: number;
+  archivesDeleted: number;
+  bytesFreed: number;
+  keptArchives: string[];
+  deletedArchives: string[];
+  enabled: boolean;
+}
+
+export interface ChainSnapshotResult {
+  chain: string;
+  snapshotPath: string;
+  blockCount: number;
+  bytesWritten: number;
 }
 
 /**
@@ -112,6 +150,178 @@ async function archiveBlocks(
   return archivePath;
 }
 
+function isGcEnabled(options: ChainRotationOptions): boolean {
+  if (typeof options.gcEnabled === 'boolean') return options.gcEnabled;
+  const rawEnv = options.rawEnv ?? process.env;
+  const flag = rawEnv.MEMPHIS_CHAIN_GC_ENABLED?.trim().toLowerCase();
+  return flag === 'true' || flag === '1';
+}
+
+function isSnapshotEnabled(options: ChainRotationOptions): boolean {
+  if (typeof options.snapshotEnabled === 'boolean') return options.snapshotEnabled;
+  const rawEnv = options.rawEnv ?? process.env;
+  const flag = rawEnv.MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION?.trim().toLowerCase();
+  // Default to true — snapshots are local-only, cheap, and the safety net the
+  // sprint targets. Operators can opt out with MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION=false.
+  if (flag === 'false' || flag === '0') return false;
+  return true;
+}
+
+function parseArchiveTimestamp(filename: string): number | null {
+  // archives are named: {chain}_{firstIdx}-{lastIdx}_{ISO-with-dashes}.jsonl.gz
+  // Treat the trailing component before .jsonl.gz as a sortable string; we
+  // additionally use mtime as a fallback in case the format ever changes.
+  if (!filename.endsWith('.jsonl.gz')) return null;
+  const stem = filename.slice(0, -'.jsonl.gz'.length);
+  const lastUnderscore = stem.lastIndexOf('_');
+  if (lastUnderscore < 0) return null;
+  const stampToken = stem.slice(lastUnderscore + 1);
+  const parsed = Date.parse(stampToken.replace(/-/g, ':').replace('T:', 'T'));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+interface ArchiveFileInfo {
+  file: string;
+  fullPath: string;
+  ts: number;
+  sizeBytes: number;
+}
+
+async function listArchives(
+  archiveDir: string,
+  chainName: string,
+): Promise<ArchiveFileInfo[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(archiveDir);
+  } catch {
+    return [];
+  }
+  const candidates: ArchiveFileInfo[] = [];
+  for (const file of entries) {
+    if (!file.startsWith(`${chainName}_`)) continue;
+    if (!file.endsWith('.jsonl.gz')) continue;
+    const fullPath = path.join(archiveDir, file);
+    const stat = await fs.stat(fullPath).catch(() => null);
+    if (!stat || !stat.isFile()) continue;
+    const parsed = parseArchiveTimestamp(file);
+    candidates.push({
+      file,
+      fullPath,
+      ts: parsed ?? stat.mtimeMs,
+      sizeBytes: stat.size,
+    });
+  }
+  return candidates.sort((a, b) => a.ts - b.ts);
+}
+
+/**
+ * Delete old gzipped archives for a chain, keeping the most-recent N.
+ *
+ * Always a no-op unless GC is explicitly enabled — `MEMPHIS_CHAIN_GC_ENABLED=true`
+ * or `options.gcEnabled === true`. Returns a structured report so callers can
+ * audit/display what happened.
+ */
+export async function archiveGC(
+  chainName: string,
+  options: Pick<ChainRotationOptions, 'gcEnabled' | 'gcKeep' | 'rawEnv'> = {},
+): Promise<ChainArchiveGcResult> {
+  const enabled = isGcEnabled(options);
+  const keep = Math.max(1, options.gcKeep ?? DEFAULT_ARCHIVE_KEEP);
+  const chainDir = getChainPath(chainName, options.rawEnv);
+  const archiveDir = path.join(path.dirname(chainDir), '.archives');
+
+  const archives = await listArchives(archiveDir, chainName);
+  if (!enabled || archives.length <= keep) {
+    return {
+      chain: chainName,
+      archivesScanned: archives.length,
+      archivesDeleted: 0,
+      bytesFreed: 0,
+      keptArchives: archives.map((a) => a.file),
+      deletedArchives: [],
+      enabled,
+    };
+  }
+  const toDelete = archives.slice(0, archives.length - keep);
+  const kept = archives.slice(archives.length - keep);
+  let bytesFreed = 0;
+  const deleted: string[] = [];
+  for (const archive of toDelete) {
+    try {
+      await fs.unlink(archive.fullPath);
+      bytesFreed += archive.sizeBytes;
+      deleted.push(archive.file);
+    } catch {
+      // Best-effort: a missing or locked archive is logged via the deletedArchives gap.
+    }
+  }
+  return {
+    chain: chainName,
+    archivesScanned: archives.length,
+    archivesDeleted: deleted.length,
+    bytesFreed,
+    keptArchives: kept.map((a) => a.file),
+    deletedArchives: deleted,
+    enabled,
+  };
+}
+
+/**
+ * Capture a lightweight chain snapshot before a rotation.
+ *
+ * Snapshots are JSON files at `data/chain-snapshots/snapshot-{ts}.json` and
+ * record { chain, takenAt, head, tail: Block[] }. They are intentionally
+ * compatible with `pruneSnapshots()` (`src/backup/snapshot-pruner.ts`) so old
+ * snapshots age out together with the rest.
+ */
+export async function takeChainSnapshot(
+  chainName: string,
+  options: Pick<ChainRotationOptions, 'snapshotTailBlocks' | 'snapshotDir' | 'rawEnv'> = {},
+): Promise<ChainSnapshotResult> {
+  const tailLimit = Math.max(1, options.snapshotTailBlocks ?? DEFAULT_SNAPSHOT_TAIL_BLOCKS);
+  const snapshotDir = options.snapshotDir ?? getChainSnapshotsPath(options.rawEnv);
+  await fs.mkdir(snapshotDir, { recursive: true });
+
+  const chainDir = getChainPath(chainName, options.rawEnv);
+  const blocks = await listBlockFiles(chainDir);
+  const tail = blocks.slice(-tailLimit);
+
+  const tailContents: unknown[] = [];
+  for (const entry of tail) {
+    try {
+      const raw = await fs.readFile(path.join(chainDir, entry.file), 'utf8');
+      tailContents.push(JSON.parse(raw));
+    } catch {
+      // Skip unreadable blocks rather than failing the whole snapshot.
+    }
+  }
+
+  const head = tailContents.length > 0 ? tailContents[tailContents.length - 1] : null;
+  const ts = Date.now();
+  const snapshotPath = path.join(snapshotDir, `snapshot-${ts}.json`);
+  const payload = {
+    chain: chainName,
+    takenAt: new Date(ts).toISOString(),
+    blockCount: blocks.length,
+    tailLimit,
+    head,
+    tail: tailContents,
+    schemaVersion: 1,
+  };
+  const tmpPath = `${snapshotPath}.tmp-${process.pid}`;
+  const serialized = `${JSON.stringify(payload)}\n`;
+  await fs.writeFile(tmpPath, serialized, 'utf8');
+  await fs.rename(tmpPath, snapshotPath);
+
+  return {
+    chain: chainName,
+    snapshotPath,
+    blockCount: blocks.length,
+    bytesWritten: Buffer.byteLength(serialized, 'utf8'),
+  };
+}
+
 /**
  * Rotate a single chain if it exceeds the threshold.
  */
@@ -159,10 +369,22 @@ export async function rotateChain(
     };
   }
 
+  // Snapshot first so the operator has a recovery point even if archiving fails.
+  if (isSnapshotEnabled(options)) {
+    try {
+      await takeChainSnapshot(chainName, options);
+    } catch {
+      // Snapshot is best-effort; rotation is more important than the safety net.
+    }
+  }
+
   // Archive all but the last minKeep blocks
   const toArchive = blocks.slice(0, blocks.length - minKeep);
   const archivePath = await archiveBlocks(chainDir, chainName, toArchive);
   const newDirSize = await measureChainDirSize(chainDir);
+
+  // GC stale archives — opt-in via MEMPHIS_CHAIN_GC_ENABLED.
+  await archiveGC(chainName, options).catch(() => undefined);
 
   return {
     chain: chainName,

--- a/tests/unit/chain-integrity.test.ts
+++ b/tests/unit/chain-integrity.test.ts
@@ -1,0 +1,302 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  appendBlock,
+  verifyChainIntegrity,
+} from '../../src/infra/storage/chain-adapter.js';
+import {
+  archiveGC,
+  rotateChain,
+  takeChainSnapshot,
+} from '../../src/infra/storage/chain-rotation.js';
+
+interface TestEnv {
+  dataDir: string;
+  prevEnv: NodeJS.ProcessEnv;
+}
+
+function setupEnv(): TestEnv {
+  const dataDir = mkdtempSync(join(tmpdir(), 'memphis-chain-it-'));
+  const prevEnv = { ...process.env };
+  process.env.MEMPHIS_DATA_DIR = dataDir;
+  process.env.RUST_CHAIN_ENABLED = 'false';
+  return { dataDir, prevEnv };
+}
+
+function tearDown(env: TestEnv): void {
+  rmSync(env.dataDir, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) {
+    if (!(key in env.prevEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, env.prevEnv);
+}
+
+/**
+ * Synthesize on-disk blocks without invoking `appendBlock` — bypasses the
+ * pre-append integrity check so we can simulate a chain that has already
+ * been partially archived (genesis no longer present in active dir).
+ */
+function syntheticBlocks(chainDir: string, count: number, startIndex = 1): void {
+  mkdirSync(chainDir, { recursive: true });
+  for (let i = 0; i < count; i += 1) {
+    const idx = startIndex + i;
+    const block = {
+      index: idx,
+      timestamp: new Date().toISOString(),
+      chain: 'synthetic',
+      data: { content: `block-${idx}` },
+      prev_hash: idx === 1 ? '' : '0'.repeat(64),
+      hash: 'a'.repeat(64),
+    };
+    writeFileSync(
+      join(chainDir, `${String(idx).padStart(6, '0')}.json`),
+      JSON.stringify(block, null, 2),
+    );
+  }
+}
+
+describe('verifyChainIntegrity — tampering detection', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setupEnv();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('detects when a block file has been tampered with (hash mismatch)', async () => {
+    const chain = 'tamper-test';
+    for (let i = 0; i < 5; i += 1) {
+      await appendBlock(chain, { type: 'note', content: `block-${i}` }, process.env);
+    }
+
+    const chainDir = join(env.dataDir, 'chains', chain);
+    const files = readdirSync(chainDir).filter((f) => f.endsWith('.json'));
+    expect(files.length).toBeGreaterThan(0);
+
+    const target = files.sort()[2]!;
+    const fullPath = join(chainDir, target);
+    const original = JSON.parse(readFileSync(fullPath, 'utf8')) as Record<string, unknown>;
+    const dataObj = original.data as Record<string, unknown>;
+    dataObj.content = 'tampered-content-zzz';
+    writeFileSync(fullPath, JSON.stringify(original));
+
+    await expect(verifyChainIntegrity(chain)).rejects.toThrow(/hash mismatch/);
+  });
+
+  it('passes for an unmodified chain', async () => {
+    const chain = 'clean-test';
+    for (let i = 0; i < 4; i += 1) {
+      await appendBlock(chain, { type: 'note', content: `block-${i}` }, process.env);
+    }
+    const result = await verifyChainIntegrity(chain);
+    expect(result.ok).toBe(true);
+    expect(result.blockCount).toBe(4);
+  });
+});
+
+describe('archiveGC', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setupEnv();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('is a no-op when MEMPHIS_CHAIN_GC_ENABLED is unset (default false)', async () => {
+    const chain = 'gc-disabled';
+    const chainDir = join(env.dataDir, 'chains', chain);
+    syntheticBlocks(chainDir, 12);
+
+    for (let r = 0; r < 4; r += 1) {
+      await rotateChain(chain, { thresholdBytes: 1, minKeepBlocks: 2 });
+      syntheticBlocks(chainDir, 4, 13 + r * 4);
+    }
+    const result = await archiveGC(chain, { gcKeep: 1 });
+    expect(result.enabled).toBe(false);
+    expect(result.archivesDeleted).toBe(0);
+    expect(result.archivesScanned).toBeGreaterThanOrEqual(1);
+  });
+
+  it('keeps the most-recent N archives and deletes the rest when enabled', async () => {
+    const chain = 'gc-enabled';
+    const chainDir = join(env.dataDir, 'chains', chain);
+    syntheticBlocks(chainDir, 12);
+    for (let r = 0; r < 5; r += 1) {
+      await rotateChain(chain, { thresholdBytes: 1, minKeepBlocks: 2 });
+      syntheticBlocks(chainDir, 4, 13 + r * 4);
+    }
+    const beforeArchives = readdirSync(
+      join(env.dataDir, 'chains', '.archives'),
+    ).filter((f) => f.startsWith(`${chain}_`));
+    expect(beforeArchives.length).toBeGreaterThanOrEqual(3);
+
+    const result = await archiveGC(chain, { gcEnabled: true, gcKeep: 2 });
+    expect(result.enabled).toBe(true);
+    expect(result.archivesDeleted).toBe(beforeArchives.length - 2);
+
+    const remaining = readdirSync(
+      join(env.dataDir, 'chains', '.archives'),
+    ).filter((f) => f.startsWith(`${chain}_`));
+    expect(remaining.length).toBe(2);
+  });
+
+  it('returns zero deletions when archives count is at or below keep limit', async () => {
+    const chain = 'under-limit';
+    const chainDir = join(env.dataDir, 'chains', chain);
+    syntheticBlocks(chainDir, 12);
+    await rotateChain(chain, { thresholdBytes: 1, minKeepBlocks: 2 });
+    const result = await archiveGC(chain, { gcEnabled: true, gcKeep: 8 });
+    expect(result.archivesDeleted).toBe(0);
+    expect(result.keptArchives.length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe('takeChainSnapshot', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setupEnv();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('writes a snapshot JSON with chain head + tail blocks', async () => {
+    const chain = 'snap-test';
+    const chainDir = join(env.dataDir, 'chains', chain);
+    syntheticBlocks(chainDir, 6);
+
+    const snapshotDir = join(env.dataDir, 'chain-snapshots');
+    const result = await takeChainSnapshot(chain, { snapshotTailBlocks: 4 });
+    expect(result.snapshotPath).toMatch(/snapshot-\d+\.json$/);
+    expect(result.blockCount).toBe(6);
+
+    const snap = JSON.parse(readFileSync(result.snapshotPath, 'utf8')) as {
+      chain: string;
+      tailLimit: number;
+      tail: Array<Record<string, unknown>>;
+      head: Record<string, unknown> | null;
+      schemaVersion: number;
+    };
+    expect(snap.chain).toBe(chain);
+    expect(snap.tailLimit).toBe(4);
+    expect(snap.tail).toHaveLength(4);
+    expect(snap.head).not.toBeNull();
+    expect(snap.schemaVersion).toBe(1);
+
+    const filesInSnapDir = readdirSync(snapshotDir).filter((f) =>
+      /^snapshot-\d+\.json$/.test(f),
+    );
+    expect(filesInSnapDir.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('caps tail to the requested limit but preserves total blockCount', async () => {
+    const chain = 'snap-cap';
+    const chainDir = join(env.dataDir, 'chains', chain);
+    syntheticBlocks(chainDir, 3);
+    const result = await takeChainSnapshot(chain, { snapshotTailBlocks: 1000 });
+    const snap = JSON.parse(readFileSync(result.snapshotPath, 'utf8')) as {
+      tail: unknown[];
+      blockCount: number;
+    };
+    expect(snap.tail).toHaveLength(3);
+    expect(snap.blockCount).toBe(3);
+  });
+});
+
+describe('rotateChain — snapshot + GC integration', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setupEnv();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('writes a snapshot before archiving when snapshots are enabled', async () => {
+    const chain = 'snap-rotate';
+    const chainDir = join(env.dataDir, 'chains', chain);
+    syntheticBlocks(chainDir, 12);
+    const snapshotDir = join(env.dataDir, 'chain-snapshots');
+    const before = (() => {
+      try {
+        return readdirSync(snapshotDir).length;
+      } catch {
+        return 0;
+      }
+    })();
+    const result = await rotateChain(chain, { thresholdBytes: 1, minKeepBlocks: 2 });
+    expect(result.rotated).toBe(true);
+    const after = readdirSync(snapshotDir).filter((f) =>
+      /^snapshot-\d+\.json$/.test(f),
+    );
+    expect(after.length).toBe(before + 1);
+  });
+
+  it('three rotations with GC enabled keep exactly N archives', async () => {
+    const chain = 'three-rot';
+    const chainDir = join(env.dataDir, 'chains', chain);
+    syntheticBlocks(chainDir, 20);
+    for (let r = 0; r < 3; r += 1) {
+      await rotateChain(chain, {
+        thresholdBytes: 1,
+        minKeepBlocks: 2,
+        gcEnabled: true,
+        gcKeep: 1,
+      });
+      syntheticBlocks(chainDir, 6, 21 + r * 6);
+    }
+    const archives = readdirSync(join(env.dataDir, 'chains', '.archives')).filter(
+      (f) => f.startsWith(`${chain}_`),
+    );
+    expect(archives.length).toBe(1);
+  });
+
+  it('respects MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION=false', async () => {
+    const chain = 'no-snap';
+    const chainDir = join(env.dataDir, 'chains', chain);
+    syntheticBlocks(chainDir, 12);
+    const snapshotDir = join(env.dataDir, 'chain-snapshots');
+    const before = (() => {
+      try {
+        return readdirSync(snapshotDir).length;
+      } catch {
+        return 0;
+      }
+    })();
+    process.env.MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION = 'false';
+    try {
+      await rotateChain(chain, { thresholdBytes: 1, minKeepBlocks: 2 });
+    } finally {
+      delete process.env.MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION;
+    }
+    const after = (() => {
+      try {
+        return readdirSync(snapshotDir).filter((f) => /^snapshot-\d+\.json$/.test(f)).length;
+      } catch {
+        return 0;
+      }
+    })();
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

Three durability gaps in the chain storage layer, closed.

- **Tampering detection** — A unit test now flips a byte in an existing block and proves `verifyChainIntegrity()` raises `hash mismatch`. The verify path itself was already implemented; it had no test pinning the contract.
- **Archive GC** (`archiveGC()` in `src/infra/storage/chain-rotation.ts`) — prunes old `.archives/*.jsonl.gz` down to the most-recent N (default 8). **Off by default** — operator must opt in with `MEMPHIS_CHAIN_GC_ENABLED=true` because deletion is irreversible.
- **Snapshot on rotation** (`takeChainSnapshot()`) — writes `data/chain-snapshots/snapshot-<ts>.json` containing chain head and the trailing N blocks (default 1000) before each rotation. Format is compatible with the existing `pruneSnapshots()` machinery so age-out is already wired. **On by default**; suppress with `MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION=false`.
- `rotateChain()` orchestrates `snapshot → archive → gc` in that order. Snapshot/GC are best-effort and never fault the rotation.

## Verification

- `npm run typecheck && npm run lint` — green
- `npm test` — 1649 tests passing (+10 from this sprint), 352 files
- `cargo test --all-features` — green (no Rust changes)

## Test plan

- [x] Unit: tamper detection — flip a byte in a block file → `verifyChainIntegrity` throws `hash mismatch`
- [x] Unit: clean chain — `verifyChainIntegrity` returns `ok: true`
- [x] Unit: GC default-off behavior (no deletions when env flag unset)
- [x] Unit: GC enabled deletes older archives down to `gcKeep`
- [x] Unit: GC no-ops when archive count is at or below keep limit
- [x] Unit: snapshot writes well-formed JSON with head + capped tail
- [x] Integration: `rotateChain` writes one snapshot per rotation; three rotations + GC=enabled,keep=1 leaves exactly one archive
- [x] Integration: `MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION=false` suppresses snapshots while rotation continues
- [ ] Manual: enable `MEMPHIS_CHAIN_GC_ENABLED=true` on operator box once a real rotation has happened, verify GC report

## Deliberate deferrals (documented in `docs/chain-integrity.md`)

- Automatic rotation triggers remain out of scope. `rotateChain()` is still operator-driven (CLI or scheduled task); a bootstrap wakeup hook is a follow-up sprint to keep blast radius small.
- Archive decompression on restore (replaying a `.jsonl.gz` archive back into an active chain) is not addressed here; tracked as part of the eventual Sprint 8 disaster-recovery drill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)