### PR TITLE
feat: provider hot-swap — DEFAULT_PROVIDER now hot, via post-apply hook registry

### DIFF
--- a/docs/config-on-the-fly.md
+++ b/docs/config-on-the-fly.md
@@ -88,11 +88,24 @@ A field marked `warm` indicates the value is owned by a module that may
 still hold a cached copy until its next re-init. The hot-reload engine
 makes the new value visible in `process.env` immediately; downstream
 consumers that need a kick (rate limiter singletons, structured loggers)
-remain follow-up work and are intentionally out of Sprint 6 scope.
+remain follow-up work.
 
-Provider hot-swap is deliberately deferred: `OrchestrationService` caches
-`defaultProvider` at construction and there is no runtime setter today.
-Setting `DEFAULT_PROVIDER` via `/config set` updates `.env` and
-`process.env`, but the running orchestration keeps its previous default
-until the next restart. The cascade order (`MEMPHIS_PROVIDER_CASCADE`)
-*is* re-read per request and switches immediately.
+## Post-apply hooks
+
+Subsystems that own cached env values can register a post-apply hook
+keyed by env name (`src/infra/config/post-apply-hooks.ts`). When a
+`/config reload` swaps that env, the hook fires with the old/new
+values and a `process.env` snapshot. Hook errors are caught and
+reported in the reload result; a failing hook never aborts the swap.
+
+Wired today:
+
+| Env key | Hook | What it does |
+|---|---|---|
+| `DEFAULT_PROVIDER` | `orchestration.setDefaultProvider` | Validates the new name against the registered provider list and updates the `OrchestrationService` cached default so the very next turn lands on the new provider. |
+
+`MEMPHIS_PROVIDER_CASCADE` doesn't need a hook — the cascade list is
+already re-read per request inside `OrchestrationService`.
+
+Rate-limit singletons and per-instance loggers are the next two
+candidates for hooks; they remain follow-up work.

--- a/src/app/container.ts
+++ b/src/app/container.ts
@@ -1,6 +1,7 @@
 import { dirname, join } from 'node:path';
 
 import { ConversationContextService } from '../gateway/conversation-context-service.js';
+import { registerPostApplyHook } from '../infra/config/post-apply-hooks.js';
 import type { AppConfig } from '../infra/config/schema.js';
 import { createSqliteClient, runMigrations } from '../infra/storage/sqlite/client.js';
 import { SqliteAgentPeerRepository } from '../infra/storage/sqlite/repositories/agent-peer-repository.js';
