### PR TITLE
Sprint 10: observability — request-id, alert fan-out, Grafana dashboard

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,105 @@
+# Observability
+
+Sprint 10 added three things:
+
+1. **Request-id propagation** at the HTTP boundary so every log line
+   produced during one request or turn can be correlated across layers.
+2. **Grafana dashboard template** that reads the existing `/metrics`
+   Prometheus endpoint — operators import once and see request rate,
+   latency percentiles, rate-limit hits, chain growth, and more.
+3. **Alert fan-out** to Slack and generic webhooks on top of the
+   existing PagerDuty + OpsGenie transports. Alerts now reach every
+   configured channel in parallel.
+
+OpenTelemetry SDK integration (distributed tracing) is *not* in this
+sprint — the request-id plumbing lays the substrate so OTel can overlay
+later without refactoring callers.
+
+## Contextual logger
+
+`src/infra/logging/contextual.ts` exports `createContextualLogger()`
+and `withContext()` — wrappers around Pino `child()` that carry the
+well-known observability fields:
+
+```ts
+const log = createContextualLogger({
+  requestId,            // uuid per HTTP request
+  surface,              // 'http' | 'tui' | 'telegram' | 'http:worker' | ...
+  actorId,              // telegram chat id / operator did / ip
+  turnId,               // uuid per gateway turn (Sprint 11 frame id)
+  route,                // normalized URL path
+});
+log.info({ event: 'turn.start' }, 'processing turn');
+```
+
+Undefined / null / empty values are stripped so log lines stay compact.
+
+## HTTP boundary
+
+`src/infra/http/server.ts` — the `onRequest` hook now stamps a child
+logger onto `request.log` and keeps setting the `x-request-id` response
+header (unchanged). Downstream code that wants structured fields should
+read `request.log` instead of importing a new logger; that way
+`requestId` propagates for free.
+
+## Grafana dashboard
+
+`docs/observability/grafana-memphis.json` — import into Grafana via
+Dashboards → Import → Upload JSON. The dashboard points at the default
+Prometheus datasource and reads:
+
+- `requests_total`, `errors_total` — request volume and error rate
+- `request_duration_seconds_bucket` — histogram for p50/p95/p99
+- `ask_request_duration_seconds_*`, `ask_requests_total` — provider
+  latency and volume
+- `queue_overload_total`, `safe_mode_denial_route_total` — back-pressure
+  and policy rejections
+- `dual_approval_transition_state_total` — Model D approval flow
+- `chain_blocks_total`, `chain_size_bytes` — chain growth
+- `embed_cache_hits_total` / `embed_cache_misses_total` — cache health
+- `model_d_proposals_by_vote_total` — voting outcomes
+- `schedule_jobs_created_total` / `schedule_jobs_completed_total` —
+  scheduler throughput
+
+The panels assume the Prometheus scrape target is the Memphis
+`/metrics` endpoint. Protect `/v1/metrics` behind auth as before; the
+unauthenticated `/metrics` endpoint stays open for local scrapers.
+
+## Alert routing
+
+`src/infra/logging/alert-transport.ts` — new transports:
+
+| Env | Behavior |
+|---|---|
+| `MEMPHIS_ALERT_SLACK_WEBHOOK` | Posts a formatted `{text}` payload with severity emoji + detail bullets to a Slack incoming webhook. |
+| `MEMPHIS_ALERT_WEBHOOK_URL` | Posts a normalized JSON payload `{id, severity, message, source, timestamp, details}` to an arbitrary HTTPS endpoint. |
+
+All configured transports receive every alert **in parallel** — the
+sender succeeds if at least one delivery worked, so a down Slack
+webhook doesn't knock out PagerDuty. The alert is considered failed
+(and surfaces via the emergency-log fallback) only when every
+transport returns non-OK.
+
+`AlertEmitter` still dedupes identical alerts within
+`ALERT_THROTTLE_SECONDS` (already in `.env.example`, default 1800)
+before they reach the transports, so a stuck upstream doesn't flood
+Slack.
+
+## What's deliberately not here
+
+- **OpenTelemetry SDK** — adding the `@opentelemetry/sdk-node` runtime
+  is a substantial change and deserves its own sprint. Sprint 10 sets
+  up structured fields so a later OTel overlay can reuse them.
+- **Log aggregation shipper** — no fluentbit/vector config; operators
+  wire their own pipe against the local Pino JSON stream.
+- **Escalation** — the transports fire; they don't escalate on
+  unacknowledged alerts. Add PagerDuty escalation policies in the
+  PagerDuty UI, not here.
+
+## Tests
+
+- `tests/unit/contextual-logger.test.ts` — child bindings, undefined
+  stripping, field extension via `withContext`.
+- `tests/unit/alert-transport-slack.test.ts` — Slack payload shape,
+  generic webhook payload shape, fan-out semantics (one fail + one
+  succeed → ok; all fail → throw).

