### PR TITLE
Sprint 7: MCP surface parity with TUI host (presence + config)

### DIFF
--- a/docs/surface-parity.md
+++ b/docs/surface-parity.md
@@ -1,0 +1,85 @@
+# Surface parity
+
+Memphis exposes several operator-facing surfaces that historically each
+grew their own capability list. Sprint 7 closes the gap so capabilities
+that one surface offers are available on every surface that should
+logically carry them — and makes that expectation testable.
+
+## Surface layers
+
+| Surface | Transport | Primary user |
+|---|---|---|
+| **Telegram** | grammY bot on Telegram Bot API | remote operator on phone |
+| **TUI host** | JSON-RPC over stdio to the Rust TUI client | local operator in the terminal |
+| **MCP stdio** | Model Context Protocol stdio server | external MCP-speaking clients (Claude Code, etc.) |
+| **HTTP** | Fastify REST at `/v1/*` and `/api/*` | programmatic callers, dashboards, workers |
+| **Rust / NAPI** | `crates/memphis-napi` native bindings | internal bridge for TypeScript → Rust primitives |
+
+Rust/NAPI is an **internal bridge**, not an operator surface. It
+intentionally exposes low-level primitives (chain, vault, embed, soul)
+rather than operator commands. The four operator surfaces that should
+carry parity are Telegram, TUI, MCP stdio, and HTTP.
+
+## Capability matrix
+
+Legend:  ✓ present · — intentionally absent · (see) follow-up sprint
+
+| Capability | Telegram | TUI host | MCP stdio | HTTP | Notes |
+|---|---|---|---|---|---|
+| `/status` | ✓ `/status` | ✓ `health.status` | ✓ `memphis_health` | ✓ `/v1/ops/status` | Sprint 5 |
+| cross-surface presence | ✓ in `/status` | ✓ `presence.snapshot` | ✓ `memphis_presence` | ✓ `/v1/ops/status.activeSurfaces` | Sprint 5 + Sprint 7 (MCP) |
+| cognitive mode get / set | ✓ `/mode` | ✓ `cognitive.mode` | — (not yet wired) | — | Sprint 4; MCP wiring is a follow-up |
+| tier elevation (1/2) | ✓ `/tier 2` | ✓ `security.tier.elevate` | — | — | Telegram-native flow |
+| tier-3 elevation | ✓ `/tier 3 <pass>` | ✓ `security.tier.elevate --tier 3` | — | — | intentionally operator-only |
+| config show | ✓ `/config show` | ✓ `config.show` | ✓ `memphis_config_show` | ✓ `/v1/ops/config/show` | Sprint 6 + Sprint 7 (MCP) |
+| config set | ✓ `/config set KEY=V` | ✓ `config.set` | — (read-only) | ✓ `/v1/ops/config/set` | MCP intentionally read-only (no tier-3 prompt) |
+| config reload | ✓ `/config reload` | ✓ `config.reload` | ✓ `memphis_config_reload` | ✓ `/v1/ops/config/reload` | Sprint 6 + Sprint 7 (MCP) |
+| surface policy set | — | ✓ `config.surfaces.set` | — | — | operator-local policy editing |
+| chain verify | — | ✓ via CLI | — | — | Sprint 12 CLI |
+| pulse / heartbeat status | — | ✓ `pulse.status` | — | — | local runtime health |
+| fs read/write (code-read, fs-ops, fs-write) | ✓ (tier 2+) | ✓ (tier 2+) | ✓ | — | policy-gated via `assertFsPermission` |
+| exec (shell) | ✓ (tier 2+) | ✓ (tier 2+) | ✓ | — | policy-gated via `assertExecCommand` |
+| web_fetch / web_search | ✓ | ✓ | ✓ | — | network-gated |
+| vault (encrypt / decrypt / list) | — | — | ✓ | ✓ | operator-facing vault uses the CLI, not chat |
+
+## Enforcement parity
+
+Every surface that can execute a side-effect routes through the same
+enforcement points:
+
+- `resolveSurfacePolicy()` (`src/gateway/surface-policy.ts`) — per-surface
+  tier ceiling for tool dispatch.
+- `applyTier3EnvOverride()` (`src/gateway/turn-runtime.ts`, Sprint 2) —
+  overlays tier-3 environment variables when an active session exists.
+- `assertFsPermission()` (`src/mcp/tools/fs-permission.ts`) — tier-gated
+  filesystem sandbox for `memphis_fs_*` tools.
+- `assertExecCommand()` (`src/gateway/exec-policy.ts`) — tier-gated
+  command allowlist for `memphis_exec`.
+
+The MCP tool additions in Sprint 7 (`memphis_presence`,
+`memphis_config_show`, `memphis_config_reload`) do not bypass these
+checks because they don't touch the filesystem or exec paths —
+`config.*` only mutates `process.env` + `.env` via the vetted
+`setDotEnvValues()` helper, and `presence` is pure read.
+
+## Contract tests
+
+`tests/integration/surface-parity.test.ts` — for each Sprint-7 MCP tool,
+assert the shape and values returned by MCP match the corresponding
+TUI host capability when both read from the same in-process registry
+/ env state.
+
+The test is a lightweight surface contract: when a Sprint adds a new
+capability to one surface, adding it to the parity test here catches
+drift if a future sprint ships to only one surface.
+
+## What Sprint 7 is not
+
+- It is not a rewrite of the NAPI surface. NAPI is the internal TS⇄Rust
+  bridge; it stays a set of low-level primitives.
+- It is not a unified RPC. Each surface keeps its native protocol
+  (Telegram commands, TUI host JSON-RPC, MCP stdio, HTTP REST) — the
+  parity is at the *capability* level, not the wire format.
+- It does not add surface-level rate limits or quotas. Rate limits
+  remain where they already are (HTTP global + sensitive limiters
+  from Sprint 2's hardening, per-chat Telegram tier TTL).

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -209,6 +209,24 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
     description: 'Inspect host and Memphis runtime system details',
     featureFlag: 'experimental-tools',
   },
