### PR TITLE
feat: self-modify boot-failure auto-revert (Phase 2.3)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -51,6 +51,12 @@ import {
 } from '../infra/runtime/scheduler.js';
 import { writeSecurityCriticalEvent } from '../infra/runtime/security-critical.js';
 import {
+  evaluateAutoRevert,
+  performAutoRevert,
+  recordBootAttempt,
+  recordBootSuccess,
+} from '../infra/runtime/self-modify-revert.js';
+import {
   evaluateRevocationCacheStartup,
   evaluateTrustRootStartup,
   type RevocationCacheStartupStatus,
@@ -79,6 +85,23 @@ import { getCognitiveMode, ensureIskra, ensureSoulManifest } from '../soul/manif
 import { loadSoulMemory } from '../soul/memory.js';
 
 export async function bootstrap(): Promise<void> {
+  // Phase 2.3 production sprint: bump the boot-attempt counter BEFORE
+  // any risky init. If we crash mid-init, the next process sees the
+  // failure and may auto-revert a recent self-modify commit.
+  recordBootAttempt(process.env);
+
+  // Then evaluate whether the prior crashes warrant a revert. If yes,
+  // perform it and continue boot — the just-reverted code is what we'll
+  // run from this point.
+  const revertDecision = evaluateAutoRevert(process.env);
+  if (revertDecision.shouldRevert) {
+    const result = await performAutoRevert(revertDecision);
+    process.stderr.write(
+      `[memphis-bootstrap] self-modify auto-revert: ` +
+        `${result.ok ? 'reverted to ' + result.revertedTo : 'FAILED — ' + result.error}\n`,
+    );
+  }
+
   const envFilePath = resolveBootstrapEnvPath(process.env);
 
   if (!existsSync(envFilePath)) {
@@ -311,6 +334,12 @@ export async function bootstrap(): Promise<void> {
       { name: 'scheduled-backup-loop', stop: () => scheduledBackupHandle.stop() },
     ],
   });
+
+  // Phase 2.3: we made it past every risky init step. Clear the boot-
+  // failure counter so the next process starts at zero. If a self-modify
+  // commit was the cause of a prior crash, this resets the auto-revert
+  // bookkeeping for the new (presumably-good) code.
+  recordBootSuccess(process.env);
 }
 
 const bootstrapLog = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });

