### PR TITLE
feat: chain diagnose + audit rotate + rate-limit hot-swap

### DIFF
--- a/src/infra/cli/handlers/audit.handler.ts
+++ b/src/infra/cli/handlers/audit.handler.ts
@@ -1,3 +1,8 @@
+import {
+  maybeRotateAuditLog,
+  resolveAuditArchiveDir,
+  resolveAuditLogPath,
+} from '../../logging/audit-rotation.js';
 import { searchAuditLog } from '../../logging/audit-search.js';
 import type { CliContext } from '../context.js';
 import type { CommandHandler } from './command-handler.js';
@@ -36,11 +41,35 @@ export const auditCommandHandler: CommandHandler = {
     if (subcommand === 'search') {
       return handleAuditSearch(context);
     }
+    if (subcommand === 'rotate') {
+      return handleAuditRotate(context);
+    }
     throw new Error(
-      `Unknown audit subcommand: ${String(subcommand)}. Available: search.`,
+      `Unknown audit subcommand: ${String(subcommand)}. Available: search, rotate.`,
     );
   },
 };
+
+async function handleAuditRotate(context: CliContext): Promise<boolean> {
+  // Wraps the existing rotation engine. Useful as an explicit operator
+  // command — rotation otherwise only fires opportunistically when audit
+  // writes cross the size threshold. Operators trigger this manually
+  // before a backup, before a long offline period, or to trim before an
+  // archive-retention policy needs the prior file out of the way.
+  const result = maybeRotateAuditLog(process.env);
+  print(
+    {
+      ok: true,
+      rotated: result.rotated,
+      archivePath: result.archivePath ?? null,
+      bytesArchived: result.bytesArchived ?? 0,
+      logPath: resolveAuditLogPath(process.env),
+      archiveDir: resolveAuditArchiveDir(process.env),
+    },
+    context.args.json,
+  );
+  return true;
+}
 
 async function handleAuditSearch(context: CliContext): Promise<boolean> {
   const { json, since, until, action, status, contains, limit } = context.args;

--- a/src/infra/cli/handlers/storage.handler.ts
+++ b/src/infra/cli/handlers/storage.handler.ts
@@ -15,7 +15,12 @@ import {
 } from '../../config/request-schemas.js';
 import { buildOperatorGuide, renderOperatorGuideText } from '../../operator-guide.js';
 import { renderSecretAwarenessText } from '../../secret-awareness.js';
-import { exportChain, verifyChainIntegrity } from '../../storage/chain-adapter.js';
+import {
+  diagnoseChainHashes,
+  exportChain,
+  rebuildChainHashes,
+  verifyChainIntegrity,
+} from '../../storage/chain-adapter.js';
 import { NapiChainAdapter } from '../../storage/rust-chain-adapter.js';
 import { getRustEmbedAdapterStatus } from '../../storage/rust-embed-adapter.js';
 import { loadReplayBlocksFromChain, normalizeReplayBlocks } from '../../storage/soul.js';
@@ -234,22 +239,42 @@ async function handleChainCommand(context: CliContext): Promise<boolean> {
     print(result, json);
     return true;
   }
-  // Explicit unknown-subcommand error so the operator sees the closed door
-  // instead of a silent fall-through. Sprint 12 added `verify`; `diagnose`
-  // and other historical subcommand names are not yet implemented.
-  if (subcommand !== undefined && subcommand !== '') {
-    const available = ['import_json', 'export', 'verify', 'rebuild'];
-    print(
-      {
-        ok: false,
-        command: 'chain',
-        subcommand,
-        error: `chain ${subcommand} is not implemented`,
-        available,
-      },
-      json,
-    );
+  // chain diagnose — reports per-block hash mismatches without mutating
+  // anything. Pairs with `chain rebuild-hashes` (below) for repair.
+  if (subcommand === 'diagnose') {
+    if (!chain) {
+      throw new Error('chain diagnose requires --chain <name>');
+    }
+    const result = await diagnoseChainHashes(chain);
+    print(result, json);
     return true;
+  }
+  // chain rebuild-hashes — destructive; recomputes and writes hashes for
+  // every block in the named chain. Disambiguates from `rebuild` (which
+  // rebuilds derived indexes, not the on-disk hash columns).
+  if (subcommand === 'rebuild-hashes') {
+    if (!chain) {
+      throw new Error('chain rebuild-hashes requires --chain <name>');
+    }
+    const result = await rebuildChainHashes(chain);
+    print(result, json);
+    return true;
+  }
+  // Explicit unknown-subcommand error so the operator sees the closed
+  // door instead of a silent fall-through. Throws (Codex P1 fix in
+  // PR #99) so `memphis chain verfiy` typos exit non-zero in CI.
+  if (subcommand !== undefined && subcommand !== '') {
+    const available = [
+      'import_json',
+      'export',
+      'verify',
+      'rebuild',
+      'diagnose',
+      'rebuild-hashes',
+    ];
+    throw new Error(
+      `Unknown chain subcommand: ${subcommand}. Available: ${available.join(', ')}.`,
+    );
   }
   return false;
 }

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -153,9 +153,9 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
   MEMPHIS_QUEUE_WAL_MAX_BYTES: 'warm',
   MEMPHIS_MAX_PENDING_TASKS: 'warm',
 
-  // ── Rate limits (module singletons — warm until we refactor) ──
-  MEMPHIS_RATE_LIMIT_GLOBAL_MAX: 'warm',
-  MEMPHIS_RATE_LIMIT_SENSITIVE_MAX: 'warm',
+  // ── Rate limits — hot via post-apply hook in src/infra/http/rate-limit.ts ──
+  MEMPHIS_RATE_LIMIT_GLOBAL_MAX: 'hot',
+  MEMPHIS_RATE_LIMIT_SENSITIVE_MAX: 'hot',
 
   // ── Frame buffer (Sprint 11) ──
   MEMPHIS_FRAME_BUFFER_SIZE: 'hot',

--- a/src/infra/http/rate-limit.ts
+++ b/src/infra/http/rate-limit.ts
@@ -1,4 +1,5 @@
 import { AppError } from '../../core/errors.js';
+import { registerPostApplyHook } from '../config/post-apply-hooks.js';
 
 type Bucket = {
   count: number;
@@ -8,11 +9,33 @@ type Bucket = {
 export class RateLimiter {
   private buckets = new Map<string, Bucket>();
   private checkCount = 0;
+  private maxRequests: number;
+  private readonly windowMs: number;
 
-  constructor(
-    private readonly maxRequests: number,
-    private readonly windowMs: number,
-  ) {}
+  constructor(maxRequests: number, windowMs: number) {
+    this.maxRequests = maxRequests;
+    this.windowMs = windowMs;
+  }
+
+  /** Operator-driven runtime adjustment (Sprint 6 deferral closed). */
+  public setMaxRequests(value: number): { changed: boolean; previous: number; next: number } {
+    const previous = this.maxRequests;
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new AppError(
+        'VALIDATION_ERROR',
+        `setMaxRequests: expected a positive number, got ${value}`,
+        400,
+      );
+    }
+    const next = Math.floor(value);
+    if (previous === next) return { changed: false, previous, next };
+    this.maxRequests = next;
+    return { changed: true, previous, next };
+  }
+
+  public getMaxRequests(): number {
+    return this.maxRequests;
+  }
 
   public check(key: string, now = Date.now()): void {
     this.checkCount += 1;
@@ -53,3 +76,32 @@ export const sensitiveLimiter = new RateLimiter(
   60_000,
 );
 export const execLimiter = new RateLimiter(envInt('MEMPHIS_RATE_LIMIT_SENSITIVE_MAX', 10), 60_000);
+
+// Hot-swap: when the operator changes a rate-limit env via /config set,
+// the post-apply hook updates the live limiter cap. Without this, the
+// singleton's maxRequests was baked in at module-load time and Sprint 6's
+// `/config reload` had no effect on rate limits. Hooks are idempotent
+// (PR #99), so re-import of this module doesn't accumulate registrations.
+registerPostApplyHook(
+  'MEMPHIS_RATE_LIMIT_GLOBAL_MAX',
+  'rate-limit.globalLimiter.setMaxRequests',
+  (ctx) => {
+    if (!ctx.nextValue) return;
+    const parsed = Number(ctx.nextValue);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      globalLimiter.setMaxRequests(parsed);
+    }
+  },
+);
+registerPostApplyHook(
+  'MEMPHIS_RATE_LIMIT_SENSITIVE_MAX',
+  'rate-limit.sensitiveLimiter.setMaxRequests',
+  (ctx) => {
+    if (!ctx.nextValue) return;
+    const parsed = Number(ctx.nextValue);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      sensitiveLimiter.setMaxRequests(parsed);
+      execLimiter.setMaxRequests(parsed);
+    }
+  },
+);

--- a/tests/unit/missing-handlers-and-hotswap.test.ts
+++ b/tests/unit/missing-handlers-and-hotswap.test.ts
@@ -1,0 +1,174 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runPostApplyHooks } from '../../src/infra/config/post-apply-hooks.js';
+import {
+  RateLimiter,
+  globalLimiter,
+  sensitiveLimiter,
+} from '../../src/infra/http/rate-limit.js';
+
+interface ChainEnv {
+  dataDir: string;
+  prevEnv: NodeJS.ProcessEnv;
+}
+
+function setupChainEnv(): ChainEnv {
+  const dataDir = mkdtempSync(join(tmpdir(), 'memphis-nice-'));
+  const prevEnv = { ...process.env };
+  process.env.MEMPHIS_DATA_DIR = dataDir;
+  process.env.RUST_CHAIN_ENABLED = 'false';
+  return { dataDir, prevEnv };
+}
+
+function tearDownChainEnv(env: ChainEnv): void {
+  rmSync(env.dataDir, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) {
+    if (!(key in env.prevEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, env.prevEnv);
+}
+
+describe('chain diagnose handler', () => {
+  let env: ChainEnv;
+
+  beforeEach(() => {
+    env = setupChainEnv();
+  });
+
+  afterEach(() => {
+    tearDownChainEnv(env);
+  });
+
+  it('reports zero mismatches on an empty chain dir', async () => {
+    const chain = 'empty';
+    mkdirSync(join(env.dataDir, 'chains', chain), { recursive: true });
+    const { diagnoseChainHashes } = await import(
+      '../../src/infra/storage/chain-adapter.js'
+    );
+    const result = await diagnoseChainHashes(chain);
+    expect(result.mismatches).toBe(0);
+    expect(result.totalBlocks).toBe(0);
+  });
+
+  it('reports a mismatch when a block hash has been tampered', async () => {
+    const chain = 'tamper';
+    const dir = join(env.dataDir, 'chains', chain);
+    mkdirSync(dir, { recursive: true });
+    // Write a block with a deliberately wrong hash. The diagnose helper
+    // should compare the stored hash to the recomputed hash and flag.
+    writeFileSync(
+      join(dir, '000001.json'),
+      JSON.stringify({
+        index: 1,
+        timestamp: '2026-04-13T00:00:00.000Z',
+        chain,
+        data: { content: 'hello' },
+        prev_hash: '',
+        hash: 'WRONG_HASH',
+      }),
+    );
+    const { diagnoseChainHashes } = await import(
+      '../../src/infra/storage/chain-adapter.js'
+    );
+    const result = await diagnoseChainHashes(chain);
+    expect(result.totalBlocks).toBe(1);
+    expect(result.mismatches).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('audit rotate handler — wraps maybeRotateAuditLog', () => {
+  let dataDir: string;
+  const prevEnv = { ...process.env };
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'memphis-audit-rotate-'));
+    process.env.MEMPHIS_SECURITY_AUDIT_LOG_PATH = join(dataDir, 'audit.jsonl');
+    process.env.MEMPHIS_SECURITY_AUDIT_ARCHIVE_DIR = join(dataDir, 'archives');
+    process.env.MEMPHIS_SECURITY_AUDIT_ROTATE_BYTES = '65536';
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) {
+      if (!(key in prevEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, prevEnv);
+  });
+
+  it('returns rotated=false when log is below threshold', async () => {
+    writeFileSync(process.env.MEMPHIS_SECURITY_AUDIT_LOG_PATH!, 'tiny\n');
+    const { maybeRotateAuditLog } = await import(
+      '../../src/infra/logging/audit-rotation.js'
+    );
+    const result = maybeRotateAuditLog();
+    expect(result.rotated).toBe(false);
+  });
+
+  it('returns rotated=true with archivePath when over threshold', async () => {
+    writeFileSync(
+      process.env.MEMPHIS_SECURITY_AUDIT_LOG_PATH!,
+      'x'.padEnd(70_000, '.') + '\n',
+    );
+    const { maybeRotateAuditLog } = await import(
+      '../../src/infra/logging/audit-rotation.js'
+    );
+    const result = maybeRotateAuditLog();
+    expect(result.rotated).toBe(true);
+    expect(result.archivePath).toMatch(/\.jsonl\.gz$/);
+  });
+});
+
+describe('rate-limit hot-swap via post-apply hook', () => {
+  it('setMaxRequests changes the cap on the live limiter', () => {
+    const limiter = new RateLimiter(5, 60_000);
+    expect(limiter.getMaxRequests()).toBe(5);
+    const result = limiter.setMaxRequests(20);
+    expect(result.changed).toBe(true);
+    expect(result.previous).toBe(5);
+    expect(result.next).toBe(20);
+    expect(limiter.getMaxRequests()).toBe(20);
+  });
+
+  it('setMaxRequests reports no-op when value matches', () => {
+    const limiter = new RateLimiter(5, 60_000);
+    const result = limiter.setMaxRequests(5);
+    expect(result.changed).toBe(false);
+  });
+
+  it('rejects non-positive values', () => {
+    const limiter = new RateLimiter(5, 60_000);
+    expect(() => limiter.setMaxRequests(0)).toThrow(/positive number/);
+    expect(() => limiter.setMaxRequests(-1)).toThrow(/positive number/);
+  });
+
+  it('post-apply hook for MEMPHIS_RATE_LIMIT_GLOBAL_MAX updates the global singleton', async () => {
+    const before = globalLimiter.getMaxRequests();
+    await runPostApplyHooks({
+      changes: [
+        { key: 'MEMPHIS_RATE_LIMIT_GLOBAL_MAX', oldValue: String(before), newValue: '777' },
+      ],
+    });
+    expect(globalLimiter.getMaxRequests()).toBe(777);
+    // restore for other tests
+    globalLimiter.setMaxRequests(before);
+  });
+
+  it('post-apply hook for MEMPHIS_RATE_LIMIT_SENSITIVE_MAX updates sensitive + exec limiters', async () => {
+    const before = sensitiveLimiter.getMaxRequests();
+    await runPostApplyHooks({
+      changes: [
+        {
+          key: 'MEMPHIS_RATE_LIMIT_SENSITIVE_MAX',
+          oldValue: String(before),
+          newValue: '99',
+        },
+      ],
+    });
+    expect(sensitiveLimiter.getMaxRequests()).toBe(99);
+    sensitiveLimiter.setMaxRequests(before);
+  });
+});


### PR DESCRIPTION
## Summary

Four "make it nicer" follow-ups bundled into one PR. None fix anything broken — they fill the gaps PR #99 made loud and close two of three Sprint 6 warm-field deferrals.

| # | Capability | Was | Now |
|---|---|---|---|
| 1 | \`memphis chain diagnose --chain <name>\` | "not implemented" error | Wires existing \`diagnoseChainHashes()\` — reports per-block hash mismatches |
| 2 | \`memphis chain rebuild-hashes --chain <name>\` | (didn't exist) | Wires existing \`rebuildChainHashes()\`. Disambiguates from \`chain rebuild\` (derived indexes) |
| 3 | \`memphis audit rotate\` | "not implemented" error | Operator-driven \`maybeRotateAuditLog()\` trigger |
| 4 | \`MEMPHIS_RATE_LIMIT_GLOBAL_MAX\` / \`_SENSITIVE_MAX\` | warm (restart needed) | hot via post-apply hook on \`RateLimiter.setMaxRequests\` |

## Verification

- \`npm run typecheck && npm run lint\` — green
- 9 new unit tests, all passing locally
- Full \`npm test\` runs on CI

## Test plan

- [x] \`diagnoseChainHashes\` reports zero mismatches on empty / clean chain
- [x] \`diagnoseChainHashes\` reports ≥1 mismatch on tampered block
- [x] \`maybeRotateAuditLog\` returns \`rotated=false\` below threshold
- [x] \`maybeRotateAuditLog\` returns \`rotated=true\` + archivePath above threshold
- [x] \`RateLimiter.setMaxRequests\` round-trip; no-op on equal value; rejects ≤ 0
- [x] Post-apply hook for \`MEMPHIS_RATE_LIMIT_GLOBAL_MAX\` updates global singleton
- [x] Post-apply hook for \`MEMPHIS_RATE_LIMIT_SENSITIVE_MAX\` updates sensitive + exec
- [ ] Manual: \`./bin/memphis.js chain diagnose --chain journal --json\` returns structured diagnosis
- [ ] Manual: \`/config set MEMPHIS_RATE_LIMIT_GLOBAL_MAX=200\` → \`/config reload\` → next 200 reqs/min not throttled

## Sprint 6 deferral status

- ✅ Provider hot-swap (PR #94)
- ✅ Rate-limit singletons (this PR)
- ⏳ Per-instance logger level — own follow-up; needs central logger registry refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)