### PR TITLE
feat: scheduled chain rotation loop (closes deferred item #5)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -33,6 +33,7 @@ import { startAlertSuppressionFlushLoop } from '../infra/logging/alert-runtime.j
 import '../infra/logging/contextual.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
 import { writeSecurityAudit } from '../infra/logging/security-audit.js';
+import { startChainRotationLoop } from '../infra/runtime/chain-rotation-loop.js';
 import { inStrictMode } from '../infra/runtime/emergency-log.js';
 import { EXIT_CODES, MemphisExitError } from '../infra/runtime/exit-codes.js';
 import { HeartbeatWatchdog, writeBootPulse } from '../infra/runtime/heartbeat-watchdog.js';
@@ -268,6 +269,10 @@ export async function bootstrap(): Promise<void> {
   startLocalWorkerIfEnabled(container);
 
   startReflectionLoop({ rawEnv: process.env });
+
+  // Closes deferred item #5 — operators can opt into scheduled rotation
+  // via MEMPHIS_CHAIN_ROTATE_INTERVAL_MS. Default (env unset) is no-op.
+  startChainRotationLoop({ rawEnv: process.env });
 
   // Start built-in task scheduler
   startScheduler({

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -171,6 +171,9 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
   MEMPHIS_CHAIN_GC_KEEP_ARCHIVES: 'warm',
   MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION: 'warm',
   MEMPHIS_CHAIN_SNAPSHOT_TAIL_BLOCKS: 'warm',
+  // Cold: changing the loop interval after start would require restarting
+  // the timer; for now operators set this once at boot.
+  MEMPHIS_CHAIN_ROTATE_INTERVAL_MS: 'cold',
 
   // ── Voice (Sprint 9) ──
   MEMPHIS_TTS_DAILY_CHAT_LIMIT: 'hot',

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -171,6 +171,14 @@ export const envSchema = z.object({
   MEMPHIS_CHAIN_GC_KEEP_ARCHIVES: z.coerce.number().int().min(1).max(1000).optional(),
   MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION: boolFromString.default(true),
   MEMPHIS_CHAIN_SNAPSHOT_TAIL_BLOCKS: z.coerce.number().int().min(1).max(100000).optional(),
+  // Closes deferred item #5 — when set, src/infra/runtime/chain-rotation-loop.ts
+  // calls rotateAllChains on this interval. Min 60s, max 24h. Unset = no-op.
+  MEMPHIS_CHAIN_ROTATE_INTERVAL_MS: z.coerce
+    .number()
+    .int()
+    .min(60_000)
+    .max(86_400_000)
+    .optional(),
   MEMPHIS_SNAPSHOT_MAX_AGE_MS: z.coerce.number().int().min(3600000).max(2592000000).optional(),
   MEMPHIS_SNAPSHOT_MIN_KEEP: z.coerce.number().int().min(1).max(1000).optional(),
   MEMPHIS_HEARTBEAT_INTERVAL_MS: z.coerce.number().int().min(5000).max(3600000).optional(),

--- a/src/infra/runtime/chain-rotation-loop.ts
+++ b/src/infra/runtime/chain-rotation-loop.ts
@@ -1,0 +1,136 @@
+/**
+ * Scheduled chain rotation loop (closes deferred item #5).
+ *
+ * Operator-driven `chain rotate` has shipped since Sprint 4. This loop
+ * adds the "rotate on a schedule" half: when
+ * `MEMPHIS_CHAIN_ROTATE_INTERVAL_MS` is set to a positive integer, the
+ * loop calls `rotateAllChains()` on that interval. Default behaviour
+ * (env unset) is no-op — operators opt in.
+ *
+ * The loop reuses the existing rotation pipeline:
+ *   - threshold check (`MEMPHIS_CHAIN_ROTATION_THRESHOLD_BYTES`, default
+ *     50 MB)
+ *   - snapshot before archive (`MEMPHIS_CHAIN_SNAPSHOT_ON_ROTATION`)
+ *   - GC of stale archives (`MEMPHIS_CHAIN_GC_ENABLED`)
+ *
+ * Errors during a tick are logged and dropped — the loop keeps ticking
+ * so a transient I/O failure on one chain doesn't disable rotation for
+ * the rest.
+ */
+
+import { createPinoLogger } from '../logging/pino.js';
+import { rotateAllChains, type ChainRotationResult } from '../storage/chain-rotation.js';
+
+const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+
+/** Hard floor — anything below 60s is almost certainly a misconfiguration. */
+export const MIN_INTERVAL_MS = 60_000;
+/** Hard ceiling — 24 h. Beyond that, schedule via cron instead. */
+export const MAX_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export interface ChainRotationLoopState {
+  lastTickAt?: string;
+  lastResults?: ChainRotationResult[];
+  lastError?: string;
+}
+
+export interface ChainRotationLoopOptions {
+  rawEnv?: NodeJS.ProcessEnv;
+  intervalMs?: number;
+  /** Test seam: substitute the rotation function. */
+  rotateFn?: () => Promise<ChainRotationResult[]>;
+  /** Test seam: invoked on each tick (success or failure) for assertions. */
+  onTick?: (state: ChainRotationLoopState) => void;
+}
+
+interface ChainRotationLoopHandle {
+  stop: () => void;
+  /** Tick once now (test/manual). */
+  tickNow: () => Promise<ChainRotationLoopState>;
+  /** Last observed state. */
+  state: () => ChainRotationLoopState;
+}
+
+function readIntervalFromEnv(rawEnv: NodeJS.ProcessEnv): number | null {
+  const raw = rawEnv.MEMPHIS_CHAIN_ROTATE_INTERVAL_MS?.trim();
+  if (!raw) return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return null;
+  if (parsed < MIN_INTERVAL_MS || parsed > MAX_INTERVAL_MS) return null;
+  return Math.floor(parsed);
+}
+
+/**
+ * Start the scheduled rotation loop. Returns a handle with `stop()` so
+ * tests / shutdown hooks can tear it down.
+ *
+ * If `MEMPHIS_CHAIN_ROTATE_INTERVAL_MS` is unset / out of bounds and no
+ * explicit `intervalMs` override was passed, the loop does NOT start —
+ * the function returns a no-op handle.
+ */
+export function startChainRotationLoop(
+  options: ChainRotationLoopOptions = {},
+): ChainRotationLoopHandle {
+  const rawEnv = options.rawEnv ?? process.env;
+  const interval =
+    options.intervalMs ??
+    readIntervalFromEnv(rawEnv) ??
+    null;
+
+  const rotate = options.rotateFn ?? (() => rotateAllChains({ rawEnv }));
+  const state: ChainRotationLoopState = {};
+
+  const tickNow = async (): Promise<ChainRotationLoopState> => {
+    try {
+      const results = await rotate();
+      state.lastTickAt = new Date().toISOString();
+      state.lastResults = results;
+      state.lastError = undefined;
+      const rotated = results.filter((r) => r.rotated);
+      if (rotated.length > 0) {
+        log.info(
+          {
+            event: 'chain.rotation.scheduled',
+            rotatedChains: rotated.map((r) => r.chain),
+            archivedBlocks: rotated.reduce((sum, r) => sum + r.archivedBlocks, 0),
+          },
+          'scheduled chain rotation completed',
+        );
+      }
+    } catch (err) {
+      state.lastTickAt = new Date().toISOString();
+      state.lastError = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { event: 'chain.rotation.scheduled.error', error: state.lastError },
+        'scheduled chain rotation failed',
+      );
+    } finally {
+      options.onTick?.(state);
+    }
+    return state;
+  };
+
+  if (interval === null) {
+    return {
+      stop: () => {},
+      tickNow,
+      state: () => state,
+    };
+  }
+
+  const timer = setInterval(() => void tickNow(), interval);
+  if (typeof timer === 'object' && 'unref' in timer) {
+    timer.unref();
+  }
+
+  log.info(
+    { event: 'chain.rotation.loop.started', intervalMs: interval },
+    'scheduled chain rotation loop started',
+  );
+
+  return {
+    stop: () => clearInterval(timer),
+    tickNow,
+    state: () => state,
+  };
+}

--- a/tests/unit/chain-rotation-loop.test.ts
+++ b/tests/unit/chain-rotation-loop.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  MAX_INTERVAL_MS,
+  MIN_INTERVAL_MS,
+  startChainRotationLoop,
+} from '../../src/infra/runtime/chain-rotation-loop.js';
+import type { ChainRotationResult } from '../../src/infra/storage/chain-rotation.js';
+
+const SAMPLE_RESULT_NOOP: ChainRotationResult = {
+  chain: 'memphis',
+  rotated: false,
+  archivedBlocks: 0,
+  remainingBlocks: 5,
+  dirSizeBytes: 1024,
+};
+
+const SAMPLE_RESULT_ROTATED: ChainRotationResult = {
+  chain: 'memphis',
+  rotated: true,
+  archivedBlocks: 90,
+  archivePath: '/tmp/archive.jsonl.gz',
+  remainingBlocks: 10,
+  dirSizeBytes: 2048,
+};
+
+describe('startChainRotationLoop (deferred item #5)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does NOT start when MEMPHIS_CHAIN_ROTATE_INTERVAL_MS is unset', () => {
+    const rotateFn = vi.fn(async (): Promise<ChainRotationResult[]> => [SAMPLE_RESULT_NOOP]);
+    const handle = startChainRotationLoop({
+      rawEnv: {} as NodeJS.ProcessEnv,
+      rotateFn,
+    });
+    vi.advanceTimersByTime(120_000);
+    expect(rotateFn).not.toHaveBeenCalled();
+    handle.stop();
+  });
+
+  it('refuses intervals below the floor (< 60s)', () => {
+    const rotateFn = vi.fn(async () => [SAMPLE_RESULT_NOOP]);
+    startChainRotationLoop({
+      rawEnv: { MEMPHIS_CHAIN_ROTATE_INTERVAL_MS: '5000' } as NodeJS.ProcessEnv,
+      rotateFn,
+    });
+    vi.advanceTimersByTime(120_000);
+    expect(rotateFn).not.toHaveBeenCalled();
+  });
+
+  it('refuses intervals above the ceiling (> 24h)', () => {
+    const rotateFn = vi.fn(async () => [SAMPLE_RESULT_NOOP]);
+    startChainRotationLoop({
+      rawEnv: {
+        MEMPHIS_CHAIN_ROTATE_INTERVAL_MS: String(MAX_INTERVAL_MS + 1),
+      } as NodeJS.ProcessEnv,
+      rotateFn,
+    });
+    vi.advanceTimersByTime(120_000);
+    expect(rotateFn).not.toHaveBeenCalled();
+  });
+
+  it('ticks at the configured interval when env is set', () => {
+    const rotateFn = vi.fn(async () => [SAMPLE_RESULT_NOOP]);
+    const handle = startChainRotationLoop({
+      rawEnv: {
+        MEMPHIS_CHAIN_ROTATE_INTERVAL_MS: String(MIN_INTERVAL_MS),
+      } as NodeJS.ProcessEnv,
+      rotateFn,
+    });
+    vi.advanceTimersByTime(MIN_INTERVAL_MS * 3);
+    expect(rotateFn.mock.calls.length).toBeGreaterThanOrEqual(3);
+    handle.stop();
+  });
+
+  it('records lastResults on success', async () => {
+    const rotateFn = vi.fn(async () => [SAMPLE_RESULT_ROTATED]);
+    const handle = startChainRotationLoop({
+      rawEnv: {} as NodeJS.ProcessEnv,
+      rotateFn,
+    });
+    const state = await handle.tickNow();
+    expect(state.lastResults).toEqual([SAMPLE_RESULT_ROTATED]);
+    expect(state.lastError).toBeUndefined();
+    expect(state.lastTickAt).toBeTruthy();
+  });
+
+  it('records lastError on failure and continues ticking', async () => {
+    let calls = 0;
+    const rotateFn = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('disk full');
+      return [SAMPLE_RESULT_NOOP];
+    });
+    const handle = startChainRotationLoop({
+      rawEnv: {} as NodeJS.ProcessEnv,
+      rotateFn,
+    });
+    const failedState = await handle.tickNow();
+    expect(failedState.lastError).toBe('disk full');
+
+    const recoveredState = await handle.tickNow();
+    expect(recoveredState.lastError).toBeUndefined();
+    expect(recoveredState.lastResults).toEqual([SAMPLE_RESULT_NOOP]);
+  });
+
+  it('explicit intervalMs override bypasses env check', () => {
+    const rotateFn = vi.fn(async () => [SAMPLE_RESULT_NOOP]);
+    const handle = startChainRotationLoop({
+      rawEnv: {} as NodeJS.ProcessEnv,
+      intervalMs: MIN_INTERVAL_MS,
+      rotateFn,
+    });
+    vi.advanceTimersByTime(MIN_INTERVAL_MS);
+    expect(rotateFn).toHaveBeenCalledTimes(1);
+    handle.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Closes deferred item #5: operators can opt into automatic chain rotation by setting `MEMPHIS_CHAIN_ROTATE_INTERVAL_MS=<ms>` (min 60s, max 24h). Default behaviour (env unset) is no-op — `chain rotate` remains operator-driven.

### Files
- `src/infra/runtime/chain-rotation-loop.ts` — new loop wrapping `rotateAllChains()` in setInterval; errors logged + dropped so one chain's transient failure doesn't disable rotation for the rest
- `src/app/bootstrap.ts` — starts the loop alongside reflection loop
- `src/infra/config/schema.ts` — new optional `MEMPHIS_CHAIN_ROTATE_INTERVAL_MS` field with bounds matching the loop
- `src/infra/config/mutability.ts` — classified `cold` (changing the timer interval mid-run would require restarting it)

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] 7 new cases in `tests/unit/chain-rotation-loop.test.ts`:
  - unset env → no-op
  - interval below floor (<60s) refused
  - interval above ceiling (>24h) refused
  - ticks at interval when env set
  - records lastResults on success
  - records lastError on failure and continues ticking
  - explicit intervalMs override bypasses env check

🤖 Generated with [Claude Code](https://claude.com/claude-code)