+  memphis_presence: {
+    name: 'memphis_presence',
+    tier: 0,
+    capabilities: ['read'],
+    description: 'Cross-surface presence snapshot (TUI / Telegram / HTTP)',
+  },
+  memphis_config_show: {
+    name: 'memphis_config_show',
+    tier: 0,
+    capabilities: ['read'],
+    description: 'Show current runtime config (redacted)',
+  },
+  memphis_config_reload: {
+    name: 'memphis_config_reload',
+    tier: 2,
+    capabilities: ['write'],
+    description: 'Re-read .env and hot-swap mutable fields',
+  },
 };
 
 export function getToolMeta(name: string): ToolMeta | undefined {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,6 +5,10 @@ import { runMemphisBuild } from './tools/build.js';
 import { runMemphisCaseAppend, runMemphisCaseQuery } from './tools/case-entry.js';
 import { runMemphisChainQuery } from './tools/chain-query.js';
 import { runMemphisCodeRead } from './tools/code-read.js';
+import {
+  runMemphisConfigReload,
+  runMemphisConfigShow,
+} from './tools/config.js';
 import { runMemphisDb } from './tools/db.js';
 import { runMemphisDecide } from './tools/decide.js';
 import { runMemphisDeploy } from './tools/deploy.js';
@@ -19,6 +23,7 @@ import { runMemphisHealth } from './tools/health.js';
 import { runMemphisJournal } from './tools/journal.js';
 import { runMemphisLoopStep } from './tools/loop-step.js';
 import { runMemphisPackage } from './tools/package.js';
+import { runMemphisPresence } from './tools/presence.js';
 import { runMemphisProviders } from './tools/providers.js';
 import { runMemphisRecall } from './tools/recall.js';
 import { runMemphisSearch } from './tools/search.js';
@@ -1067,6 +1072,80 @@ export function createMemphisMcpServer(
           };
         },
       ),
