### PR TITLE
fix: Codex Round 4 — restart-passphrase leak + first-run + rate-limit throw

### DIFF
--- a/src/infra/cli/commands/restart.ts
+++ b/src/infra/cli/commands/restart.ts
@@ -37,11 +37,29 @@ export async function handleSelfRestartCommand(
   // session-granting flows are Telegram `/tier 3 <pass>` and TUI
   // `security.tier.elevate`. Run the operator-passphrase gate locally and
   // pass `alreadyElevated` to the engine.
-  const authorized = await requireOperatorAuth(
-    undefined,
-    process.env,
-    args.operatorPassphrase,
-  );
+  //
+  // Codex P2 (Round 4): requireOperatorAuth → validateOperatorPassphrase
+  // throws on the attempt rate-limit. Catch so brute-force attempts
+  // surface a refusal rather than an unhandled exception stack.
+  let authorized: boolean;
+  try {
+    authorized = await requireOperatorAuth(
+      undefined,
+      process.env,
+      args.operatorPassphrase,
+    );
+  } catch (err) {
+    print(
+      {
+        mode: 'restart',
+        ok: false,
+        reason: 'not-elevated',
+        message: `restart refused — ${err instanceof Error ? err.message : 'passphrase check failed'}`,
+      },
+      args.json,
+    );
+    return true;
+  }
   if (!authorized) {
     print(
       {

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -808,30 +808,42 @@ export function createHttpServer(
       '../auth/operator-gate.js'
     );
 
-    let alreadyElevated = false;
-    let elevatedVia: string | undefined;
-    // If operator hasn't set a passphrase yet (first-run state),
-    // loadOperatorConfig returns null — fall through without requiring one.
+    let alreadyElevated: boolean;
+    let elevatedVia: string;
     if (loadOperatorConfig(process.env)) {
       if (!passphrase) {
-        const blocked = {
+        return reply.status(403).send({
           ok: false,
           reason: 'not-elevated' as const,
           message:
             'restart refused — operator passphrase required in request body as `passphrase` field.',
-        };
-        return reply.status(403).send(blocked);
+        });
       }
-      if (!validateOperatorPassphrase(passphrase, process.env)) {
-        const blocked = {
+      // Codex P2 (Round 4): validateOperatorPassphrase throws on the
+      // attempt rate-limit. Catch so brute-force doesn't surface as a 500.
+      try {
+        if (!validateOperatorPassphrase(passphrase, process.env)) {
+          return reply.status(403).send({
+            ok: false,
+            reason: 'not-elevated' as const,
+            message: 'restart refused — operator passphrase did not validate.',
+          });
+        }
+      } catch (err) {
+        return reply.status(403).send({
           ok: false,
           reason: 'not-elevated' as const,
-          message: 'restart refused — operator passphrase did not validate.',
-        };
-        return reply.status(403).send(blocked);
+          message: `restart refused — ${err instanceof Error ? err.message : 'passphrase check failed'}`,
+        });
       }
       alreadyElevated = true;
       elevatedVia = 'http-passphrase-body';
+    } else {
+      // Codex P2 (Round 4): first-run — no operator config set yet. HTTP
+      // has no session-minting flow, so mark the call as pre-validated.
+      // Access is still gated by MEMPHIS_API_TOKEN (see auth-policy).
+      alreadyElevated = true;
+      elevatedVia = 'http-first-run-no-config';
     }
 
     const outcome = await requestRestart({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -129,11 +129,34 @@ function pendingResult(data: Record<string, unknown>): ToolResult {
   };
 }
 
+/**
+ * Strip redacted fields from args before they're persisted to the approval
+ * SQLite table. The original `args` passed to the handler are NOT modified
+ * — the handler still receives the real values at execution time. Only
+ * the persisted / later-echoed copy loses the secret.
+ *
+ * Codex P1 (Round 4): memphis_restart accepts `passphrase` in its input;
+ * without redaction, that operator secret ended up in SQLite and in the
+ * output of `memphis config tools pending` and sibling listing commands.
+ */
+function redactForStorage(
+  args: Record<string, unknown>,
+  redactFields: readonly string[],
+): Record<string, unknown> {
+  if (redactFields.length === 0) return args;
+  const copy = { ...args };
+  for (const key of redactFields) {
+    if (key in copy) copy[key] = '[REDACTED]';
+  }
+  return copy;
+}
+
 function withApprovalGate<T extends Record<string, unknown>>(
   toolName: string,
   policy: ToolPolicy,
   approvals: SqliteToolCallApprovalRepository,
   handler: (args: T) => Promise<ToolResult>,
+  redactFields: readonly string[] = [],
 ): (args: T) => Promise<ToolResult> {
   if (policy === 'allow') return handler;
 
@@ -162,10 +185,12 @@ function withApprovalGate<T extends Record<string, unknown>>(
       }
     }
 
-    // Create a pending approval request
+    // Create a pending approval request — redact sensitive fields so the
+    // persisted arguments_json (and later approval-listing output) don't
+    // leak the operator passphrase or similar secrets.
     const request = approvals.createRequest({
       toolName,
-      arguments: args as Record<string, unknown>,
+      arguments: redactForStorage(args as Record<string, unknown>, redactFields),
     });
 
     return pendingResult({
@@ -1177,6 +1202,10 @@ export function createMemphisMcpServer(
             structuredContent: result as unknown as Record<string, unknown>,
           };
         },
+        // Codex P1 (Round 4): `passphrase` must not be persisted to the
+        // approvals SQLite table nor echoed by operator-facing listing
+        // commands. Redact before store.
+        ['passphrase'],
       ),
     );
   }

--- a/src/mcp/tools/restart.ts
+++ b/src/mcp/tools/restart.ts
@@ -12,14 +12,23 @@ export type MemphisRestartOutput = RestartOutcome;
  * Codex P1 (Round 2): MCP has no tier-3 session flow — no `/tier 3 <pass>`
  * equivalent exists. The caller must include the operator `passphrase` in
  * the tool input; we validate here and pass `alreadyElevated: true` to the
- * engine. If no operator config is set yet (first-run state), the
- * passphrase requirement is relaxed.
+ * engine.
+ *
+ * Codex P2 (Round 4): when no operator config exists (first-run state),
+ * this previously left alreadyElevated=false and the engine then refused
+ * with "not-elevated" — MCP has no session-minting flow so the engine
+ * could never succeed on that path. Now the first-run branch explicitly
+ * marks the call as pre-validated (no secret to leak in that state).
+ *
+ * Codex P2 (Round 4): validateOperatorPassphrase throws on the attempt
+ * rate-limit. Wrap in try/catch so brute-force attempts surface as a
+ * controlled refusal instead of an uncaught exception leaking internals.
  */
 export async function runMemphisRestart(
   input: { reason?: string; actor_id?: string; passphrase?: string } = {},
 ): Promise<MemphisRestartOutput> {
-  let alreadyElevated = false;
-  let elevatedVia: string | undefined;
+  let alreadyElevated: boolean;
+  let elevatedVia: string;
   if (loadOperatorConfig(process.env)) {
     if (!input.passphrase) {
       return {
@@ -29,15 +38,28 @@ export async function runMemphisRestart(
           'restart refused — operator passphrase required. Pass `passphrase` in the MCP tool input.',
       };
     }
-    if (!validateOperatorPassphrase(input.passphrase, process.env)) {
+    try {
+      if (!validateOperatorPassphrase(input.passphrase, process.env)) {
+        return {
+          ok: false,
+          reason: 'not-elevated',
+          message: 'restart refused — operator passphrase did not validate.',
+        };
+      }
+    } catch (err) {
       return {
         ok: false,
         reason: 'not-elevated',
-        message: 'restart refused — operator passphrase did not validate.',
+        message: `restart refused — ${err instanceof Error ? err.message : 'passphrase check failed'}`,
       };
     }
     alreadyElevated = true;
     elevatedVia = 'mcp-passphrase-arg';
+  } else {
+    // First-run: no operator config yet. The engine's tier-3 session gate
+    // would still refuse on MCP (no session-minting flow), so pre-validate.
+    alreadyElevated = true;
+    elevatedVia = 'mcp-first-run-no-config';
   }
 
   return requestRestart({

--- a/tests/integration/mcp-require-approval.test.ts
+++ b/tests/integration/mcp-require-approval.test.ts
@@ -174,4 +174,43 @@ describe('MCP require-approval policy', () => {
     const names = tools.map((t) => t.name);
     expect(names).not.toContain('memphis_exec');
   });
+
+  it('Codex P1 (Round 4): passphrase is redacted before being stored in the approvals table', async () => {
+    // memphis_restart accepts a `passphrase` field. Without redaction,
+    // that secret was JSON-stringified into the approvals table and
+    // later echoed back by `memphis config tools pending`. The
+    // withApprovalGate redactFields mechanism must replace it with
+    // `[REDACTED]` before persistence.
+    const db = await setupDb();
+    const { SqliteToolPermissionRepository } =
+      await import('../../src/infra/storage/sqlite/repositories/tool-permission-repository.js');
+    const { SqliteToolCallApprovalRepository } =
+      await import('../../src/infra/storage/sqlite/repositories/tool-call-approval-repository.js');
+    const permRepo = new SqliteToolPermissionRepository(db);
+    const approvalRepo = new SqliteToolCallApprovalRepository(db);
+    permRepo.set('memphis_restart', 'require-approval');
+
+    const c = await connect();
+    const result = await c.callTool({
+      name: 'memphis_restart',
+      arguments: {
+        reason: 'operator-triggered',
+        passphrase: 'super-secret-operator-passphrase',
+      },
+    });
+
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0].text);
+    expect(parsed.state).toBe('pending');
+
+    const stored = approvalRepo.get(parsed.requestId);
+    expect(stored).toBeTruthy();
+    const storedArgs = JSON.parse(stored!.argumentsJson) as Record<string, unknown>;
+    expect(storedArgs.passphrase).toBe('[REDACTED]');
+    // Non-secret fields must still pass through so operators can see what
+    // they're approving.
+    expect(storedArgs.reason).toBe('operator-triggered');
+    // And the raw secret must not appear anywhere in the stored JSON.
+    expect(stored!.argumentsJson).not.toContain('super-secret-operator-passphrase');
+  });
 });


### PR DESCRIPTION
## Summary

Three findings on PR #102 commit a8ace1076c.

### P1 — passphrase persisted in MCP approval store
`withApprovalGate` stored the full args payload via `approvals.createRequest()`. For `memphis_restart` that meant the operator passphrase landed in `arguments_json` and was later echoed by `memphis config tools pending`.

**Fix:** added optional `redactFields` parameter to `withApprovalGate`. `memphis_restart` registers with `['passphrase']`. The handler still receives the original (unredacted) value at execution time — redaction only happens at the storage boundary.

### P2 — first-run no-config restart returned not-elevated (MCP/HTTP)
When `loadOperatorConfig()` returns null (operator hasn't run `memphis init`), `alreadyElevated` stayed false. The engine then enforced tier-3 and refused even though MCP/HTTP have no session-minting flow. Both surfaces now set `alreadyElevated: true` in the no-config branch (`elevatedVia: '*-first-run-no-config'`).

### P2 — validateOperatorPassphrase throw → unhandled 500
`validateOperatorPassphrase()` throws after `MAX_ATTEMPTS`. HTTP / MCP / CLI restart paths now wrap the call in try/catch and return a controlled `not-elevated` refusal.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npm run test:ts` — 1845/1845 passing
- [x] New integration regression in `mcp-require-approval`: calls `memphis_restart` with `passphrase: 'super-secret-operator-passphrase'`, asserts stored `arguments_json` contains `[REDACTED]` and never contains the raw secret string

🤖 Generated with [Claude Code](https://claude.com/claude-code)