### PR TITLE
Sprint 9: voice policy — /voice on|off|status + per-chat daily TTS quota

### DIFF
--- a/docs/voice.md
+++ b/docs/voice.md
@@ -1,0 +1,95 @@
+# Voice (STT/TTS) — Telegram
+
+Sprint 9 closes out the voice path that was scaffolded earlier. STT
+and TTS in `src/gateway/voice/voice-service.ts` were already wired
+into `bot.on('message:voice', ...)` — Sprint 9 adds the missing
+operator controls: a per-chat enable/disable toggle and a daily TTS
+quota so a chatty chat can't run up the bill.
+
+## What works end-to-end
+
+1. **Inbound voice** — Telegram OGG/OPUS message arrives →
+   `bot.on('message:voice')` downloads via `getFile` →
+   `speechToText()` calls HuggingFace Whisper (default
+   `openai/whisper-large-v3`) → transcript prefixed with
+   `[Transkrypcja]` is echoed to the chat → the same text feeds the
+   normal turn pipeline as if the operator had typed it.
+2. **Outbound TTS** — when the inbound message was voice, the next
+   `send()` from the agent automatically synthesizes the reply via
+   `textToSpeech()` (HuggingFace `facebook/mms-tts-pol` by default,
+   or Google Cloud TTS when `MEMPHIS_TTS_PROVIDER=google`) and ships
+   it as a Telegram voice message **in addition** to the text reply.
+   Text always goes first; TTS is best-effort.
+
+## Sprint 9 additions
+
+### `/voice on|off|status`
+
+```
+/voice              # show current preference + today's TTS usage
+/voice status       # alias of /voice
+/voice on           # enable TTS replies (default)
+/voice off          # text only — voice → text input still works
+```
+
+State is per-chat and in-process; restart resets to `on`. Operators
+who want a durable default should set their own `.env` defaults; the
+toggle is for short-term overrides.
+
+### Daily TTS quota
+
+Every TTS call increments a per-chat day counter. `MEMPHIS_TTS_DAILY_CHAT_LIMIT`
+caps utterances/chat/day (default 100; `0` disables TTS entirely as a
+kill switch).
+
+When a chat hits its limit Memphis sends a single text notice:
+
+```
+(voice reply skipped — daily TTS limit 100/100 reached; resets at UTC midnight)
+```
+
+This is intentional — silently dropping voice replies is the wrong
+default; the operator deserves to know why.
+
+When the chat preference is `off` or the env kill switch is `0`, the
+voice reply is silently skipped (no notice). The operator opted in to
+no-voice and shouldn't get a notification on every turn.
+
+Counters reset at UTC midnight. The day key is computed inside
+`voice-policy.ts` via the same `now` clock that the policy reads, so
+tests can fast-forward without mocking globals.
+
+## Configuration
+
+| Env | Default | Meaning |
+|---|---|---|
+| `HUGGINGFACE_API_TOKEN` | (required) | HF Inference token; without it, voice is disabled entirely |
+| `MEMPHIS_STT_MODEL` | `openai/whisper-large-v3` | STT model on HF Inference |
+| `MEMPHIS_TTS_PROVIDER` | `huggingface` | `huggingface` or `google` |
+| `MEMPHIS_TTS_MODEL` | `facebook/mms-tts-pol` (HF) or `pl-PL-Standard-B` (Google) | TTS model/voice |
+| `GOOGLE_TTS_API_KEY` | — | required when `MEMPHIS_TTS_PROVIDER=google` |
+| `MEMPHIS_TTS_DAILY_CHAT_LIMIT` | `100` | per-chat per-day TTS quota; `0` disables TTS |
+
+`MEMPHIS_TTS_DAILY_CHAT_LIMIT` is **hot** — change it and call
+`/config reload` from any surface; the next TTS call sees the new
+ceiling.
+
+## Failure modes
+
+| Symptom | Cause | What happens |
+|---|---|---|
+| STT returns empty text | HF rate limit, slow audio | Operator gets `STT error: ...` reply; turn is **not** dispatched |
+| TTS returns 503 | HF model warming | Text reply still ships; voice reply silently skipped (best-effort) |
+| Daily limit reached | Quota | One-line text notice; subsequent voice messages still get text replies |
+| `/voice off` set | Operator preference | Voice → text input keeps working; replies are text only |
+| `MEMPHIS_TTS_DAILY_CHAT_LIMIT=0` | Kill switch | No TTS attempts; no notice; voice → text input still works |
+
+## Tests
+
+`tests/unit/voice-policy.test.ts` — preference default + isolation,
+quota allow/block paths, env kill switch, invalid env fallback,
+midnight rollover behavior, preference persistence across rollover.
+
+The voice-service network paths (HF / Google fetch) stay deferred to
+the existing service-level tests — Sprint 9 focuses on the policy
+layer, which is what the operator actually controls.

