### PR TITLE
fix: Codex Round 6 — bundled hotfix for production-sprint PR findings (13 items)

### DIFF
--- a/.github/workflows/telegram-smoke.yml
+++ b/.github/workflows/telegram-smoke.yml
@@ -49,7 +49,10 @@ jobs:
       - uses: actions/setup-node@v4
         if: steps.check-secrets.outputs.skipped != 'true'
         with:
-          node-version: '20'
+          # Codex Round 6 P2 fix (PR #125): project declares
+          # `"engines": { "node": ">=22" }` — using 20 here made the
+          # smoke signal noisy on version-specific differences.
+          node-version: '22'
           cache: npm
 
       - name: Install
@@ -66,5 +69,8 @@ jobs:
           MEMPHIS_TELEGRAM_BOT_TOKEN: ${{ secrets.MEMPHIS_TELEGRAM_SMOKE_BOT_TOKEN }}
           MEMPHIS_TELEGRAM_ALLOWED_USER_IDS: ${{ secrets.MEMPHIS_TELEGRAM_SMOKE_CHAT_ID }}
         run: |
-          node dist/src/cli/index.js telegram smoke-test --json \
+          # Codex Round 6 P1 fix (PR #125): TS rootDir is `src/`, so the
+          # compiled CLI lives at `dist/infra/cli/index.js` (matches
+          # `bin/memphis.js`), NOT `dist/src/cli/index.js`.
+          node bin/memphis.js telegram smoke-test --json \
             --value "🟢 Memphis CI smoke-test @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ($GITHUB_SHA)"

--- a/bin/memphis.js
+++ b/bin/memphis.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 // Get script directory (not cwd)
 const __filename = fileURLToPath(import.meta.url);
@@ -10,6 +10,42 @@ const __dirname = dirname(__filename);
 const packageRoot = resolve(__dirname, '..');
 
 const distEntry = resolve(packageRoot, 'dist/infra/cli/index.js');
+
+// Codex Round 6 P1 fix (PR #124): bump the boot-attempt counter BEFORE
+// any dist module imports. If a bad self-modify commit introduced a
+// syntax / import-time crash in a module bootstrap.ts statically
+// imports, the old recordBootAttempt call inside bootstrap() never
+// ran, so the auto-revert counter never advanced. By counting here
+// (pre-import, using only node built-ins) we guarantee a crash loop
+// is visible to evaluateAutoRevert on the next boot.
+//
+// Only bumps for the `serve` entry — `memphis <other>` CLI invocations
+// are diagnostic and shouldn't contribute.
+function recordBootAttemptEarly() {
+  if (process.argv[2] !== 'serve') return;
+  try {
+    const dataDir =
+      process.env.MEMPHIS_DATA_DIR ??
+      join(process.env.HOME ?? '/tmp', '.memphis');
+    const statePath = join(dataDir, 'state', 'boot-failures.json');
+    mkdirSync(dirname(statePath), { recursive: true });
+    let record = { failures: [] };
+    try {
+      if (existsSync(statePath)) {
+        record = JSON.parse(readFileSync(statePath, 'utf8'));
+        if (!Array.isArray(record.failures)) record.failures = [];
+      }
+    } catch {
+      /* start fresh on parse error */
+    }
+    record.failures.push({ at: new Date().toISOString() });
+    record.failures = record.failures.slice(-50);
+    writeFileSync(statePath, JSON.stringify(record), 'utf8');
+  } catch {
+    /* best-effort — never break CLI because of bookkeeping */
+  }
+}
+recordBootAttemptEarly();
 
 if (process.env.MEMPHIS_DEBUG) {
   console.error('[DEBUG] Package root:', packageRoot);

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -100,6 +100,21 @@ export async function bootstrap(): Promise<void> {
       `[memphis-bootstrap] self-modify auto-revert: ` +
         `${result.ok ? 'reverted to ' + result.revertedTo : 'FAILED — ' + result.error}\n`,
     );
+    // Codex Round 6 P2 fix (PR #124): git reset --hard changes files
+    // on disk but does NOT reload already-imported modules. The
+    // current process is still running the BAD in-memory code — and
+    // since bootstrap.ts statically imports most of Memphis at the
+    // top, continuing here risks executing the pre-revert code or
+    // crashing again mid-init. Exit so the supervisor restarts and
+    // the NEXT boot picks up the reverted code.
+    if (result.ok) {
+      process.stderr.write(
+        `[memphis-bootstrap] exiting for supervisor restart — reverted code will load on next boot\n`,
+      );
+      // Exit code 75 (EX_TEMPFAIL) so systemd/pm2/memphis-service
+      // treats this as a retryable stop, not a clean exit.
+      process.exit(75);
+    }
   }
 
   const envFilePath = resolveBootstrapEnvPath(process.env);

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -39,6 +39,7 @@ import {
   applyCognitiveMode,
   type CognitiveModeContribution,
 } from '../cognitive/mode-dispatch.js';
+import { AppError } from '../core/errors.js';
 import type { RuntimeTelemetry, TokenUsage } from '../core/types.js';
 import { metrics } from '../infra/logging/metrics.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
