### PR TITLE
feat: per-provider circuit breaker (Phase 2.1)

### DIFF
--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -797,6 +797,16 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     metrics.recordProviderCall(llm.provider, false, Date.now() - startedAt);
     throw capError;
   }
+  // Phase 2.1 production sprint: circuit breaker — if this provider has
+  // tripped recently, fail fast so the cascade falls through to the
+  // next tier instead of waiting for another timeout.
+  try {
+    const { admitProviderCall } = await import('../infra/runtime/circuit-breaker.js');
+    admitProviderCall(llm.provider, rawEnvWithTier3);
+  } catch (breakerError) {
+    metrics.recordProviderCall(llm.provider, false, Date.now() - startedAt);
+    throw breakerError;
+  }
   let result: Awaited<ReturnType<typeof runAgentLoop>>;
   try {
     result = await runAgentLoop({
@@ -815,9 +825,23 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     });
   } catch (error) {
     metrics.recordProviderCall(llm.provider, false, Date.now() - startedAt);
+    // Phase 2.1: record outcome for the breaker. A run of failures trips
+    // the breaker and subsequent calls fail fast.
+    try {
+      const { recordProviderOutcome } = await import('../infra/runtime/circuit-breaker.js');
+      recordProviderOutcome(llm.provider, false, rawEnvWithTier3);
+    } catch {
+      /* breaker recording is best-effort */
+    }
     throw error;
   }
   metrics.recordProviderCall(llm.provider, true, Date.now() - startedAt);
+  try {
+    const { recordProviderOutcome } = await import('../infra/runtime/circuit-breaker.js');
+    recordProviderOutcome(llm.provider, true, rawEnvWithTier3);
+  } catch {
+    /* breaker recording is best-effort */
+  }
 
   // Phase 1.3 production sprint: record token usage post-call so the
   // budget counter advances. Uses any usage telemetry runAgentLoop

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -198,6 +198,12 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
   MEMPHIS_COST_CAP_OLLAMA_DAILY_TOKENS: 'hot',
   MEMPHIS_COST_CAP_OLLAMA_MONTHLY_TOKENS: 'hot',
 
