### PR TITLE
fix: Codex hotfix #2/5 — sandbox + tier-3 scope security cluster (P1)

### DIFF
--- a/src/gateway/channels/telegram.ts
+++ b/src/gateway/channels/telegram.ts
@@ -170,14 +170,27 @@ async function handleTierCommand(ctx: {
   }
 
   if (tier === 0) {
+    // Critical: `getSessionTier` checks tier-3 first, so without this
+    // revoke the /tier 0 command replies "downgraded" while effective
+    // permissions stay at tier 3 until the session TTL expires.
+    const wasTier3 = revokeTier3Session('telegram', chatId, 'operator-telegram-tier-downgrade');
     setSessionTier(chatId, 0);
-    await ctx.reply('Tier downgraded to 0 (safe mode).');
+    await ctx.reply(
+      wasTier3
+        ? 'Tier 3 revoked AND tier downgraded to 0 (safe mode).'
+        : 'Tier downgraded to 0 (safe mode).',
+    );
     return;
   }
 
   if (tier === 1) {
+    const wasTier3 = revokeTier3Session('telegram', chatId, 'operator-telegram-tier-downgrade');
     setSessionTier(chatId, 1);
-    await ctx.reply('Tier set to 1 (reduced operator mode). Expires in 15min.');
+    await ctx.reply(
+      wasTier3
+        ? 'Tier 3 revoked AND tier set to 1 (reduced operator mode). Expires in 15min.'
+        : 'Tier set to 1 (reduced operator mode). Expires in 15min.',
+    );
     return;
   }
 
@@ -220,8 +233,15 @@ async function handleTierCommand(ctx: {
     }
   }
 
+  // /tier 2 must revoke any active tier-3 too; otherwise the same
+  // misleading-downgrade bug as /tier 0|1 (Codex P1 on PR #77).
+  const wasTier3 = revokeTier3Session('telegram', chatId, 'operator-telegram-tier-downgrade');
   setSessionTier(chatId, DEFAULT_TELEGRAM_SESSION_TIER);
-  await ctx.reply('Tier 2 restored (default full companion mode).');
+  await ctx.reply(
+    wasTier3
+      ? 'Tier 3 revoked AND tier 2 restored (default full companion mode).'
+      : 'Tier 2 restored (default full companion mode).',
+  );
 }
 
 // ─── Adapter ─────────────────────────────────────────────────────────────────
