### PR TITLE
fix: register memphis self-update in the CLI dispatcher

### DIFF
--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -70,6 +70,7 @@ export const CLI_COMMAND_REGISTRY = [
       'configure',
       'deploy',
       'backup',
+      'self-update',
       'health',
       'workspace',
       'context',
@@ -253,6 +254,7 @@ export const CLI_COMPLETION_COMMANDS = [
   'guide',
   'completion',
   'help',
+  'self-update',
 ] as const;
 
 type CommandKey = string | undefined;


### PR DESCRIPTION
## Summary

Caught by the operator-validation pass after Sprint 14 landed.

`memphis self-update check` was throwing \`Unknown command: self-update\` because the dispatcher's command registry didn't route the command name to the system handler bundle (even though the handler itself was wired in `src/infra/cli/handlers/system.handler.ts`). One-line fix: add `'self-update'` to the system command list in `src/infra/cli/registry.ts` plus the completion command list so shell tab-completion offers it.

## Verification

```
$ npm run build && ./bin/memphis.js self-update check --json
{
  "ok": true,
  "currentVersion": "1.3.0",
  "latestVersion": "1.3.0",
  "updateAvailable": false,
  "release": { "tag": "v1.3.0", ... }
}
```

- `npm run typecheck && npm run lint` — green
- No new tests; this is a pure registry plumbing fix that the existing self-update tests (Sprint 14) didn't exercise because they don't go through the CLI dispatcher

## Test plan

- [x] Manual: `./bin/memphis.js self-update check` returns structured result
- [x] Manual: `./bin/memphis.js self-update check --json` returns valid JSON
- [ ] Tab completion offers `self-update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)