+  // ── Circuit breaker (Phase 2.1 production sprint) ──
+  // All hot — operator can re-tune sensitivity at runtime.
+  MEMPHIS_BREAKER_DEFAULT_FAILURES: 'hot',
+  MEMPHIS_BREAKER_DEFAULT_WINDOW_MS: 'hot',
+  MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: 'hot',
+
   // ── OpenTelemetry overlay ──
   // All cold: starting the SDK after boot would require re-wiring the
   // global tracer provider. Operators restart to turn OTel on/off.

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -203,6 +203,14 @@ export const envSchema = z.object({
   MEMPHIS_COST_CAP_OLLAMA_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
   MEMPHIS_COST_CAP_OLLAMA_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
 
+  // Phase 2.1 production sprint — per-provider circuit breaker.
+  // _DEFAULT_ keys apply to any provider lacking a specific override.
+  // failureThreshold + windowMs trip the breaker; cooldownMs gates
+  // half-open recovery probes.
+  MEMPHIS_BREAKER_DEFAULT_FAILURES: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_BREAKER_DEFAULT_WINDOW_MS: z.coerce.number().int().min(1000).optional(),
+  MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: z.coerce.number().int().min(1000).optional(),
+
   // Closes deferred item #3 — OpenTelemetry SDK overlay. When
   // MEMPHIS_OTEL_ENDPOINT is set, Memphis starts the OTLP/HTTP exporter
   // and installs a process-wide tracer. Unset = no-op.

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -83,6 +83,25 @@ export type HealthPayload = {
     monthly: { used: number; cap?: number; pctUsed?: number };
   }>;
   /**
+   * Phase 2.1 production sprint: per-provider circuit breaker state.
+   * Operators see "anthropic OPEN since 14:23" instead of guessing
+   * why latency just spiked. Empty until at least one provider call
+   * has been made (we don't pre-emit unconfigured-but-plausible state).
+   */
+  providerBreakers?: Array<{
+    provider: string;
+    state: 'closed' | 'open' | 'half-open';
+    recentFailures: number;
+    failureThreshold: number;
+    windowMs: number;
+    cooldownMs: number;
+    lastFailureAt?: string;
+    openedAt?: string;
+    halfOpenAt?: string;
+    totalTrips: number;
+    totalRecoveries: number;
+  }>;
+  /**
    * Phase 1.2 production sprint: scheduled-backup observability.
    * Operators see the latest backup age + drill outcome + staleness flag
    * so they can confirm "yes, my data is being protected" at a glance.
@@ -276,6 +295,8 @@ export async function buildHealthPayload(
   const backupReport = getScheduledBackupState(rawEnv);
   const { getAllProviderBudgets } = await import('../runtime/cost-cap.js');
   const providerBudgets = getAllProviderBudgets(rawEnv);
+  const { getAllBreakerSnapshots } = await import('../runtime/circuit-breaker.js');
+  const providerBreakers = getAllBreakerSnapshots(rawEnv);
   const topLevelStatus: HealthPayload['status'] = shutdown.shuttingDown
     ? 'shutting_down'
     : requiredHealthy && runtimeHealthy
@@ -300,6 +321,7 @@ export async function buildHealthPayload(
     uptime_seconds: Math.floor(process.uptime()),
     shutdown: shutdown.shuttingDown ? shutdown : undefined,
     providerBudgets: providerBudgets.length > 0 ? providerBudgets : undefined,
+    providerBreakers: providerBreakers.length > 0 ? providerBreakers : undefined,
     backups: {
       enabled: backupReport.state.enabled,
       intervalMs: backupReport.state.intervalMs,

--- a/src/infra/runtime/circuit-breaker.ts
+++ b/src/infra/runtime/circuit-breaker.ts
@@ -1,0 +1,230 @@
+/**
+ * Per-provider circuit breaker (Phase 2.1 production sprint).
+ *
+ * If Ollama hangs for 60s, every request routed to Ollama hangs for
+ * 60s. The cascade catches errors but not slow timeouts past some
+ * threshold. One stuck provider = every request stuck. Grafana spikes,
+ * users see "the bot is dead." Standard breaker pattern fixes this.
+ *
+ * Three states (Hystrix-style):
+ *   - CLOSED     — normal, requests pass through
+ *   - OPEN       — too many recent failures; fail fast (immediate
+ *                  throw so cascade falls through to the next tier)
+ *   - HALF_OPEN  — cooldown elapsed; let ONE request through to probe
+ *                  recovery. Success → CLOSED. Failure → back to OPEN.
+ *
+ * Failure window: rolling N seconds with up to M failures. Operator-
+ * tunable per provider via env. Defaults are conservative for an
+ * operator who hasn't tuned yet.
+ *
+ * /v1/ops/status surfaces breaker state per provider so operators see
+ * "anthropic OPEN since 14:23" instead of guessing why latency spiked.
+ */
+
+import { AppError } from '../../core/errors.js';
+
+export type BreakerState = 'closed' | 'open' | 'half-open';
+
+export interface BreakerSnapshot {
+  provider: string;
+  state: BreakerState;
+  recentFailures: number;
+  failureThreshold: number;
+  windowMs: number;
+  cooldownMs: number;
+  lastFailureAt?: string;
+  openedAt?: string;
+  halfOpenAt?: string;
+  totalTrips: number;
+  totalRecoveries: number;
+}
+
+interface BreakerRecord {
+  state: BreakerState;
+  failureTimestamps: number[];
+  lastFailureAt?: number;
+  openedAt?: number;
+  halfOpenAt?: number;
+  /** Used to admit ONLY ONE probe request when half-open */
+  halfOpenProbeInFlight: boolean;
+  totalTrips: number;
+  totalRecoveries: number;
+}
+
+const breakers = new Map<string, BreakerRecord>();
+
+export const DEFAULT_FAILURE_THRESHOLD = 5;
+export const DEFAULT_WINDOW_MS = 60_000;
+export const DEFAULT_COOLDOWN_MS = 30_000;
+
+function getOrCreate(provider: string): BreakerRecord {
+  let rec = breakers.get(provider);
+  if (!rec) {
+    rec = {
+      state: 'closed',
+      failureTimestamps: [],
+      halfOpenProbeInFlight: false,
+      totalTrips: 0,
+      totalRecoveries: 0,
+    };
+    breakers.set(provider, rec);
+  }
+  return rec;
+}
+
+function envThresholds(
+  provider: string,
+  rawEnv: NodeJS.ProcessEnv,
+): { failureThreshold: number; windowMs: number; cooldownMs: number } {
+  const upper = provider.toUpperCase().replaceAll('-', '_');
+  const failureThreshold =
+    parsePositiveInt(rawEnv[`MEMPHIS_BREAKER_${upper}_FAILURES`]) ??
+    parsePositiveInt(rawEnv.MEMPHIS_BREAKER_DEFAULT_FAILURES) ??
+    DEFAULT_FAILURE_THRESHOLD;
+  const windowMs =
+    parsePositiveInt(rawEnv[`MEMPHIS_BREAKER_${upper}_WINDOW_MS`]) ??
+    parsePositiveInt(rawEnv.MEMPHIS_BREAKER_DEFAULT_WINDOW_MS) ??
+    DEFAULT_WINDOW_MS;
+  const cooldownMs =
+    parsePositiveInt(rawEnv[`MEMPHIS_BREAKER_${upper}_COOLDOWN_MS`]) ??
+    parsePositiveInt(rawEnv.MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS) ??
+    DEFAULT_COOLDOWN_MS;
+  return { failureThreshold, windowMs, cooldownMs };
+}
+
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
+/**
+ * Pre-flight gate. Throws PROVIDER_RATE_LIMIT (429) when the breaker
+ * is OPEN so the cascade falls through fast. When HALF_OPEN, allows
+ * exactly ONE probe request through.
+ */
+export function admitProviderCall(
+  provider: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: number = Date.now(),
+): void {
+  const rec = getOrCreate(provider);
+  const { cooldownMs } = envThresholds(provider, rawEnv);
+
+  if (rec.state === 'open') {
+    // Has the cooldown elapsed? If yes, transition to half-open and
+    // admit the probe; if no, fail fast.
+    if (rec.openedAt !== undefined && now - rec.openedAt >= cooldownMs) {
+      rec.state = 'half-open';
+      rec.halfOpenAt = now;
+      rec.halfOpenProbeInFlight = true;
+      return;
+    }
+    throw new AppError(
+      'PROVIDER_RATE_LIMIT',
+      `provider ${provider} circuit breaker is OPEN — failing fast (cascade will fall through)`,
+      429,
+      { provider, state: 'open', cooldownMs },
+    );
+  }
+
+  if (rec.state === 'half-open') {
+    if (rec.halfOpenProbeInFlight) {
+      // A probe is already in flight; subsequent calls fail fast.
+      throw new AppError(
+        'PROVIDER_RATE_LIMIT',
+        `provider ${provider} circuit breaker is HALF-OPEN — probe in flight, failing fast`,
+        429,
+        { provider, state: 'half-open' },
+      );
+    }
+    rec.halfOpenProbeInFlight = true;
+    return;
+  }
+
+  // CLOSED — admit normally
+}
+
+/**
+ * Record the outcome of a provider call. Failures may trip the breaker;
+ * a half-open success closes it; a half-open failure re-opens.
+ */
+export function recordProviderOutcome(
+  provider: string,
+  ok: boolean,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: number = Date.now(),
+): void {
+  const rec = getOrCreate(provider);
+  const { failureThreshold, windowMs } = envThresholds(provider, rawEnv);
+
+  if (rec.state === 'half-open') {
+    rec.halfOpenProbeInFlight = false;
+    if (ok) {
+      // Probe succeeded — close the breaker
+      rec.state = 'closed';
+      rec.failureTimestamps = [];
+      rec.openedAt = undefined;
+      rec.halfOpenAt = undefined;
+      rec.totalRecoveries += 1;
+    } else {
+      // Probe failed — back to open with a fresh cooldown
+      rec.state = 'open';
+      rec.openedAt = now;
+      rec.lastFailureAt = now;
+      rec.totalTrips += 1;
+    }
+    return;
+  }
+
+  if (ok) {
+    // Successful call in CLOSED state — drop stale failures
+    rec.failureTimestamps = rec.failureTimestamps.filter((t) => now - t < windowMs);
+    return;
+  }
+
+  // Failure in CLOSED state
+  rec.failureTimestamps.push(now);
+  rec.lastFailureAt = now;
+  rec.failureTimestamps = rec.failureTimestamps.filter((t) => now - t < windowMs);
+  if (rec.failureTimestamps.length >= failureThreshold) {
+    rec.state = 'open';
+    rec.openedAt = now;
+    rec.totalTrips += 1;
+  }
+}
+
+export function getBreakerSnapshot(
+  provider: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): BreakerSnapshot {
+  const rec = getOrCreate(provider);
+  const { failureThreshold, windowMs, cooldownMs } = envThresholds(provider, rawEnv);
+  return {
+    provider,
+    state: rec.state,
+    recentFailures: rec.failureTimestamps.length,
+    failureThreshold,
+    windowMs,
+    cooldownMs,
+    lastFailureAt: rec.lastFailureAt
+      ? new Date(rec.lastFailureAt).toISOString()
+      : undefined,
+    openedAt: rec.openedAt ? new Date(rec.openedAt).toISOString() : undefined,
+    halfOpenAt: rec.halfOpenAt ? new Date(rec.halfOpenAt).toISOString() : undefined,
+    totalTrips: rec.totalTrips,
+    totalRecoveries: rec.totalRecoveries,
+  };
+}
+
+export function getAllBreakerSnapshots(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): BreakerSnapshot[] {
+  return Array.from(breakers.keys()).map((provider) => getBreakerSnapshot(provider, rawEnv));
+}
+
+/** Test-only. */
+export function __resetBreakersForTests(): void {
+  breakers.clear();
+}

--- a/tests/unit/circuit-breaker.test.ts
+++ b/tests/unit/circuit-breaker.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetBreakersForTests,
+  admitProviderCall,
+  DEFAULT_COOLDOWN_MS,
+  DEFAULT_FAILURE_THRESHOLD,
+  DEFAULT_WINDOW_MS,
+  getAllBreakerSnapshots,
+  getBreakerSnapshot,
+  recordProviderOutcome,
+} from '../../src/infra/runtime/circuit-breaker.js';
+
+describe('circuit breaker (Phase 2.1 production sprint)', () => {
+  beforeEach(() => {
+    __resetBreakersForTests();
+  });
+
+  afterEach(() => {
+    __resetBreakersForTests();
+  });
+
+  it('starts CLOSED and admits without throwing', () => {
+    expect(() => admitProviderCall('anthropic', {} as NodeJS.ProcessEnv)).not.toThrow();
+    const snap = getBreakerSnapshot('anthropic', {} as NodeJS.ProcessEnv);
+    expect(snap.state).toBe('closed');
+    expect(snap.failureThreshold).toBe(DEFAULT_FAILURE_THRESHOLD);
+    expect(snap.windowMs).toBe(DEFAULT_WINDOW_MS);
+    expect(snap.cooldownMs).toBe(DEFAULT_COOLDOWN_MS);
+  });
+
+  it('trips OPEN after failureThreshold failures within window', () => {
+    const env = { MEMPHIS_BREAKER_DEFAULT_FAILURES: '3' } as NodeJS.ProcessEnv;
+    for (let i = 0; i < 3; i += 1) {
+      recordProviderOutcome('anthropic', false, env, 1000 + i);
+    }
+    const snap = getBreakerSnapshot('anthropic', env);
+    expect(snap.state).toBe('open');
+    expect(snap.totalTrips).toBe(1);
+  });
+
+  it('OPEN admit fails fast with PROVIDER_RATE_LIMIT', () => {
+    const env = { MEMPHIS_BREAKER_DEFAULT_FAILURES: '2' } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 2000);
+    expect(() => admitProviderCall('anthropic', env, 3000)).toThrow(/circuit breaker is OPEN/);
+  });
+
+  it('OPEN → HALF_OPEN after cooldown elapses; admits one probe', () => {
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '2',
+      MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: '5000',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 2000);
+    expect(getBreakerSnapshot('anthropic', env).state).toBe('open');
+    // Before cooldown — fails fast
+    expect(() => admitProviderCall('anthropic', env, 3000)).toThrow();
+    // After cooldown — admits probe and transitions to half-open
+    expect(() => admitProviderCall('anthropic', env, 8000)).not.toThrow();
+    expect(getBreakerSnapshot('anthropic', env).state).toBe('half-open');
+  });
+
+  it('HALF_OPEN admits ONE probe; subsequent calls fail fast', () => {
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '2',
+      MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: '5000',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 2000);
+    admitProviderCall('anthropic', env, 8000); // probe in flight
+    expect(() => admitProviderCall('anthropic', env, 8001)).toThrow(/HALF-OPEN.*probe in flight/);
+  });
+
+  it('HALF_OPEN probe success → CLOSED + recovery counted', () => {
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '2',
+      MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: '5000',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 2000);
+    admitProviderCall('anthropic', env, 8000);
+    recordProviderOutcome('anthropic', true, env, 8500);
+    const snap = getBreakerSnapshot('anthropic', env);
+    expect(snap.state).toBe('closed');
+    expect(snap.totalRecoveries).toBe(1);
+    expect(snap.recentFailures).toBe(0);
+  });
+
+  it('HALF_OPEN probe failure → re-OPEN with fresh cooldown', () => {
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '2',
+      MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: '5000',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 2000);
+    admitProviderCall('anthropic', env, 8000);
+    recordProviderOutcome('anthropic', false, env, 8500);
+    const snap = getBreakerSnapshot('anthropic', env);
+    expect(snap.state).toBe('open');
+    expect(snap.totalTrips).toBe(2);
+  });
+
+  it('failures outside the rolling window are forgotten', () => {
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '3',
+      MEMPHIS_BREAKER_DEFAULT_WINDOW_MS: '1000',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 1500);
+    // Big gap — old failures fall off when next ones land
+    recordProviderOutcome('anthropic', false, env, 5000);
+    recordProviderOutcome('anthropic', false, env, 5100);
+    const snap = getBreakerSnapshot('anthropic', env);
+    expect(snap.state).toBe('closed');
+    expect(snap.recentFailures).toBe(2);
+  });
+
+  it('per-provider override beats default', () => {
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '5',
+      MEMPHIS_BREAKER_ANTHROPIC_FAILURES: '2',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 2000);
+    expect(getBreakerSnapshot('anthropic', env).state).toBe('open');
+    // minimax keeps the default
+    recordProviderOutcome('minimax', false, env, 1000);
+    recordProviderOutcome('minimax', false, env, 2000);
+    expect(getBreakerSnapshot('minimax', env).state).toBe('closed');
+  });
+
+  it('getAllBreakerSnapshots returns one entry per touched provider', () => {
+    recordProviderOutcome('anthropic', true, {} as NodeJS.ProcessEnv);
+    recordProviderOutcome('minimax', false, {} as NodeJS.ProcessEnv);
+    const all = getAllBreakerSnapshots({} as NodeJS.ProcessEnv);
+    expect(all).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2.1. If Ollama hangs for 60s, every Ollama-routed request hangs for 60s. Cascade catches errors but not slow timeouts past some threshold. Standard Hystrix-style breaker fixes it.

### States
- **CLOSED** — pass-through
- **OPEN** — too many recent failures → fail fast (cascade falls through)
- **HALF_OPEN** — cooldown elapsed → admit ONE probe; success → CLOSED, failure → re-OPEN

### Tunables
| Env | Default | Purpose |
|---|---|---|
| `MEMPHIS_BREAKER_<P>_FAILURES` | 5 | trip threshold |
| `MEMPHIS_BREAKER_<P>_WINDOW_MS` | 60s | rolling failure window |
| `MEMPHIS_BREAKER_<P>_COOLDOWN_MS` | 30s | half-open gate |
| `MEMPHIS_BREAKER_DEFAULT_*` | (above) | fallback for any provider lacking specific override |

### `/v1/ops/status` surface
```jsonc
"providerBreakers": [
  {
    "provider": "anthropic",
    "state": "open",
    "recentFailures": 5,
    "openedAt": "2026-04-14T14:23:01Z",
    "totalTrips": 3,
    "totalRecoveries": 2
  }
]
```

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] 10 new cases in `tests/unit/circuit-breaker.test.ts` covering full state machine + per-provider overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)