### PR TITLE
feat: provider cost cap as observable feature (Phase 1.3)

### DIFF
--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -787,6 +787,16 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     });
   }
   const llm = resolveLlm(options, prepared.cognitiveModeContribution);
+  // Phase 1.3 production sprint: pre-flight check the provider budget.
+  // Throws PROVIDER_RATE_LIMIT (429) if cap is exceeded; the cascade
+  // caller catches and falls through to the next tier.
+  try {
+    const { checkProviderBudget } = await import('../infra/runtime/cost-cap.js');
+    checkProviderBudget(llm.provider, rawEnvWithTier3);
+  } catch (capError) {
+    metrics.recordProviderCall(llm.provider, false, Date.now() - startedAt);
+    throw capError;
+  }
   let result: Awaited<ReturnType<typeof runAgentLoop>>;
   try {
     result = await runAgentLoop({
@@ -808,6 +818,30 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     throw error;
   }
   metrics.recordProviderCall(llm.provider, true, Date.now() - startedAt);
+
+  // Phase 1.3 production sprint: record token usage post-call so the
+  // budget counter advances. Uses any usage telemetry runAgentLoop
+  // returned. Soft-warning thresholds (50/75/90%) emit a one-shot alert.
+  try {
+    const { recordProviderUsage, consumeSoftWarning } = await import(
+      '../infra/runtime/cost-cap.js'
+    );
+    const inTok = result.usage?.inputTokens ?? 0;
+    const outTok = result.usage?.outputTokens ?? 0;
+    if (inTok > 0 || outTok > 0) {
+      recordProviderUsage(llm.provider, inTok, outTok, rawEnvWithTier3);
+      const warn = consumeSoftWarning(llm.provider, rawEnvWithTier3);
+      if (warn !== null) {
+        await emitRuntimeSecurityEvent({
+          action: 'provider.budget.soft_warning',
+          status: 'allowed',
+          details: { provider: llm.provider, threshold: warn },
+        });
+      }
+    }
+  } catch {
+    // budget tracking is best-effort; never let it break a turn
+  }
 
   const guarded = await guardModelOutput(result.reply, options.auditSurface ?? options.surface);
   let messages = updateFinalAssistantMessage(result.messages, guarded.output);

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -183,6 +183,21 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
   MEMPHIS_BACKUP_STALE_ALERT_MS: 'hot',
   MEMPHIS_BACKUP_KEEP: 'hot',
 
+  // ── Provider cost caps (Phase 1.3 production sprint) ──
+  // All hot — operator can raise the cap mid-day if the agent is
+  // doing real work and needs more budget. cost-cap.ts re-reads the
+  // env on every check.
+  MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_ANTHROPIC_MONTHLY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_MINIMAX_DAILY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_MINIMAX_MONTHLY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_DEEPSEEK_DAILY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_DEEPSEEK_MONTHLY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_GLM_DAILY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_GLM_MONTHLY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_OLLAMA_DAILY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_OLLAMA_MONTHLY_TOKENS: 'hot',
+
   // ── OpenTelemetry overlay ──
   // All cold: starting the SDK after boot would require re-wiring the
   // global tracer provider. Operators restart to turn OTel on/off.

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -189,6 +189,20 @@ export const envSchema = z.object({
   MEMPHIS_BACKUP_DRILL_EVERY_N: z.coerce.number().int().min(1).max(1000).optional(),
   MEMPHIS_BACKUP_STALE_ALERT_MS: z.coerce.number().int().min(60_000).optional(),
   MEMPHIS_BACKUP_KEEP: z.coerce.number().int().min(1).max(1000).optional(),
+  // Phase 1.3 production sprint — per-provider cost caps. Enforced in
+  // turn-runtime via checkProviderBudget. Daily/monthly token budgets;
+  // unset = no cap (legacy). Names match envKey() in cost-cap.ts.
+  MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_ANTHROPIC_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_MINIMAX_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_MINIMAX_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_DEEPSEEK_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_DEEPSEEK_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_GLM_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_GLM_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_OLLAMA_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_OLLAMA_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
+
   // Closes deferred item #3 — OpenTelemetry SDK overlay. When
   // MEMPHIS_OTEL_ENDPOINT is set, Memphis starts the OTLP/HTTP exporter
   // and installs a process-wide tracer. Unset = no-op.

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -71,6 +71,18 @@ export type HealthPayload = {
     remainingAfterDrain?: number;
   };
   /**
+   * Phase 1.3 production sprint: per-provider cost-cap status.
+   * Operators see daily/monthly burn rate per provider so the "did
+   * Memphis just blow my budget?" question is one /status hit away.
+   */
+  providerBudgets?: Array<{
+    provider: string;
+    allowed: boolean;
+    reason?: string;
+    daily: { used: number; cap?: number; pctUsed?: number };
+    monthly: { used: number; cap?: number; pctUsed?: number };
+  }>;
+  /**
    * Phase 1.2 production sprint: scheduled-backup observability.
    * Operators see the latest backup age + drill outcome + staleness flag
    * so they can confirm "yes, my data is being protected" at a glance.
@@ -262,6 +274,8 @@ export async function buildHealthPayload(
   const shutdown = getShutdownState();
   const { getScheduledBackupState } = await import('../runtime/scheduled-backup.js');
   const backupReport = getScheduledBackupState(rawEnv);
+  const { getAllProviderBudgets } = await import('../runtime/cost-cap.js');
+  const providerBudgets = getAllProviderBudgets(rawEnv);
   const topLevelStatus: HealthPayload['status'] = shutdown.shuttingDown
     ? 'shutting_down'
     : requiredHealthy && runtimeHealthy
@@ -285,6 +299,7 @@ export async function buildHealthPayload(
     version: appVersion(),
     uptime_seconds: Math.floor(process.uptime()),
     shutdown: shutdown.shuttingDown ? shutdown : undefined,
+    providerBudgets: providerBudgets.length > 0 ? providerBudgets : undefined,
     backups: {
       enabled: backupReport.state.enabled,
       intervalMs: backupReport.state.intervalMs,

--- a/src/infra/runtime/cost-cap.ts
+++ b/src/infra/runtime/cost-cap.ts
@@ -1,0 +1,237 @@
+/**
+ * Provider cost cap & budget observability (Phase 1.3 production sprint).
+ *
+ * "Memphis watches the bill so I don't have to."
+ *
+ * Without this, a bugged agent / runaway loop / prompt-injection attack
+ * could trivially burn through the operator's Anthropic credits in
+ * minutes. Rate limits at the HTTP layer protect Memphis from clients;
+ * NOTHING was protecting the operator from Memphis.
+ *
+ * Approach (operator-friendly, NOT a nanny):
+ *   - Per-provider rolling token counters keyed by day and month.
+ *   - Operator sets MEMPHIS_COST_CAP_<PROVIDER>_DAILY_TOKENS / _MONTHLY.
+ *     Both optional; unset = no cap (legacy behavior preserved).
+ *   - On each provider call, increment the counter by inputTokens +
+ *     outputTokens. Counters reset at day/month rollover.
+ *   - Soft alerts at 50/75/90% — operator gets notified BEFORE the cap
+ *     bites, so they can plan rather than react.
+ *   - Hard cap at 100% — provider call throws CostCapExceededError so
+ *     the cascade falls through to the next tier (local-fallback in the
+ *     worst case). Operator sees a clear message, NOT silent failure.
+ *   - Operator can bump caps at runtime via /config set
+ *     (MEMPHIS_COST_CAP_*_DAILY_TOKENS is `hot`). Tier-3 not required
+ *     because the operator setting their own budget is operational, not
+ *     destructive.
+ *   - /v1/ops/status surfaces the burn rate per provider. Grafana panel
+ *     becomes a one-click "where's my budget going" view.
+ */
+
+import { AppError } from '../../core/errors.js';
+
+export type CostCapDecision = {
+  allowed: boolean;
+  reason?:
+    | 'no-cap-configured'
+    | 'within-budget'
+    | 'soft-warning-50'
+    | 'soft-warning-75'
+    | 'soft-warning-90'
+    | 'cap-exceeded';
+  provider: string;
+  daily: { used: number; cap?: number; pctUsed?: number };
+  monthly: { used: number; cap?: number; pctUsed?: number };
+};
+
+interface CounterRecord {
+  dayKey: string;
+  dayUsed: number;
+  monthKey: string;
+  monthUsed: number;
+  /** Soft-warning thresholds already alerted in the current window
+   * (so we don't spam the operator multiple times per cycle). */
+  alertedSoft: Set<50 | 75 | 90>;
+}
+
+const counters = new Map<string, CounterRecord>();
+
+function dayKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+function monthKey(d: Date): string {
+  return d.toISOString().slice(0, 7);
+}
+
+function getOrCreate(provider: string, now: Date): CounterRecord {
+  const existing = counters.get(provider);
+  const today = dayKey(now);
+  const thisMonth = monthKey(now);
+  if (existing) {
+    if (existing.dayKey !== today) {
+      existing.dayKey = today;
+      existing.dayUsed = 0;
+      existing.alertedSoft.clear();
+    }
+    if (existing.monthKey !== thisMonth) {
+      existing.monthKey = thisMonth;
+      existing.monthUsed = 0;
+      existing.alertedSoft.clear();
+    }
+    return existing;
+  }
+  const fresh: CounterRecord = {
+    dayKey: today,
+    dayUsed: 0,
+    monthKey: thisMonth,
+    monthUsed: 0,
+    alertedSoft: new Set(),
+  };
+  counters.set(provider, fresh);
+  return fresh;
+}
+
+function envKey(provider: string, suffix: 'DAILY_TOKENS' | 'MONTHLY_TOKENS'): string {
+  // anthropic → MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS
+  return `MEMPHIS_COST_CAP_${provider.toUpperCase().replaceAll('-', '_')}_${suffix}`;
+}
+
+function readCap(
+  rawEnv: NodeJS.ProcessEnv,
+  provider: string,
+  suffix: 'DAILY_TOKENS' | 'MONTHLY_TOKENS',
+): number | undefined {
+  const raw = rawEnv[envKey(provider, suffix)]?.trim();
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+}
+
+/**
+ * Record token usage for a provider call. Returns the decision outcome
+ * for the NEXT call (so the caller can surface a soft-warning back to
+ * the operator UI). Does NOT throw — recording is non-destructive.
+ */
+export function recordProviderUsage(
+  provider: string,
+  inputTokens: number,
+  outputTokens: number,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): CostCapDecision {
+  const total = (inputTokens || 0) + (outputTokens || 0);
+  const rec = getOrCreate(provider, now);
+  rec.dayUsed += total;
+  rec.monthUsed += total;
+  return queryProviderBudget(provider, rawEnv, now);
+}
+
+/**
+ * Read-only check: would the next call exceed the cap? Used by the
+ * provider adapter to decide whether to reject before spending the
+ * tokens. Returns CostCapDecision; throws when allowed=false.
+ */
+export function checkProviderBudget(
+  provider: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): CostCapDecision {
+  const decision = queryProviderBudget(provider, rawEnv, now);
+  if (!decision.allowed) {
+    throw new AppError(
+      'PROVIDER_RATE_LIMIT',
+      `provider ${provider} budget cap exceeded — daily ${decision.daily.used}/${decision.daily.cap ?? '∞'}, monthly ${decision.monthly.used}/${decision.monthly.cap ?? '∞'}. Cascade will fall through to the next tier.`,
+      429,
+      {
+        provider,
+        decision,
+      },
+    );
+  }
+  return decision;
+}
+
+export function queryProviderBudget(
+  provider: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): CostCapDecision {
+  const dailyCap = readCap(rawEnv, provider, 'DAILY_TOKENS');
+  const monthlyCap = readCap(rawEnv, provider, 'MONTHLY_TOKENS');
+  const rec = getOrCreate(provider, now);
+  const dailyPct = dailyCap ? rec.dayUsed / dailyCap : undefined;
+  const monthlyPct = monthlyCap ? rec.monthUsed / monthlyCap : undefined;
+  const dailyExceeded = dailyCap !== undefined && rec.dayUsed >= dailyCap;
+  const monthlyExceeded = monthlyCap !== undefined && rec.monthUsed >= monthlyCap;
+  const exceeded = dailyExceeded || monthlyExceeded;
+
+  let reason: CostCapDecision['reason'] = 'no-cap-configured';
+  if (dailyCap !== undefined || monthlyCap !== undefined) {
+    if (exceeded) {
+      reason = 'cap-exceeded';
+    } else {
+      const worst = Math.max(dailyPct ?? 0, monthlyPct ?? 0);
+      if (worst >= 0.9) reason = 'soft-warning-90';
+      else if (worst >= 0.75) reason = 'soft-warning-75';
+      else if (worst >= 0.5) reason = 'soft-warning-50';
+      else reason = 'within-budget';
+    }
+  }
+
+  return {
+    allowed: !exceeded,
+    reason,
+    provider,
+    daily: {
+      used: rec.dayUsed,
+      cap: dailyCap,
+      pctUsed: dailyPct === undefined ? undefined : Math.round(dailyPct * 1000) / 1000,
+    },
+    monthly: {
+      used: rec.monthUsed,
+      cap: monthlyCap,
+      pctUsed: monthlyPct === undefined ? undefined : Math.round(monthlyPct * 1000) / 1000,
+    },
+  };
+}
+
+/**
+ * After a usage record, check if we just crossed a soft-warning
+ * threshold (50/75/90) — call this from the provider adapter to fire
+ * a one-shot alert. Returns the threshold level just crossed, or null
+ * if no new threshold was crossed.
+ */
+export function consumeSoftWarning(
+  provider: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): 50 | 75 | 90 | null {
+  const decision = queryProviderBudget(provider, rawEnv, now);
+  if (decision.allowed === false) return null; // cap-exceeded handled separately
+  const worst = Math.max(decision.daily.pctUsed ?? 0, decision.monthly.pctUsed ?? 0);
+  const rec = getOrCreate(provider, now);
+  for (const threshold of [90, 75, 50] as const) {
+    if (worst >= threshold / 100 && !rec.alertedSoft.has(threshold)) {
+      rec.alertedSoft.add(threshold);
+      return threshold;
+    }
+  }
+  return null;
+}
+
+/** Snapshot of all providers — for /status payload. */
+export function getAllProviderBudgets(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): CostCapDecision[] {
+  const out: CostCapDecision[] = [];
+  for (const provider of counters.keys()) {
+    out.push(queryProviderBudget(provider, rawEnv, now));
+  }
+  return out;
+}
+
+/** Test-only: clear all counters. */
+export function __resetCostCapForTests(): void {
+  counters.clear();
+}

--- a/tests/unit/cost-cap.test.ts
+++ b/tests/unit/cost-cap.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetCostCapForTests,
+  checkProviderBudget,
+  consumeSoftWarning,
+  getAllProviderBudgets,
+  queryProviderBudget,
+  recordProviderUsage,
+} from '../../src/infra/runtime/cost-cap.js';
+
+describe('cost cap & budget observability (Phase 1.3)', () => {
+  beforeEach(() => {
+    __resetCostCapForTests();
+  });
+
+  afterEach(() => {
+    __resetCostCapForTests();
+  });
+
+  it('no cap configured → allowed=true, reason=no-cap-configured', () => {
+    const decision = queryProviderBudget('anthropic', {} as NodeJS.ProcessEnv);
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe('no-cap-configured');
+    expect(decision.daily.cap).toBeUndefined();
+    expect(decision.monthly.cap).toBeUndefined();
+  });
+
+  it('records usage; daily and monthly counters increment', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '10000',
+    } as NodeJS.ProcessEnv;
+    recordProviderUsage('anthropic', 100, 200, env);
+    recordProviderUsage('anthropic', 50, 75, env);
+    const d = queryProviderBudget('anthropic', env);
+    expect(d.daily.used).toBe(425);
+    expect(d.monthly.used).toBe(425);
+    expect(d.daily.cap).toBe(10000);
+  });
+
+  it('within budget → reason=within-budget below 50%', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '10000',
+    } as NodeJS.ProcessEnv;
+    recordProviderUsage('anthropic', 1000, 1000, env);
+    const d = queryProviderBudget('anthropic', env);
+    expect(d.reason).toBe('within-budget');
+  });
+
+  it('soft-warning thresholds at 50/75/90%', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '1000',
+    } as NodeJS.ProcessEnv;
+    recordProviderUsage('anthropic', 250, 250, env); // 50%
+    expect(queryProviderBudget('anthropic', env).reason).toBe('soft-warning-50');
+    recordProviderUsage('anthropic', 250, 0, env); // 75%
+    expect(queryProviderBudget('anthropic', env).reason).toBe('soft-warning-75');
+    recordProviderUsage('anthropic', 150, 0, env); // 90%
+    expect(queryProviderBudget('anthropic', env).reason).toBe('soft-warning-90');
+  });
+
+  it('hard cap → checkProviderBudget throws PROVIDER_RATE_LIMIT', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '500',
+    } as NodeJS.ProcessEnv;
+    recordProviderUsage('anthropic', 600, 0, env);
+    expect(() => checkProviderBudget('anthropic', env)).toThrow(/budget cap exceeded/);
+  });
+
+  it('cap-exceeded message names both daily and monthly status', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '500',
+      MEMPHIS_COST_CAP_ANTHROPIC_MONTHLY_TOKENS: '5000',
+    } as NodeJS.ProcessEnv;
+    recordProviderUsage('anthropic', 600, 0, env);
+    try {
+      checkProviderBudget('anthropic', env);
+    } catch (err) {
+      expect((err as Error).message).toMatch(/600\/500/);
+      expect((err as Error).message).toMatch(/5000/);
+    }
+  });
+
+  it('consumeSoftWarning fires once per threshold crossing', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '1000',
+    } as NodeJS.ProcessEnv;
+    recordProviderUsage('anthropic', 500, 0, env); // crosses 50
+    expect(consumeSoftWarning('anthropic', env)).toBe(50);
+    // Second call without further usage → no new threshold
+    expect(consumeSoftWarning('anthropic', env)).toBe(null);
+    recordProviderUsage('anthropic', 250, 0, env); // crosses 75
+    expect(consumeSoftWarning('anthropic', env)).toBe(75);
+    recordProviderUsage('anthropic', 150, 0, env); // crosses 90
+    expect(consumeSoftWarning('anthropic', env)).toBe(90);
+  });
+
+  it('day rollover resets daily counter (monthly persists)', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '1000',
+      MEMPHIS_COST_CAP_ANTHROPIC_MONTHLY_TOKENS: '50000',
+    } as NodeJS.ProcessEnv;
+    const day1 = new Date('2026-04-14T12:00:00Z');
+    recordProviderUsage('anthropic', 800, 0, env, day1);
+    const day2 = new Date('2026-04-15T12:00:00Z');
+    const d = queryProviderBudget('anthropic', env, day2);
+    expect(d.daily.used).toBe(0);
+    expect(d.monthly.used).toBe(800);
+  });
+
+  it('month rollover resets both', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_MONTHLY_TOKENS: '5000',
+    } as NodeJS.ProcessEnv;
+    const apr = new Date('2026-04-30T23:00:00Z');
+    recordProviderUsage('anthropic', 4000, 0, env, apr);
+    const may = new Date('2026-05-01T01:00:00Z');
+    const d = queryProviderBudget('anthropic', env, may);
+    expect(d.monthly.used).toBe(0);
+    expect(d.daily.used).toBe(0);
+  });
+
+  it('per-provider counters are independent', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '1000',
+      MEMPHIS_COST_CAP_MINIMAX_DAILY_TOKENS: '2000',
+    } as NodeJS.ProcessEnv;
+    recordProviderUsage('anthropic', 500, 0, env);
+    recordProviderUsage('minimax', 1500, 0, env);
+    expect(queryProviderBudget('anthropic', env).daily.used).toBe(500);
+    expect(queryProviderBudget('minimax', env).daily.used).toBe(1500);
+    expect(queryProviderBudget('minimax', env).reason).toBe('soft-warning-75');
+  });
+
+  it('getAllProviderBudgets returns one entry per provider with usage', () => {
+    const env = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '1000',
+      MEMPHIS_COST_CAP_MINIMAX_DAILY_TOKENS: '2000',
+    } as NodeJS.ProcessEnv;
+    recordProviderUsage('anthropic', 100, 0, env);
+    recordProviderUsage('minimax', 200, 0, env);
+    const all = getAllProviderBudgets(env);
+    expect(all).toHaveLength(2);
+    expect(all.map((b) => b.provider).sort()).toEqual(['anthropic', 'minimax']);
+  });
+
+  it('cap raise at runtime (env mid-day) takes effect immediately', () => {
+    const tightEnv = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '500',
+    } as NodeJS.ProcessEnv;
+    recordProviderUsage('anthropic', 600, 0, tightEnv);
+    expect(() => checkProviderBudget('anthropic', tightEnv)).toThrow();
+    // Operator raises the cap
+    const looserEnv = {
+      MEMPHIS_COST_CAP_ANTHROPIC_DAILY_TOKENS: '5000',
+    } as NodeJS.ProcessEnv;
+    expect(() => checkProviderBudget('anthropic', looserEnv)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1.3 of the production sprint. **"Memphis watches the bill so I don't have to."**

Without this, a bugged agent / runaway loop / prompt-injection attack could trivially burn through the operator's Anthropic credits in minutes. HTTP rate limits protect Memphis from clients; nothing was protecting the operator from Memphis.

### Approach (operator-friendly, NOT a nanny)
- Per-provider rolling token counters keyed by day AND month
- Operator opts in via `MEMPHIS_COST_CAP_<PROVIDER>_{DAILY,MONTHLY}_TOKENS` (both optional, unset = no cap)
- **Soft warnings at 50/75/90%** — operator gets notified BEFORE the cap bites, so they can plan rather than react. One alert per threshold per cycle (no spam)
- **Hard cap at 100%** throws `PROVIDER_RATE_LIMIT` (429); cascade falls through to next tier. Clear "budget exceeded for anthropic this month" — NOT silent failure
- **Operator can raise the cap at runtime** via `/config set` (all keys are `hot`) — setting your own budget is operational, not destructive

### Day/month semantics
- Day rollover resets daily counter
- Month rollover resets both
- Each rollover clears soft-warning state (alerts fire fresh in the new window)

### Surface on `/v1/ops/status`
```jsonc
"providerBudgets": [
  {
    "provider": "anthropic",
    "allowed": true,
    "reason": "soft-warning-75",
    "daily":   { "used": 7500, "cap": 10000, "pctUsed": 0.75 },
    "monthly": { "used": 145000, "cap": 200000, "pctUsed": 0.725 }
  }
]
```

Grafana panel becomes a one-click "where's my budget going" view.

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] 12 new cases in `tests/unit/cost-cap.test.ts`
  - no cap → allowed; soft-warning thresholds; hard-cap throws
  - day/month rollovers; per-provider isolation; runtime raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)