--- a/docs/observability/grafana-memphis.json
+++ b/docs/observability/grafana-memphis.json
@@ -1,0 +1,161 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "title": "Request rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(rate(requests_total[1m])) by (method, route)",
+          "legendFormat": "{{method}} {{route}}"
+        }
+      ],
+      "description": "Incoming HTTP request rate per method and route."
+    },
+    {
+      "title": "Error rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(rate(errors_total[1m])) by (method, route, status_class)",
+          "legendFormat": "{{method}} {{route}} {{status_class}}"
+        }
+      ],
+      "description": "HTTP responses with status \u2265 400."
+    },
+    {
+      "title": "Request latency p50 / p95 / p99",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p50 {{route}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p95 {{route}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p99 {{route}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "title": "Ask / provider latency by provider",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum(rate(ask_request_duration_seconds_sum[5m])) by (provider) / sum(rate(ask_request_duration_seconds_count[5m])) by (provider)",
+          "legendFormat": "avg {{provider}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "title": "Ask request volume by provider",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum(rate(ask_requests_total[1m])) by (provider)",
+          "legendFormat": "{{provider}}"
+        }
+      ]
+    },
+    {
+      "title": "Rate-limit queue overload (429s)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "expr": "sum(rate(queue_overload_total[1m]))",
+          "legendFormat": "overload/s"
+        }
+      ]
+    },
+    {
+      "title": "Safe-mode denials",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 24 },
+      "targets": [
+        {
+          "expr": "sum(rate(safe_mode_denial_route_total[1m])) by (route)",
+          "legendFormat": "{{route}}"
+        }
+      ]
+    },
+    {
+      "title": "Dual-approval transitions",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 24 },
+      "targets": [
+        {
+          "expr": "sum(rate(dual_approval_transition_state_total[5m])) by (action, to_state)",
+          "legendFormat": "{{action}} \u2192 {{to_state}}"
+        }
+      ]
+    },
+    {
+      "title": "Chain blocks (gauge)",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 30 },
+      "targets": [{ "expr": "chain_blocks_total" }]
+    },
+    {
+      "title": "Chain size bytes (gauge)",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 30 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [{ "expr": "chain_size_bytes" }]
+    },
+    {
+      "title": "Embedding cache hit ratio",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 30 },
+      "targets": [
+        {
+          "expr": "sum(rate(embed_cache_hits_total[5m])) / (sum(rate(embed_cache_hits_total[5m])) + sum(rate(embed_cache_misses_total[5m])))",
+          "legendFormat": "hit ratio"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "min": 0 } }
+    },
+    {
+      "title": "Model D proposals",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 36 },
+      "targets": [
+        {
+          "expr": "sum(rate(model_d_proposals_by_vote_total[5m])) by (vote)",
+          "legendFormat": "{{vote}}"
+        }
+      ]
+    },
+    {
+      "title": "Scheduled jobs (created vs completed)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 36 },
+      "targets": [
+        { "expr": "sum(rate(schedule_jobs_created_total[1m]))", "legendFormat": "created" },
+        { "expr": "sum(rate(schedule_jobs_completed_total[1m]))", "legendFormat": "completed" }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["memphis", "ops"],
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Memphis runtime — operator overview",
+  "uid": "memphis-runtime",
+  "version": 1
+}

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -64,6 +64,10 @@ import {
 } from '../config/request-schemas.js';
 import type { AppConfig } from '../config/schema.js';
 import { envSchema } from '../config/schema.js';
+import {
+  createContextualLogger,
+  type ContextLogger,
+} from '../logging/contextual.js';
 import { createLogger } from '../logging/logger.js';
 import { metrics } from '../logging/metrics.js';
 import { writeSecurityAudit } from '../logging/security-audit.js';
@@ -173,6 +177,13 @@ export function createHttpServer(
   const apiToken = process.env.MEMPHIS_API_TOKEN;
 
   app.addHook('onRequest', async (request, reply) => {
+    const contextLogger = createContextualLogger({
+      requestId: request.id,
+      route: normalizeRoutePath(request.url),
+      method: request.method,
+      surface: 'http',
+    });
+    (request as typeof request & { log?: ContextLogger }).log = contextLogger;
     reply.header('x-request-id', request.id);
     reply.header(
       'Access-Control-Allow-Origin',

--- a/src/infra/logging/alert-transport.ts
+++ b/src/infra/logging/alert-transport.ts
@@ -102,6 +102,64 @@ function opsGenieSender(
   };
 }
 
+function slackSender(
+  webhookUrl: string,
+  rawEnv: NodeJS.ProcessEnv,
+  fetchFn: typeof fetch,
+): AlertSender {
+  return async (alert: AlertLike) => {
+    const severityEmoji = {
+      critical: ':rotating_light:',
+      high: ':warning:',
+      medium: ':bell:',
+      low: ':information_source:',
+    }[alert.severity];
+    const detailLines = alert.details
+      ? Object.entries(alert.details).map(([k, v]) => `• ${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
+      : [];
+    const text = [
+      `${severityEmoji} *${alert.severity.toUpperCase()}* [${source(rawEnv)}]`,
+      alert.message,
+      ...(detailLines.length > 0 ? ['', ...detailLines] : []),
+    ].join('\n');
+    const res = await fetchFn(webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text }),
+      signal: withTimeout(parseTimeoutMs(rawEnv)),
+    });
+    if (!res.ok) {
+      throw new Error(`slack transport failed status=${res.status}`);
+    }
+  };
+}
+
+function genericWebhookSender(
+  webhookUrl: string,
+  rawEnv: NodeJS.ProcessEnv,
+  fetchFn: typeof fetch,
+): AlertSender {
+  return async (alert: AlertLike) => {
+    const payload = {
+      id: alert.id ?? null,
+      severity: alert.severity,
+      message: alert.message,
+      source: source(rawEnv),
+      timestamp: new Date().toISOString(),
+      details: alert.details ?? {},
+    };
+    const res = await fetchFn(webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: withTimeout(parseTimeoutMs(rawEnv)),
+    });
+    if (!res.ok) {
+      throw new Error(`webhook transport failed status=${res.status}`);
+    }
+  };
+}
+
 export function createConfiguredAlertSender(
   rawEnv: NodeJS.ProcessEnv = process.env,
   options: AlertTransportOptions = {},
@@ -123,21 +181,37 @@ export function createConfiguredAlertSender(
     senders.push(opsGenieSender(opsGenieKey, endpoint, rawEnv, fetchFn));
   }
 
+  const slackWebhook = rawEnv.MEMPHIS_ALERT_SLACK_WEBHOOK?.trim();
+  if (slackWebhook) {
+    senders.push(slackSender(slackWebhook, rawEnv, fetchFn));
+  }
+
+  const genericWebhook = rawEnv.MEMPHIS_ALERT_WEBHOOK_URL?.trim();
+  if (genericWebhook) {
+    senders.push(genericWebhookSender(genericWebhook, rawEnv, fetchFn));
+  }
+
   if (senders.length === 0) {
     return async () => {};
   }
 
+  // Fan out to every configured transport in parallel. The alert succeeds as
+  // long as at least one transport delivers; we surface a comprehensive error
+  // only when *all* transports fail. This preserves existing pagerduty ↔
+  // opsgenie behavior (they're both paging channels) while letting slack +
+  // generic webhooks receive every alert in addition.
   return async (alert: AlertLike) => {
-    const errors: string[] = [];
-    for (const sender of senders) {
-      try {
-        await sender(alert);
-        return;
-      } catch (error) {
-        errors.push(error instanceof Error ? error.message : String(error));
-      }
+    const results = await Promise.allSettled(senders.map((sender) => sender(alert)));
+    const failures = results
+      .map((result, index) =>
+        result.status === 'rejected'
+          ? `transport[${index}]: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`
+          : null,
+      )
+      .filter((s): s is string => s !== null);
+    const successes = results.length - failures.length;
+    if (successes === 0) {
+      throw new Error(`all alert transports failed: ${failures.join('; ')}`);
     }
-
-    throw new Error(`all alert transports failed: ${errors.join('; ')}`);
   };
 }

--- a/src/infra/logging/contextual.ts
+++ b/src/infra/logging/contextual.ts
@@ -1,0 +1,74 @@
+/**
+ * Contextual logger helpers for Sprint 10 observability.
+ *
+ * A contextual logger is a Pino child logger that carries well-known fields —
+ * `requestId`, `surface`, `actorId`, `turnId` — so every log line produced
+ * during one request or turn can be correlated across layers.
+ *
+ * Usage at HTTP boundary:
+ *     const log = createContextualLogger({ requestId, route });
+ *     log.info({ event: 'turn.start' }, 'processing turn');
+ *
+ * Usage deep in the call tree (pass the logger rather than importing a new
+ * one; that way structured fields propagate):
+ *     function handleTool(log: ContextLogger) { log.info(...); }
+ */
+
+import type { Logger } from 'pino';
+
+import { createPinoLogger } from './pino.js';
+
+export interface LogContext {
+  requestId?: string;
+  surface?: string;
+  actorId?: string;
+  turnId?: string;
+  route?: string;
+  [extra: string]: unknown;
+}
+
+export type ContextLogger = Logger;
+
+let rootLogger: ContextLogger | null = null;
+
+function getRootLogger(): ContextLogger {
+  if (rootLogger) return rootLogger;
+  rootLogger = createPinoLogger({
+    level: process.env.LOG_LEVEL ?? 'info',
+    base: undefined,
+  });
+  return rootLogger;
+}
+
+/** Reset the cached root logger — for tests, not for production code. */
+export function resetRootLogger(): void {
+  rootLogger = null;
+}
+
+/**
+ * Create a child logger that carries the supplied context fields.
+ * Undefined fields are stripped so the log line stays compact.
+ */
+export function createContextualLogger(context: LogContext = {}): ContextLogger {
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (value !== undefined && value !== null && value !== '') {
+      cleaned[key] = value;
+    }
+  }
+  return getRootLogger().child(cleaned);
+}
+
+/** Extend an existing contextual logger with more fields without resetting. */
+export function withContext(
+  logger: ContextLogger,
+  context: LogContext,
+): ContextLogger {
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (value !== undefined && value !== null && value !== '') {
+      cleaned[key] = value;
+    }
+  }
+  return logger.child(cleaned);
+}

--- a/tests/unit/alert-transport-slack.test.ts
+++ b/tests/unit/alert-transport-slack.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createConfiguredAlertSender } from '../../src/infra/logging/alert-transport.js';
+
+function mockFetch(ok: boolean, status = 200): typeof fetch {
+  return vi.fn(async () =>
+    Promise.resolve({
+      ok,
+      status,
+    } as Response),
+  ) as unknown as typeof fetch;
+}
+
+describe('alert-transport — Slack webhook', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('posts to MEMPHIS_ALERT_SLACK_WEBHOOK with a structured text block', async () => {
+    const fetchFn = mockFetch(true);
+    const sender = createConfiguredAlertSender(
+      {
+        MEMPHIS_ALERT_SLACK_WEBHOOK: 'https://hooks.slack.example/services/abc',
+        MEMPHIS_ALERT_SOURCE: 'memphis-test',
+      } as NodeJS.ProcessEnv,
+      { fetchFn },
+    );
+    await sender({
+      severity: 'critical',
+      message: 'provider cascade degraded',
+      details: { provider: 'anthropic', reason: 'rate-limit' },
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const call = (fetchFn as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]!;
+    const url = call[0] as string;
+    const init = call[1] as { body: string };
+    expect(url).toBe('https://hooks.slack.example/services/abc');
+    const body = JSON.parse(init.body) as { text: string };
+    expect(body.text).toMatch(/CRITICAL/);
+    expect(body.text).toMatch(/memphis-test/);
+    expect(body.text).toContain('provider cascade degraded');
+    expect(body.text).toContain('provider: anthropic');
+  });
+
+  it('throws when the slack webhook returns non-ok', async () => {
+    const fetchFn = mockFetch(false, 500);
+    const sender = createConfiguredAlertSender(
+      {
+        MEMPHIS_ALERT_SLACK_WEBHOOK: 'https://hooks.slack.example/x',
+      } as NodeJS.ProcessEnv,
+      { fetchFn },
+    );
+    await expect(
+      sender({ severity: 'high', message: 'x' }),
+    ).rejects.toThrow(/all alert transports failed/);
+  });
+});
+
+describe('alert-transport — generic webhook', () => {
+  it('posts a normalized JSON payload to MEMPHIS_ALERT_WEBHOOK_URL', async () => {
+    const fetchFn = mockFetch(true);
+    const sender = createConfiguredAlertSender(
+      {
+        MEMPHIS_ALERT_WEBHOOK_URL: 'https://alerts.internal.example/hook',
+      } as NodeJS.ProcessEnv,
+      { fetchFn },
+    );
+    await sender({
+      id: 'alert-7',
+      severity: 'medium',
+      message: 'chain rotation lagging',
+      details: { chain: 'journal' },
+    });
+    const call = (fetchFn as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]!;
+    const init = call[1] as { body: string };
+    const body = JSON.parse(init.body) as {
+      id: string;
+      severity: string;
+      message: string;
+      details: Record<string, unknown>;
+    };
+    expect(body.id).toBe('alert-7');
+    expect(body.severity).toBe('medium');
+    expect(body.message).toBe('chain rotation lagging');
+    expect(body.details.chain).toBe('journal');
+  });
+});
+
+describe('alert-transport — fan-out semantics', () => {
+  it('succeeds when one transport works and another fails', async () => {
+    const calls: string[] = [];
+    const fetchFn = vi.fn(async (url: string) => {
+      calls.push(url);
+      if (url.includes('slack')) {
+        return { ok: false, status: 500 } as Response;
+      }
+      return { ok: true, status: 200 } as Response;
+    }) as unknown as typeof fetch;
+
+    const sender = createConfiguredAlertSender(
+      {
+        MEMPHIS_ALERT_SLACK_WEBHOOK: 'https://slack.example/x',
+        MEMPHIS_ALERT_WEBHOOK_URL: 'https://webhook.example/x',
+      } as NodeJS.ProcessEnv,
+      { fetchFn },
+    );
+    await expect(sender({ severity: 'high', message: 'x' })).resolves.toBeUndefined();
+    expect(calls.length).toBe(2);
+  });
+
+  it('throws only when every configured transport fails', async () => {
+    const fetchFn = vi.fn(async () => ({ ok: false, status: 500 } as Response)) as unknown as typeof fetch;
+    const sender = createConfiguredAlertSender(
+      {
+        MEMPHIS_ALERT_SLACK_WEBHOOK: 'https://slack.example/x',
+        MEMPHIS_ALERT_WEBHOOK_URL: 'https://webhook.example/x',
+      } as NodeJS.ProcessEnv,
+      { fetchFn },
+    );
+    await expect(sender({ severity: 'high', message: 'x' })).rejects.toThrow(
+      /all alert transports failed/,
+    );
+  });
+});

--- a/tests/unit/contextual-logger.test.ts
+++ b/tests/unit/contextual-logger.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createContextualLogger,
+  resetRootLogger,
+  withContext,
+} from '../../src/infra/logging/contextual.js';
+
+beforeEach(() => {
+  resetRootLogger();
+});
+
+describe('createContextualLogger', () => {
+  it('returns a logger that carries the supplied context fields', () => {
+    const logger = createContextualLogger({
+      requestId: 'req-1',
+      surface: 'http',
+      actorId: 'operator',
+    });
+    // Pino bindings surface the fields attached via child(..).
+    const bindings = (logger as unknown as { bindings(): Record<string, unknown> }).bindings();
+    expect(bindings.requestId).toBe('req-1');
+    expect(bindings.surface).toBe('http');
+    expect(bindings.actorId).toBe('operator');
+  });
+
+  it('strips undefined, null, and empty-string fields', () => {
+    const logger = createContextualLogger({
+      requestId: 'req-2',
+      actorId: undefined,
+      turnId: '',
+    });
+    const bindings = (logger as unknown as { bindings(): Record<string, unknown> }).bindings();
+    expect(bindings.requestId).toBe('req-2');
+    expect('actorId' in bindings).toBe(false);
+    expect('turnId' in bindings).toBe(false);
+  });
+
+  it('withContext extends an existing logger without overwriting prior fields', () => {
+    const parent = createContextualLogger({ requestId: 'req-3', surface: 'http' });
+    const extended = withContext(parent, { turnId: 'turn-a' });
+    const bindings = (extended as unknown as { bindings(): Record<string, unknown> }).bindings();
+    expect(bindings.requestId).toBe('req-3');
+    expect(bindings.surface).toBe('http');
+    expect(bindings.turnId).toBe('turn-a');
+  });
+
+  it('accepts arbitrary extra fields via the index signature', () => {
+    const logger = createContextualLogger({
+      requestId: 'req-4',
+      customLabel: 'value',
+    });
+    const bindings = (logger as unknown as { bindings(): Record<string, unknown> }).bindings();
+    expect(bindings.customLabel).toBe('value');
+  });
+});


### PR DESCRIPTION
## Summary

Three durable observability improvements, none requiring a new runtime dependency.

- **Contextual logger** (`src/infra/logging/contextual.ts`) — `createContextualLogger` + `withContext` wrap Pino `child()` with the observability fields operators actually correlate on: `requestId`, `surface`, `actorId`, `turnId`, `route`. Undefined/null/empty values are stripped.
- **HTTP request-id propagation** (`src/infra/http/server.ts`) — the `onRequest` hook now attaches a child logger onto `request.log` in addition to the existing `x-request-id` response header. Sets up the substrate for OTel tracing later without touching callers.
- **Alert fan-out** (`src/infra/logging/alert-transport.ts`) — new Slack and generic-webhook transports alongside the existing PagerDuty + OpsGenie senders. All configured transports now run in parallel via `Promise.allSettled`; the alert succeeds if *one* transport delivers. `MEMPHIS_ALERT_SLACK_WEBHOOK` posts a formatted `{text}` with severity emoji + detail bullets; `MEMPHIS_ALERT_WEBHOOK_URL` posts normalized JSON `{id, severity, message, source, timestamp, details}`.
- **Grafana dashboard** (`docs/observability/grafana-memphis.json`) — importable; drives off the existing Prometheus `/metrics` endpoint: request rate, error rate, p50/p95/p99 latency, provider latency/volume, rate-limit overload, safe-mode denials, dual-approval transitions, chain growth, embedding hit ratio, model-D votes, scheduler throughput.
- **Docs** (`docs/observability.md`).

## Verification

- `npm run typecheck && npm run lint` — green
- `npm test` — 1663 tests passing (+9 Sprint 10), 355 files
- `cargo test --all-features` — green (no Rust changes)

## Test plan

- [x] Unit: contextual logger bindings / strip / withContext extension
- [x] Unit: Slack webhook payload (severity emoji + detail bullets + source)
- [x] Unit: generic webhook payload shape (id, severity, source, timestamp, details)
- [x] Unit: fan-out semantics — one transport fail + one succeed ⇒ ok
- [x] Unit: all transports fail ⇒ throw
- [ ] Manual: import `docs/observability/grafana-memphis.json` against a scraped Memphis instance; confirm panels render

## Deliberate deferrals (documented in `docs/observability.md`)

- **OpenTelemetry SDK** — substantial runtime change; its own sprint. Sprint 10 sets up structured fields so OTel can overlay later.
- **Log aggregation shipper** — operators wire their own pipe against the local Pino JSON stream.
- **Escalation** — the transports fire; escalation (unacknowledged → page) belongs in PagerDuty escalation policies, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)