--- a/src/infra/runtime/self-modify-revert.ts
+++ b/src/infra/runtime/self-modify-revert.ts
@@ -1,0 +1,328 @@
+/**
+ * Self-modify boot-failure auto-revert (Phase 2.3 production sprint).
+ *
+ * `memphis_self_modify` has content scanning + a test-gate before
+ * commit (good). But if a committed modification breaks STARTUP
+ * (import crash, syntax-valid-but-runtime-fatal), the agent doesn't
+ * boot and nothing rolls back. The whole point of self-modify is
+ * autonomy; one bad self-modification turns autonomy into a brick.
+ *
+ * Approach:
+ *
+ * 1. Every successful self-modify commit writes a marker file recording
+ *    the commit hash, timestamp, and the "previous known-good" hash
+ *    (HEAD before the commit).
+ *
+ * 2. At BOOT, we read this marker. If we see it AND the boot has
+ *    failed N times in M minutes (tracked in a separate boot-failure
+ *    counter file), we revert HEAD to the previous-known-good hash via
+ *    `git reset --hard <prev>` and write a security-audit + alert.
+ *
+ * 3. Boot success clears the failure counter.
+ *
+ * The signal "boot failed N times" comes from a sidecar boot-counter
+ * that bootstrap.ts writes BEFORE doing anything risky. If bootstrap
+ * crashes mid-init, the counter persists; if it completes, the counter
+ * is reset. Net effect: the next process to start counts the prior
+ * crash and decides whether to revert.
+ *
+ * Env:
+ *   MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES   — default 3
+ *   MEMPHIS_SELF_MODIFY_REVERT_WINDOW_MS              — default 5 min
+ *   MEMPHIS_SELF_MODIFY_AUTO_REVERT                   — default true
+ *
+ * The boot-counter check runs ASAP in bootstrap so a crash loop is
+ * caught fast (rather than after the operator notices and SSH'es in).
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { writeSecurityAudit } from '../logging/security-audit.js';
+
+export const DEFAULT_REVERT_AFTER_FAILURES = 3;
+export const DEFAULT_REVERT_WINDOW_MS = 5 * 60 * 1000;
+
+interface SelfModifyMarker {
+  commitHash: string;
+  previousHash: string;
+  intent: string;
+  committedAt: string;
+}
+
+interface BootFailureRecord {
+  failures: Array<{ at: string }>;
+}
+
+function markerPath(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  const dataDir = rawEnv.MEMPHIS_DATA_DIR ?? join(process.env.HOME ?? '/tmp', '.memphis');
+  return join(dataDir, 'state', 'last-self-modify.json');
+}
+
+function bootFailurePath(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  const dataDir = rawEnv.MEMPHIS_DATA_DIR ?? join(process.env.HOME ?? '/tmp', '.memphis');
+  return join(dataDir, 'state', 'boot-failures.json');
+}
+
+function readJson<T>(path: string): T | null {
+  try {
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(value), 'utf8');
+}
+
+/**
+ * Called at the END of a successful self-modify commit. Persists the
+ * "if this turns out to be bad, revert here" pointer so a later boot
+ * crash loop can roll back.
+ */
+export function recordSelfModifyCommit(
+  marker: { commitHash: string; previousHash: string; intent: string },
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): void {
+  const record: SelfModifyMarker = {
+    ...marker,
+    committedAt: new Date().toISOString(),
+  };
+  writeJson(markerPath(rawEnv), record);
+}
+
+/**
+ * Called at the START of bootstrap (before risky init). Increments
+ * the failure counter; if a prior boot completed successfully it
+ * starts at 0.
+ */
+export function recordBootAttempt(rawEnv: NodeJS.ProcessEnv = process.env): void {
+  const path = bootFailurePath(rawEnv);
+  const existing = readJson<BootFailureRecord>(path) ?? { failures: [] };
+  existing.failures.push({ at: new Date().toISOString() });
+  // Cap to last 50 entries — anything past that is just history bloat.
+  existing.failures = existing.failures.slice(-50);
+  writeJson(path, existing);
+}
+
+/**
+ * Called at the END of successful bootstrap. Clears the failure
+ * counter — we made it through.
+ */
+export function recordBootSuccess(rawEnv: NodeJS.ProcessEnv = process.env): void {
+  try {
+    const path = bootFailurePath(rawEnv);
+    if (existsSync(path)) unlinkSync(path);
+  } catch {
+    // best-effort
+  }
+}
+
+export interface AutoRevertDecision {
+  shouldRevert: boolean;
+  reason:
+    | 'no-marker'
+    | 'no-failures'
+    | 'failures-below-threshold'
+    | 'marker-too-old'
+    | 'auto-revert-disabled'
+    | 'will-revert';
+  marker?: SelfModifyMarker;
+  failuresInWindow: number;
+  threshold: number;
+  windowMs: number;
+}
+
+function readEnvBoolDefault(raw: string | undefined, defaultValue: boolean): boolean {
+  if (!raw) return defaultValue;
+  const lower = raw.trim().toLowerCase();
+  if (lower === 'false' || lower === '0' || lower === 'no') return false;
+  if (lower === 'true' || lower === '1' || lower === 'yes') return true;
+  return defaultValue;
+}
+
+function readEnvInt(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return defaultValue;
+  return parsed;
+}
+
+/**
+ * Decide whether the current boot should auto-revert. Pure (no side
+ * effects); call `performAutoRevert` to actually do it.
+ */
+export function evaluateAutoRevert(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): AutoRevertDecision {
+  const enabled = readEnvBoolDefault(rawEnv.MEMPHIS_SELF_MODIFY_AUTO_REVERT, true);
+  const threshold = readEnvInt(
+    rawEnv.MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES,
+    DEFAULT_REVERT_AFTER_FAILURES,
+  );
+  const windowMs = readEnvInt(
+    rawEnv.MEMPHIS_SELF_MODIFY_REVERT_WINDOW_MS,
+    DEFAULT_REVERT_WINDOW_MS,
+  );
+  const marker = readJson<SelfModifyMarker>(markerPath(rawEnv));
+  const failureRecord = readJson<BootFailureRecord>(bootFailurePath(rawEnv)) ?? {
+    failures: [],
+  };
+
+  // Failures within the window
+  const cutoff = now.getTime() - windowMs;
+  const failuresInWindow = failureRecord.failures.filter(
+    (f) => new Date(f.at).getTime() >= cutoff,
+  ).length;
+
+  if (!enabled) {
+    return {
+      shouldRevert: false,
+      reason: 'auto-revert-disabled',
+      marker: marker ?? undefined,
+      failuresInWindow,
+      threshold,
+      windowMs,
+    };
+  }
+  if (!marker) {
+    return {
+      shouldRevert: false,
+      reason: 'no-marker',
+      failuresInWindow,
+      threshold,
+      windowMs,
+    };
+  }
+  if (failuresInWindow === 0) {
+    return {
+      shouldRevert: false,
+      reason: 'no-failures',
+      marker,
+      failuresInWindow,
+      threshold,
+      windowMs,
+    };
+  }
+  // Only revert if the marker is RECENT — i.e. committed within the
+  // failure window. Otherwise the boot crash isn't the self-modify's
+  // fault.
+  const markerAge = now.getTime() - new Date(marker.committedAt).getTime();
+  if (markerAge > windowMs) {
+    return {
+      shouldRevert: false,
+      reason: 'marker-too-old',
+      marker,
+      failuresInWindow,
+      threshold,
+      windowMs,
+    };
+  }
+  if (failuresInWindow < threshold) {
+    return {
+      shouldRevert: false,
+      reason: 'failures-below-threshold',
+      marker,
+      failuresInWindow,
+      threshold,
+      windowMs,
+    };
+  }
+  return {
+    shouldRevert: true,
+    reason: 'will-revert',
+    marker,
+    failuresInWindow,
+    threshold,
+    windowMs,
+  };
+}
+
+/**
+ * Actually perform the revert. `git reset --hard <previousHash>` in
+ * the project root + clear the marker + log + audit.
+ */
+export async function performAutoRevert(
+  decision: AutoRevertDecision,
+  options: {
+    projectRoot?: string;
+    rawEnv?: NodeJS.ProcessEnv;
+    /** Test seam: substitute the git operation. */
+    gitResetFn?: (previousHash: string, projectRoot: string) => Promise<void>;
+  } = {},
+): Promise<{ ok: boolean; revertedTo?: string; error?: string }> {
+  if (!decision.shouldRevert || !decision.marker) {
+    return { ok: false, error: 'evaluateAutoRevert did not request a revert' };
+  }
+  const rawEnv = options.rawEnv ?? process.env;
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const gitReset =
+    options.gitResetFn ??
+    (async (hash: string, root: string) => {
+      const { execFile } = await import('node:child_process');
+      const { promisify } = await import('node:util');
+      const execFileAsync = promisify(execFile);
+      await execFileAsync('git', ['reset', '--hard', hash], { cwd: root });
+    });
+
+  try {
+    await gitReset(decision.marker.previousHash, projectRoot);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    writeSecurityAudit({
+      action: 'self_modify.auto_revert.failed',
+      status: 'blocked',
+      details: {
+        previousHash: decision.marker.previousHash,
+        commitHash: decision.marker.commitHash,
+        error: message,
+      },
+    });
+    return { ok: false, error: message };
+  }
+
+  // Clear marker so a second boot doesn't try to re-revert
+  try {
+    unlinkSync(markerPath(rawEnv));
+  } catch {
+    // best-effort
+  }
+  // Clear failure counter — we just intervened, give the new (reverted)
+  // process a clean slate
+  try {
+    unlinkSync(bootFailurePath(rawEnv));
+  } catch {
+    // best-effort
+  }
+
+  writeSecurityAudit({
+    action: 'self_modify.auto_revert.executed',
+    status: 'allowed',
+    details: {
+      revertedFrom: decision.marker.commitHash,
+      revertedTo: decision.marker.previousHash,
+      intent: decision.marker.intent,
+      failuresInWindow: decision.failuresInWindow,
+    },
+  });
+
+  return { ok: true, revertedTo: decision.marker.previousHash };
+}
+
+/** Test-only: reset both state files. */
+export function __resetSelfModifyRevertForTests(rawEnv: NodeJS.ProcessEnv = process.env): void {
+  try {
+    unlinkSync(markerPath(rawEnv));
+  } catch {
+    /* noop */
+  }
+  try {
+    unlinkSync(bootFailurePath(rawEnv));
+  } catch {
+    /* noop */
+  }
+}