@@ -318,6 +338,20 @@ export function createTelegramAdapter(
       bot.command('config', async (ctx) => {
         const msg = ctx.message;
         if (!msg) return;
+        // Allowlist gate — matches message:text / message:voice. Without this,
+        // any chat reachable by the bot token could execute /config show /
+        // /config set / /config reload. When the allowlist is empty
+        // (MEMPHIS_TELEGRAM_ALLOWED_USER_IDS unset), skip — operator has
+        // explicitly disabled the list. When populated, enforce strictly.
+        const allowedIds = parseTelegramAllowedUserIds(process.env);
+        const fromId = msg.from?.id;
+        if (
+          allowedIds.length > 0 &&
+          (fromId === undefined || !allowedIds.includes(String(fromId)))
+        ) {
+          await ctx.reply('Access denied.');
+          return;
+        }
         const chatId = String(msg.chat.id);
         const tier = getSessionTier(chatId);
         if (tier < 2) {

--- a/src/mcp/tools/db.ts
+++ b/src/mcp/tools/db.ts
@@ -50,13 +50,68 @@ function resolveDbPath(database?: string): string {
   return resolved;
 }
 
-function validateSql(sql: string, action: DbAction): string | undefined {
-  const trimmed = sql.trim().toUpperCase();
-  // Block dangerous operations
-  if (trimmed.startsWith('DROP ') || trimmed.startsWith('ALTER ')) {
+/**
+ * Strip SQL comments before opcode detection. Without this, the DROP/ALTER
+ * guard is bypassed by leading comments:
+ *   /* filler *\/ DROP TABLE ...
+ *   -- filler\nALTER TABLE ...
+ * Per Codex P1 on PR #76.
+ *
+ * Handles:
+ *   • block comments   /* ... *\/
+ *   • line comments    -- ... <newline>
+ *   • interleaved whitespace
+ *
+ * Does NOT attempt to strip string-literal content; any SQL reaching this
+ * validator should be a single canonical statement, not an attempt to hide
+ * DDL in a string that's then somehow re-executed.
+ */
+function stripSqlCommentsAndWhitespace(sql: string): string {
+  let out = '';
+  let i = 0;
+  while (i < sql.length) {
+    const c = sql[i];
+    const next = sql[i + 1];
+    if (c === '/' && next === '*') {
+      const end = sql.indexOf('*/', i + 2);
+      i = end === -1 ? sql.length : end + 2;
+      continue;
+    }
+    if (c === '-' && next === '-') {
+      const end = sql.indexOf('\n', i + 2);
+      i = end === -1 ? sql.length : end + 1;
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out.trimStart();
+}
+
+// Exported for direct unit testing (so the comment-bypass regression test
+// doesn't have to stand up a real SQLite database to exercise the guard).
+export function validateSql(sql: string, action: DbAction): string | undefined {
+  const stripped = stripSqlCommentsAndWhitespace(sql);
+  const trimmed = stripped.toUpperCase();
+  // Block dangerous operations — checked AFTER comment stripping so
+  // `/*x*/DROP TABLE foo` and `--evil\nALTER TABLE bar` don't slip through.
+  if (
+    trimmed.startsWith('DROP ') ||
+    trimmed.startsWith('ALTER ') ||
+    trimmed.startsWith('DROP\t') ||
+    trimmed.startsWith('ALTER\t') ||
+    trimmed.startsWith('DROP\n') ||
+    trimmed.startsWith('ALTER\n')
+  ) {
     return 'DROP and ALTER statements are blocked for safety';
   }
-  if (action === 'query' && !trimmed.startsWith('SELECT') && !trimmed.startsWith('WITH') && !trimmed.startsWith('EXPLAIN') && !trimmed.startsWith('PRAGMA')) {
+  if (
+    action === 'query' &&
+    !trimmed.startsWith('SELECT') &&
+    !trimmed.startsWith('WITH') &&
+    !trimmed.startsWith('EXPLAIN') &&
+    !trimmed.startsWith('PRAGMA')
+  ) {
     return `Action 'query' only supports SELECT, WITH, EXPLAIN, and PRAGMA statements`;
   }
   return undefined;

--- a/src/mcp/tools/fs-permission.ts
+++ b/src/mcp/tools/fs-permission.ts
@@ -17,12 +17,11 @@
  *     - .git/ directories (source of truth for state)
  *     - node_modules/ (reproducible from package-lock.json)
  */
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 import { AppError } from '../../core/errors.js';
-import { hasAnyActiveTier3Session } from '../../security/tier3-session.js';
 
 export type FsPermissionOperation =
   | 'create-new'   // fs-write mode=write (fails loud if exists outside sandbox)
@@ -61,10 +60,47 @@ function memphisSandboxDir(): string {
   return path.join(os.homedir(), 'memphis');
 }
 
+/**
+ * Resolve a path through any symlinks. If the path itself doesn't exist yet
+ * (e.g. a create-new target), walk up to the nearest existing ancestor,
+ * realpath that, and re-append the non-existent suffix. Returns the input
+ * when no existing ancestor is found (e.g. nonexistent root), which the
+ * caller then evaluates against the sandbox prefix as-is.
+ */
+function realpathOrNearest(resolvedPath: string): string {
+  try {
+    return realpathSync(resolvedPath);
+  } catch {
+    // Path doesn't exist; walk up.
+  }
+  const segments = path.normalize(resolvedPath).split(path.sep);
+  for (let depth = segments.length - 1; depth > 0; depth -= 1) {
+    const ancestor = segments.slice(0, depth).join(path.sep) || path.sep;
+    try {
+      const realAncestor = realpathSync(ancestor);
+      const suffix = segments.slice(depth).join(path.sep);
+      return suffix.length > 0 ? path.join(realAncestor, suffix) : realAncestor;
+    } catch {
+      // keep walking up
+    }
+  }
+  return path.normalize(resolvedPath);
+}
+
 export function isInsideMemphisSandbox(resolvedPath: string): boolean {
   const sandbox = memphisSandboxDir();
-  const normalized = path.normalize(resolvedPath);
-  return normalized === sandbox || normalized.startsWith(sandbox + path.sep);
+  // Resolve real paths so a symlink inside ~/memphis/ that points at /etc
+  // doesn't trick the prefix check into believing the target is inside the
+  // sandbox. Both sides are realpath'd in case ~/memphis itself is a symlink
+  // (common on NixOS / containerised setups).
+  let realSandbox: string;
+  try {
+    realSandbox = realpathSync(sandbox);
+  } catch {
+    realSandbox = sandbox;
+  }
+  const realTarget = realpathOrNearest(resolvedPath);
+  return realTarget === realSandbox || realTarget.startsWith(realSandbox + path.sep);
 }
 
 function assertNotAlwaysBlocked(resolvedPath: string): void {
@@ -123,17 +159,19 @@ export function assertFsPermission(resolvedPath: string, context: FsPermissionCo
 }
 
 /**
- * Read the tier-3 fs bypass flag from the current process env. Kept as a
- * helper so call sites can pass a custom rawEnv (for tests) without each
- * site duplicating the parsing.
+ * Read the tier-3 fs bypass flag from the REQUEST env. This must be the
+ * per-turn overlay set by `applyTier3EnvOverride(surface, actorId)`, not a
+ * process-global "any tier-3 session is active anywhere" fallback.
+ *
+ * The earlier `hasAnyActiveTier3Session` fallback broke per-actor isolation:
+ * one surface's tier-3 session (e.g. TUI elevation) would light up the
+ * bypass for every other surface's turn (e.g. a Telegram tier-2 request).
+ * That turned the fs bypass into a process-global privilege, contradicting
+ * the sprint-2 "tier-3 is scoped per surface+actor" contract.
+ *
+ * Surface code is responsible for threading the env overlay through to the
+ * tool executor — that's the only valid signal here.
  */
 export function isTier3FsBypassActive(rawEnv: NodeJS.ProcessEnv = process.env): boolean {
-  if ((rawEnv.MEMPHIS_TIER3_FS_UNRESTRICTED ?? '').toLowerCase() === 'true') {
-    return true;
-  }
-  // Fallback: if any tier-3 session is active in this process (e.g. TUI /tier 3
-  // elevation whose env override hasn't been threaded to the tool executor's
-  // rawEnv), respect it. Surface policy is the primary tier gate, so this
-  // cannot escalate a non-elevated surface past its declared maxToolTier.
-  return hasAnyActiveTier3Session(rawEnv);
+  return (rawEnv.MEMPHIS_TIER3_FS_UNRESTRICTED ?? '').toLowerCase() === 'true';
 }

--- a/tests/unit/db-sql-comment-bypass.test.ts
+++ b/tests/unit/db-sql-comment-bypass.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateSql } from '../../src/mcp/tools/db.js';
+
+/**
+ * Regression net for Codex P1 against PR #76: the SQL safety filter only
+ * checked `trim().toUpperCase().startsWith('DROP ' | 'ALTER ')`, so any SQL
+ * comment in front of the destructive keyword bypassed the guard. The fix
+ * strips block / line comments before the prefix check.
+ *
+ * Tests target `validateSql` directly so we don't have to stand up a real
+ * SQLite database — the guard fires before any DB I/O.
+ */
+
+describe('validateSql — SQL comment bypass guard', () => {
+  it.each([
+    '/* x */ DROP TABLE foo',
+    '/*x*/DROP TABLE foo',
+    '   /* multi\n   line */DROP TABLE bar',
+    '-- evil comment\nDROP TABLE qux',
+    '--\nDROP TABLE x',
+    '/*sql*/--also\nDROP TABLE y',
+    '/* x */ ALTER TABLE foo ADD COLUMN evil TEXT',
+    '-- x\nALTER TABLE foo DROP COLUMN safe',
+    '   --comment\n  /*more*/ DROP TABLE z',
+  ])('rejects DROP/ALTER hidden behind comments: %s', (sql) => {
+    expect(validateSql(sql, 'execute')).toMatch(/DROP and ALTER statements are blocked/);
+  });
+
+  it.each([
+    'DROP TABLE foo',
+    'ALTER TABLE foo ADD COLUMN x INT',
+    '  drop table foo',
+    'DROP\tTABLE foo',
+    'DROP\nTABLE foo',
+  ])('blocks plain DROP / ALTER (regression check): %s', (sql) => {
+    expect(validateSql(sql, 'execute')).toMatch(/DROP and ALTER statements are blocked/);
+  });
+
+  it('allows SELECT (regression check)', () => {
+    expect(validateSql('SELECT 1', 'query')).toBeUndefined();
+  });
+
+  it('allows comments before SELECT (regression check)', () => {
+    expect(validateSql('/* benign */ SELECT 1', 'query')).toBeUndefined();
+    expect(validateSql('-- benign\nSELECT 1', 'query')).toBeUndefined();
+  });
+
+  it("does not false-positive on a SELECT containing 'DROP' in a string literal", () => {
+    expect(validateSql("SELECT 'DROP TABLE evil' AS s", 'query')).toBeUndefined();
+  });
+
+  it('rejects non-SELECT for query action (regression check)', () => {
+    expect(validateSql('UPDATE foo SET a = 1', 'query')).toMatch(/SELECT, WITH, EXPLAIN, and PRAGMA/);
+  });
+});

--- a/tests/unit/fs-permission-symlink.test.ts
+++ b/tests/unit/fs-permission-symlink.test.ts
@@ -1,0 +1,149 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  assertFsPermission,
+  isInsideMemphisSandbox,
+  isTier3FsBypassActive,
+} from '../../src/mcp/tools/fs-permission.js';
+
+/**
+ * Regression net for Codex P1 against PR #76: the fs sandbox check only
+ * called `path.normalize`, so a symlink at ~/memphis/link -> /etc let a
+ * caller escape the sandbox. The fix resolves symlinks via `realpathSync`
+ * (walking up to the nearest existing ancestor for create-new paths).
+ *
+ * Also covers the second PR #77 P1: `isTier3FsBypassActive` used to fall
+ * back to the process-wide `hasAnyActiveTier3Session`, so one surface's
+ * tier-3 elevation leaked fs-mutation rights to every other surface. The
+ * fix now reads ONLY the per-request env override.
+ */
+
+interface TestEnv {
+  tmpHome: string;
+  sandboxDir: string;
+  origHome: string | undefined;
+}
+
+function setup(): TestEnv {
+  const tmpHome = mkdtempSync(path.join(os.tmpdir(), 'memphis-fs-perm-'));
+  const sandboxDir = path.join(tmpHome, 'memphis');
+  mkdirSync(sandboxDir, { recursive: true });
+  const origHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  return { tmpHome, sandboxDir, origHome };
+}
+
+function tearDown(env: TestEnv): void {
+  if (env.origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = env.origHome;
+  rmSync(env.tmpHome, { recursive: true, force: true });
+}
+
+describe('fs-permission — symlink escape protection (Codex P1)', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('flags a symlink inside ~/memphis that points at /etc as OUTSIDE sandbox', () => {
+    // /etc should exist in every real environment. On a CI host where it
+    // doesn't, the realpath call falls back; this test still exercises the
+    // intent — a symlink inside the sandbox whose target is outside must be
+    // rejected regardless.
+    const linkPath = path.join(env.sandboxDir, 'escape');
+    symlinkSync('/etc', linkPath);
+    // The symlink itself is inside the sandbox, but its realpath target
+    // (/etc) is not. isInsideMemphisSandbox must return false for the link.
+    expect(isInsideMemphisSandbox(linkPath)).toBe(false);
+  });
+
+  it('flags a symlink inside ~/memphis pointing at /tmp as OUTSIDE sandbox', () => {
+    const otherDir = mkdtempSync(path.join(os.tmpdir(), 'memphis-escape-target-'));
+    try {
+      const linkPath = path.join(env.sandboxDir, 'esc-link');
+      symlinkSync(otherDir, linkPath);
+      expect(isInsideMemphisSandbox(linkPath)).toBe(false);
+
+      // And descending through the symlink — should still be outside.
+      const childThroughLink = path.join(linkPath, 'child.txt');
+      expect(isInsideMemphisSandbox(childThroughLink)).toBe(false);
+    } finally {
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a regular file inside ~/memphis', () => {
+    const filePath = path.join(env.sandboxDir, 'legit.txt');
+    writeFileSync(filePath, 'ok', 'utf8');
+    expect(isInsideMemphisSandbox(filePath)).toBe(true);
+  });
+
+  it('accepts a not-yet-existing path inside ~/memphis (create-new)', () => {
+    const filePath = path.join(env.sandboxDir, 'new.txt');
+    expect(isInsideMemphisSandbox(filePath)).toBe(true);
+  });
+
+  it('refuses delete on a symlink-escape path even without tier-3', () => {
+    const linkPath = path.join(env.sandboxDir, 'danger');
+    const outside = mkdtempSync(path.join(os.tmpdir(), 'memphis-escape-'));
+    try {
+      const innerFile = path.join(outside, 'payload.txt');
+      writeFileSync(innerFile, 'sensitive', 'utf8');
+      symlinkSync(outside, linkPath);
+      // Delete on inner-file via the link: must trip the outside-sandbox
+      // gate (no tier-3 in this env), even though the path starts with
+      // ~/memphis.
+      expect(() =>
+        assertFsPermission(path.join(linkPath, 'payload.txt'), {
+          operation: 'delete',
+          tier3Active: false,
+        }),
+      ).toThrow();
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('fs-permission — tier-3 bypass is per-request only (Codex P1)', () => {
+  it('returns true only when the request env has the explicit override', () => {
+    expect(
+      isTier3FsBypassActive({
+        MEMPHIS_TIER3_FS_UNRESTRICTED: 'true',
+      } as NodeJS.ProcessEnv),
+    ).toBe(true);
+  });
+
+  it('returns false without the env override (no process-wide fallback)', () => {
+    // Even if the test harness had ambient tier-3 sessions, the fs bypass
+    // must not light up without the per-request env override.
+    expect(isTier3FsBypassActive({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it('case-insensitive on the env value', () => {
+    expect(
+      isTier3FsBypassActive({
+        MEMPHIS_TIER3_FS_UNRESTRICTED: 'TRUE',
+      } as NodeJS.ProcessEnv),
+    ).toBe(true);
+  });
+
+  it('rejects non-"true" values', () => {
+    for (const value of ['false', '1', 'yes', 'on', '']) {
+      expect(
+        isTier3FsBypassActive({
+          MEMPHIS_TIER3_FS_UNRESTRICTED: value,
+        } as NodeJS.ProcessEnv),
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Second of five Codex-driven hotfix PRs. Five P1 findings against PRs #76 / #77 / #84 — the security cluster. Together they fix three classes of escape: filesystem-sandbox escape via symlinks, SQL DDL execution via comment-prefix bypass, and process-wide privilege leak from one elevated surface to another.

1. **fs-permission symlink escape** (P1, PR #76) — `isInsideMemphisSandbox` only normalised the input string, so a symlink at `~/memphis/escape -> /etc` passed the prefix check. Now resolves both sides via `realpathSync` (walks up to the nearest existing ancestor for create-new targets), so the sandbox decision is made on the link's actual destination.
2. **fs-permission process-wide tier-3 leak** (P1, PR #77) — `isTier3FsBypassActive` fell back to `hasAnyActiveTier3Session()` when the per-request env override was missing, so one surface's tier-3 elevation lit up the bypass for every other surface's turn. The fallback is removed; only `MEMPHIS_TIER3_FS_UNRESTRICTED` (set by `applyTier3EnvOverride(surface, actorId)`) is honoured.
3. **db.ts SQL comment bypass** (P1, PR #76) — `/*x*/DROP TABLE` and `--evil\nALTER TABLE` slipped past the `startsWith('DROP '|'ALTER ')` filter. New `stripSqlCommentsAndWhitespace` strips block + line comments before the check.
4. **Telegram /tier 0|1|2 doesn't revoke active tier-3** (P1, PR #77) — `getSessionTier` checks tier-3 first, so /tier 0 replied "downgraded" while effective permissions stayed at tier 3 until expiry. All three lower-tier branches now call `revokeTier3Session()` first.
5. **Telegram /config missing allowlist gate** (P1, PR #84) — the new `/config` handler bypassed the `parseTelegramAllowedUserIds` check that exists on every other message path. Allowlist gate added at the top, matching `bot.on('message:text')`.

## Verification

- `npm run typecheck && npm run lint` — green
- Targeted unit tests: 27 new, all passing locally
- Full `npm test` — running on CI

## Test plan

- [x] symlink at `~/memphis/escape → /etc` flagged as outside sandbox
- [x] symlink to a tmp dir + descent through it both flagged outside
- [x] regular file inside sandbox accepted; create-new path inside accepted
- [x] tier-2 delete via symlink-escape path is rejected
- [x] `isTier3FsBypassActive` returns true ONLY when `MEMPHIS_TIER3_FS_UNRESTRICTED=true`; case-insensitive; rejects `1`/`yes`/`on`/etc
- [x] 9 SQL-comment-bypass attempts all rejected (block comment, line comment, multi-line block, mixed, tab/newline variants)
- [x] Plain DROP / ALTER (no comment) still rejected (regression check)
- [x] SELECT with `'DROP TABLE evil'` in a string literal NOT false-positived

## Next in the hotfix sequence

- #3 — config-show redaction (MCP / HTTP / Telegram all currently leak unclassified env vars)
- #4 — functional P1s (TTS quota timing, container hook leak, mode tuning on `options.llm`, `DEFAULT_PROVIDER` fallback, chain diagnose exit code, `--pepper-restore` order, `latestVersion` self-refresh)
- #5 — P2 cleanup bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)