@@ -836,9 +837,21 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     metrics.recordProviderCall(llm.provider, false, Date.now() - startedAt);
     // Phase 2.1: record outcome for the breaker. A run of failures trips
     // the breaker and subsequent calls fail fast.
+    //
+    // Codex Round 6 P1 (PR #122): only count TRANSIENT provider faults
+    // against the breaker. Validation / 4xx bursts must not trip it.
+    // PROVIDER_TIMEOUT / PROVIDER_UNAVAILABLE / PROVIDER_RATE_LIMIT are
+    // the AppError codes that genuinely indicate provider-side trouble.
     try {
-      const { recordProviderOutcome } = await import('../infra/runtime/circuit-breaker.js');
-      recordProviderOutcome(llm.provider, false, rawEnvWithTier3);
+      const isTransient =
+        error instanceof AppError &&
+        (error.code === 'PROVIDER_TIMEOUT' ||
+          error.code === 'PROVIDER_UNAVAILABLE' ||
+          error.code === 'PROVIDER_RATE_LIMIT');
+      if (isTransient) {
+        const { recordProviderOutcome } = await import('../infra/runtime/circuit-breaker.js');
+        recordProviderOutcome(llm.provider, false, rawEnvWithTier3);
+      }
     } catch {
       /* breaker recording is best-effort */
     }

--- a/src/infra/cli/commands/backup.ts
+++ b/src/infra/cli/commands/backup.ts
@@ -266,7 +266,7 @@ function extractFallbackArchive(archivePath: string, targetRoot: string): void {
   }
 }
 
