### PR TITLE
feat: concurrent-turn admission + user-visible queue (Phase 2.2)

### DIFF
--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -741,6 +741,15 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     options.auditSurface,
     options.actorId,
   );
+
+  // Phase 2.2 production sprint: admission control. Throws 429 if the
+  // queue is full so callers can surface "system saturated, try again"
+  // instead of OOMing under a flood. ticket.release() in finally so
+  // even uncaught exceptions free the slot.
+  const { acquireTurnSlot } = await import('../infra/runtime/turn-admission.js');
+  const admissionTicket = await acquireTurnSlot(rawEnvWithTier3);
+
+  try {
   const surfacePolicy = resolveSurfacePolicy(auditSurface, rawEnvWithTier3);
   const conversationOverlay =
     options.conversationContext && options.conversationId
@@ -1045,4 +1054,9 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     telemetry,
     persistence,
   };
+  } finally {
+    // Phase 2.2: release the admission slot — finally so even uncaught
+    // exceptions free the slot for the next caller.
+    admissionTicket.release();
+  }
 }

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -204,6 +204,11 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
   MEMPHIS_BREAKER_DEFAULT_WINDOW_MS: 'hot',
   MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: 'hot',
 
+  // ── Turn admission (Phase 2.2 production sprint) ──
+  // Hot — operator can scale capacity up/down without restart.
+  MEMPHIS_MAX_CONCURRENT_TURNS: 'hot',
+  MEMPHIS_MAX_QUEUED_TURNS: 'hot',
+
   // ── OpenTelemetry overlay ──
   // All cold: starting the SDK after boot would require re-wiring the
   // global tracer provider. Operators restart to turn OTel on/off.

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -211,6 +211,12 @@ export const envSchema = z.object({
   MEMPHIS_BREAKER_DEFAULT_WINDOW_MS: z.coerce.number().int().min(1000).optional(),
   MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: z.coerce.number().int().min(1000).optional(),
 
+  // Phase 2.2 production sprint — concurrent-turn admission control.
+  // Semaphore that admits up to N turns at a time; queues up to M;
+  // rejects past M.
+  MEMPHIS_MAX_CONCURRENT_TURNS: z.coerce.number().int().min(1).max(1000).optional(),
+  MEMPHIS_MAX_QUEUED_TURNS: z.coerce.number().int().min(0).max(100_000).optional(),
+
   // Closes deferred item #3 — OpenTelemetry SDK overlay. When
   // MEMPHIS_OTEL_ENDPOINT is set, Memphis starts the OTLP/HTTP exporter
   // and installs a process-wide tracer. Unset = no-op.

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -83,6 +83,20 @@ export type HealthPayload = {
     monthly: { used: number; cap?: number; pctUsed?: number };
   }>;
   /**
+   * Phase 2.2 production sprint: turn admission depth.
+   * Operators see "we're under load" before hitting the rejection
+   * threshold. `queued > 0` is the early signal; `totalRejected` rising
+   * means the cap is biting.
+   */
+  turnAdmission?: {
+    active: number;
+    queued: number;
+    totalAdmitted: number;
+    totalRejected: number;
+    totalQueued: number;
+    emaTurnDurationMs: number;
+  };
+  /**
    * Phase 2.1 production sprint: per-provider circuit breaker state.
    * Operators see "anthropic OPEN since 14:23" instead of guessing
    * why latency just spiked. Empty until at least one provider call
@@ -297,6 +311,8 @@ export async function buildHealthPayload(
   const providerBudgets = getAllProviderBudgets(rawEnv);
   const { getAllBreakerSnapshots } = await import('../runtime/circuit-breaker.js');
   const providerBreakers = getAllBreakerSnapshots(rawEnv);
+  const { getAdmissionState } = await import('../runtime/turn-admission.js');
+  const turnAdmission = getAdmissionState();
   const topLevelStatus: HealthPayload['status'] = shutdown.shuttingDown
     ? 'shutting_down'
     : requiredHealthy && runtimeHealthy
@@ -322,6 +338,7 @@ export async function buildHealthPayload(
     shutdown: shutdown.shuttingDown ? shutdown : undefined,
     providerBudgets: providerBudgets.length > 0 ? providerBudgets : undefined,
     providerBreakers: providerBreakers.length > 0 ? providerBreakers : undefined,
+    turnAdmission,
     backups: {
       enabled: backupReport.state.enabled,
       intervalMs: backupReport.state.intervalMs,

--- a/src/infra/runtime/turn-admission.ts
+++ b/src/infra/runtime/turn-admission.ts
@@ -1,0 +1,226 @@
+/**
+ * Concurrent-turn admission control with user-visible queue (Phase 2.2).
+ *
+ * Without this, a Telegram message flood → N simultaneous LLM calls →
+ * OOM risk + provider rate-limit cascade. The runtime tracks turn
+ * controllers for drain but doesn't admission-control them. One spam
+ * wave is one bad day away from an OOM kill.
+ *
+ * Approach: semaphore that admits up to `MEMPHIS_MAX_CONCURRENT_TURNS`
+ * (default 10) at a time. Excess turns wait in a FIFO queue. When a
+ * caller is queued, they get a synchronous `queuePosition` they can
+ * surface back to the user ("queued, 3 ahead, ~15s wait").
+ *
+ * Hard ceiling: when the queue depth exceeds
+ * `MEMPHIS_MAX_QUEUED_TURNS` (default 50), new turns are REJECTED with
+ * a clear message. Better fast-fail than slow-fail at this load.
+ *
+ * /v1/ops/status surfaces queue depth + active count so operators see
+ * "we're under load" before hitting the rejection threshold.
+ */
+
+import { AppError } from '../../core/errors.js';
+
+export const DEFAULT_MAX_CONCURRENT_TURNS = 10;
+export const DEFAULT_MAX_QUEUED_TURNS = 50;
+
+export interface AdmissionTicket {
+  /** Position the caller was at when admission started: 0 = ran immediately,
+   *  N = N callers ahead at the moment of queue entry. */
+  queuePositionAtEntry: number;
+  /** Estimated wait at entry (rough — uses the rolling ema). */
+  estimatedWaitMs: number;
+  /** Release the slot back to the semaphore. MUST be called in finally. */
+  release: () => void;
+  /** Acquired-at, for telemetry. */
+  acquiredAt: number;
+}
+
+export interface AdmissionState {
+  active: number;
+  queued: number;
+  totalAdmitted: number;
+  totalRejected: number;
+  totalQueued: number;
+  emaTurnDurationMs: number;
+}
+
+interface QueueEntry {
+  resolve: (ticket: AdmissionTicket) => void;
+  reject: (err: Error) => void;
+  enqueuedAt: number;
+}
+
+const state: AdmissionState = {
+  active: 0,
+  queued: 0,
+  totalAdmitted: 0,
+  totalRejected: 0,
+  totalQueued: 0,
+  emaTurnDurationMs: 1000, // seed; rolling EMA updates as turns complete
+};
+
+const waitQueue: QueueEntry[] = [];
+
+function readMaxConcurrent(rawEnv: NodeJS.ProcessEnv): number {
+  const raw = rawEnv.MEMPHIS_MAX_CONCURRENT_TURNS?.trim();
+  if (!raw) return DEFAULT_MAX_CONCURRENT_TURNS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1 || parsed > 1000) {
+    return DEFAULT_MAX_CONCURRENT_TURNS;
+  }
+  return parsed;
+}
+
+function readMaxQueued(rawEnv: NodeJS.ProcessEnv): number {
+  const raw = rawEnv.MEMPHIS_MAX_QUEUED_TURNS?.trim();
+  if (!raw) return DEFAULT_MAX_QUEUED_TURNS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100_000) {
+    return DEFAULT_MAX_QUEUED_TURNS;
+  }
+  return parsed;
+}
+
+function admitOne(): void {
+  // Called when a slot frees up — pump the queue.
+  if (state.active >= 1 && waitQueue.length === 0) return;
+  // (the active >= 1 check is just paranoid — the only caller already
+  // confirmed we're admitting after a release)
+  const next = waitQueue.shift();
+  if (!next) return;
+  state.queued -= 1;
+  const acquiredAt = Date.now();
+  state.active += 1;
+  state.totalAdmitted += 1;
+  next.resolve({
+    queuePositionAtEntry: 0, // they were the head when slot freed
+    estimatedWaitMs: acquiredAt - next.enqueuedAt,
+    release: makeRelease(acquiredAt),
+    acquiredAt,
+  });
+}
+
+function makeRelease(acquiredAt: number): () => void {
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    state.active -= 1;
+    // Update EMA on actual duration so estimatedWaitMs gets more accurate
+    const duration = Math.max(50, Date.now() - acquiredAt);
+    state.emaTurnDurationMs = Math.round(
+      0.7 * state.emaTurnDurationMs + 0.3 * duration,
+    );
+    admitOne();
+  };
+}
+
+/**
+ * Acquire a turn admission slot. Resolves immediately when below the
+ * concurrency cap; otherwise queues. Rejects when the queue itself is
+ * full (over the configured ceiling).
+ *
+ * Caller MUST call `ticket.release()` in finally — otherwise the slot
+ * leaks.
+ */
+export async function acquireTurnSlot(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): Promise<AdmissionTicket> {
+  const maxConcurrent = readMaxConcurrent(rawEnv);
+  const maxQueued = readMaxQueued(rawEnv);
+
+  // Fast path: under cap, no queue
+  if (state.active < maxConcurrent && waitQueue.length === 0) {
+    const acquiredAt = Date.now();
+    state.active += 1;
+    state.totalAdmitted += 1;
+    return {
+      queuePositionAtEntry: 0,
+      estimatedWaitMs: 0,
+      release: makeRelease(acquiredAt),
+      acquiredAt,
+    };
+  }
+
+  // Queue-rejection path: too many already waiting
+  if (waitQueue.length >= maxQueued) {
+    state.totalRejected += 1;
+    throw new AppError(
+      'PROVIDER_RATE_LIMIT',
+      `turn admission refused — ${state.active} active + ${waitQueue.length} queued (cap ${maxConcurrent} active / ${maxQueued} queued). Try again in a few seconds.`,
+      429,
+      {
+        active: state.active,
+        queued: waitQueue.length,
+        maxConcurrent,
+        maxQueued,
+      },
+    );
+  }
+
+  // Queue
+  const positionAtEntry = waitQueue.length; // 0 = next up
+  const enqueuedAt = Date.now();
+  state.queued += 1;
+  state.totalQueued += 1;
+
+  return new Promise<AdmissionTicket>((resolve, reject) => {
+    waitQueue.push({
+      resolve: (ticket) => {
+        // Override the positionAtEntry with what we observed at enqueue
+        resolve({
+          ...ticket,
+          queuePositionAtEntry: positionAtEntry,
+          estimatedWaitMs: positionAtEntry * state.emaTurnDurationMs,
+        });
+      },
+      reject,
+      enqueuedAt,
+    });
+  });
+}
+
+/**
+ * For surfaces (Telegram) that want a synchronous "you're queued" hint
+ * BEFORE awaiting acquireTurnSlot — peek at the current queue depth +
+ * EMA so the user gets feedback fast.
+ */
+export function previewQueueState(): {
+  active: number;
+  queued: number;
+  estimatedWaitMs: number;
+  willQueue: boolean;
+  willReject: boolean;
+} {
+  const env = process.env;
+  const maxConcurrent = readMaxConcurrent(env);
+  const maxQueued = readMaxQueued(env);
+  const willQueue = state.active >= maxConcurrent;
+  const willReject = willQueue && waitQueue.length >= maxQueued;
+  // EstimatedWait = positionAheadOfYou * emaTurnDuration. If you're not
+  // queued yet, your "position" is `queued` (you'd land at the back).
+  const aheadOfYou = willQueue ? waitQueue.length : 0;
+  return {
+    active: state.active,
+    queued: waitQueue.length,
+    estimatedWaitMs: aheadOfYou * state.emaTurnDurationMs,
+    willQueue,
+    willReject,
+  };
+}
+
+export function getAdmissionState(): AdmissionState {
+  return { ...state, active: state.active, queued: waitQueue.length };
+}
+
+/** Test-only: clear queue + counters so a fresh test starts at zero. */
+export function __resetTurnAdmissionForTests(): void {
+  state.active = 0;
+  state.queued = 0;
+  state.totalAdmitted = 0;
+  state.totalRejected = 0;
+  state.totalQueued = 0;
+  state.emaTurnDurationMs = 1000;
+  while (waitQueue.length > 0) waitQueue.pop();
+}

