### PR TITLE
fix: Codex hotfix #3/5 — config-show whitelist (secret leak fix, P1×3)

### DIFF
--- a/src/gateway/channels/telegram.ts
+++ b/src/gateway/channels/telegram.ts
@@ -12,6 +12,7 @@ import {
 } from '../../infra/config/hot-reload.js';
 import {
   classifyField,
+  listKnownFields,
   requiresElevatedTier,
   requiresRestart,
 } from '../../infra/config/mutability.js';
@@ -339,8 +340,22 @@ export function createTelegramAdapter(
         const [verb, ...rest] = text.split(/\s+/);
         const remainder = rest.join(' ').trim();
         if (verb === 'show') {
+          // Codex P1 fix: enumerate listKnownFields() instead of all of
+          // process.env, and reject single-key requests that aren't on the
+          // whitelist. Otherwise unrelated env vars (legacy operator
+          // credentials, host-side secrets, etc.) get echoed verbatim
+          // because redactFieldValue only masks keys it knows are secret.
+          const known = listKnownFields();
+          const knownKeySet = new Set(known.map((f) => f.key));
           const key = remainder || null;
           if (key) {
+            if (!knownKeySet.has(key)) {
+              await ctx.reply(
+                `Unknown config key: ${key}. /config show only exposes keys defined in envSchema. ` +
+                  `Use /config show (no key) to list them.`,
+              );
+              return;
+            }
             const value = process.env[key];
             await ctx.reply(
               value === undefined
@@ -349,11 +364,10 @@ export function createTelegramAdapter(
             );
           } else {
             const lines: string[] = ['Config fields (redacted):'];
-            for (const [name, raw] of Object.entries(process.env)) {
+            for (const field of known) {
+              const raw = process.env[field.key];
               if (raw === undefined) continue;
-              const tierLabel = classifyField(name);
-              if (tierLabel === 'cold' && !(name in process.env)) continue;
-              lines.push(`  ${name}=${redactFieldValue(name, raw)} (${tierLabel})`);
+              lines.push(`  ${field.key}=${redactFieldValue(field.key, raw)} (${field.tier})`);
               if (lines.length > 60) {
                 lines.push(`  ...truncated, use /config show <KEY> for specifics`);
                 break;

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -660,9 +660,27 @@ export function createHttpServer(
 
   // GET /v1/ops/config/show — redacted view of the current hot-reloadable env
   // surface + field classification. Never echoes secret values.
-  app.get('/v1/ops/config/show', async (request) => {
+  //
+  // Codex P1 fix: when `?key=…` is supplied, it must appear in
+  // listKnownFields(). Without the whitelist, an authenticated caller
+  // could pass any env var name (e.g. legacy operator-only credentials
+  // not tracked in the schema) and the response would echo the value
+  // verbatim because redactFieldValue only masks keys it knows are
+  // `secret`. This endpoint is for inspecting Memphis runtime config,
+  // not arbitrary process.env exfiltration.
+  app.get('/v1/ops/config/show', async (request, reply) => {
     const query = request.query as { key?: string } | undefined;
     const known = listKnownFields();
+    const knownKeySet = new Set(known.map((k) => k.key));
+
+    if (query?.key !== undefined && !knownKeySet.has(query.key)) {
+      return reply.status(400).send({
+        ok: false,
+        error: `Unknown config key: ${query.key}. /v1/ops/config/show only exposes keys defined in envSchema; use GET /v1/ops/config/show (no key) to list them.`,
+        requestedKey: query.key,
+      });
+    }
+
     const shownKeys = query?.key ? [query.key] : known.map((k) => k.key);
     const values: Record<string, string> = {};
     for (const key of shownKeys) {

--- a/src/mcp/tools/config.ts
+++ b/src/mcp/tools/config.ts
@@ -13,11 +13,35 @@ export interface MemphisConfigShowOutput {
   fields: Array<{ key: string; tier: MutabilityTier }>;
   values: Record<string, string>;
   requestedKey: string | null;
+  /** Set when the caller asked for a key not in the known-fields whitelist. */
+  unknownKey?: string;
 }
 
-/** Redacted view of the current hot-reloadable env surface. */
+/**
+ * Redacted view of the current hot-reloadable env surface.
+ *
+ * **Whitelist enforcement (Codex P1 fix):** when `input.key` is supplied,
+ * it must appear in `listKnownFields()` — i.e., a key actually defined in
+ * `envSchema` and classified in `mutability.ts`. Without this whitelist,
+ * a caller could pass any env var name (e.g. an operator-only legacy
+ * credential not tracked in the schema) and the response would echo the
+ * value verbatim because `redactFieldValue` only masks keys it knows are
+ * `secret`. Defense-in-depth: this tool is for inspecting Memphis runtime
+ * config, not for arbitrary `process.env` exfiltration.
+ */
 export function runMemphisConfigShow(input: { key?: string } = {}): MemphisConfigShowOutput {
   const fields = listKnownFields();
+  const knownKeySet = new Set(fields.map((f) => f.key));
+
+  if (input.key !== undefined && !knownKeySet.has(input.key)) {
+    return {
+      fields,
+      values: {},
+      requestedKey: input.key,
+      unknownKey: input.key,
+    };
+  }
+
   const targetKeys = input.key ? [input.key] : fields.map((f) => f.key);
   const values: Record<string, string> = {};
   for (const name of targetKeys) {

--- a/tests/unit/config-show-redaction.test.ts
+++ b/tests/unit/config-show-redaction.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMemphisConfigShow } from '../../src/mcp/tools/config.js';
+
+/**
+ * Regression net for Codex P1 against PRs #84 (Telegram /config show, HTTP
+ * /v1/ops/config/show) and #88 (MCP memphis_config_show). The bug: all
+ * three call sites accepted any caller-supplied key, read process.env[key]
+ * directly, and only redacted when classifyField(key) === 'secret'. Unknown
+ * env vars (host-side credentials, legacy operator-only env, etc.) leaked
+ * verbatim because the default tier for unknown keys is 'warm' (not secret).
+ *
+ * Fix: whitelist the request to listKnownFields() and reject anything else.
+ * Tested here for the MCP variant; the HTTP and Telegram fixes mirror it
+ * — see PR description for surface coverage notes.
+ */
+
+const SECRET_VAR = 'OPERATOR_LEGACY_TOKEN';
+const SECRET_VALUE = 'sk-leak-this-please-no-thanks';
+
+const savedEnv = { ...process.env };
+
+beforeEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, savedEnv);
+  // Set both a known and an unknown env to prove which gets returned.
+  process.env.GEN_MAX_TOKENS = '4096';
+  process.env[SECRET_VAR] = SECRET_VALUE;
+});
+
+afterEach(() => {
+  delete process.env.GEN_MAX_TOKENS;
+  delete process.env[SECRET_VAR];
+});
+
+describe('runMemphisConfigShow — whitelist enforcement (Codex P1)', () => {
+  it('lists known fields when no key is supplied (and never includes unknown env vars)', () => {
+    const result = runMemphisConfigShow();
+    expect(result.values.GEN_MAX_TOKENS).toBe('4096');
+    expect(result.values).not.toHaveProperty(SECRET_VAR);
+    // Sanity: the value of the leak candidate is nowhere in the response
+    expect(JSON.stringify(result)).not.toContain(SECRET_VALUE);
+  });
+
+  it('returns a single known key when supplied', () => {
+    const result = runMemphisConfigShow({ key: 'GEN_MAX_TOKENS' });
+    expect(result.requestedKey).toBe('GEN_MAX_TOKENS');
+    expect(result.values.GEN_MAX_TOKENS).toBe('4096');
+  });
+
+  it('refuses to echo an unknown env var even when the operator asks for it by name', () => {
+    const result = runMemphisConfigShow({ key: SECRET_VAR });
+    expect(result.requestedKey).toBe(SECRET_VAR);
+    expect(result.unknownKey).toBe(SECRET_VAR);
+    expect(result.values).toEqual({});
+    expect(JSON.stringify(result)).not.toContain(SECRET_VALUE);
+  });
+
+  it('refuses unknown keys with a typo-ish name (defense against probing)', () => {
+    const result = runMemphisConfigShow({ key: 'GEN_MAX_TOKEN' /* missing trailing S */ });
+    expect(result.unknownKey).toBe('GEN_MAX_TOKEN');
+    expect(result.values).toEqual({});
+  });
+
+  it('still redacts known SECRET fields when listing all', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-secret';
+    try {
+      const result = runMemphisConfigShow();
+      expect(result.values.ANTHROPIC_API_KEY).toBe('***redacted***');
+      expect(JSON.stringify(result)).not.toContain('sk-ant-secret');
+    } finally {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  it('still redacts a known SECRET field when requested by name', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-secret';
+    try {
+      const result = runMemphisConfigShow({ key: 'ANTHROPIC_API_KEY' });
+      expect(result.values.ANTHROPIC_API_KEY).toBe('***redacted***');
+    } finally {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Third of five Codex-driven hotfix PRs. Three P1s, all the same bug shape across surfaces: \`config show\` accepted any caller-supplied key, read \`process.env[key]\` directly, and only redacted when classified as \`secret\` in mutability.ts. Unknown env vars (host-side credentials, legacy operator-only env, CI tokens) inherited the default \`warm\` classification and were echoed **verbatim** — turning a "view known config" tool into a generic process.env exfiltration channel.

Three call sites, one fix shape: enumerate \`listKnownFields()\` (which matches \`envSchema\`) and reject anything not on the whitelist.

| Site | Behavior change |
|---|---|
| MCP \`memphis_config_show\` | Returns \`{unknownKey, values: {}}\` for off-whitelist keys |
| HTTP \`GET /v1/ops/config/show?key=\` | 400 with clear error naming the key |
| Telegram \`/config show <KEY>\` | Replies "Unknown config key" pointing at the list form; no-key list iterates whitelist instead of all of process.env |

## Verification

- \`npm run typecheck && npm run lint\` — green
- 6 new unit tests against the MCP variant (whitelist enforcement, redaction-still-works regressions, secret never appears in JSON.stringify of any path)
- Full \`npm test\` — runs on CI

## Test plan

- [x] No-key list never includes unknown env vars
- [x] No-key list still redacts known secret fields (\`***redacted***\`)
- [x] Single-key request for known field returns the value (or redacted)
- [x] Single-key request for unknown env var returns \`unknownKey\`, no value
- [x] Single-key request for typo'd name (e.g. \`GEN_MAX_TOKEN\` missing 's') rejected
- [x] Secret value never appears anywhere in the response object

## Sequence

- ✅ #96 vault correctness + audit integrity
- ✅ #97 sandbox + tier-3 scope security cluster
- ✅ #98 (this PR) config-show redaction
- ⏳ #99 functional P1s
- ⏳ #100 P2 cleanup bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)