+    );
+  }
+
+  // ── Sprint 7: surface parity — expose TUI-host capabilities to MCP ────────
+  // These tools are the MCP mirror of TUI host capabilities `presence.snapshot`
+  // (Sprint 5), `config.show`, and `config.reload` (Sprint 6). Adding them
+  // here gives any MCP-speaking client the same capability ceiling as TUI.
+
+  const presencePolicy = getToolPolicy(permissions, 'memphis_presence', resolvedManifest);
+  if (shouldRegisterTool('memphis_presence', presencePolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_presence',
+      {
+        description:
+          'Cross-surface presence snapshot — which surfaces (TUI, Telegram, HTTP) are active and when they last acted.',
+        inputSchema: {
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate('memphis_presence', presencePolicy, approvals, async () => {
+        const result = runMemphisPresence();
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    );
+  }
+
+  const configShowPolicy = getToolPolicy(permissions, 'memphis_config_show', resolvedManifest);
+  if (shouldRegisterTool('memphis_config_show', configShowPolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_config_show',
+      {
+        description:
+          'Show current runtime config values (redacted). Pass `key` to narrow to one field; omit to list every known field.',
+        inputSchema: {
+          key: z.string().optional(),
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate(
+        'memphis_config_show',
+        configShowPolicy,
+        approvals,
+        async ({ key }) => {
+          const result = runMemphisConfigShow({ key });
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        },
+      ),
+    );
+  }
+
+  const configReloadPolicy = getToolPolicy(permissions, 'memphis_config_reload', resolvedManifest);
+  if (shouldRegisterTool('memphis_config_reload', configReloadPolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_config_reload',
+      {
+        description:
+          'Re-read .env, validate, swap hot/warm fields; refuse cold-field changes (restart required). Returns the redacted diff.',
+        inputSchema: {
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate('memphis_config_reload', configReloadPolicy, approvals, async () => {
+        const result = runMemphisConfigReload();
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
     );
   }
 

--- a/src/mcp/tools/config.ts
+++ b/src/mcp/tools/config.ts
@@ -1,0 +1,47 @@
+import {
+  performHotReload,
+  redactFieldValue,
+  type HotReloadResult,
+} from '../../infra/config/hot-reload.js';
+import {
+  classifyField,
+  listKnownFields,
+  type MutabilityTier,
+} from '../../infra/config/mutability.js';
+
+export interface MemphisConfigShowOutput {
+  fields: Array<{ key: string; tier: MutabilityTier }>;
+  values: Record<string, string>;
+  requestedKey: string | null;
+}
+
+/** Redacted view of the current hot-reloadable env surface. */
+export function runMemphisConfigShow(input: { key?: string } = {}): MemphisConfigShowOutput {
+  const fields = listKnownFields();
+  const targetKeys = input.key ? [input.key] : fields.map((f) => f.key);
+  const values: Record<string, string> = {};
+  for (const name of targetKeys) {
+    const raw = process.env[name];
+    if (raw === undefined) continue;
+    values[name] = redactFieldValue(name, raw);
+  }
+  return { fields, values, requestedKey: input.key ?? null };
+}
+
+export interface MemphisConfigReloadOutput extends HotReloadResult {
+  /** Surface-parity convenience: classification of every key in the diff. */
+  classification: Array<{ key: string; tier: MutabilityTier }>;
+}
+
+/**
+ * Re-read `.env`, validate, swap hot/warm fields; refuse cold fields.
+ * Returns the redacted result.
+ */
+export function runMemphisConfigReload(): MemphisConfigReloadOutput {
+  const result = performHotReload();
+  const classification = result.changes.map((c) => ({
+    key: c.key,
+    tier: classifyField(c.key),
+  }));
+  return { ...result, classification };
+}

--- a/src/mcp/tools/presence.ts
+++ b/src/mcp/tools/presence.ts
@@ -1,0 +1,28 @@
+import {
+  formatSurfaceStatusLines,
+  getActiveSurfacesSnapshot,
+  type SurfaceActivitySnapshot,
+} from '../../core/surface-presence.js';
+
+export interface MemphisPresenceOutput {
+  snapshots: SurfaceActivitySnapshot[];
+  active: number;
+  total: number;
+  surfaceStatus: string[];
+}
+
+/**
+ * Cross-surface presence snapshot. Matches the shape returned by the TUI
+ * host capability `presence.snapshot` and the `/v1/ops/status` payload so
+ * MCP-speaking clients see the same data as every other surface.
+ */
+export function runMemphisPresence(): MemphisPresenceOutput {
+  const snapshots = getActiveSurfacesSnapshot();
+  const active = snapshots.filter((s) => !s.stale).length;
+  return {
+    snapshots,
+    active,
+    total: snapshots.length,
+    surfaceStatus: formatSurfaceStatusLines(snapshots),
+  };
+}

--- a/tests/integration/surface-parity.test.ts
+++ b/tests/integration/surface-parity.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  recordSurfaceActivity,
+  resetSurfacePresence,
+} from '../../src/core/surface-presence.js';
+import { executeTuiHostCommand } from '../../src/infra/tui-host/commands.js';
+import {
+  runMemphisConfigReload,
+  runMemphisConfigShow,
+} from '../../src/mcp/tools/config.js';
+import { runMemphisPresence } from '../../src/mcp/tools/presence.js';
+
+function makeCtx() {
+  const lines: Array<{ level: string; text: string }> = [];
+  return {
+    lines,
+    ctx: {
+      emitLine: (level: 'info' | 'warning' | 'error', text: string) => {
+        lines.push({ level, text });
+      },
+      signal: new AbortController().signal,
+    },
+  };
+}
+
+describe('surface parity — MCP mirrors TUI host capabilities (Sprint 7)', () => {
+  beforeEach(() => {
+    resetSurfacePresence();
+  });
+
+  describe('presence.snapshot', () => {
+    it('MCP tool exposes the same snapshot shape as the TUI host capability', async () => {
+      recordSurfaceActivity({
+        surface: 'telegram',
+        actorId: 'telegram:42',
+        tier: 2,
+        telegramChatId: 999,
+      });
+
+      // Read MCP before TUI so we compare on equivalent state. TUI's own
+      // call records a 'tui' surface activity as a side-effect.
+      const mcpBefore = runMemphisPresence();
+      const { ctx } = makeCtx();
+      const tuiResult = (await executeTuiHostCommand(
+        'presence.snapshot',
+        undefined,
+        ctx,
+      )) as { snapshots: unknown[]; active: number; total: number };
+      const mcpAfter = runMemphisPresence();
+
+      // Shape parity — both expose the same top-level keys.
+      expect(Object.keys(mcpBefore).sort()).toEqual(
+        ['active', 'snapshots', 'surfaceStatus', 'total'].sort(),
+      );
+      // Before TUI ran, MCP saw only the telegram activity.
+      expect(mcpBefore.snapshots.map((s) => s.surface)).toEqual(['telegram']);
+      // After TUI ran, both agree on the full roster.
+      expect(mcpAfter.total).toBe(tuiResult.total);
+      const mcpSurfaces = mcpAfter.snapshots.map((s) => s.surface).sort();
+      const tuiSurfaces = tuiResult.snapshots
+        .map((s) => (s as { surface: string }).surface)
+        .sort();
+      expect(mcpSurfaces).toEqual(tuiSurfaces);
+    });
+
+    it('presence.snapshot is reachable via both TUI and MCP from the same in-process registry', async () => {
+      recordSurfaceActivity({
+        surface: 'http',
+        actorId: '10.0.0.1',
+        tier: 2,
+      });
+
+      const { ctx } = makeCtx();
+      const tuiResult = (await executeTuiHostCommand('presence.snapshot', undefined, ctx)) as {
+        snapshots: Array<{ surface: string; tier: number }>;
+      };
+      const mcpResult = runMemphisPresence();
+
+      const mcpHttp = mcpResult.snapshots.find((s) => s.surface === 'http');
+      const tuiHttp = tuiResult.snapshots.find((s) => s.surface === 'http');
+      expect(mcpHttp?.tier).toBe(tuiHttp?.tier);
+      expect(mcpHttp?.tier).toBe(2);
+    });
+  });
+
+  describe('config.show', () => {
+    it('MCP and TUI both return the same redacted values for known keys', async () => {
+      process.env.GEN_MAX_TOKENS = '4096';
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-test-secret';
+      try {
+        const { ctx } = makeCtx();
+        const tuiResult = (await executeTuiHostCommand('config.show', undefined, ctx)) as {
+          values: Record<string, string>;
+        };
+        const mcpResult = runMemphisConfigShow();
+        expect(mcpResult.values.GEN_MAX_TOKENS).toBe('4096');
+        expect(mcpResult.values.GEN_MAX_TOKENS).toBe(tuiResult.values.GEN_MAX_TOKENS);
+        expect(mcpResult.values.ANTHROPIC_API_KEY).toBe('***redacted***');
+        expect(mcpResult.values.ANTHROPIC_API_KEY).toBe(tuiResult.values.ANTHROPIC_API_KEY);
+      } finally {
+        delete process.env.GEN_MAX_TOKENS;
+        delete process.env.ANTHROPIC_API_KEY;
+      }
+    });
+
+    it('config.show with `key` returns just that field', () => {
+      process.env.GEN_MAX_TOKENS = '2048';
+      try {
+        const result = runMemphisConfigShow({ key: 'GEN_MAX_TOKENS' });
+        expect(result.requestedKey).toBe('GEN_MAX_TOKENS');
+        expect(result.values.GEN_MAX_TOKENS).toBe('2048');
+      } finally {
+        delete process.env.GEN_MAX_TOKENS;
+      }
+    });
+  });
+
+  describe('config.reload', () => {
+    it('returns a structured diff and a classification table', () => {
+      const result = runMemphisConfigReload();
+      expect(typeof result.ok).toBe('boolean');
+      expect(Array.isArray(result.changes)).toBe(true);
+      expect(Array.isArray(result.classification)).toBe(true);
+      // classification mirrors the changes array 1:1
+      expect(result.classification.length).toBe(result.changes.length);
+    });
+  });
+});

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -12,7 +12,7 @@ import {
 
 describe('tool registry', () => {
   it('exports all registered tools', () => {
-    expect(getToolNames()).toHaveLength(28);
+    expect(getToolNames()).toHaveLength(31);
   });
 
   it('hides experimental preview tools by default', () => {
@@ -69,7 +69,7 @@ describe('tool registry', () => {
 
   it('getToolsByTier returns correct tools', () => {
     const tier0 = getToolsByTier(0);
-    expect(tier0.length).toBe(11);
+    expect(tier0.length).toBe(13);
     expect(tier0.every((t) => t.tier === 0)).toBe(true);
 
     const tier1 = getToolsByTier(1);
@@ -77,8 +77,28 @@ describe('tool registry', () => {
     expect(tier1.map((t) => t.name).sort()).toEqual(['memphis_health_check'].sort());
 
     const tier2 = getToolsByTier(2);
-    expect(tier2.length).toBe(16);
-    expect(tier2.map((t) => t.name).sort()).toEqual(['memphis_build', 'memphis_code_read', 'memphis_cron', 'memphis_db', 'memphis_deploy', 'memphis_exec', 'memphis_fs_ops', 'memphis_fs_write', 'memphis_git', 'memphis_glob', 'memphis_grep', 'memphis_package', 'memphis_self_modify', 'memphis_test', 'memphis_web_fetch', 'memphis_web_search'].sort());
+    expect(tier2.length).toBe(17);
+    expect(tier2.map((t) => t.name).sort()).toEqual(
+      [
+        'memphis_build',
+        'memphis_code_read',
+        'memphis_config_reload',
+        'memphis_cron',
+        'memphis_db',
+        'memphis_deploy',
+        'memphis_exec',
+        'memphis_fs_ops',
+        'memphis_fs_write',
+        'memphis_git',
+        'memphis_glob',
+        'memphis_grep',
+        'memphis_package',
+        'memphis_self_modify',
+        'memphis_test',
+        'memphis_web_fetch',
+        'memphis_web_search',
+      ].sort(),
+    );
   });
 
   it('getToolsByTier includes preview tier-0 tools when the feature flag is enabled', () => {


### PR DESCRIPTION
## Summary

Closes the gap the operator named directly: the TS MCP layer should be on the same capability footing as the TUI and Telegram surfaces. After Sprints 5 (cross-surface presence) and 6 (on-the-fly config), the TUI host had three operator-facing capabilities that MCP-speaking clients couldn't reach. Sprint 7 ships those and pins the parity expectation in a contract test.

- **New MCP tools** (`src/mcp/server.ts`, `src/mcp/tools/presence.ts`, `src/mcp/tools/config.ts`):
  - `memphis_presence` — cross-surface snapshot matching TUI host `presence.snapshot`. Tier 0.
  - `memphis_config_show` — redacted view of hot-reloadable env. Tier 0.
  - `memphis_config_reload` — re-read `.env`, validate, swap hot/warm fields, refuse cold. Tier 2.
- **Tool registry** (`src/gateway/tool-registry.ts`) — three new entries with tier + capability metadata.
- **Contract test** (`tests/integration/surface-parity.test.ts`) — asserts MCP and TUI read the same in-process state and return the same shape; catches future drift.
- **Capability matrix** (`docs/surface-parity.md`) — every capability on every surface (Telegram, TUI, MCP stdio, HTTP, Rust NAPI).

## Verification

- `npm run typecheck && npm run lint` — green
- `npm test` — expected +5 Sprint 7 tests + 2 updated registry counts → target ≥1668 passing
- `cargo test --all-features` — green (no Rust changes)

## Test plan

- [x] Unit: `tool-registry` counts updated for three new tools (tier-0 11→13, tier-2 16→17, total 28→31)
- [x] Integration: MCP `memphis_presence` returns same shape + values as TUI `presence.snapshot`
- [x] Integration: MCP `memphis_config_show` returns same redacted values as TUI `config.show` (hot fields visible, secrets redacted)
- [x] Integration: MCP `memphis_config_reload` returns structured diff with classification table
- [ ] Manual: invoke all three via Claude Code's MCP client against a live Memphis instance

## Deliberate deferrals (in `docs/surface-parity.md`)

- **MCP `config.set`** — secret writes need a tier-3 passphrase prompt that doesn't fit MCP's stateless call model. Operators still use Telegram `/config set` or TUI `config.set` for mutations.
- **NAPI surface** — stays a low-level TS⇄Rust bridge, not an operator surface.
- **Cognitive mode get/set on MCP** — follow-up; not Sprint 7 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)