### PR TITLE
fix: Codex Round 3 — Anthropic OAuth full-pair requirement

### DIFF
--- a/src/infra/config/env.ts
+++ b/src/infra/config/env.ts
@@ -23,25 +23,46 @@ function describeRequirement(requirement: ProviderRequirement): string {
  * a fresh-host setup with `DEFAULT_PROVIDER=anthropic` but only Minimax
  * keys lands on Minimax instead of collapsing straight to local-fallback
  * (and short-circuiting the operator-preferred cascade).
+ *
+ * Codex P2 (Round 3): entries now support a `check(config)` predicate for
+ * providers whose "configured" state doesn't reduce to a flat list of
+ * alternative keys. Anthropic uses this to mirror runtime-registry's
+ * requirement: (API_KEY direct OR vault) OR (OAuth pair: CLIENT_ID AND
+ * (CLIENT_SECRET direct OR vault)). Previously a single OAuth field was
+ * enough to mark Anthropic as configured, which let the cascade pick it
+ * even when no Anthropic client could actually be built.
  */
+type ProviderCheck = (config: AppConfig) => boolean;
+
 const PROVIDER_REQUIREMENTS: Array<{
   provider: AppConfig['DEFAULT_PROVIDER'];
   keys: ProviderRequirement[];
+  check?: ProviderCheck;
 }> = [
   {
     provider: 'anthropic',
-    // Codex P2 (Round 2): accept OAuth-only Anthropic configs. `runtime-registry`
-    // builds an Anthropic client when either API_KEY/VAULT_KEY is set OR the
-    // OAuth pair (CLIENT_ID + CLIENT_SECRET) is present. Mirror that here so
-    // the cascade picker doesn't skip an OAuth-configured Anthropic.
+    // Displayed in the `requireConfiguredProvider` warning message; the
+    // actual gating is done by `check` below.
     keys: [
       [
         'ANTHROPIC_API_KEY',
         'ANTHROPIC_VAULT_KEY',
-        'ANTHROPIC_OAUTH_CLIENT_ID',
-        'ANTHROPIC_OAUTH_SECRET_VAULT_KEY',
+        'ANTHROPIC_OAUTH_CLIENT_ID + ANTHROPIC_OAUTH_CLIENT_SECRET',
       ],
     ],
+    check: (config) => {
+      const hasApiKey =
+        hasValue(config.ANTHROPIC_API_KEY as string | undefined) ||
+        hasValue(config.ANTHROPIC_VAULT_KEY as string | undefined);
+      if (hasApiKey) return true;
+      // OAuth path needs the FULL pair: client id plus a source for the
+      // secret (direct env or vault-referenced secret).
+      const hasOauthId = hasValue(config.ANTHROPIC_OAUTH_CLIENT_ID as string | undefined);
+      const hasOauthSecret =
+        hasValue(config.ANTHROPIC_OAUTH_CLIENT_SECRET as string | undefined) ||
+        hasValue(config.ANTHROPIC_OAUTH_SECRET_VAULT_KEY as string | undefined);
+      return hasOauthId && hasOauthSecret;
+    },
   },
   { provider: 'minimax', keys: [['MINIMAX_API_KEY', 'MINIMAX_VAULT_KEY']] },
   { provider: 'shared-llm', keys: ['SHARED_LLM_API_BASE', 'SHARED_LLM_API_KEY'] },
@@ -55,9 +76,10 @@ const PROVIDER_REQUIREMENTS: Array<{
 
 function isProviderConfigured(
   config: AppConfig,
-  requiredKeys: ProviderRequirement[],
+  entry: { keys: ProviderRequirement[]; check?: ProviderCheck },
 ): boolean {
-  for (const key of requiredKeys) {
+  if (entry.check) return entry.check(config);
+  for (const key of entry.keys) {
     if (Array.isArray(key)) {
       if (!key.some((option) => hasValue(config[option as keyof AppConfig] as string))) {
         return false;
@@ -102,7 +124,7 @@ function pickCascadeFallback(
       continue;
     }
     const entry = PROVIDER_REQUIREMENTS.find((p) => p.provider === candidate);
-    if (entry && isProviderConfigured(config, entry.keys)) {
+    if (entry && isProviderConfigured(config, entry)) {
       return entry.provider;
     }
   }

--- a/tests/unit/default-provider-cascade-fallback.test.ts
+++ b/tests/unit/default-provider-cascade-fallback.test.ts
@@ -78,10 +78,9 @@ describe('loadConfig — DEFAULT_PROVIDER cascade fallback', () => {
     expect(config.DEFAULT_PROVIDER).toBe('local-fallback');
   });
 
-  it('accepts Anthropic OAuth-only configs in the cascade picker', () => {
-    // Codex P2 (Round 2): Anthropic can be configured via OAuth credentials
-    // (client id + vault secret key). The cascade picker must recognize those
-    // and not skip an OAuth-only Anthropic to a later tier.
+  it('accepts Anthropic OAuth when BOTH client id and secret (vault) are set', () => {
+    // Codex P2 (Round 2): Anthropic can be configured via OAuth. The
+    // cascade picker must recognize it and not skip to a later tier.
     const config = loadConfig(
       envWith({
         DEFAULT_PROVIDER: 'shared-llm',
@@ -90,6 +89,44 @@ describe('loadConfig — DEFAULT_PROVIDER cascade fallback', () => {
       }),
     );
     expect(config.DEFAULT_PROVIDER).toBe('anthropic');
+  });
+
+  it('accepts Anthropic OAuth when BOTH client id and CLIENT_SECRET env are set', () => {
+    const config = loadConfig(
+      envWith({
+        DEFAULT_PROVIDER: 'shared-llm',
+        ANTHROPIC_OAUTH_CLIENT_ID: 'oauth-client-id',
+        ANTHROPIC_OAUTH_CLIENT_SECRET: 'plaintext-oauth-secret',
+      }),
+    );
+    expect(config.DEFAULT_PROVIDER).toBe('anthropic');
+  });
+
+  it('REJECTS Anthropic when only OAuth CLIENT_ID is set (no secret)', () => {
+    // Codex P2 (Round 3): one OAuth field is NOT enough — runtime-registry
+    // requires the full pair (client id + secret). Before this fix the
+    // cascade picker treated any single OAuth field as "configured", so
+    // loadConfig could select anthropic when no Anthropic client could
+    // actually register at runtime.
+    const config = loadConfig(
+      envWith({
+        DEFAULT_PROVIDER: 'shared-llm',
+        ANTHROPIC_OAUTH_CLIENT_ID: 'oauth-client-id',
+        // no ANTHROPIC_OAUTH_CLIENT_SECRET and no ANTHROPIC_OAUTH_SECRET_VAULT_KEY
+      }),
+    );
+    expect(config.DEFAULT_PROVIDER).toBe('local-fallback');
+  });
+
+  it('REJECTS Anthropic when only OAuth SECRET_VAULT_KEY is set (no client id)', () => {
+    const config = loadConfig(
+      envWith({
+        DEFAULT_PROVIDER: 'shared-llm',
+        ANTHROPIC_OAUTH_SECRET_VAULT_KEY: 'vault:oauth-secret',
+        // no ANTHROPIC_OAUTH_CLIENT_ID
+      }),
+    );
+    expect(config.DEFAULT_PROVIDER).toBe('local-fallback');
   });
 
   it('honors MEMPHIS_PROVIDER_CASCADE override when picking fallback', () => {


### PR DESCRIPTION
## Summary

Codex Round 3 P2 on PR #99's Round 2 fix (commit 82a4bf6f26):

> This requirement list is evaluated as a single OR group by isProviderConfigured, so setting only one OAuth field (for example just ANTHROPIC_OAUTH_CLIENT_ID) is enough to mark Anthropic as configured. In src/providers/runtime-registry.ts, Anthropic OAuth registration requires both client ID and secret (or a refresh-token path), so the fallback picker can now choose anthropic even when no usable Anthropic provider will actually register.

### Root cause
Round 2's fix put all four Anthropic credential sources (API_KEY / VAULT_KEY / OAUTH_CLIENT_ID / OAUTH_SECRET_VAULT_KEY) into one flat OR group. A single OAuth field was enough to pass the check.

### Fix
Added an optional `check(config)` predicate to `PROVIDER_REQUIREMENTS`. Anthropic now mirrors `runtime-registry.ts` exactly:
```
hasApiKey       := ANTHROPIC_API_KEY OR ANTHROPIC_VAULT_KEY
hasOauthId      := ANTHROPIC_OAUTH_CLIENT_ID
hasOauthSecret  := ANTHROPIC_OAUTH_CLIENT_SECRET OR ANTHROPIC_OAUTH_SECRET_VAULT_KEY
configured      := hasApiKey OR (hasOauthId AND hasOauthSecret)
```

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] New: REJECTS Anthropic when only CLIENT_ID set (regression for the exact Codex flag)
- [x] New: REJECTS Anthropic when only SECRET_VAULT_KEY set
- [x] New: ACCEPTS Anthropic when CLIENT_ID + plaintext CLIENT_SECRET set
- [x] Existing: ACCEPTS Anthropic when CLIENT_ID + SECRET_VAULT_KEY set
- [x] Existing: ACCEPTS Anthropic when API_KEY set (direct or vault)
- [x] default-provider-cascade-fallback tests: 10/10 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)