--- a/src/gateway/channels/telegram.ts
+++ b/src/gateway/channels/telegram.ts
@@ -27,6 +27,12 @@ import {
 import { getCognitiveMode, setCognitiveMode } from '../../soul/manifest.js';
 import type { ChannelAdapter, MessageHandler } from '../chat-types.js';
 import {
+  checkTtsQuota,
+  consumeTtsQuota,
+  getVoicePreference,
+  setVoicePreference,
+} from '../voice/voice-policy.js';
+import {
   resolveVoiceConfig,
   speechToText,
   textToSpeech,
@@ -554,6 +560,35 @@ export function createTelegramAdapter(
         }
       });
 
+      bot.command('voice', async (ctx) => {
+        const msg = ctx.message;
+        if (!msg) return;
+        const chatId = String(msg.chat.id);
+        const arg = (msg.text ?? '').replace(/^\/voice\s*/, '').trim().toLowerCase();
+        if (!arg || arg === 'status') {
+          const pref = getVoicePreference(chatId);
+          const quota = checkTtsQuota(chatId);
+          await ctx.reply(
+            [
+              `Voice replies: ${pref}`,
+              `TTS today: ${quota.used}/${quota.limit} (${quota.remaining} remaining)`,
+              `Toggle with: /voice on  |  /voice off`,
+            ].join('\n'),
+          );
+          return;
+        }
+        if (arg !== 'on' && arg !== 'off') {
+          await ctx.reply('Usage: /voice [on|off|status]');
+          return;
+        }
+        setVoicePreference(chatId, arg);
+        await ctx.reply(
+          arg === 'on'
+            ? 'Voice replies enabled. Send a voice message to try it.'
+            : 'Voice replies disabled. Voice → text input still works; replies will be text only.',
+        );
+      });
+
       // Voice messages — STT → agent → TTS response
       const voiceConfig = resolveVoiceConfig(process.env);
       if (voiceConfig) {
@@ -640,14 +675,30 @@ export function createTelegramAdapter(
       for (const chunk of chunks) {
         await bot.api.sendMessage(chatId, chunk);
       }
-      // If this was a voice message, also send TTS audio reply
+      // If this was a voice message, also send TTS audio reply (quota-gated)
       if (pendingVoiceReply.has(chatId) && voiceConf) {
+        const quota = checkTtsQuota(chatId);
+        if (!quota.allowed) {
+          if (quota.reason === 'daily_limit_reached') {
+            try {
+              await bot.api.sendMessage(
+                chatId,
+                `(voice reply skipped — daily TTS limit ${quota.used}/${quota.limit} reached; resets at UTC midnight)`,
+              );
+            } catch {
+              // best-effort notice
+            }
+          }
+          // preference_off / limit_disabled stay silent — operator opted in
+          return;
+        }
         try {
           // Truncate to ~500 chars for TTS (voice messages should be concise)
           const ttsText = trimmed.length > 500 ? trimmed.slice(0, 497) + '...' : trimmed;
           const ttsResult = await textToSpeech(ttsText, voiceConf);
           if (!ttsResult.error && ttsResult.audio.length > 0) {
             await bot.api.sendVoice(chatId, new InputFile(ttsResult.audio, 'reply.ogg'));
+            consumeTtsQuota(chatId);
           }
         } catch {
           // TTS is best-effort — text reply was already sent

--- a/src/gateway/voice/voice-policy.ts
+++ b/src/gateway/voice/voice-policy.ts
@@ -1,0 +1,140 @@
+/**
+ * Per-chat voice policy for Sprint 9.
+ *
+ * Two responsibilities:
+ * 1. Per-chat enable/disable toggle for outbound TTS replies. Operators
+ *    flip this with `/voice on|off` from Telegram.
+ * 2. Daily TTS quota per chat — `MEMPHIS_TTS_DAILY_CHAT_LIMIT`
+ *    utterances/chat/day. TTS calls are paid (HF Inference / Google
+ *    Cloud); the governor stops a chatty chat from running up the bill.
+ *
+ * State lives in-process — Telegram bot restart resets the toggles and
+ * the daily counters. Operators that want durable preferences should
+ * record them in `.env` defaults rather than `/voice`.
+ */
+
+export const DEFAULT_TTS_DAILY_CHAT_LIMIT = 100;
+
+export type VoicePreference = 'on' | 'off';
+
+interface ChatVoiceState {
+  preference: VoicePreference;
+  dayKey: string;
+  ttsCallsToday: number;
+}
+
+const chatStates = new Map<string, ChatVoiceState>();
+
+function todayKey(now: Date = new Date()): string {
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
+}
+
+function readDailyLimit(rawEnv: NodeJS.ProcessEnv): number {
+  const raw = rawEnv.MEMPHIS_TTS_DAILY_CHAT_LIMIT?.trim();
+  if (!raw) return DEFAULT_TTS_DAILY_CHAT_LIMIT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_TTS_DAILY_CHAT_LIMIT;
+  return parsed;
+}
+
+function ensureState(chatId: string, now: Date): ChatVoiceState {
+  const dayKey = todayKey(now);
+  const existing = chatStates.get(chatId);
+  if (!existing) {
+    const fresh: ChatVoiceState = { preference: 'on', dayKey, ttsCallsToday: 0 };
+    chatStates.set(chatId, fresh);
+    return fresh;
+  }
+  if (existing.dayKey !== dayKey) {
+    existing.dayKey = dayKey;
+    existing.ttsCallsToday = 0;
+  }
+  return existing;
+}
+
+export function getVoicePreference(chatId: string, now: Date = new Date()): VoicePreference {
+  return ensureState(chatId, now).preference;
+}
+
+export function setVoicePreference(
+  chatId: string,
+  preference: VoicePreference,
+  now: Date = new Date(),
+): VoicePreference {
+  const state = ensureState(chatId, now);
+  state.preference = preference;
+  return state.preference;
+}
+
+export interface QuotaCheck {
+  allowed: boolean;
+  used: number;
+  limit: number;
+  remaining: number;
+  reason?: 'preference_off' | 'daily_limit_reached' | 'limit_disabled';
+}
+
+/**
+ * Read-only quota check — does not consume. Use `consumeTtsQuota` to
+ * actually decrement after a successful TTS call.
+ */
+export function checkTtsQuota(
+  chatId: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): QuotaCheck {
+  const state = ensureState(chatId, now);
+  const limit = readDailyLimit(rawEnv);
+  if (state.preference === 'off') {
+    return {
+      allowed: false,
+      used: state.ttsCallsToday,
+      limit,
+      remaining: Math.max(0, limit - state.ttsCallsToday),
+      reason: 'preference_off',
+    };
+  }
+  if (limit === 0) {
+    return {
+      allowed: false,
+      used: state.ttsCallsToday,
+      limit,
+      remaining: 0,
+      reason: 'limit_disabled',
+    };
+  }
+  if (state.ttsCallsToday >= limit) {
+    return {
+      allowed: false,
+      used: state.ttsCallsToday,
+      limit,
+      remaining: 0,
+      reason: 'daily_limit_reached',
+    };
+  }
+  return {
+    allowed: true,
+    used: state.ttsCallsToday,
+    limit,
+    remaining: limit - state.ttsCallsToday,
+  };
+}
+
+/**
+ * Increment the counter — call after a TTS request returns. Returns the
+ * post-increment usage snapshot.
+ */
+export function consumeTtsQuota(
+  chatId: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): QuotaCheck {
+  const state = ensureState(chatId, now);
+  state.ttsCallsToday += 1;
+  return checkTtsQuota(chatId, rawEnv, now);
+}
+
+/** Test-only reset. */
+export function resetVoicePolicy(): void {
+  chatStates.clear();
+}

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -162,6 +162,9 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
   MEMPHIS_CHAIN_GC_KEEP_ARCHIVES: 'warm',
   MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION: 'warm',
   MEMPHIS_CHAIN_SNAPSHOT_TAIL_BLOCKS: 'warm',
+
+  // ── Voice (Sprint 9) ──
+  MEMPHIS_TTS_DAILY_CHAT_LIMIT: 'hot',
 };
 
 export const DEFAULT_TIER_FOR_UNKNOWN: MutabilityTier = 'warm';

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -183,6 +183,7 @@ export const envSchema = z.object({
   MEMPHIS_RATE_LIMIT_SENSITIVE_MAX: z.coerce.number().int().min(1).max(10000).default(60),
   MEMPHIS_TELEGRAM_TOKEN_OVERRIDE: z.string().optional(),
   MEMPHIS_TELEGRAM_ALLOWED_USER_IDS: z.string().optional(),
+  MEMPHIS_TTS_DAILY_CHAT_LIMIT: z.coerce.number().int().min(0).max(100000).optional(),
 
   COGNITIVE: cognitiveSchema.partial().optional(),
 });

--- a/tests/unit/voice-policy.test.ts
+++ b/tests/unit/voice-policy.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_TTS_DAILY_CHAT_LIMIT,
+  checkTtsQuota,
+  consumeTtsQuota,
+  getVoicePreference,
+  resetVoicePolicy,
+  setVoicePreference,
+} from '../../src/gateway/voice/voice-policy.js';
+
+const FIXED_DAY = new Date('2026-04-13T10:00:00Z');
+const FIXED_NEXT_DAY = new Date('2026-04-14T01:00:00Z');
+
+beforeEach(() => {
+  resetVoicePolicy();
+});
+
+afterEach(() => {
+  delete process.env.MEMPHIS_TTS_DAILY_CHAT_LIMIT;
+});
+
+describe('voice preference', () => {
+  it('defaults to "on" for any new chat', () => {
+    expect(getVoicePreference('chat-1', FIXED_DAY)).toBe('on');
+  });
+
+  it('honors a setVoicePreference("off")', () => {
+    setVoicePreference('chat-1', 'off', FIXED_DAY);
+    expect(getVoicePreference('chat-1', FIXED_DAY)).toBe('off');
+  });
+
+  it('keeps preferences isolated across chats', () => {
+    setVoicePreference('chat-1', 'off', FIXED_DAY);
+    expect(getVoicePreference('chat-2', FIXED_DAY)).toBe('on');
+  });
+});
+
+describe('TTS quota', () => {
+  it('is allowed on the first call with default limit', () => {
+    const quota = checkTtsQuota('chat-1', process.env, FIXED_DAY);
+    expect(quota.allowed).toBe(true);
+    expect(quota.limit).toBe(DEFAULT_TTS_DAILY_CHAT_LIMIT);
+    expect(quota.used).toBe(0);
+    expect(quota.remaining).toBe(DEFAULT_TTS_DAILY_CHAT_LIMIT);
+  });
+
+  it('decrements after consume', () => {
+    consumeTtsQuota('chat-1', process.env, FIXED_DAY);
+    consumeTtsQuota('chat-1', process.env, FIXED_DAY);
+    const quota = checkTtsQuota('chat-1', process.env, FIXED_DAY);
+    expect(quota.used).toBe(2);
+    expect(quota.remaining).toBe(DEFAULT_TTS_DAILY_CHAT_LIMIT - 2);
+  });
+
+  it('blocks once daily limit is reached', () => {
+    process.env.MEMPHIS_TTS_DAILY_CHAT_LIMIT = '3';
+    for (let i = 0; i < 3; i += 1) {
+      consumeTtsQuota('chat-1', process.env, FIXED_DAY);
+    }
+    const quota = checkTtsQuota('chat-1', process.env, FIXED_DAY);
+    expect(quota.allowed).toBe(false);
+    expect(quota.reason).toBe('daily_limit_reached');
+    expect(quota.used).toBe(3);
+    expect(quota.remaining).toBe(0);
+  });
+
+  it('blocks when the chat preference is "off"', () => {
+    setVoicePreference('chat-1', 'off', FIXED_DAY);
+    const quota = checkTtsQuota('chat-1', process.env, FIXED_DAY);
+    expect(quota.allowed).toBe(false);
+    expect(quota.reason).toBe('preference_off');
+  });
+
+  it('blocks when MEMPHIS_TTS_DAILY_CHAT_LIMIT=0 (kill switch)', () => {
+    process.env.MEMPHIS_TTS_DAILY_CHAT_LIMIT = '0';
+    const quota = checkTtsQuota('chat-1', process.env, FIXED_DAY);
+    expect(quota.allowed).toBe(false);
+    expect(quota.reason).toBe('limit_disabled');
+    expect(quota.limit).toBe(0);
+  });
+
+  it('falls back to default when env value is invalid', () => {
+    process.env.MEMPHIS_TTS_DAILY_CHAT_LIMIT = 'banana';
+    const quota = checkTtsQuota('chat-1', process.env, FIXED_DAY);
+    expect(quota.limit).toBe(DEFAULT_TTS_DAILY_CHAT_LIMIT);
+  });
+
+  it('isolates counters per chat', () => {
+    process.env.MEMPHIS_TTS_DAILY_CHAT_LIMIT = '5';
+    for (let i = 0; i < 5; i += 1) {
+      consumeTtsQuota('chat-1', process.env, FIXED_DAY);
+    }
+    expect(checkTtsQuota('chat-1', process.env, FIXED_DAY).allowed).toBe(false);
+    expect(checkTtsQuota('chat-2', process.env, FIXED_DAY).allowed).toBe(true);
+  });
+
+  it('resets the counter at UTC midnight', () => {
+    process.env.MEMPHIS_TTS_DAILY_CHAT_LIMIT = '3';
+    for (let i = 0; i < 3; i += 1) {
+      consumeTtsQuota('chat-1', process.env, FIXED_DAY);
+    }
+    expect(checkTtsQuota('chat-1', process.env, FIXED_DAY).allowed).toBe(false);
+
+    const nextDay = checkTtsQuota('chat-1', process.env, FIXED_NEXT_DAY);
+    expect(nextDay.allowed).toBe(true);
+    expect(nextDay.used).toBe(0);
+    expect(nextDay.remaining).toBe(3);
+  });
+
+  it('preference persists across day rollover', () => {
+    setVoicePreference('chat-1', 'off', FIXED_DAY);
+    const quota = checkTtsQuota('chat-1', process.env, FIXED_NEXT_DAY);
+    expect(quota.allowed).toBe(false);
+    expect(quota.reason).toBe('preference_off');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the voice path. STT and TTS in `voice-service.ts` were already wired into `bot.on('message:voice')` from earlier work; Sprint 9 adds the missing **operator controls** — per-chat enable/disable plus a daily TTS quota so a chatty chat can't quietly run up the HuggingFace / Google bill.

- **`src/gateway/voice/voice-policy.ts`** (new) — in-process per-chat state holding `preference: 'on' | 'off'` and a UTC-day-keyed counter. `checkTtsQuota()` is read-only; `consumeTtsQuota()` decrements after a successful TTS call. Day rollover detected from the supplied `now` clock so tests fast-forward without globals.
- **`/voice on|off|status`** — Telegram command:
  - `on` (default) — TTS replies enabled
  - `off` — text-only; voice → text input keeps working
  - `status` (or no arg) — shows preference + today's TTS usage
- **Quota gate inside `send()`** — wraps the existing TTS path. On `daily_limit_reached` we send a single text notice (operator deserves to know why); on `preference_off` / `limit_disabled` we silently skip (operator opted in to no-voice).
- **`MEMPHIS_TTS_DAILY_CHAT_LIMIT`** — new env (default 100; `0` is a kill switch). Hot-reloadable via Sprint 6 (`/config reload`). Added to `envSchema` + the mutability map.
- **Docs** (`docs/voice.md`) — inbound STT, outbound TTS, `/voice` command, quota notice, env config, failure-mode table.

## Verification

- `npm run typecheck && npm run lint` — green
- `npm test` — 1719 tests passing (+12 Sprint 9), 359 files
- `cargo test --all-features` — green (no Rust changes)

## Test plan

- [x] Unit: preference default `on`; setVoicePreference round-trip; per-chat isolation
- [x] Unit: quota allowed at default limit; consume → decrement; per-chat counter isolation
- [x] Unit: blocks at `daily_limit_reached` with reason
- [x] Unit: blocks when preference is `off` with reason
- [x] Unit: `MEMPHIS_TTS_DAILY_CHAT_LIMIT=0` kill switch returns `limit_disabled`
- [x] Unit: invalid env value falls back to default
- [x] Unit: counter resets at UTC midnight; preference persists across rollover
- [ ] Manual: send a voice message in Telegram, run `/voice off`, send another voice → text reply only

## Roadmap status

This was the last sprint of the post-PR-#77 roadmap. Operator's explicit asks are now all done:
- ABCDE cognitive modes operationalized (Sprint 4 + 11)
- Cross-surface presence (Sprint 5)
- `/status` boost (Sprint 5)
- On-the-fly config (Sprint 6)
- Rust NAPI / TS MCP parity with TUI + Telegram (Sprint 7)
- Provider cascade Anthropic → Minimax → Ollama tuned for slow-but-eventual offline (Sprint 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)