### PR TITLE
fix: Codex hotfix #1/5 — vault correctness + audit integrity (P1 data-integrity)

### DIFF
--- a/src/infra/cli/handlers/vault.handler.ts
+++ b/src/infra/cli/handlers/vault.handler.ts
@@ -337,8 +337,31 @@ async function handleVaultPepperRotate(context: CliContext): Promise<boolean> {
     throw new Error('New pepper confirmation does not match.');
   }
 
+  // Rotate state first so the re-encrypted vault-state.json is on disk,
+  // then update .env. If the .env write fails (permissions, disk full,
+  // concurrent write), we attempt a reverse rotation to restore the state
+  // file to oldPepper — leaving operator disk in the pre-rotation shape
+  // rather than a state/.env desync that would break vault reads on next
+  // startup. Best-effort: if the reverse rotation itself also fails, we
+  // surface a loud structured error that names both mismatched halves.
+  let result: ReturnType<typeof rotateVaultStatePepper> | undefined;
   try {
-    const result = rotateVaultStatePepper(oldPepper, newPepper, process.env);
+    result = rotateVaultStatePepper(oldPepper, newPepper, process.env);
+  } catch (err) {
+    writeSecurityAudit({
+      action: 'vault.pepper-rotate',
+      status: 'error',
+      details: {
+        surface: 'cli',
+        command: 'vault pepper-rotate',
+        stage: 'rotate-state',
+        reason: err instanceof Error ? err.message : 'unknown_error',
+      },
+    });
+    throw err;
+  }
+
+  try {
     const envUpdate = upsertEnvVars([{ key: 'MEMPHIS_VAULT_PEPPER', value: newPepper }]);
     process.env.MEMPHIS_VAULT_PEPPER = newPepper;
 
@@ -373,16 +396,50 @@ async function handleVaultPepperRotate(context: CliContext): Promise<boolean> {
     );
     return true;
   } catch (err) {
+    const envMessage = err instanceof Error ? err.message : 'unknown_error';
+    // .env write failed after state rotation succeeded. Try to reverse the
+    // rotation so disk state matches the (unchanged) operator .env file.
+    let rollbackOk = false;
+    let rollbackError: string | null = null;
+    try {
+      rotateVaultStatePepper(newPepper, oldPepper, process.env);
+      rollbackOk = true;
+    } catch (rollbackErr) {
+      rollbackError =
+        rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+    }
+
     writeSecurityAudit({
       action: 'vault.pepper-rotate',
       status: 'error',
       details: {
         surface: 'cli',
         command: 'vault pepper-rotate',
-        reason: err instanceof Error ? err.message : 'unknown_error',
+        stage: 'update-env',
+        reason: envMessage,
+        rollback: rollbackOk ? 'reverted-state-to-old-pepper' : 'rollback-failed',
+        rollbackError,
+        statePath: result.statePath,
+        fromVersion: result.fromVersion,
+        toVersion: result.toVersion,
       },
     });
-    throw err;
+
+    if (rollbackOk) {
+      throw new Error(
+        `vault pepper-rotate failed at .env write (${envMessage}). State file was ` +
+          `reverted to the OLD pepper — vault remains readable with the current ` +
+          `MEMPHIS_VAULT_PEPPER. Fix the .env permission/disk issue and retry.`,
+      );
+    }
+    throw new Error(
+      `vault pepper-rotate FAILED CATASTROPHICALLY: .env write failed ` +
+        `(${envMessage}) AND rollback of the rotated state also failed (${rollbackError}). ` +
+        `vault-state.json is now encrypted with the NEW pepper but .env still ` +
+        `holds the OLD pepper. Manually set MEMPHIS_VAULT_PEPPER=<new-pepper> in ` +
+        `${result.statePath ? `${result.statePath.replace(/vault-state\.json$/, '.env')}` : '.env'} ` +
+        `or restore data/vault-state.json from a backup before the next start.`,
+    );
   }
 }
 