@@ -85,6 +86,16 @@ export function createAppContainer(
     providerCooldownMs: 15_000,
     providers,
     cascadeOrder: parseCascadeOrder(config.MEMPHIS_PROVIDER_CASCADE),
+  });
+
+  // Hot-swap: when the operator changes DEFAULT_PROVIDER via /config set,
+  // the post-apply hook (Sprint: provider hot-swap) updates the live cache
+  // so the very next turn lands on the new default. Without this hook the
+  // env value would update but OrchestrationService would keep its
+  // construction-time default until restart.
+  registerPostApplyHook('DEFAULT_PROVIDER', 'orchestration.setDefaultProvider', (ctx) => {
+    if (!ctx.nextValue) return;
+    orchestration.setDefaultProvider(ctx.nextValue);
   });
   const sessionTokenService = new SessionTokenService(
     process.env.MEMPHIS_SESSION_TOKEN_SECRET ??

--- a/src/gateway/channels/telegram.ts
+++ b/src/gateway/channels/telegram.ts
@@ -396,7 +396,7 @@ export function createTelegramAdapter(
           return;
         }
         if (verb === 'reload') {
-          const result = performHotReload();
+          const result = await performHotReload();
           if (!result.ok) {
             if (result.validationError) {
               await ctx.reply(`Reload blocked: ${result.validationError}`);

--- a/src/infra/config/hot-reload.ts
+++ b/src/infra/config/hot-reload.ts
@@ -19,6 +19,10 @@ import { existsSync, readFileSync } from 'node:fs';
 
 import { resolveDotEnvPath } from './dotenv-file.js';
 import { classifyField, type MutabilityTier } from './mutability.js';
+import {
+  runPostApplyHooks,
+  type PostApplyHookOutcome,
+} from './post-apply-hooks.js';
 import { envSchema } from './schema.js';
 
 export type FieldChangeStatus = 'applied' | 'rejected-cold' | 'unchanged' | 'invalid';
@@ -42,6 +46,12 @@ export interface HotReloadResult {
   invalidCount: number;
   rejectedCold: string[];
   validationError?: string;
+  /**
+   * Outcomes from any subsystem post-apply hooks fired after the env swap
+   * (Sprint: provider hot-swap). Empty when no hooks were registered for
+   * any of the changed keys.
+   */
+  hookOutcomes?: PostApplyHookOutcome[];
 }
 
 export interface HotReloadOptions {
@@ -244,10 +254,35 @@ export function redactReloadResult(result: HotReloadResult): HotReloadResult {
 }
 
 /**
- * Coordinated reload: read `.env` from disk, classify, validate, diff, apply.
- * Returns a redacted result ready to hand to HTTP/TUI/Telegram callers.
+ * Coordinated reload: read `.env` from disk, classify, validate, diff, apply,
+ * fire any registered subsystem hooks. Returns a redacted result ready to hand
+ * to HTTP/TUI/Telegram/MCP callers.
  */
-export function performHotReload(options: HotReloadOptions = {}): HotReloadResult {
+export async function performHotReload(
+  options: HotReloadOptions = {},
+): Promise<HotReloadResult> {
+  const plan = computeReloadPlan(options);
+  if (!plan.ok) return redactReloadResult(plan);
+  applyReloadPlan(plan, options);
+  const hookOutcomes = await runPostApplyHooks({
+    changes: plan.changes
+      .filter((c) => c.status === 'applied')
+      .map((c) => ({ key: c.key, oldValue: c.oldValue, newValue: c.newValue })),
+    rawEnv: options.baseEnv ?? process.env,
+  });
+  const enrichedPlan: HotReloadResult = {
+    ...plan,
+    hookOutcomes: hookOutcomes.length > 0 ? hookOutcomes : undefined,
+  };
+  return redactReloadResult(enrichedPlan);
+}
+
+/**
+ * Synchronous variant for callers that can't await (existing TUI host
+ * pattern, for instance). Skips post-apply hooks; the caller is on the
+ * hook for not having any cache-bound fields in the change set.
+ */
+export function performHotReloadSync(options: HotReloadOptions = {}): HotReloadResult {
   const plan = computeReloadPlan(options);
   if (!plan.ok) return redactReloadResult(plan);
   applyReloadPlan(plan, options);

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -50,8 +50,11 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
   MEMPHIS_REFLECTION_ENABLED: 'warm',
   MEMPHIS_REFLECTION_INTERVAL_MS: 'warm',
 
-  // ── Provider selection — warm (orchestration caches defaultProvider) ──
-  DEFAULT_PROVIDER: 'warm',
+  // ── Provider selection ──
+  // DEFAULT_PROVIDER: hot via the post-apply hook registered at bootstrap
+  // (see src/app/bootstrap.ts). MEMPHIS_PROVIDER_CASCADE has always been hot
+  // because the cascade list is re-read per request inside OrchestrationService.
+  DEFAULT_PROVIDER: 'hot',
   MEMPHIS_PROVIDER_CASCADE: 'hot',
 
   // ── Anthropic ──

--- a/src/infra/config/post-apply-hooks.ts
+++ b/src/infra/config/post-apply-hooks.ts
@@ -1,0 +1,116 @@
+/**
+ * Post-apply hook registry for hot config reload.
+ *
+ * Sprint 6 shipped the `.env` → `process.env` swap engine but kept the
+ * engine pure w.r.t. subsystems — caller responsibility to make
+ * caches notice the change. That works for fields read fresh on every
+ * use (e.g. `GEN_MAX_TOKENS`); it doesn't work for fields cached
+ * inside long-lived service instances (e.g. `DEFAULT_PROVIDER` lives
+ * inside `OrchestrationService` for the life of the process).
+ *
+ * This module gives subsystems a place to register a callback keyed
+ * by env name. When `performHotReload` swaps that env, the registered
+ * hook runs with `(oldValue, newValue, baseEnv)`. Hook errors are
+ * caught and reported in the result; they never abort the swap.
+ *
+ * Bootstrap is the natural place to register: subsystems that own
+ * cached env values call `registerPostApplyHook(...)` once, after they
+ * construct, before the bot/HTTP/MCP surfaces start serving.
+ */
+
+export interface PostApplyHookContext {
+  /** The env key whose value just changed in process.env. */
+  key: string;
+  /** Previous value (`undefined` if the key was unset). */
+  previousValue: string | undefined;
+  /** New value (`undefined` if the key was removed). */
+  nextValue: string | undefined;
+  /** Snapshot of `process.env` at the time the hook fires. */
+  rawEnv: NodeJS.ProcessEnv;
+}
+
+export type PostApplyHook = (
+  ctx: PostApplyHookContext,
+) => void | Promise<void>;
+
+export interface PostApplyHookOutcome {
+  key: string;
+  hookName: string;
+  ok: boolean;
+  error?: string;
+}
+
+interface RegistryEntry {
+  hookName: string;
+  hook: PostApplyHook;
+}
+
+/**
+ * One env key can have multiple hooks (e.g. metrics + orchestration both
+ * need to react to `DEFAULT_PROVIDER`). Registration order = invocation
+ * order; a failing hook does not stop later ones from firing.
+ */
+const registry = new Map<string, RegistryEntry[]>();
+
+export function registerPostApplyHook(
+  envKey: string,
+  hookName: string,
+  hook: PostApplyHook,
+): void {
+  const bucket = registry.get(envKey) ?? [];
+  bucket.push({ hookName, hook });
+  registry.set(envKey, bucket);
+}
+
+export function listPostApplyHooks(): Array<{ key: string; hookNames: string[] }> {
+  return [...registry.entries()].map(([key, entries]) => ({
+    key,
+    hookNames: entries.map((e) => e.hookName),
+  }));
+}
+
+/** Test-only — clears every registered hook. */
+export function clearPostApplyHooks(): void {
+  registry.clear();
+}
+
+/** Test-only — drops hooks for a single key. */
+export function unregisterPostApplyHooks(envKey: string): void {
+  registry.delete(envKey);
+}
+
+export interface RunPostApplyHooksInput {
+  /** Successfully-applied changes from the hot-reload engine. */
+  changes: Array<{ key: string; oldValue?: string; newValue?: string }>;
+  rawEnv?: NodeJS.ProcessEnv;
+}
+
+export async function runPostApplyHooks(
+  input: RunPostApplyHooksInput,
+): Promise<PostApplyHookOutcome[]> {
+  const baseEnv = input.rawEnv ?? process.env;
+  const outcomes: PostApplyHookOutcome[] = [];
+  for (const change of input.changes) {
+    const entries = registry.get(change.key);
+    if (!entries || entries.length === 0) continue;
+    for (const entry of entries) {
+      try {
+        await entry.hook({
+          key: change.key,
+          previousValue: change.oldValue,
+          nextValue: change.newValue,
+          rawEnv: baseEnv,
+        });
+        outcomes.push({ key: change.key, hookName: entry.hookName, ok: true });
+      } catch (error) {
+        outcomes.push({
+          key: change.key,
+          hookName: entry.hookName,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+  return outcomes;
+}

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -758,7 +758,7 @@ export function createHttpServer(
   // POST /v1/ops/config/reload — re-read .env, validate, swap hot/warm fields,
   // refuse cold fields with HTTP 409.
   app.post('/v1/ops/config/reload', async (request, reply) => {
-    const result = performHotReload();
+    const result = await performHotReload();
     writeSecurityAudit({
       action: 'config.reload',
       status: result.ok ? 'allowed' : 'blocked',

--- a/src/infra/tui-host/commands.ts
+++ b/src/infra/tui-host/commands.ts
@@ -550,7 +550,7 @@ async function executeConfigSet(
 
 async function executeConfigReload(context: TuiHostCommandContext): Promise<unknown> {
   context.emitLine('info', 'Reloading config from .env...');
-  const result = performHotReload();
+  const result = await performHotReload();
   assertNotAborted(context.signal);
   if (!result.ok) {
     if (result.validationError) {

--- a/src/mcp/tools/config.ts
+++ b/src/mcp/tools/config.ts
@@ -37,8 +37,8 @@ export interface MemphisConfigReloadOutput extends HotReloadResult {
  * Re-read `.env`, validate, swap hot/warm fields; refuse cold fields.
  * Returns the redacted result.
  */
-export function runMemphisConfigReload(): MemphisConfigReloadOutput {
-  const result = performHotReload();
+export async function runMemphisConfigReload(): Promise<MemphisConfigReloadOutput> {
+  const result = await performHotReload();
   const classification = result.changes.map((c) => ({
     key: c.key,
     tier: classifyField(c.key),

--- a/src/modules/orchestration/service.ts
+++ b/src/modules/orchestration/service.ts
@@ -95,11 +95,18 @@ function isRetryable(error: unknown): boolean {
   );
 }
 
+export interface DefaultProviderSwapResult {
+  changed: boolean;
+  previous: ProviderName;
+  next: ProviderName;
+}
+
 export class OrchestrationService {
   private readonly providers = new Map<ProviderName, RuntimeProvider>();
   private readonly maxRetries: number;
   private readonly providerPolicy: ProviderPolicy;
   private readonly cascadeOrder: ProviderName[];
+  private currentDefaultProvider: ProviderName;
 
   constructor(private readonly deps: OrchestratorDeps) {
     for (const provider of deps.providers) {
@@ -112,6 +119,7 @@ export class OrchestrationService {
       deps.cascadeOrder && deps.cascadeOrder.length > 0
         ? [...deps.cascadeOrder]
         : [...DEFAULT_PROVIDER_CASCADE];
+    this.currentDefaultProvider = deps.defaultProvider;
   }
 
   /** Read-only view of the configured cascade order (for /status + tests). */
@@ -119,13 +127,51 @@ export class OrchestrationService {
     return [...this.cascadeOrder];
   }
 
+  /** Current default provider — reflects any runtime hot-swaps. */
+  public getDefaultProvider(): ProviderName {
+    return this.currentDefaultProvider;
+  }
+
+  /**
+   * Hot-swap the default provider at runtime. Validates the name against the
+   * registered provider list (typo on a `/config set DEFAULT_PROVIDER=...`
+   * shouldn't silently land on local-fallback). Caller is responsible for the
+   * audit log entry; this method just mutates the live cache.
+   *
+   * Returns `{ changed }` so the caller can skip the audit + reply when the
+   * value already matches.
+   */
+  public setDefaultProvider(name: string): DefaultProviderSwapResult {
+    if (!(PROVIDER_NAMES as readonly string[]).includes(name)) {
+      throw new AppError(
+        'VALIDATION_ERROR',
+        `setDefaultProvider: unknown provider '${name}'. Valid: ${PROVIDER_NAMES.join(', ')}`,
+        400,
+      );
+    }
+    const next = name as ProviderName;
+    if (!this.providers.has(next)) {
+      throw new AppError(
+        'PROVIDER_UNAVAILABLE',
+        `setDefaultProvider: '${next}' is a known provider name but is not registered in this runtime. Configure its credentials before swapping.`,
+        400,
+      );
+    }
+    const previous = this.currentDefaultProvider;
+    if (previous === next) {
+      return { changed: false, previous, next };
+    }
+    this.currentDefaultProvider = next;
+    return { changed: true, previous, next };
+  }
+
   private pickAutoProvider(strategy: 'default' | 'latency-aware'): ProviderName {
-    if (strategy === 'default') return this.deps.defaultProvider;
+    if (strategy === 'default') return this.currentDefaultProvider;
 
     const available = [...this.providers.keys()].filter(
       (name) => !this.providerPolicy.isInCooldown(name),
     );
-    if (available.length === 0) return this.deps.defaultProvider;
+    if (available.length === 0) return this.currentDefaultProvider;
 
     const stats = metrics.snapshot().providers;
     const ordered = [...available].sort((a, b) => {
@@ -136,7 +182,7 @@ export class OrchestrationService {
       return la - lb;
     });
 
-    return ordered[0] ?? this.deps.defaultProvider;
+    return ordered[0] ?? this.currentDefaultProvider;
   }
 
   public resolveProvider(
@@ -206,7 +252,7 @@ export class OrchestrationService {
       }
     };
     push(resolvedRequested);
-    push(this.deps.defaultProvider);
+    push(this.currentDefaultProvider);
     for (const name of this.cascadeOrder) push(name);
     // local-fallback is the always-succeeds terminator; make sure it's in the
     // walk even if the operator omitted it from cascadeOrder and default.
@@ -454,7 +500,7 @@ export class OrchestrationService {
    * Used by doctor-v2 Tier A (Architecture Health) checks.
    */
   public getPrimaryProvider(): ProviderName {
-    return this.deps.defaultProvider;
+    return this.currentDefaultProvider;
   }
 
   /**

--- a/tests/integration/config-reload-provider-swap.test.ts
+++ b/tests/integration/config-reload-provider-swap.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { LLMProvider } from '../../src/core/contracts/llm-provider.js';
+import type { ProviderName } from '../../src/core/types.js';
+import { performHotReload } from '../../src/infra/config/hot-reload.js';
+import {
+  clearPostApplyHooks,
+  registerPostApplyHook,
+} from '../../src/infra/config/post-apply-hooks.js';
+import { OrchestrationService } from '../../src/modules/orchestration/service.js';
+
+function fakeProvider(name: ProviderName): LLMProvider {
+  return {
+    name,
+    defaultModel: () => `${name}-model`,
+    listModels: async () => [`${name}-model`],
+    health: async () => ({ ok: true, provider: name }),
+    generate: async () => ({
+      content: 'ok',
+      model: `${name}-model`,
+      provider: name,
+    }),
+  } as unknown as LLMProvider;
+}
+
+interface TestEnv {
+  envDir: string;
+  envPath: string;
+  prevEnv: NodeJS.ProcessEnv;
+}
+
+function setupEnv(initialDefault: ProviderName): TestEnv {
+  const envDir = mkdtempSync(join(tmpdir(), 'memphis-cfg-swap-'));
+  const envPath = join(envDir, '.env');
+  const prevEnv = { ...process.env };
+  process.env.MEMPHIS_ENV_FILE = envPath;
+  process.env.DEFAULT_PROVIDER = initialDefault;
+  writeFileSync(envPath, `DEFAULT_PROVIDER=${initialDefault}\n`, 'utf8');
+  return { envDir, envPath, prevEnv };
+}
+
+function tearDown(env: TestEnv): void {
+  rmSync(env.envDir, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) {
+    if (!(key in env.prevEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, env.prevEnv);
+}
+
+describe('hot-reload → DEFAULT_PROVIDER hot-swap end-to-end', () => {
+  let env: TestEnv;
+  let orchestration: OrchestrationService;
+
+  beforeEach(() => {
+    env = setupEnv('anthropic');
+    clearPostApplyHooks();
+    orchestration = new OrchestrationService({
+      defaultProvider: 'anthropic',
+      providers: [
+        fakeProvider('anthropic'),
+        fakeProvider('minimax'),
+        fakeProvider('ollama'),
+        fakeProvider('local-fallback'),
+      ],
+    });
+    registerPostApplyHook('DEFAULT_PROVIDER', 'orchestration.setDefaultProvider', (ctx) => {
+      if (!ctx.nextValue) return;
+      orchestration.setDefaultProvider(ctx.nextValue);
+    });
+  });
+
+  afterEach(() => {
+    clearPostApplyHooks();
+    tearDown(env);
+  });
+
+  it('swaps the live OrchestrationService default after performHotReload', async () => {
+    expect(orchestration.getDefaultProvider()).toBe('anthropic');
+
+    writeFileSync(env.envPath, 'DEFAULT_PROVIDER=minimax\n', 'utf8');
+    const result = await performHotReload();
+
+    expect(result.ok).toBe(true);
+    expect(result.appliedCount).toBeGreaterThanOrEqual(1);
+    expect(process.env.DEFAULT_PROVIDER).toBe('minimax');
+    expect(orchestration.getDefaultProvider()).toBe('minimax');
+    expect(result.hookOutcomes).toEqual([
+      { key: 'DEFAULT_PROVIDER', hookName: 'orchestration.setDefaultProvider', ok: true },
+    ]);
+  });
+
+  it('next resolveProvider("auto") call lands on the swapped default', async () => {
+    expect(orchestration.resolveProvider('auto').name).toBe('anthropic');
+
+    writeFileSync(env.envPath, 'DEFAULT_PROVIDER=ollama\n', 'utf8');
+    await performHotReload();
+
+    expect(orchestration.resolveProvider('auto').name).toBe('ollama');
+  });
+
+  it('records a failed hook outcome when the new value is invalid (provider not registered)', async () => {
+    writeFileSync(env.envPath, 'DEFAULT_PROVIDER=shared-llm\n', 'utf8');
+    const result = await performHotReload();
+
+    // The env value still applies (shared-llm is in PROVIDER_NAMES so the
+    // schema accepts it); the hook is what catches that the provider isn't
+    // registered in this runtime and reports the failure.
+    expect(process.env.DEFAULT_PROVIDER).toBe('shared-llm');
+    expect(orchestration.getDefaultProvider()).toBe('anthropic');
+    expect(result.hookOutcomes?.[0]?.ok).toBe(false);
+    expect(result.hookOutcomes?.[0]?.error).toMatch(/not registered/);
+  });
+
+  it('skips hook firing when DEFAULT_PROVIDER did not change', async () => {
+    writeFileSync(env.envPath, 'DEFAULT_PROVIDER=anthropic\n', 'utf8');
+    const result = await performHotReload();
+    // unchanged → not in `applied` → no hook outcome
+    expect(result.hookOutcomes).toBeUndefined();
+    expect(orchestration.getDefaultProvider()).toBe('anthropic');
+  });
+});

--- a/tests/integration/surface-parity.test.ts
+++ b/tests/integration/surface-parity.test.ts
@@ -117,8 +117,8 @@ describe('surface parity — MCP mirrors TUI host capabilities (Sprint 7)', () =
   });
 
   describe('config.reload', () => {
-    it('returns a structured diff and a classification table', () => {
-      const result = runMemphisConfigReload();
+    it('returns a structured diff and a classification table', async () => {
+      const result = await runMemphisConfigReload();
       expect(typeof result.ok).toBe('boolean');
       expect(Array.isArray(result.changes)).toBe(true);
       expect(Array.isArray(result.classification)).toBe(true);

--- a/tests/unit/config-hot-reload.test.ts
+++ b/tests/unit/config-hot-reload.test.ts
@@ -117,16 +117,16 @@ describe('hot-reload — performHotReload mutates process.env', () => {
     Object.assign(process.env, savedEnv);
   });
 
-  it('writes hot field changes into process.env', () => {
+  it('writes hot field changes into process.env', async () => {
     writeEnv(testEnv.envPath, { GEN_MAX_TOKENS: '4096' });
-    const result = performHotReload();
+    const result = await performHotReload();
     expect(result.ok).toBe(true);
     expect(process.env.GEN_MAX_TOKENS).toBe('4096');
   });
 
-  it('refuses to mutate process.env when a cold field is changing', () => {
+  it('refuses to mutate process.env when a cold field is changing', async () => {
     writeEnv(testEnv.envPath, { PORT: '5555', GEN_MAX_TOKENS: '4096' });
-    const result = performHotReload();
+    const result = await performHotReload();
     expect(result.ok).toBe(false);
     expect(process.env.PORT).toBe('3000');
     expect(process.env.GEN_MAX_TOKENS).toBe('1024');

--- a/tests/unit/config-mutability.test.ts
+++ b/tests/unit/config-mutability.test.ts
@@ -15,7 +15,7 @@ describe('config-mutability', () => {
     expect(classifyField('GEN_TEMPERATURE')).toBe('hot');
     expect(classifyField('OLLAMA_URL')).toBe('hot');
     expect(classifyField('LOG_LEVEL')).toBe('warm');
-    expect(classifyField('DEFAULT_PROVIDER')).toBe('warm');
+    expect(classifyField('DEFAULT_PROVIDER')).toBe('hot');
     expect(classifyField('PORT')).toBe('cold');
     expect(classifyField('HOST')).toBe('cold');
     expect(classifyField('DATABASE_URL')).toBe('cold');

--- a/tests/unit/orchestration-default-provider-swap.test.ts
+++ b/tests/unit/orchestration-default-provider-swap.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LLMProvider } from '../../src/core/contracts/llm-provider.js';
+import type { ProviderName } from '../../src/core/types.js';
+import { OrchestrationService } from '../../src/modules/orchestration/service.js';
+
+function fakeProvider(name: ProviderName): LLMProvider {
+  return {
+    name,
+    defaultModel: () => `${name}-model`,
+    listModels: async () => [`${name}-model`],
+    health: async () => ({ ok: true, provider: name }),
+    generate: async () => ({
+      content: 'ok',
+      model: `${name}-model`,
+      provider: name,
+    }),
+  } as unknown as LLMProvider;
+}
+
+function makeService(initialDefault: ProviderName): OrchestrationService {
+  return new OrchestrationService({
+    defaultProvider: initialDefault,
+    providers: [
+      fakeProvider('anthropic'),
+      fakeProvider('minimax'),
+      fakeProvider('ollama'),
+      fakeProvider('local-fallback'),
+    ],
+  });
+}
+
+describe('OrchestrationService — default provider hot-swap', () => {
+  it('exposes the construction-time default via getDefaultProvider', () => {
+    const svc = makeService('anthropic');
+    expect(svc.getDefaultProvider()).toBe('anthropic');
+  });
+
+  it('setDefaultProvider replaces the cached default and reports the change', () => {
+    const svc = makeService('anthropic');
+    const result = svc.setDefaultProvider('minimax');
+    expect(result.changed).toBe(true);
+    expect(result.previous).toBe('anthropic');
+    expect(result.next).toBe('minimax');
+    expect(svc.getDefaultProvider()).toBe('minimax');
+  });
+
+  it('reports changed=false when the new value equals the current one', () => {
+    const svc = makeService('anthropic');
+    const result = svc.setDefaultProvider('anthropic');
+    expect(result.changed).toBe(false);
+    expect(svc.getDefaultProvider()).toBe('anthropic');
+  });
+
+  it('rejects unknown provider names with a validation error', () => {
+    const svc = makeService('anthropic');
+    expect(() => svc.setDefaultProvider('not-a-real-provider')).toThrow(
+      /unknown provider/,
+    );
+    expect(svc.getDefaultProvider()).toBe('anthropic');
+  });
+
+  it('rejects known names that are not registered in this runtime', () => {
+    // shared-llm is in PROVIDER_NAMES but not provided to this service
+    const svc = makeService('anthropic');
+    expect(() => svc.setDefaultProvider('shared-llm')).toThrow(
+      /not registered in this runtime/,
+    );
+    expect(svc.getDefaultProvider()).toBe('anthropic');
+  });
+
+  it('next provider lookup uses the swapped default (resolveProvider strategy=default)', () => {
+    const svc = makeService('anthropic');
+    expect(svc.resolveProvider('auto').name).toBe('anthropic');
+    svc.setDefaultProvider('minimax');
+    expect(svc.resolveProvider('auto').name).toBe('minimax');
+  });
+});

--- a/tests/unit/post-apply-hooks.test.ts
+++ b/tests/unit/post-apply-hooks.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearPostApplyHooks,
+  listPostApplyHooks,
+  registerPostApplyHook,
+  runPostApplyHooks,
+  unregisterPostApplyHooks,
+} from '../../src/infra/config/post-apply-hooks.js';
+
+beforeEach(() => {
+  clearPostApplyHooks();
+});
+
+afterEach(() => {
+  clearPostApplyHooks();
+});
+
+describe('post-apply hook registry', () => {
+  it('starts empty', () => {
+    expect(listPostApplyHooks()).toEqual([]);
+  });
+
+  it('runs hooks for changed keys with full context', async () => {
+    const calls: Array<{
+      key: string;
+      previousValue: string | undefined;
+      nextValue: string | undefined;
+    }> = [];
+    registerPostApplyHook('GEN_MAX_TOKENS', 'test.capture', (ctx) => {
+      calls.push({
+        key: ctx.key,
+        previousValue: ctx.previousValue,
+        nextValue: ctx.nextValue,
+      });
+    });
+    const outcomes = await runPostApplyHooks({
+      changes: [{ key: 'GEN_MAX_TOKENS', oldValue: '1024', newValue: '4096' }],
+    });
+    expect(outcomes).toEqual([
+      { key: 'GEN_MAX_TOKENS', hookName: 'test.capture', ok: true },
+    ]);
+    expect(calls).toEqual([
+      { key: 'GEN_MAX_TOKENS', previousValue: '1024', nextValue: '4096' },
+    ]);
+  });
+
+  it('skips keys with no registered hook', async () => {
+    const outcomes = await runPostApplyHooks({
+      changes: [{ key: 'UNREGISTERED_KEY', oldValue: 'a', newValue: 'b' }],
+    });
+    expect(outcomes).toEqual([]);
+  });
+
+  it('captures hook errors without aborting later hooks', async () => {
+    const fired: string[] = [];
+    registerPostApplyHook('LOG_LEVEL', 'first.fails', () => {
+      fired.push('first');
+      throw new Error('boom');
+    });
+    registerPostApplyHook('LOG_LEVEL', 'second.runs', () => {
+      fired.push('second');
+    });
+    const outcomes = await runPostApplyHooks({
+      changes: [{ key: 'LOG_LEVEL', oldValue: 'info', newValue: 'debug' }],
+    });
+    expect(fired).toEqual(['first', 'second']);
+    expect(outcomes[0]?.ok).toBe(false);
+    expect(outcomes[0]?.error).toBe('boom');
+    expect(outcomes[1]?.ok).toBe(true);
+  });
+
+  it('supports async hooks', async () => {
+    let captured: string | undefined;
+    registerPostApplyHook('OLLAMA_URL', 'async.capture', async (ctx) => {
+      await Promise.resolve();
+      captured = ctx.nextValue;
+    });
+    await runPostApplyHooks({
+      changes: [{ key: 'OLLAMA_URL', oldValue: 'a', newValue: 'http://ollama.local' }],
+    });
+    expect(captured).toBe('http://ollama.local');
+  });
+
+  it('listPostApplyHooks reports registered hook names by key', () => {
+    registerPostApplyHook('A', 'a1', () => {});
+    registerPostApplyHook('A', 'a2', () => {});
+    registerPostApplyHook('B', 'b1', () => {});
+    const listed = listPostApplyHooks().sort((a, b) => a.key.localeCompare(b.key));
+    expect(listed).toEqual([
+      { key: 'A', hookNames: ['a1', 'a2'] },
+      { key: 'B', hookNames: ['b1'] },
+    ]);
+  });
+
+  it('unregisterPostApplyHooks drops hooks for one key only', async () => {
+    const fired: string[] = [];
+    registerPostApplyHook('A', 'a-hook', () => fired.push('a'));
+    registerPostApplyHook('B', 'b-hook', () => fired.push('b'));
+    unregisterPostApplyHooks('A');
+    await runPostApplyHooks({
+      changes: [
+        { key: 'A', oldValue: '1', newValue: '2' },
+        { key: 'B', oldValue: '3', newValue: '4' },
+      ],
+    });
+    expect(fired).toEqual(['b']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the most-pain Sprint 6 deferral. Operators can now change `DEFAULT_PROVIDER` via `/config set` on any surface and the very next turn lands on the new provider — no restart. The cascade order was already hot; the default provider was cached inside `OrchestrationService` and took a restart to swap. That asymmetry is exactly what operators hit first when they tried to use Sprint 6 for the most common config knob.

Approach: a pluggable **post-apply hook registry**, not a one-off setter. Subsystems that own cached env values register a callback keyed by env name; when `/config reload` swaps that env, the hook fires. Future deferrals (rate-limiter singletons, per-instance loggers) can close themselves by dropping a single registration into bootstrap.

- **`OrchestrationService`** (`src/modules/orchestration/service.ts`): extracted `defaultProvider` into a live field; added `getDefaultProvider()` and `setDefaultProvider(name)` with fail-loud validation against `PROVIDER_NAMES` *and* the providers actually registered in this runtime (catches typos before cascade silently re-routes).
- **Post-apply hook registry** (`src/infra/config/post-apply-hooks.ts`, new): `registerPostApplyHook(envKey, name, hookFn)`; hooks fire after `process.env` swaps with `{previousValue, nextValue, rawEnv}`. Errors captured into the reload result; a failing hook never aborts the swap.
- **hot-reload engine** (`src/infra/config/hot-reload.ts`): `performHotReload` becomes async, runs hooks after the swap, surfaces `hookOutcomes` in the result.
- **Container wiring** (`src/app/container.ts`): single load-bearing line registers `orchestration.setDefaultProvider` for `DEFAULT_PROVIDER`.
- **Surface adapters** (HTTP `/v1/ops/config/reload`, TUI host `config.reload`, Telegram `/config reload`, MCP `memphis_config_reload`): each awaits `performHotReload`. Surfaces don't need to know about the hook registry.
- **Mutability table**: `DEFAULT_PROVIDER` `warm` → `hot`.
- **Docs** (`docs/config-on-the-fly.md`): deletes the Sprint 6 "deliberately deferred" paragraph; adds a "Post-apply hooks" section with the registry table. Lists rate-limiter + logger as the next two candidates.

## Verification

- `npm run typecheck && npm run lint` — green
- `npm test` — **1749 tests passing** (+17 Sprint + 4 fixes of existing fallout), 363 files
- `cargo test --all-features` — green (no Rust changes)

## Test plan

- [x] Unit: `setDefaultProvider` round-trip, no-op, unknown-name rejection, known-but-unregistered rejection, live `resolveProvider('auto')` reflects the swap
- [x] Unit: hook registration, context passed correctly, unknown-key no-op, error captured + later hooks still fire, async hooks, list/unregister APIs
- [x] Integration: write `DEFAULT_PROVIDER` to `.env` + `performHotReload` → `OrchestrationService.getDefaultProvider()` reflects the swap
- [x] Integration: next `resolveProvider('auto')` after the hot-swap lands on the new provider
- [x] Integration: bad swap target reported via failed `hookOutcomes[0]`
- [x] Integration: unchanged value fires no hook
- [ ] Manual on operator box: `/config set DEFAULT_PROVIDER=ollama` from Telegram → next turn `/status` shows Ollama as default

## Deliberate deferrals (now unblocked for future sprints)

- **Rate-limiter singletons** — can now register a `setLimit(n)` hook
- **Per-instance loggers** — can now register a hook that walks a logger registry and updates levels
- **Other `warm` fields in `mutability.ts`** — each can graduate to `hot` by adding a hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)