-function listArchiveContents(archivePath: string): string[] {
+export function listArchiveContents(archivePath: string): string[] {
   try {
     return readFallbackArchive(archivePath).entries.map((entry) =>
       entry.kind === 'dir' ? `${entry.path}/` : entry.path,

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -197,6 +197,10 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
   MEMPHIS_COST_CAP_GLM_MONTHLY_TOKENS: 'hot',
   MEMPHIS_COST_CAP_OLLAMA_DAILY_TOKENS: 'hot',
   MEMPHIS_COST_CAP_OLLAMA_MONTHLY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_SHARED_LLM_DAILY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_SHARED_LLM_MONTHLY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_DECENTRALIZED_LLM_DAILY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_DECENTRALIZED_LLM_MONTHLY_TOKENS: 'hot',
 
   // ── Circuit breaker (Phase 2.1 production sprint) ──
   // All hot — operator can re-tune sensitivity at runtime.

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -202,6 +202,13 @@ export const envSchema = z.object({
   MEMPHIS_COST_CAP_GLM_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
   MEMPHIS_COST_CAP_OLLAMA_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
   MEMPHIS_COST_CAP_OLLAMA_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
+  // Codex Round 6 P2 (PR #121): shared-llm + decentralized-llm are
+  // real runtime providers; they must be capable of runtime budget
+  // control the same as the other five.
+  MEMPHIS_COST_CAP_SHARED_LLM_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_SHARED_LLM_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_DECENTRALIZED_LLM_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_DECENTRALIZED_LLM_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
 
   // Phase 2.1 production sprint — per-provider circuit breaker.
   // _DEFAULT_ keys apply to any provider lacking a specific override.

--- a/src/infra/logging/pino.ts
+++ b/src/infra/logging/pino.ts
@@ -22,15 +22,19 @@ const loggerRegistry = new FinalizationRegistry<WeakRef<Logger>>((ref) => {
 
 // Each entry is the streams array returned by pino.multistream — mutating
 // `.level` on each element propagates to the per-stream filter on the
-// next emit. We hold strong references because these arrays are not
-// reachable from the Logger instance itself.
+// next emit.
+//
+// Codex Round 6 P2 (PR #118): the old code wrapped each MultistreamEntry
+// in a WeakRef with no strong retention anywhere else, so the entry
+// could be garbage-collected while the logger was still alive. That
+// silently killed file-stream level updates in long-running processes
+// after a GC cycle. Fix: hold the entry strongly in a WeakMap keyed by
+// the Logger itself — the entry is reachable as long as the logger is,
+// and garbage-collects together with it.
 interface MultistreamEntry {
   streams: Array<{ level?: string | number; stream: DestinationStream }>;
 }
-const liveMultistreams = new Set<WeakRef<MultistreamEntry>>();
-const multistreamRegistry = new FinalizationRegistry<WeakRef<MultistreamEntry>>((ref) => {
-  liveMultistreams.delete(ref);
-});
+const multistreamByLogger = new WeakMap<Logger, MultistreamEntry>();
 
 /**
  * Resolve the local log file path.
@@ -89,10 +93,7 @@ export function createPinoLogger(options?: LoggerOptions): Logger {
     ];
     const multistream = pino.multistream(streamsArray);
     logger = pino(options ?? {}, multistream);
-    const entry: MultistreamEntry = { streams: streamsArray };
-    const msRef = new WeakRef(entry);
-    liveMultistreams.add(msRef);
-    multistreamRegistry.register(logger, msRef);
+    multistreamByLogger.set(logger, { streams: streamsArray });
   } else {
     logger = pino(options ?? {}, stderrStream);
   }
@@ -131,13 +132,16 @@ export function setAllPinoLoggerLevels(level: string): {
       // pino throws on unknown levels — best-effort, skip and continue
     }
   }
+  // Walk the logger registry and look each one up in the multistream
+  // WeakMap. Since the entry is strongly referenced FROM the logger
+  // (via the WeakMap), it can't be GC'd independently — the Codex
+  // Round 6 P2 failure mode.
   let multistreamsUpdated = 0;
-  for (const ref of liveMultistreams) {
-    const entry = ref.deref();
-    if (!entry) {
-      liveMultistreams.delete(ref);
-      continue;
-    }
+  for (const ref of liveLoggers) {
+    const logger = ref.deref();
+    if (!logger) continue;
+    const entry = multistreamByLogger.get(logger);
+    if (!entry) continue;
     for (const streamEntry of entry.streams) {
       streamEntry.level = level;
     }
@@ -149,5 +153,5 @@ export function setAllPinoLoggerLevels(level: string): {
 /** Test-only: clear the registry (does not destroy the loggers themselves). */
 export function __resetPinoRegistryForTests(): void {
   liveLoggers.clear();
-  liveMultistreams.clear();
+  // multistreamByLogger is a WeakMap — entries auto-clear when loggers GC
 }

--- a/src/infra/runtime/circuit-breaker.ts
+++ b/src/infra/runtime/circuit-breaker.ts
@@ -184,7 +184,18 @@ export function recordProviderOutcome(
     return;
   }
 
-  // Failure in CLOSED state
+  // Failure in closed state — maintain the window and maybe trip.
+  // Codex Round 6 P1 fix (PR #122): if we're already OPEN (because
+  // concurrent requests raced past the trip and their failures
+  // landed here AFTER state flipped), we must NOT reset openedAt or
+  // increment totalTrips — otherwise a stampede of stale failures
+  // keeps pushing the cooldown window forward and delays recovery.
+  // lastFailureAt is still useful for diagnostics; we update that.
+  if (rec.state === 'open') {
+    rec.lastFailureAt = now;
+    return;
+  }
+
   rec.failureTimestamps.push(now);
   rec.lastFailureAt = now;
   rec.failureTimestamps = rec.failureTimestamps.filter((t) => now - t < windowMs);

--- a/src/infra/runtime/graceful-shutdown.ts
+++ b/src/infra/runtime/graceful-shutdown.ts
@@ -24,10 +24,18 @@
  */
 
 import { writePulseEvent } from './heartbeat-watchdog.js';
-import { activeTurnCount } from './self-restart.js';
+import { activeTurnCount, signalDrain } from './self-restart.js';
 import type { AppLogger } from '../logging/logger.js';
 import { writeSecurityAudit } from '../logging/security-audit.js';
 import { shutdownOtel } from '../observability/otel.js';
+
+/**
+ * Default per-stopper timeout. Codex Round 6 P1 (PR #119): without a
+ * per-stopper bound, one hung close() (e.g. a Fastify server with open
+ * connections) blocked the entire shutdown sequence forever and we
+ * never reached PULSE/OTel completion or exitFn.
+ */
+export const DEFAULT_STOPPER_TIMEOUT_MS = 5_000;
 
 export const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 15_000;
 
@@ -58,6 +66,11 @@ export interface GracefulShutdownOptions {
    * Failures are logged + swallowed; one stuck loop must not prevent shutdown.
    */
   stopFns?: Array<{ name: string; stop: () => void | Promise<void> }>;
+  /**
+   * Per-stopper timeout. Codex Round 6 P1 (PR #119): a hung stopper
+   * must not block the whole shutdown. Default 5s per stopper.
+   */
+  stopperTimeoutMs?: number;
   /** Optional logger; if absent, structured stderr writes are used. */
   logger?: AppLogger;
 }
@@ -154,7 +167,15 @@ export async function performGracefulShutdown(
     // best-effort
   }
 
-  // 2. Drain in-flight (turn controllers self-abort on signal; we just wait)
+  // 2. Signal every registered turn controller to abort (Codex Round 6
+  //    P2 fix — previously we only polled activeTurnCount, so turns
+  //    that depended on the abort signal to unwind hit the timeout
+  //    unnecessarily. Now we tell them explicitly, then wait.)
+  try {
+    signalDrain(`graceful shutdown (${reason})`);
+  } catch {
+    // signalDrain is best-effort; we proceed with the poll regardless
+  }
   const { drained, remaining } = await waitForDrain(drainTimeoutMs);
   state.remainingAfterDrain = remaining;
   if (!drained) {
@@ -166,12 +187,30 @@ export async function performGracefulShutdown(
     );
   }
 
-  // 3. Stop background loops in parallel
+  // 3. Stop background loops in parallel, each bounded by a timeout
+  //    so one hung close() doesn't block the whole shutdown sequence
+  //    (Codex Round 6 P1 fix on PR #119).
   const stoppers = options.stopFns ?? [];
+  const stopperTimeoutMs =
+    options.stopperTimeoutMs ?? DEFAULT_STOPPER_TIMEOUT_MS;
   await Promise.all(
     stoppers.map(async ({ name, stop }) => {
       try {
-        await stop();
+        await Promise.race([
+          Promise.resolve().then(() => stop()),
+          new Promise<void>((_, reject) => {
+            const timer = setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `stopper '${name}' did not complete within ${stopperTimeoutMs}ms`,
+                  ),
+                ),
+              stopperTimeoutMs,
+            );
+            if (typeof timer === 'object' && 'unref' in timer) timer.unref?.();
+          }),
+        ]);
       } catch (err) {
         logLine(
           options.logger,
@@ -220,8 +259,17 @@ export async function performGracefulShutdown(
   exitFn(exitCode);
 }
 
+const installedHandlers: Array<{ signal: NodeJS.Signals; handler: () => void }> = [];
+
 /**
  * Install signal handlers. Idempotent — re-calling is a no-op.
+ *
+ * Codex Round 6 P1 fix (PR #119): uses `process.on` (persistent)
+ * instead of `process.once` so a SECOND signal during shutdown still
+ * hits our handler (which ignores it via the `shuttingDown` guard)
+ * rather than Node's default "terminate immediately" behavior. The
+ * old code meant an impatient double-Ctrl-C killed the process
+ * mid-drain and defeated the whole point of the graceful path.
  */
 export function installShutdownHandlers(options: GracefulShutdownOptions = {}): void {
   if (installed) return;
@@ -231,8 +279,12 @@ export function installShutdownHandlers(options: GracefulShutdownOptions = {}): 
     void performGracefulShutdown(reason, options);
   };
 
-  process.once('SIGTERM', handler('SIGTERM'));
-  process.once('SIGINT', handler('SIGINT'));
+  const sigterm = handler('SIGTERM');
+  const sigint = handler('SIGINT');
+  process.on('SIGTERM', sigterm);
+  process.on('SIGINT', sigint);
+  installedHandlers.push({ signal: 'SIGTERM', handler: sigterm });
+  installedHandlers.push({ signal: 'SIGINT', handler: sigint });
 }
 
 /** Snapshot for /status payloads. */
@@ -244,4 +296,8 @@ export function getShutdownState(): ShutdownState {
 export function __resetShutdownStateForTests(): void {
   state = { shuttingDown: false };
   installed = false;
+  // Detach any handlers we installed — tests re-install fresh.
+  for (const h of installedHandlers.splice(0)) {
+    process.off(h.signal, h.handler);
+  }
 }

--- a/src/infra/runtime/scheduled-backup.ts
+++ b/src/infra/runtime/scheduled-backup.ts
@@ -116,23 +116,25 @@ function readKeep(rawEnv: NodeJS.ProcessEnv): number {
 }
 
 /**
- * Default restore-drill: extract the archive to a tmp dir and verify
- * the directory structure looks sane. A real production drill would
- * re-run `chain verify` against the extracted chain dir; this one is
- * intentionally fast (a few hundred ms) so it can run frequently.
+ * Default restore-drill: verify the archive is listable + contains at
+ * least one chain block file.
+ *
+ * Codex Round 6 P1 fix (PR #120): the old drill unconditionally ran
+ * `tar -tzf`, but `createBackup` can produce a fallback gzip/JSON
+ * archive when tar is unavailable (EPERM/EACCES path). That made every
+ * drill on those hosts emit a false drill_failed alert. Use the
+ * canonical `listArchiveContents` from backup.ts which already
+ * handles BOTH formats.
  */
 async function defaultDrill(backupPath: string): Promise<void> {
   const drillDir = mkdtempSync(join(tmpdir(), 'memphis-backup-drill-'));
   try {
-    const { execFile } = await import('node:child_process');
-    const { promisify } = await import('node:util');
-    const execFileAsync = promisify(execFile);
-    await execFileAsync('tar', ['-tzf', backupPath]);
-    // Lightweight extraction sanity: the archive must contain at least
-    // one chain block file. We use `tar -tzf` instead of full extract
-    // for speed; a test PR can extend with a real `chain verify` pass.
-    const { stdout } = await execFileAsync('tar', ['-tzf', backupPath]);
-    const hasBlocks = /chains\/.+\.json/.test(stdout);
+    const { listArchiveContents } = await import('../cli/commands/backup.js');
+    const entries = listArchiveContents(backupPath);
+    if (entries.length === 0) {
+      throw new Error('drill failed: archive has no entries');
+    }
+    const hasBlocks = entries.some((e) => /chains\/.+\.json/.test(e));
     if (!hasBlocks) {
       throw new Error('drill failed: archive contains no chain block files');
     }
@@ -152,9 +154,10 @@ export function startScheduledBackupLoop(
   options: ScheduledBackupOptions = {},
 ): ScheduledBackupHandle {
   const rawEnv = options.rawEnv ?? process.env;
+  // Interval is bound at setInterval and can't change post-start.
+  // drillEveryN + keep ARE classified hot in mutability.ts, so we
+  // re-read them on every tick (Codex Round 6 P2 fix on PR #120).
   const interval = options.intervalMs ?? readIntervalFromEnv(rawEnv);
-  const drillEveryN = readDrillEveryN(rawEnv);
-  const keep = readKeep(rawEnv);
   const drillFn = options.drillFn ?? defaultDrill;
 
   const createBackupFn =
@@ -169,8 +172,10 @@ export function startScheduledBackupLoop(
   const cleanFn =
     options.cleanFn ??
     (async () => {
+      // Re-read keep on each clean so /config set MEMPHIS_BACKUP_KEEP
+      // actually takes effect immediately.
       const { cleanBackups } = await import('../cli/commands/backup.js');
-      await cleanBackups({ keep });
+      await cleanBackups({ keep: readKeep(rawEnv) });
     });
 
   let inFlight = false;
@@ -185,6 +190,8 @@ export function startScheduledBackupLoop(
     }
     inFlight = true;
     try {
+      // Re-read on each tick so hot-reload via /config set picks up.
+      const drillEveryN = readDrillEveryN(rawEnv);
       log.info({ event: 'backup.scheduled.start' }, 'scheduled backup starting');
       const result = await createBackupFn();
       state.lastSuccessAt = new Date().toISOString();
@@ -290,7 +297,12 @@ export function startScheduledBackupLoop(
   }
 
   log.info(
-    { event: 'backup.scheduled.loop.started', intervalMs: interval, drillEveryN, keep },
+    {
+      event: 'backup.scheduled.loop.started',
+      intervalMs: interval,
+      drillEveryN: readDrillEveryN(rawEnv),
+      keep: readKeep(rawEnv),
+    },
     'scheduled backup loop started',
   );
 

--- a/src/infra/runtime/self-restart.ts
+++ b/src/infra/runtime/self-restart.ts
@@ -98,11 +98,18 @@ export function activeTurnCount(): number {
   return turnControllers.size;
 }
 
-function signalDrain(): number {
+/**
+ * Signal every registered turn controller to abort. Used by BOTH the
+ * restart flow AND the graceful-shutdown flow (Codex Round 6 P2 fix —
+ * shutdown previously just polled activeTurnCount without telling the
+ * controllers to bail, so turns that depended on the abort signal to
+ * unwind hit the drain timeout unnecessarily).
+ */
+export function signalDrain(reason = 'draining in-flight turn'): number {
   const count = turnControllers.size;
   for (const controller of turnControllers) {
     try {
-      controller.abort(new AppError('VALIDATION_ERROR', 'restart draining in-flight turn', 503));
+      controller.abort(new AppError('VALIDATION_ERROR', reason, 503));
     } catch {
       // abort failures are best-effort — we're tearing down anyway
     }

--- a/src/infra/runtime/turn-admission.ts
+++ b/src/infra/runtime/turn-admission.ts
@@ -84,9 +84,16 @@ function readMaxQueued(rawEnv: NodeJS.ProcessEnv): number {
 
 function admitOne(): void {
   // Called when a slot frees up — pump the queue.
-  if (state.active >= 1 && waitQueue.length === 0) return;
-  // (the active >= 1 check is just paranoid — the only caller already
-  // confirmed we're admitting after a release)
+  // Codex Round 6 P1 fix (PR #123): re-read the cap here so hot
+  // changes to MEMPHIS_MAX_CONCURRENT_TURNS actually take effect
+  // while a backlog exists. Without this, operators could `/config
+  // set MEMPHIS_MAX_CONCURRENT_TURNS=50` and throughput would stay
+  // at the old cap until the queue drained on its own.
+  const maxConcurrent = readMaxConcurrent(process.env);
+  // Respect the current cap — if a release frees a slot but the cap
+  // was just lowered below the active count, DON'T admit the next
+  // waiter. Let the queue drain naturally as more releases happen.
+  if (state.active >= maxConcurrent) return;
   const next = waitQueue.shift();
   if (!next) return;
   state.queued -= 1;
@@ -99,6 +106,12 @@ function admitOne(): void {
     release: makeRelease(acquiredAt),
     acquiredAt,
   });
+  // Cap may have been raised — keep pumping until we reach it or
+  // the queue is empty. This is the "raise 1→10 takes effect
+  // immediately" half of the fix.
+  if (state.active < maxConcurrent && waitQueue.length > 0) {
+    admitOne();
+  }
 }
 
 function makeRelease(acquiredAt: number): () => void {

--- a/src/infra/storage/migrations/runner.ts
+++ b/src/infra/storage/migrations/runner.ts
@@ -12,7 +12,7 @@
  *   - never touches data/ if ANY chain fails in dry-run
  */
 
-import { createHash } from 'node:crypto';
+import * as nodeCrypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
@@ -26,6 +26,7 @@ import type {
 } from './types.js';
 import { getChainPath } from '../../../config/paths.js';
 import { writeSecurityAudit } from '../../logging/security-audit.js';
+import { hashBlock } from '../chain-adapter.js';
 
 const SAFE_CHAIN_NAME = /^[A-Za-z0-9_-]{1,64}$/;
 
@@ -36,40 +37,46 @@ function detectVersion(block: MigratableBlock): number {
   return 1;
 }
 
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== 'object') return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
-  const rec = value as Record<string, unknown>;
-  const keys = Object.keys(rec).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(rec[k])}`).join(',')}}`;
-}
-
-function recomputeHash(block: MigratableBlock): string {
-  const { hash: _unused, ...rest } = block;
-  void _unused;
-  // Keep canonical hash input simple + deterministic (sorted keys).
-  // Any new migration that changes this MUST advance the schema
-  // version so old-vs-new hashes don't collide.
-  return createHash('sha256').update(stableStringify(rest)).digest('hex');
-}
-
+/**
+ * Codex Round 6 P1 fix (PR #126): use the canonical chain-adapter
+ * hashBlock so migrated blocks pass normal integrity checks
+ * (diagnoseChainHashes, checkBlockHashMismatch). The old bespoke
+ * stableStringify hashed the WHOLE block including schemaVersion +
+ * extras, which didn't match the `{index, timestamp, chain, data,
+ * prev_hash}` payload the rest of the system validates against.
+ *
+ * Any migration that wants to CHANGE the canonical hash input needs to
+ * extend chain-adapter's hashBlock under a new schema version rather
+ * than silently diverging here.
+ */
 function applyMigrations(
   block: MigratableBlock,
   migrations: ChainMigration[],
   targetVersion: number,
+  prevHashOverride: string | null,
 ): MigratableBlock {
   let current = block;
   for (const m of migrations) {
     current = m.transformBlock(current);
   }
-  // After all migrations: stamp the version and rehash.
-  const migrated: MigratableBlock = {
-    ...current,
-    schemaVersion: targetVersion,
-    hash: '', // placeholder; recomputeHash excludes hash
+  // If a prior block in this run was migrated, its hash changed; we
+  // MUST update this block's prev_hash to the new predecessor hash so
+  // the chain's prev_hash linkage stays intact. (Codex Round 6 P1 fix.)
+  const linkedPrevHash = prevHashOverride ?? current.prev_hash;
+  const canonicalInput = {
+    index: current.index,
+    timestamp: current.timestamp,
+    chain: current.chain,
+    data: current.data,
+    prev_hash: linkedPrevHash,
   };
-  migrated.hash = recomputeHash(migrated);
-  return migrated;
+  const newHash = hashBlock(canonicalInput, nodeCrypto);
+  return {
+    ...current,
+    prev_hash: linkedPrevHash,
+    schemaVersion: targetVersion,
+    hash: newHash,
+  };
 }
 
 async function listBlockFiles(
@@ -152,7 +159,14 @@ async function migrateChain(
       };
     }
     try {
-      const migrated = applyMigrations(raw, applicable, targetVersion);
+      // Codex Round 6 P1 fix (PR #126): thread the previous converted
+      // block's NEW hash so prev_hash linkage stays intact after
+      // migration. Without this, blocks 2..N still point at the
+      // pre-migration hash of block 1, causing deterministic
+      // prev_hash mismatches in chain verify.
+      const prevHashOverride =
+        converted.length === 0 ? null : converted[converted.length - 1]!.block.hash;
+      const migrated = applyMigrations(raw, applicable, targetVersion, prevHashOverride);
       converted.push({ file: entry.file, block: migrated });
     } catch (err) {
       return {
@@ -177,16 +191,40 @@ async function migrateChain(
   }
 
   // Phase 2: write to tmp dir, then atomically swap.
+  //
+  // Codex Round 6 P2 fix (PR #126): the old code didn't handle the
+  // failure mode where the FIRST rename (chain → backup) succeeds but
+  // the SECOND rename (tmp → chain) fails. In that window the active
+  // chain dir is GONE and reads fail until an operator manually moves
+  // the backup back. The fix: track which renames we performed and
+  // restore the backup if the second rename throws.
   const tmpDir = `${chainDir}.migrating-${process.pid}`;
+  const backupDir = `${chainDir}.pre-migration-${Date.now()}`;
   await fs.mkdir(tmpDir, { recursive: true });
+  let backupMoved = false;
   try {
     for (const { file, block } of converted) {
       await fs.writeFile(path.join(tmpDir, file), JSON.stringify(block), 'utf8');
     }
-    // Backup original then swap
-    const backupDir = `${chainDir}.pre-migration-${Date.now()}`;
     await fs.rename(chainDir, backupDir);
-    await fs.rename(tmpDir, chainDir);
+    backupMoved = true;
+    try {
+      await fs.rename(tmpDir, chainDir);
+    } catch (secondRenameErr) {
+      // Second rename failed — restore backup so reads don't break.
+      try {
+        await fs.rename(backupDir, chainDir);
+        backupMoved = false; // restored
+      } catch (restoreErr) {
+        throw new Error(
+          `phase-2 second rename failed AND restore failed. ` +
+            `original error: ${secondRenameErr instanceof Error ? secondRenameErr.message : String(secondRenameErr)}; ` +
+            `restore error: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}. ` +
+            `Manual recovery: \`mv ${backupDir} ${chainDir}\``,
+        );
+      }
+      throw secondRenameErr;
+    }
     writeSecurityAudit({
       action: 'chain.migration.completed',
       status: 'allowed',
@@ -200,14 +238,14 @@ async function migrateChain(
     });
   } catch (err) {
     // tmpDir still exists; leave it for the operator to inspect. Real
-    // chain dir is untouched.
+    // chain dir is untouched (either never moved, or restored above).
     return {
       chain: chainName,
       fromVersion,
       toVersion: fromVersion,
       blocksConsidered: blockFiles.length,
       blocksMigrated: 0,
-      error: `phase-2 write failed: ${err instanceof Error ? err.message : String(err)}. Active chain is unchanged; tmp at ${tmpDir}`,
+      error: `phase-2 write failed: ${err instanceof Error ? err.message : String(err)}. Active chain ${backupMoved ? 'RESTORED from backup' : 'unchanged'}; tmp at ${tmpDir}`,
     };
   }
 

--- a/src/modules/orchestration/service.ts
+++ b/src/modules/orchestration/service.ts
@@ -362,10 +362,37 @@ export class OrchestrationService {
     while (attempt <= this.maxRetries) {
       const started = Date.now();
       try {
+        // Codex Round 6 P1 fix (PR #121): cost-cap + breaker gates
+        // previously only ran in runTurnRuntime, so /v1/chat/generate
+        // with mode: "provider-only" bypassed them entirely. Apply
+        // here so provider-only is subject to the same protection.
+        const [{ checkProviderBudget }, { admitProviderCall }] = await Promise.all([
+          import('../../infra/runtime/cost-cap.js'),
+          import('../../infra/runtime/circuit-breaker.js'),
+        ]);
+        checkProviderBudget(provider.name);
+        admitProviderCall(provider.name);
+
         const out = await provider.generate(input);
         const latencyMs = Date.now() - started;
         metrics.recordProviderCall(provider.name, true, latencyMs);
         this.providerPolicy.markSuccess(provider.name);
+        // Record budget + breaker outcome
+        try {
+          const [{ recordProviderUsage }, { recordProviderOutcome }] = await Promise.all([
+            import('../../infra/runtime/cost-cap.js'),
+            import('../../infra/runtime/circuit-breaker.js'),
+          ]);
+          const usage = (out as { usage?: { inputTokens?: number; outputTokens?: number } }).usage;
+          const inTok = usage?.inputTokens ?? 0;
+          const outTok = usage?.outputTokens ?? 0;
+          if (inTok > 0 || outTok > 0) {
+            recordProviderUsage(provider.name, inTok, outTok);
+          }
+          recordProviderOutcome(provider.name, true);
+        } catch {
+          // best-effort; never break orchestration
+        }
         trace.push({
           attempt: attempt + 1,
           provider: provider.name,
@@ -378,6 +405,22 @@ export class OrchestrationService {
         const latencyMs = Date.now() - started;
         metrics.recordProviderCall(provider.name, false, latencyMs);
         this.providerPolicy.markFailure(provider.name);
+        // Codex Round 6 P1 fix (PR #122): only count TRANSIENT failures
+        // against the breaker. A validation/4xx burst must not trip it
+        // and force unrelated healthy requests to fail fast.
+        // isRetryable already distinguishes PROVIDER_TIMEOUT /
+        // PROVIDER_UNAVAILABLE / PROVIDER_RATE_LIMIT from permanent
+        // errors — reuse that classification.
+        if (isRetryable(error)) {
+          try {
+            const { recordProviderOutcome } = await import(
+              '../../infra/runtime/circuit-breaker.js'
+            );
+            recordProviderOutcome(provider.name, false);
+          } catch {
+            /* best-effort */
+          }
+        }
         trace.push({
           attempt: attempt + 1,
           provider: provider.name,

--- a/tests/unit/circuit-breaker.test.ts
+++ b/tests/unit/circuit-breaker.test.ts
@@ -136,4 +136,26 @@ describe('circuit breaker (Phase 2.1 production sprint)', () => {
     const all = getAllBreakerSnapshots({} as NodeJS.ProcessEnv);
     expect(all).toHaveLength(2);
   });
+
+  it('Codex Round 6 P1: failures after breaker is already OPEN do NOT reset cooldown', () => {
+    // Trip the breaker
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '2',
+      MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: '5000',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 2000);
+    const openedAt = getBreakerSnapshot('anthropic', env).openedAt;
+    const trips = getBreakerSnapshot('anthropic', env).totalTrips;
+    expect(trips).toBe(1);
+
+    // More failures land AFTER state flipped (stale concurrent requests)
+    // — cooldown must NOT be extended and totalTrips must stay at 1.
+    recordProviderOutcome('anthropic', false, env, 3000);
+    recordProviderOutcome('anthropic', false, env, 4000);
+    const snap = getBreakerSnapshot('anthropic', env);
+    expect(snap.state).toBe('open');
+    expect(snap.openedAt).toBe(openedAt);
+    expect(snap.totalTrips).toBe(1);
+  });
 });

--- a/tests/unit/turn-admission.test.ts
+++ b/tests/unit/turn-admission.test.ts
@@ -128,6 +128,71 @@ describe('turn admission control (Phase 2.2 production sprint)', () => {
     for (const t of tickets) t.release();
   });
 
+  it('Codex Round 6 P1: raising MEMPHIS_MAX_CONCURRENT_TURNS drains queue to new cap', async () => {
+    const savedMax = process.env.MEMPHIS_MAX_CONCURRENT_TURNS;
+    process.env.MEMPHIS_MAX_CONCURRENT_TURNS = '1';
+    try {
+      // Acquire 1 (cap) + queue 3
+      const a = await acquireTurnSlot(process.env);
+      const p1 = acquireTurnSlot(process.env);
+      const p2 = acquireTurnSlot(process.env);
+      const p3 = acquireTurnSlot(process.env);
+      await Promise.resolve();
+      expect(getAdmissionState().queued).toBe(3);
+
+      // Raise cap mid-flight
+      process.env.MEMPHIS_MAX_CONCURRENT_TURNS = '4';
+
+      // Release a — admitOne should now pump ALL queued callers
+      // immediately because the new cap allows it.
+      a.release();
+      const r1 = await p1;
+      const r2 = await p2;
+      const r3 = await p3;
+      expect(getAdmissionState().active).toBe(3);
+      expect(getAdmissionState().queued).toBe(0);
+
+      r1.release();
+      r2.release();
+      r3.release();
+    } finally {
+      if (savedMax !== undefined) process.env.MEMPHIS_MAX_CONCURRENT_TURNS = savedMax;
+      else delete process.env.MEMPHIS_MAX_CONCURRENT_TURNS;
+    }
+  });
+
+  it('Codex Round 6 P1: lowering MEMPHIS_MAX_CONCURRENT_TURNS stops admission until active drains', async () => {
+    const savedMax = process.env.MEMPHIS_MAX_CONCURRENT_TURNS;
+    process.env.MEMPHIS_MAX_CONCURRENT_TURNS = '3';
+    try {
+      const a = await acquireTurnSlot(process.env);
+      const b = await acquireTurnSlot(process.env);
+      const c = await acquireTurnSlot(process.env);
+      const p1 = acquireTurnSlot(process.env);
+      await Promise.resolve();
+      expect(getAdmissionState().queued).toBe(1);
+
+      // Operator lowers cap to 1 — but 3 are already active.
+      process.env.MEMPHIS_MAX_CONCURRENT_TURNS = '1';
+
+      // Release one — admitOne must NOT admit the queued caller
+      // because active (2) is still above the new cap (1).
+      a.release();
+      await Promise.resolve();
+      expect(getAdmissionState().queued).toBe(1);
+
+      // Release the rest — once active drops below 1 again, queue admits.
+      b.release();
+      c.release();
+      const r1 = await p1;
+      expect(getAdmissionState().active).toBe(1);
+      r1.release();
+    } finally {
+      if (savedMax !== undefined) process.env.MEMPHIS_MAX_CONCURRENT_TURNS = savedMax;
+      else delete process.env.MEMPHIS_MAX_CONCURRENT_TURNS;
+    }
+  });
+
   it('totalAdmitted and totalQueued counters track lifetime traffic', async () => {
     const env = { MEMPHIS_MAX_CONCURRENT_TURNS: '1' } as NodeJS.ProcessEnv;
     const a = await acquireTurnSlot(env);


### PR DESCRIPTION
## Summary

Codex Round 6 across the production-sprint PRs #118–#126. **9 P1 + 4 P2 findings**, all addressed in one bundle per the saved `feedback_codex_bundled_hotfix.md` pattern.

## P1s (feature-broken or safety-broken)

| # | Area | Fix |
|---|---|---|
| #118 | Pino multistream level hot-swap silently died after GC | WeakMap<Logger, MultistreamEntry> — strong retention via logger lifetime |
| #119 | `process.once` dropped handler → 2nd Ctrl-C killed the drain | `process.on` + explicit detach at exit |
| #119 | `Promise.all(stopFns)` no timeout → one hung stop blocked all | per-stopper `Promise.race` against `DEFAULT_STOPPER_TIMEOUT_MS` (5s) |
| #120 | Drill assumed tar, failed on gzip/JSON fallback archives | reuse `listArchiveContents` which handles both formats |
| #121 | Cost cap bypassed on `mode: "provider-only"` | moved gate into `tryGenerateWithRetry` |
| #122 | Breaker OPEN cooldown reset by stale concurrent failures | early-return on `state === 'open'` |
| #122 | 4xx validation bursts tripped breaker | only `PROVIDER_{TIMEOUT,UNAVAILABLE,RATE_LIMIT}` count as failures |
| #123 | Admission cap not re-read in `admitOne` → hot-reload inert | read cap inside `admitOne`; recursive pump on raise |
| #124 | `recordBootAttempt` after static imports → import-crash uncounted | moved to `bin/memphis.js` pre-import (node built-ins only) |
| #125 | CI used `dist/src/cli/index.js` (wrong) | use `bin/memphis.js` canonical entrypoint |
| #126 | Migration runner used bespoke hash → broke chain verify | import `hashBlock` from `chain-adapter` with canonical payload |
| #126 | `prev_hash` not re-linked to migrated predecessors | thread previous converted block's new hash forward |

## P2s

- **#119**: call `signalDrain()` before waiting (turns self-abort promptly instead of hitting timeout)
- **#120**: re-read `drillEveryN` + `keep` on each tick so `/config reload` isn't a lie
- **#121**: schema whitelist for `shared-llm` + `decentralized-llm` cost caps
- **#124**: `process.exit(75)` after successful auto-revert (supervisor restarts to load reverted code)
- **#125**: CI Node 20 → 22 to match `engines.node`
- **#126**: restore backup if second rename fails; error message includes manual recovery command

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npm run test:ts` — **1984/1984 passing** (+3 new regression cases)
- [x] 2 new regression tests: breaker-cooldown-stability, admission-cap-hot-swap
- [x] All existing 8-phase production-sprint tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)