--- a/src/mcp/tools/self-modify.ts
+++ b/src/mcp/tools/self-modify.ts
@@ -316,9 +316,41 @@ export async function runMemphisSelfModify(
     if (testResult.passed) {
       // 6a. Commit + merge
       const commitHash = await commitAll(`evolve: ${intent}`, projectRoot, files);
+      // Phase 2.3 production sprint: record the previous-known-good
+      // hash BEFORE the merge so a boot-failure auto-revert can roll
+      // back if the merged code breaks startup.
+      const previousHash = await (async () => {
+        try {
+          const { execFile } = await import('node:child_process');
+          const { promisify } = await import('node:util');
+          const execFileAsync = promisify(execFile);
+          const { stdout } = await execFileAsync(
+            'git',
+            ['rev-parse', originalBranch],
+            { cwd: projectRoot },
+          );
+          return stdout.trim();
+        } catch {
+          return '';
+        }
+      })();
       await switchBranch(originalBranch, projectRoot);
       await mergeBranch(evolveBranch, projectRoot);
       await deleteBranch(evolveBranch, projectRoot);
+      if (previousHash) {
+        try {
+          const { recordSelfModifyCommit } = await import(
+            '../../infra/runtime/self-modify-revert.js'
+          );
+          recordSelfModifyCommit({
+            commitHash,
+            previousHash,
+            intent,
+          });
+        } catch {
+          // best-effort
+        }
+      }
 
       sessionRepo.updateStatus(session.id, 'committed', { committedHash: commitHash });
       await emitRuntimeSecurityEvent({

--- a/tests/unit/self-modify-revert.test.ts
+++ b/tests/unit/self-modify-revert.test.ts
@@ -1,0 +1,185 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetSelfModifyRevertForTests,
+  evaluateAutoRevert,
+  performAutoRevert,
+  recordBootAttempt,
+  recordBootSuccess,
+  recordSelfModifyCommit,
+} from '../../src/infra/runtime/self-modify-revert.js';
+
+describe('self-modify boot-failure auto-revert (Phase 2.3)', () => {
+  let dataDir: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'memphis-self-modify-revert-'));
+    env = { MEMPHIS_DATA_DIR: dataDir } as NodeJS.ProcessEnv;
+  });
+
+  afterEach(() => {
+    __resetSelfModifyRevertForTests(env);
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('no marker → no revert', () => {
+    recordBootAttempt(env);
+    const decision = evaluateAutoRevert(env);
+    expect(decision.shouldRevert).toBe(false);
+    expect(decision.reason).toBe('no-marker');
+  });
+
+  it('marker but no boot failures → no revert', () => {
+    recordSelfModifyCommit(
+      { commitHash: 'abc', previousHash: 'def', intent: 'test' },
+      env,
+    );
+    const decision = evaluateAutoRevert(env);
+    expect(decision.shouldRevert).toBe(false);
+    expect(decision.reason).toBe('no-failures');
+  });
+
+  it('boot failures BELOW threshold → no revert', () => {
+    recordSelfModifyCommit(
+      { commitHash: 'abc', previousHash: 'def', intent: 'test' },
+      env,
+    );
+    recordBootAttempt(env); // 1
+    recordBootAttempt(env); // 2
+    const decision = evaluateAutoRevert({
+      ...env,
+      MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES: '5',
+    } as NodeJS.ProcessEnv);
+    expect(decision.shouldRevert).toBe(false);
+    expect(decision.reason).toBe('failures-below-threshold');
+    expect(decision.failuresInWindow).toBe(2);
+  });
+
+  it('boot failures AT threshold + marker recent → revert', () => {
+    recordSelfModifyCommit(
+      { commitHash: 'abc', previousHash: 'def', intent: 'test' },
+      env,
+    );
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    const decision = evaluateAutoRevert({
+      ...env,
+      MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES: '3',
+    } as NodeJS.ProcessEnv);
+    expect(decision.shouldRevert).toBe(true);
+    expect(decision.reason).toBe('will-revert');
+    expect(decision.marker?.previousHash).toBe('def');
+  });
+
+  it('marker too old (committed before window started) → no revert', () => {
+    // Hand-write an OLD marker file directly so we don't depend on
+    // recordSelfModifyCommit's now() behavior.
+    const markerFile = join(dataDir, 'state', 'last-self-modify.json');
+    mkdirSync(dirname(markerFile), { recursive: true });
+    writeFileSync(
+      markerFile,
+      JSON.stringify({
+        commitHash: 'abc',
+        previousHash: 'def',
+        intent: 'old',
+        committedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1h ago
+      }),
+      'utf8',
+    );
+    // Recent boot failures (within window)
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    const decision = evaluateAutoRevert({
+      ...env,
+      MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES: '3',
+      MEMPHIS_SELF_MODIFY_REVERT_WINDOW_MS: '60000', // 1 min
+    } as NodeJS.ProcessEnv);
+    expect(decision.shouldRevert).toBe(false);
+    expect(decision.reason).toBe('marker-too-old');
+    expect(decision.failuresInWindow).toBe(3);
+  });
+
+  it('MEMPHIS_SELF_MODIFY_AUTO_REVERT=false disables the feature', () => {
+    recordSelfModifyCommit(
+      { commitHash: 'abc', previousHash: 'def', intent: 'test' },
+      env,
+    );
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    const decision = evaluateAutoRevert({
+      ...env,
+      MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES: '3',
+      MEMPHIS_SELF_MODIFY_AUTO_REVERT: 'false',
+    } as NodeJS.ProcessEnv);
+    expect(decision.shouldRevert).toBe(false);
+    expect(decision.reason).toBe('auto-revert-disabled');
+  });
+
+  it('recordBootSuccess clears the failure counter', () => {
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    recordBootSuccess(env);
+    const decision = evaluateAutoRevert(env);
+    expect(decision.failuresInWindow).toBe(0);
+  });
+
+  it('performAutoRevert calls git reset and clears state', async () => {
+    recordSelfModifyCommit(
+      { commitHash: 'abc', previousHash: 'def', intent: 'test' },
+      env,
+    );
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    const decision = evaluateAutoRevert({
+      ...env,
+      MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES: '3',
+    } as NodeJS.ProcessEnv);
+    expect(decision.shouldRevert).toBe(true);
+
+    const gitResetFn = vi.fn(async () => {});
+    const result = await performAutoRevert(decision, {
+      projectRoot: '/tmp/fake',
+      rawEnv: env,
+      gitResetFn,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.revertedTo).toBe('def');
+    expect(gitResetFn).toHaveBeenCalledWith('def', '/tmp/fake');
+
+    // Marker + failure counter cleared so next boot starts fresh
+    const followUp = evaluateAutoRevert(env);
+    expect(followUp.reason).toBe('no-marker');
+    expect(followUp.failuresInWindow).toBe(0);
+  });
+
+  it('performAutoRevert reports git failure cleanly', async () => {
+    recordSelfModifyCommit(
+      { commitHash: 'abc', previousHash: 'def', intent: 'test' },
+      env,
+    );
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    recordBootAttempt(env);
+    const decision = evaluateAutoRevert({
+      ...env,
+      MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES: '3',
+    } as NodeJS.ProcessEnv);
+    const result = await performAutoRevert(decision, {
+      rawEnv: env,
+      gitResetFn: async () => {
+        throw new Error('git: bad ref');
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/git: bad ref/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2.3. `memphis_self_modify` had pre-commit safety (content scan + test gate). It had **no** post-merge safety: if the merged code breaks startup, the agent is bricked.

This PR closes the loop. Boot-failure counter + recent-self-modify marker → automatic `git reset --hard` to the previous-known-good commit on detected crash loop.

### How it works
1. **Every successful self-modify commit** writes a marker (`commitHash`, `previousHash`, `intent`, `committedAt`)
2. **Every boot attempt** increments a persisted failure counter
3. **Every successful boot** clears the failure counter
4. **At boot start** (before risky init), check: if marker is recent AND failures ≥ threshold → `git reset --hard <previousHash>` + audit + alert

### Env
| Key | Default | Purpose |
|---|---|---|
| `MEMPHIS_SELF_MODIFY_AUTO_REVERT` | `true` | feature toggle |
| `MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES` | `3` | crash-loop threshold |
| `MEMPHIS_SELF_MODIFY_REVERT_WINDOW_MS` | `5 min` | how recent must the marker + failures be |

### Decisions exposed (`AutoRevertDecision.reason`)
`no-marker` · `no-failures` · `failures-below-threshold` · `marker-too-old` · `auto-revert-disabled` · `will-revert`

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] 9 new cases in `tests/unit/self-modify-revert.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)