--- a/tests/unit/turn-admission.test.ts
+++ b/tests/unit/turn-admission.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetTurnAdmissionForTests,
+  acquireTurnSlot,
+  DEFAULT_MAX_CONCURRENT_TURNS,
+  getAdmissionState,
+  previewQueueState,
+} from '../../src/infra/runtime/turn-admission.js';
+
+describe('turn admission control (Phase 2.2 production sprint)', () => {
+  beforeEach(() => {
+    __resetTurnAdmissionForTests();
+  });
+
+  afterEach(() => {
+    __resetTurnAdmissionForTests();
+  });
+
+  it('admits immediately when below cap', async () => {
+    const ticket = await acquireTurnSlot({
+      MEMPHIS_MAX_CONCURRENT_TURNS: '5',
+    } as NodeJS.ProcessEnv);
+    expect(ticket.queuePositionAtEntry).toBe(0);
+    expect(ticket.estimatedWaitMs).toBe(0);
+    expect(getAdmissionState().active).toBe(1);
+    ticket.release();
+    expect(getAdmissionState().active).toBe(0);
+  });
+
+  it('queues when at cap; admits when slot frees', async () => {
+    const env = { MEMPHIS_MAX_CONCURRENT_TURNS: '2' } as NodeJS.ProcessEnv;
+    const a = await acquireTurnSlot(env);
+    const b = await acquireTurnSlot(env);
+    // Both acquired
+    expect(getAdmissionState().active).toBe(2);
+
+    // Third caller must queue
+    const cPromise = acquireTurnSlot(env);
+    // Give the queue a tick to register
+    await Promise.resolve();
+    expect(getAdmissionState().queued).toBe(1);
+
+    // Free a slot — third caller should now resolve
+    a.release();
+    const c = await cPromise;
+    expect(c.queuePositionAtEntry).toBe(0);
+    expect(getAdmissionState().active).toBe(2);
+
+    // Cleanup
+    b.release();
+    c.release();
+  });
+
+  it('rejects with 429 when queue depth exceeds cap', async () => {
+    const env = {
+      MEMPHIS_MAX_CONCURRENT_TURNS: '1',
+      MEMPHIS_MAX_QUEUED_TURNS: '2',
+    } as NodeJS.ProcessEnv;
+    const a = await acquireTurnSlot(env);
+    // Queue 2
+    const p1 = acquireTurnSlot(env);
+    const p2 = acquireTurnSlot(env);
+    await Promise.resolve();
+    expect(getAdmissionState().queued).toBe(2);
+
+    // Third would-be queuer is rejected
+    await expect(acquireTurnSlot(env)).rejects.toThrow(/turn admission refused/);
+
+    // Cleanup — release a so queued ones can resolve
+    a.release();
+    const r1 = await p1;
+    r1.release();
+    const r2 = await p2;
+    r2.release();
+  });
+
+  it('queuePositionAtEntry reflects depth at the moment of enqueue', async () => {
+    const env = { MEMPHIS_MAX_CONCURRENT_TURNS: '1' } as NodeJS.ProcessEnv;
+    const head = await acquireTurnSlot(env);
+    const p1 = acquireTurnSlot(env);
+    const p2 = acquireTurnSlot(env);
+    const p3 = acquireTurnSlot(env);
+
+    head.release();
+    const r1 = await p1;
+    expect(r1.queuePositionAtEntry).toBe(0);
+    r1.release();
+    const r2 = await p2;
+    expect(r2.queuePositionAtEntry).toBe(1);
+    r2.release();
+    const r3 = await p3;
+    expect(r3.queuePositionAtEntry).toBe(2);
+    r3.release();
+  });
+
+  it('previewQueueState gives synchronous "you will queue" hint', async () => {
+    const env = { MEMPHIS_MAX_CONCURRENT_TURNS: '1' } as NodeJS.ProcessEnv;
+    process.env.MEMPHIS_MAX_CONCURRENT_TURNS = '1';
+    process.env.MEMPHIS_MAX_QUEUED_TURNS = '5';
+    try {
+      const head = await acquireTurnSlot(env);
+      const preview = previewQueueState();
+      expect(preview.willQueue).toBe(true);
+      expect(preview.willReject).toBe(false);
+      expect(preview.active).toBe(1);
+      head.release();
+    } finally {
+      delete process.env.MEMPHIS_MAX_CONCURRENT_TURNS;
+      delete process.env.MEMPHIS_MAX_QUEUED_TURNS;
+    }
+  });
+
+  it('release() is idempotent (double-release is a no-op)', async () => {
+    const ticket = await acquireTurnSlot({} as NodeJS.ProcessEnv);
+    ticket.release();
+    expect(getAdmissionState().active).toBe(0);
+    ticket.release(); // noop
+    expect(getAdmissionState().active).toBe(0);
+  });
+
+  it('uses default cap when env unset', async () => {
+    const tickets = [];
+    for (let i = 0; i < DEFAULT_MAX_CONCURRENT_TURNS; i += 1) {
+      tickets.push(await acquireTurnSlot({} as NodeJS.ProcessEnv));
+    }
+    expect(getAdmissionState().active).toBe(DEFAULT_MAX_CONCURRENT_TURNS);
+    for (const t of tickets) t.release();
+  });
+
+  it('totalAdmitted and totalQueued counters track lifetime traffic', async () => {
+    const env = { MEMPHIS_MAX_CONCURRENT_TURNS: '1' } as NodeJS.ProcessEnv;
+    const a = await acquireTurnSlot(env);
+    const p1 = acquireTurnSlot(env);
+    a.release();
+    const r1 = await p1;
+    r1.release();
+    const s = getAdmissionState();
+    expect(s.totalAdmitted).toBe(2);
+    expect(s.totalQueued).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2.2. Without admission control, a flood of Telegram messages → N simultaneous LLM calls → OOM. Runtime had drain-tracking but no concurrency limit.

### Mechanics
- Semaphore admits up to `MEMPHIS_MAX_CONCURRENT_TURNS` (default 10)
- Excess turns queue FIFO; queue depth capped at `MEMPHIS_MAX_QUEUED_TURNS` (default 50)
- Past queue cap → throw 429 with operator-friendly message (better fast-fail than slow-fail)
- Each ticket exposes `queuePositionAtEntry` + `estimatedWaitMs` so surfaces can show "queued, 3 ahead, ~15s wait" to the user
- `previewQueueState()` gives a synchronous "you'll queue" hint before awaiting
- Rolling EMA of turn duration powers the wait estimate
- `release()` is idempotent

### Surface on `/v1/ops/status`
```jsonc
"turnAdmission": {
  "active": 7,
  "queued": 3,
  "totalAdmitted": 1843,
  "totalRejected": 12,
  "totalQueued": 91,
  "emaTurnDurationMs": 4500
}
```

`queued > 0` → early load signal. `totalRejected` rising → time to scale up.

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] 8 new cases in `tests/unit/turn-admission.test.ts` covering admit/queue/reject/idempotent-release/counters

🤖 Generated with [Claude Code](https://claude.com/claude-code)