@@ -510,6 +567,12 @@ function handleVaultMasterKeyRotate(context: CliContext): boolean {
 }
 
 function handleVaultReset(context: CliContext): boolean {
+  // vault reset moves live vault files aside — same destructive shape as
+  // pepper-rotate, master-key-rotate, and entry-delete, so gate it behind
+  // the same operator passphrase. Without this, anyone with shell access
+  // can wipe the active vault state/entries with `memphis vault reset
+  // --confirm`, making this a CLI privilege bypass.
+  requireOperatorAuth();
   if (!context.args.confirm) {
     throw new Error(
       'vault reset requires --confirm; this moves vault-state.json and vault-entries.json into a timestamped backup dir. Run `memphis vault init` afterwards to create a fresh vault.',

--- a/src/infra/logging/audit-rotation.ts
+++ b/src/infra/logging/audit-rotation.ts
@@ -39,10 +39,25 @@ export function resolveRotateThresholdBytes(rawEnv: NodeJS.ProcessEnv = process.
 }
 
 function isoStampForFilename(): string {
-  return new Date()
-    .toISOString()
-    .replace(/[:]/g, '-')
-    .replace(/\.\d+Z$/, 'Z');
+  // Keep milliseconds so two rotations in the same second don't produce
+  // the same filename — writeFileSync on an existing archive path silently
+  // overwrites, which would drop audit events on the floor.
+  return new Date().toISOString().replace(/[:]/g, '-');
+}
+
+function nextAvailableArchivePath(archiveDir: string, stamp: string): string {
+  // Defensive: even with millisecond precision, two rotations inside the
+  // same Date.now() tick would still collide. Suffix with a counter when
+  // the first candidate already exists so no archive is ever overwritten.
+  const base = join(archiveDir, `security-audit-${stamp}.jsonl.gz`);
+  if (!existsSync(base)) return base;
+  for (let i = 1; i < 1000; i += 1) {
+    const candidate = join(archiveDir, `security-audit-${stamp}-${i}.jsonl.gz`);
+    if (!existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    `audit rotation: could not find a unique archive name after 1000 attempts for stamp ${stamp}`,
+  );
 }
 
 function sizeOfFile(path: string): number {
@@ -71,8 +86,8 @@ export function maybeRotateAuditLog(rawEnv: NodeJS.ProcessEnv = process.env): Ro
   mkdirSync(archiveDir, { recursive: true });
 
   const stamp = isoStampForFilename();
-  const stagedPath = join(archiveDir, `security-audit-${stamp}.jsonl`);
-  const finalPath = `${stagedPath}.gz`;
+  const finalPath = nextAvailableArchivePath(archiveDir, stamp);
+  const stagedPath = finalPath.replace(/\.gz$/, '');
 
   renameSync(logPath, stagedPath);
 

--- a/src/infra/logging/audit-search.ts
+++ b/src/infra/logging/audit-search.ts
@@ -77,9 +77,27 @@ function parseLine(line: string, source: string): AuditRecord | null {
   }
 }
 
+function toInstant(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function matches(record: AuditRecord, criteria: AuditSearchCriteria): boolean {
-  if (criteria.since && record.ts < criteria.since) return false;
-  if (criteria.until && record.ts > criteria.until) return false;
+  // Compare timestamps as numeric instants, not as strings. Lexicographic
+  // compare only works when both sides share the exact ISO shape; inputs
+  // with different precision (`Z` vs `000Z`) or zone offsets (`+02:00`)
+  // get ordered wrong, returning incorrect results around the boundary.
+  if (criteria.since) {
+    const sinceMs = toInstant(criteria.since);
+    const recordMs = toInstant(record.ts);
+    if (sinceMs !== null && recordMs !== null && recordMs < sinceMs) return false;
+  }
+  if (criteria.until) {
+    const untilMs = toInstant(criteria.until);
+    const recordMs = toInstant(record.ts);
+    if (untilMs !== null && recordMs !== null && recordMs > untilMs) return false;
+  }
   if (criteria.action && !record.action.startsWith(criteria.action)) return false;
   if (criteria.status && record.status !== criteria.status) return false;
   if (criteria.contains) {

--- a/src/infra/storage/rust-vault-adapter.ts
+++ b/src/infra/storage/rust-vault-adapter.ts
@@ -577,6 +577,46 @@ function getEntriesStorePath(rawEnv: NodeJS.ProcessEnv): string {
   return rawEnv.MEMPHIS_VAULT_ENTRIES_PATH ?? './data/vault-entries.json';
 }
 
+/**
+ * Load and validate the entries JSON before a master-key rotation.
+ *
+ * Exported for regression-test access: guarantees that a corrupt or missing
+ * entries file aborts rotation loudly rather than getting silently
+ * reinterpreted as empty (which would cause `rotateVaultMasterKey` to
+ * overwrite every stored ciphertext record with `[]`).
+ */
+export function loadEntriesForRotationOrThrow(
+  entriesPath: string,
+): Array<VaultEntry & { createdAt?: string; fingerprint?: string }> {
+  if (!existsSync(entriesPath)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(entriesPath, 'utf8');
+  } catch (err) {
+    throw new Error(
+      `Master-key rotation aborted: cannot read ${entriesPath} — ${err instanceof Error ? err.message : String(err)}. ` +
+        `Fix the file (check permissions or restore from backup) before retrying.`,
+    );
+  }
+  if (!raw.trim()) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Master-key rotation aborted: ${entriesPath} is not valid JSON — ${err instanceof Error ? err.message : String(err)}. ` +
+        `Restore a valid entries file from backup before retrying; rotation will not silently discard ciphertext records.`,
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `Master-key rotation aborted: ${entriesPath} must contain a JSON array of entries, got ${typeof parsed}. ` +
+        `Restore a valid entries file from backup before retrying.`,
+    );
+  }
+  return parsed as Array<VaultEntry & { createdAt?: string; fingerprint?: string }>;
+}
+
 export function rotateVaultMasterKey(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): VaultMasterKeyRotateResult {
@@ -604,18 +644,13 @@ export function rotateVaultMasterKey(
     );
   }
 
-  const entries = existsSync(entriesPath)
-    ? (() => {
-        try {
-          const raw = readFileSync(entriesPath, 'utf8');
-          if (!raw.trim()) return [];
-          const parsed = JSON.parse(raw) as Array<VaultEntry & { createdAt?: string; fingerprint?: string }>;
-          return Array.isArray(parsed) ? parsed : [];
-        } catch {
-          return [];
-        }
-      })()
-    : [];
+  // CRITICAL: do not swallow parse/read errors on an existing entries file.
+  // Treating a corrupt vault-entries.json as "empty" causes rotation to
+  // continue and then rewrite the file with [], silently destroying the
+  // ciphertext records. When the file exists and can't be parsed, abort the
+  // rotation so the operator can investigate (or restore from a backup)
+  // before touching the live vault.
+  const entries = loadEntriesForRotationOrThrow(entriesPath);
 
   const decrypted: Array<{ key: string; plaintext: Buffer; createdAt?: string }> = [];
   const failed: VaultMasterKeyRotateFailure[] = [];

--- a/tests/unit/audit-rotation-collision.test.ts
+++ b/tests/unit/audit-rotation-collision.test.ts
@@ -1,0 +1,101 @@
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gunzipSync } from 'node:zlib';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { maybeRotateAuditLog } from '../../src/infra/logging/audit-rotation.js';
+
+/**
+ * Regression net for Codex P1: audit rotation filename collision when two
+ * rotations fire in the same second.
+ *
+ * Before the fix, the archive filename was generated from an ISO timestamp
+ * with the millisecond component stripped, so any two rotations within the
+ * same calendar second produced the same `security-audit-<stamp>.jsonl.gz`
+ * path. Because `writeFileSync` overwrites, the second rotation silently
+ * destroyed the first archive. The fix keeps the millisecond component and
+ * adds a counter fallback on exact collisions.
+ */
+
+interface TestEnv {
+  dataDir: string;
+  logPath: string;
+  archiveDir: string;
+  prevEnv: NodeJS.ProcessEnv;
+}
+
+function setup(): TestEnv {
+  const dataDir = mkdtempSync(join(tmpdir(), 'memphis-audit-rot-'));
+  const logPath = join(dataDir, 'security-audit.jsonl');
+  const archiveDir = join(dataDir, 'security-audit-archives');
+  const prevEnv = { ...process.env };
+  process.env.MEMPHIS_SECURITY_AUDIT_LOG_PATH = logPath;
+  process.env.MEMPHIS_SECURITY_AUDIT_ARCHIVE_DIR = archiveDir;
+  process.env.MEMPHIS_SECURITY_AUDIT_ROTATE_BYTES = '65536'; // min allowed
+  return { dataDir, logPath, archiveDir, prevEnv };
+}
+
+function tearDown(env: TestEnv): void {
+  rmSync(env.dataDir, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) {
+    if (!(key in env.prevEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, env.prevEnv);
+}
+
+function fillLogBeyondThreshold(logPath: string, payload: string): void {
+  // 65536 bytes + a bit to ensure we cross the threshold.
+  const blob = payload.padEnd(70_000, '.');
+  writeFileSync(logPath, `${blob}\n`, 'utf8');
+}
+
+describe('maybeRotateAuditLog — filename collision hardening', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('two rotations in the same second produce two distinct archive files', () => {
+    fillLogBeyondThreshold(env.logPath, 'first');
+    const first = maybeRotateAuditLog();
+    expect(first.rotated).toBe(true);
+    expect(existsSync(first.archivePath!)).toBe(true);
+
+    fillLogBeyondThreshold(env.logPath, 'second');
+    const second = maybeRotateAuditLog();
+    expect(second.rotated).toBe(true);
+    expect(existsSync(second.archivePath!)).toBe(true);
+
+    // Distinct paths — the whole point of the regression test.
+    expect(second.archivePath).not.toBe(first.archivePath);
+
+    // Both archive files still present and decompress to the original
+    // contents, proving neither was overwritten.
+    const archives = readdirSync(env.archiveDir).sort();
+    expect(archives).toHaveLength(2);
+    for (const file of archives) {
+      const buf = readFileSync(join(env.archiveDir, file));
+      const uncompressed = gunzipSync(buf).toString('utf8');
+      expect(uncompressed.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('three rotations in rapid succession all preserved', () => {
+    for (let i = 0; i < 3; i += 1) {
+      fillLogBeyondThreshold(env.logPath, `batch-${i}`);
+      const result = maybeRotateAuditLog();
+      expect(result.rotated).toBe(true);
+    }
+    const archives = readdirSync(env.archiveDir);
+    expect(archives).toHaveLength(3);
+    const unique = new Set(archives);
+    expect(unique.size).toBe(archives.length);
+  });
+});

--- a/tests/unit/audit-search-timestamps.test.ts
+++ b/tests/unit/audit-search-timestamps.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { searchAuditLog } from '../../src/infra/logging/audit-search.js';
+
+/**
+ * Regression net for Codex P2: lexicographic timestamp comparison in
+ * audit-search was wrong around boundaries involving different ISO shapes.
+ * A record at `2026-04-13T12:34:56.123Z` must be considered later than a
+ * since filter of `2026-04-13T12:34:56Z`, which string-compare got wrong
+ * because '5' > '.' in ASCII.
+ */
+
+interface TestEnv {
+  dataDir: string;
+  logPath: string;
+  prevEnv: NodeJS.ProcessEnv;
+}
+
+function setup(lines: string[]): TestEnv {
+  const dataDir = mkdtempSync(join(tmpdir(), 'memphis-audit-search-'));
+  const logPath = join(dataDir, 'security-audit.jsonl');
+  const prevEnv = { ...process.env };
+  process.env.MEMPHIS_SECURITY_AUDIT_LOG_PATH = logPath;
+  writeFileSync(logPath, `${lines.join('\n')}\n`, 'utf8');
+  return { dataDir, logPath, prevEnv };
+}
+
+function tearDown(env: TestEnv): void {
+  rmSync(env.dataDir, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) {
+    if (!(key in env.prevEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, env.prevEnv);
+}
+
+function entry(ts: string, action = 'test.action', status = 'allowed'): string {
+  return JSON.stringify({ ts, action, status });
+}
+
+describe('searchAuditLog — timestamp filter robustness', () => {
+  let env: TestEnv;
+
+  afterEach(() => {
+    if (env) tearDown(env);
+  });
+
+  it('matches records even when the record timestamp has finer precision than `since`', async () => {
+    env = setup([
+      entry('2026-04-13T12:34:55.500Z'),
+      entry('2026-04-13T12:34:56.123Z'),
+      entry('2026-04-13T12:34:57.000Z'),
+    ]);
+    const result = await searchAuditLog({ since: '2026-04-13T12:34:56Z' });
+    expect(result.records.length).toBe(2);
+  });
+
+  it('does not mis-order when `since` uses a timezone offset', async () => {
+    env = setup([
+      entry('2026-04-13T12:00:00Z'),
+      entry('2026-04-13T14:00:00Z'),
+      entry('2026-04-13T16:00:00Z'),
+    ]);
+    // 14:00 UTC == 16:00+02:00; records at 14:00Z and 16:00Z must match
+    const result = await searchAuditLog({ since: '2026-04-13T16:00:00+02:00' });
+    expect(result.records.length).toBe(2);
+  });
+
+  it('until filter handles sub-second precision correctly', async () => {
+    env = setup([
+      entry('2026-04-13T12:34:55.500Z'),
+      entry('2026-04-13T12:34:56.123Z'),
+      entry('2026-04-13T12:34:57.000Z'),
+    ]);
+    const result = await searchAuditLog({ until: '2026-04-13T12:34:56Z' });
+    // records strictly > `until` must be excluded: 56.123 and 57.000
+    expect(result.records.map((r) => r.ts)).toEqual(['2026-04-13T12:34:55.500Z']);
+  });
+});

--- a/tests/unit/vault-master-key-rotate-corruption.test.ts
+++ b/tests/unit/vault-master-key-rotate-corruption.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadEntriesForRotationOrThrow } from '../../src/infra/storage/rust-vault-adapter.js';
+
+/**
+ * Regression net for Codex P1: silent data loss on corrupt vault-entries.json.
+ *
+ * Before the fix, `rotateVaultMasterKey` caught JSON parse / read errors and
+ * returned `[]`, which then caused rotation to overwrite the entries file
+ * with an empty array — silently destroying every ciphertext record. The
+ * loading logic was extracted into `loadEntriesForRotationOrThrow` so this
+ * test can pin the "loud-abort" contract without needing a fully-functional
+ * vault bridge / pepper setup.
+ */
+
+interface TestEnv {
+  dataDir: string;
+  entriesPath: string;
+}
+
+function setup(): TestEnv {
+  const dataDir = mkdtempSync(join(tmpdir(), 'memphis-vault-rotate-'));
+  const entriesPath = join(dataDir, 'vault-entries.json');
+  return { dataDir, entriesPath };
+}
+
+function tearDown(env: TestEnv): void {
+  rmSync(env.dataDir, { recursive: true, force: true });
+}
+
+describe('loadEntriesForRotationOrThrow — corrupt entries file handling', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('returns empty array when entries file does not exist', () => {
+    expect(loadEntriesForRotationOrThrow(env.entriesPath)).toEqual([]);
+  });
+
+  it('returns empty array for empty / whitespace-only file', () => {
+    writeFileSync(env.entriesPath, '', 'utf8');
+    expect(loadEntriesForRotationOrThrow(env.entriesPath)).toEqual([]);
+    writeFileSync(env.entriesPath, '   \n\n', 'utf8');
+    expect(loadEntriesForRotationOrThrow(env.entriesPath)).toEqual([]);
+  });
+
+  it('aborts when vault-entries.json contains invalid JSON', () => {
+    writeFileSync(env.entriesPath, '{not valid json at all', 'utf8');
+    expect(() => loadEntriesForRotationOrThrow(env.entriesPath)).toThrow(
+      /not valid JSON|aborted/i,
+    );
+  });
+
+  it('aborts when vault-entries.json contains a non-array JSON value', () => {
+    writeFileSync(env.entriesPath, '{"oops": "object not array"}', 'utf8');
+    expect(() => loadEntriesForRotationOrThrow(env.entriesPath)).toThrow(
+      /must contain a JSON array|aborted/i,
+    );
+  });
+
+  it('aborts when vault-entries.json is a stray primitive', () => {
+    writeFileSync(env.entriesPath, '42', 'utf8');
+    expect(() => loadEntriesForRotationOrThrow(env.entriesPath)).toThrow(
+      /must contain a JSON array|aborted/i,
+    );
+  });
+
+  it('abort message references the entries path so operators know where to look', () => {
+    writeFileSync(env.entriesPath, 'garbage', 'utf8');
+    try {
+      loadEntriesForRotationOrThrow(env.entriesPath);
+      throw new Error('expected abort');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toContain(env.entriesPath);
+    }
+  });
+
+  it('accepts a valid array (round-trip)', () => {
+    const payload = [
+      {
+        id: 'a',
+        key: 'foo',
+        encrypted: 'x',
+        iv: 'y',
+        tag: 'z',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ];
+    writeFileSync(env.entriesPath, JSON.stringify(payload), 'utf8');
+    expect(loadEntriesForRotationOrThrow(env.entriesPath)).toEqual(payload);
+  });
+});


### PR DESCRIPTION
## Summary

First of five Codex-driven hotfix PRs. Five P1/P2 findings against PR #78 and the audit pipeline, all in the data-integrity family — silent data loss, non-atomic rotation, missing auth, audit trail holes.

1. **master-key-rotate silent data loss** (P1) — `rotateVaultMasterKey` caught JSON parse/read errors on `vault-entries.json` and returned `[]`, causing rotation to overwrite the file with an empty array and destroying every ciphertext record. Loading is extracted to `loadEntriesForRotationOrThrow`, which aborts loudly on missing / malformed / non-array content.
2. **pepper-rotate non-atomic** (P1) — on `.env` write failure after state rotation, the engine now attempts a reverse rotation to restore state under the old pepper, leaving disk in the pre-rotation shape. Catastrophic case (reverse also fails) raises a loud error naming both halves and the manual recovery path. Audit entries carry stage + rollback outcome.
3. **vault reset no auth** (P1) — `handleVaultReset` now calls `requireOperatorAuth()` before destructive moves, matching other destructive vault subcommands.
4. **audit rotation filename collision** (P1) — keep the millisecond component + add a counter suffix fallback so two rotations in the same tick don't overwrite each other.
5. **audit-search lexicographic timestamps** (P2) — `toInstant` parses both sides via `Date.parse` and compares as numbers, so sub-second precision and timezone offsets order correctly.

## Verification

- `npm run typecheck && npm run lint` — green
- Targeted unit tests: 12 new, all passing locally
- Full `npm test` — running in background at PR-open time (will show on CI)
- `cargo test --all-features` — unaffected (no Rust changes)

## Test plan

- [x] `loadEntriesForRotationOrThrow` rejects malformed / non-array JSON with a message that names the path
- [x] Same function returns empty for missing file and empty file (existing behavior preserved)
- [x] Audit rotation creates three distinct archives across three rapid rotations; all decompress to valid content
- [x] `searchAuditLog` returns correct records when `since`/`until` use different sub-second precision
- [x] `searchAuditLog` returns correct records when `since` uses a timezone offset
- [ ] Manual: trigger a real pepper-rotate with an intentionally bad `.env` path to verify the rollback log lines land in `security-audit.jsonl`

## Next in the hotfix sequence

- #2 — sandbox + tier-3 scope bugs (fs-ops symlink escape, db.ts SQL comment bypass, `/tier 0` revoke, fs-permission process-wide bypass, Telegram `/config` allowlist)
- #3 — config-show redaction (MCP / HTTP / Telegram all currently leak unclassified env vars)
- #4 — functional P1s (TTS quota timing, container hook leak, mode tuning on `options.llm`, `DEFAULT_PROVIDER` fallback, chain diagnose exit code, `--pepper-restore` order, `latestVersion` self-refresh)
- #5 — P2 cleanup bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)