### PR TITLE
fix: security scan findings — bundled hotfix (13 items)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Audit production dependencies (fail on high+ advisories)
+        run: npm audit --omit=dev --audit-level=high
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/telegram-smoke.yml
+++ b/.github/workflows/telegram-smoke.yml
@@ -49,7 +49,10 @@ jobs:
       - uses: actions/setup-node@v4
         if: steps.check-secrets.outputs.skipped != 'true'
         with:
-          node-version: '20'
+          # Codex Round 6 P2 fix (PR #125): project declares
+          # `"engines": { "node": ">=22" }` — using 20 here made the
+          # smoke signal noisy on version-specific differences.
+          node-version: '22'
           cache: npm
 
       - name: Install
@@ -66,5 +69,8 @@ jobs:
           MEMPHIS_TELEGRAM_BOT_TOKEN: ${{ secrets.MEMPHIS_TELEGRAM_SMOKE_BOT_TOKEN }}
           MEMPHIS_TELEGRAM_ALLOWED_USER_IDS: ${{ secrets.MEMPHIS_TELEGRAM_SMOKE_CHAT_ID }}
         run: |
-          node dist/src/cli/index.js telegram smoke-test --json \
+          # Codex Round 6 P1 fix (PR #125): TS rootDir is `src/`, so the
+          # compiled CLI lives at `dist/infra/cli/index.js` (matches
+          # `bin/memphis.js`), NOT `dist/src/cli/index.js`.
+          node bin/memphis.js telegram smoke-test --json \
             --value "🟢 Memphis CI smoke-test @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ($GITHUB_SHA)"

--- a/bin/memphis.js
+++ b/bin/memphis.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 // Get script directory (not cwd)
 const __filename = fileURLToPath(import.meta.url);
@@ -10,6 +10,42 @@ const __dirname = dirname(__filename);
 const packageRoot = resolve(__dirname, '..');
 
 const distEntry = resolve(packageRoot, 'dist/infra/cli/index.js');
+
+// Codex Round 6 P1 fix (PR #124): bump the boot-attempt counter BEFORE
+// any dist module imports. If a bad self-modify commit introduced a
+// syntax / import-time crash in a module bootstrap.ts statically
+// imports, the old recordBootAttempt call inside bootstrap() never
+// ran, so the auto-revert counter never advanced. By counting here
+// (pre-import, using only node built-ins) we guarantee a crash loop
+// is visible to evaluateAutoRevert on the next boot.
+//
+// Only bumps for the `serve` entry — `memphis <other>` CLI invocations
+// are diagnostic and shouldn't contribute.
+function recordBootAttemptEarly() {
+  if (process.argv[2] !== 'serve') return;
+  try {
+    const dataDir =
+      process.env.MEMPHIS_DATA_DIR ??
+      join(process.env.HOME ?? '/tmp', '.memphis');
+    const statePath = join(dataDir, 'state', 'boot-failures.json');
+    mkdirSync(dirname(statePath), { recursive: true });
+    let record = { failures: [] };
+    try {
+      if (existsSync(statePath)) {
+        record = JSON.parse(readFileSync(statePath, 'utf8'));
+        if (!Array.isArray(record.failures)) record.failures = [];
+      }
+    } catch {
+      /* start fresh on parse error */
+    }
+    record.failures.push({ at: new Date().toISOString() });
+    record.failures = record.failures.slice(-50);
+    writeFileSync(statePath, JSON.stringify(record), 'utf8');
+  } catch {
+    /* best-effort — never break CLI because of bookkeeping */
+  }
+}
+recordBootAttemptEarly();
 
 if (process.env.MEMPHIS_DEBUG) {
   console.error('[DEBUG] Package root:', packageRoot);

--- a/package-lock.json
+++ b/package-lock.json
@@ -372,7 +372,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -385,7 +384,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -397,7 +395,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1251,9 +1248,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1429,9 +1426,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1972,9 +1969,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2052,9 +2049,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
       "cpu": [
         "arm64"
       ],
@@ -2069,9 +2066,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
       "cpu": [
         "arm64"
       ],
@@ -2086,9 +2083,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
       "cpu": [
         "x64"
       ],
@@ -2103,9 +2100,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
       "cpu": [
         "x64"
       ],
@@ -2120,9 +2117,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
       "cpu": [
         "arm"
       ],
@@ -2137,9 +2134,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
       "cpu": [
         "arm64"
       ],
@@ -2157,9 +2154,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
       "cpu": [
         "arm64"
       ],
@@ -2177,9 +2174,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2197,9 +2194,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
       "cpu": [
         "s390x"
       ],
@@ -2217,9 +2214,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
       "cpu": [
         "x64"
       ],
@@ -2237,9 +2234,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
       "cpu": [
         "x64"
       ],
@@ -2257,9 +2254,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
       "cpu": [
         "arm64"
       ],
@@ -2274,9 +2271,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
       "cpu": [
         "wasm32"
       ],
@@ -2284,16 +2281,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
       "cpu": [
         "arm64"
       ],
@@ -2308,9 +2307,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
       "cpu": [
         "x64"
       ],
@@ -2325,9 +2324,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -5659,9 +5658,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
-      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
       "funding": [
         {
           "type": "github",
@@ -6461,9 +6460,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.11",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.11.tgz",
-      "integrity": "sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -9774,9 +9773,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10174,14 +10173,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -10190,21 +10189,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/router": {
@@ -12020,16 +12019,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.4.tgz",
-      "integrity": "sha512-baBr4jUVSLJ0RPyZ2nK0zS2+W8hNHbM4hEzfvllukmRPVS3xDG5ATTNtbRXrKIOE2b8/FsPWJAOnuIxcs7g3cw==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
+        "rolldown": "1.0.0-rc.15",
         "tinyglobby": "^0.2.15"
       },
       "bin": {

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -100,6 +100,21 @@ export async function bootstrap(): Promise<void> {
       `[memphis-bootstrap] self-modify auto-revert: ` +
         `${result.ok ? 'reverted to ' + result.revertedTo : 'FAILED — ' + result.error}\n`,
     );
+    // Codex Round 6 P2 fix (PR #124): git reset --hard changes files
+    // on disk but does NOT reload already-imported modules. The
+    // current process is still running the BAD in-memory code — and
+    // since bootstrap.ts statically imports most of Memphis at the
+    // top, continuing here risks executing the pre-revert code or
+    // crashing again mid-init. Exit so the supervisor restarts and
+    // the NEXT boot picks up the reverted code.
+    if (result.ok) {
+      process.stderr.write(
+        `[memphis-bootstrap] exiting for supervisor restart — reverted code will load on next boot\n`,
+      );
+      // Exit code 75 (EX_TEMPFAIL) so systemd/pm2/memphis-service
+      // treats this as a retryable stop, not a clean exit.
+      process.exit(75);
+    }
   }
 
   const envFilePath = resolveBootstrapEnvPath(process.env);

--- a/src/bridges/mcp-native-transport.ts
+++ b/src/bridges/mcp-native-transport.ts
@@ -7,12 +7,26 @@ export type NativeMcpTransportOptions = {
   port?: number;
 };
 
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
+
 export async function startNativeMcpTransport(
   handler: (request: NativeMcpRequest) => Promise<NativeMcpResponse>,
   options: NativeMcpTransportOptions = {},
 ): Promise<{ host: string; port: number; close: () => Promise<void> }> {
   const host = options.host ?? '127.0.0.1';
   const port = options.port ?? 0;
+
+  // Fail-closed on non-loopback binding. The native transport has no auth
+  // by design — local trust is assumed. A future caller passing 0.0.0.0
+  // (or the operator setting an env var) would silently expose an
+  // unauthenticated MCP endpoint on the network (#139).
+  if (!LOOPBACK_HOSTS.has(host)) {
+    throw new Error(
+      `native MCP transport rejects non-loopback host '${host}'; only ${[
+        ...LOOPBACK_HOSTS,
+      ].join(', ')} are permitted`,
+    );
+  }
 
   const MAX_BUFFER_SIZE = 1_000_000; // 1MB
   const BUFFER_TIMEOUT_MS = 5_000; // 5 seconds

--- a/src/dashboard/web-dashboard.ts
+++ b/src/dashboard/web-dashboard.ts
@@ -14,6 +14,23 @@ import { createLogger } from '../infra/logging/logger.js';
 
 const logger = createLogger('info', 'text', { component: 'WebDashboard' });
 
+/**
+ * HTML-escape interpolated values. Predictions, insights, and actions can
+ * carry AI-generated (and federation-synced) content that reaches the
+ * operator's browser. A prior version interpolated raw — a stored XSS
+ * primitive (#138).
+ */
+const HTML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+function esc(value: unknown): string {
+  return String(value ?? '').replace(/[&<>"']/g, (c) => HTML_ESCAPES[c] ?? c);
+}
+
 export interface DashboardConfig {
   port: number;
   host: string;
@@ -153,7 +170,9 @@ export class WebDashboard {
   /**
    * Render dashboard HTML
    */
-  private renderDashboard(data: DashboardData): string {
+  // Public so that regression tests can assert HTML-escaping of dynamic
+  // fields (#138 — stored XSS) without spinning up the HTTP server.
+  public renderDashboard(data: DashboardData): string {
     const moodEmoji: Record<string, string> = {
       productive: '🔥',
       exploring: '🔍',
@@ -384,8 +403,8 @@ export class WebDashboard {
                 <div class="timestamp">Last updated: ${new Date().toLocaleString()}</div>
             </div>
             <div class="mood-badge">
-                <span style="font-size: 32px">${moodEmoji[data.mood] || '🤔'}</span>
-                <span>${data.mood.charAt(0).toUpperCase() + data.mood.slice(1)}</span>
+                <span style="font-size: 32px">${esc(moodEmoji[data.mood] || '🤔')}</span>
+                <span>${esc(data.mood.charAt(0).toUpperCase() + data.mood.slice(1))}</span>
             </div>
         </div>
         
@@ -427,8 +446,8 @@ export class WebDashboard {
                       .map(
                         (pred) => `
                         <div class="insight-card">
-                            <h3>🎯 ${pred.title}</h3>
-                            <p>${pred.reasoning}</p>
+                            <h3>🎯 ${esc(pred.title)}</h3>
+                            <p>${esc(pred.reasoning)}</p>
                             <span class="confidence-badge">${(pred.confidence * 100).toFixed(0)}% confidence</span>
                         </div>
                     `,
@@ -452,8 +471,8 @@ export class WebDashboard {
                       .map(
                         (insight) => `
                         <div class="insight-card">
-                            <h3>${this.getInsightEmoji(insight.type)} ${insight.title}</h3>
-                            <p>${insight.description}</p>
+                            <h3>${this.getInsightEmoji(insight.type)} ${esc(insight.title)}</h3>
+                            <p>${esc(insight.description)}</p>
                             <span class="confidence-badge">${(insight.confidence * 100).toFixed(0)}% confidence</span>
                         </div>
                     `,
@@ -477,7 +496,7 @@ export class WebDashboard {
                         (action, i) => `
                         <li>
                             <div class="number">${i + 1}</div>
-                            <span>${action}</span>
+                            <span>${esc(action)}</span>
                         </li>
                     `,
                       )
@@ -500,7 +519,7 @@ export class WebDashboard {
                         (win, _i) => `
                         <li>
                             <div class="number">✓</div>
-                            <span>${win}</span>
+                            <span>${esc(win)}</span>
                         </li>
                     `,
                       )
@@ -521,7 +540,7 @@ export class WebDashboard {
                     ${data.stats.topTags
                       .map(
                         ({ tag, count }) => `
-                        <span class="tag">${tag} (${count})</span>
+                        <span class="tag">${esc(tag)} (${count})</span>
                     `,
                       )
                       .join('')}

--- a/src/gateway/exec-policy.ts
+++ b/src/gateway/exec-policy.ts
@@ -1,4 +1,5 @@
 import { AppError } from '../core/errors.js';
+import { secureCompare } from '../security/constant-time.js';
 
 export interface GatewayExecPolicy {
   restrictedMode: boolean;
@@ -207,12 +208,29 @@ const DEFAULT_COMMAND_RULES: Record<string, CommandRule> = {
   },
 
   // ─── Downloaders ──────────────────────────────────────────────────
+  // NB: the old permissive `--[flag]=value` pattern accepted
+  // `--output=/etc/shadow` — arbitrary-file-write via curl/wget. Explicit
+  // allowlist here limits to read-only/observability flags. Writing-to-disk
+  // flags (-o, -O, --output, --output-document, --cookie-jar, --dump-header)
+  // are excluded by design.
   curl: {
-    allowedArgs: [SAFE_FLAG_RE, /^--[a-zA-Z-]+(=.+)?$/, /^-[A-Za-z]+$/, /^https?:\/\/[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$/, SAFE_PATH_RE],
+    allowedArgs: [
+      /^-[AfIilLsSvXk#]+$/,
+      /^--(silent|show-error|location|fail|head|include|verbose|max-time|connect-timeout|retry|retry-delay|retry-max-time|user-agent|compressed|http1\.0|http1\.1|http2|insecure)$/,
+      /^--(max-time|connect-timeout|retry|retry-delay|retry-max-time|user-agent|header|data|data-urlencode|json|url|proto|referer|range)=[A-Za-z0-9._:/ ,=+-]+$/,
+      /^-[XH]$/,
+      /^(GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH)$/,
+      /^https?:\/\/[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$/,
+    ],
     maxArgLength: 600,
   },
   wget: {
-    allowedArgs: [SAFE_FLAG_RE, /^--[a-zA-Z-]+(=.+)?$/, /^-[A-Za-z]+$/, /^https?:\/\/[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$/, SAFE_PATH_RE],
+    allowedArgs: [
+      /^-[qvncS]+$/,
+      /^--(quiet|verbose|no-verbose|continue|spider|server-response|no-check-certificate|tries|timeout|no-cache)$/,
+      /^--(tries|timeout|user-agent|header|proxy-user|proxy-password|max-redirect|wait)=[A-Za-z0-9._:/ ,=+-]+$/,
+      /^https?:\/\/[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$/,
+    ],
     maxArgLength: 600,
   },
 
@@ -297,6 +315,21 @@ export function enforceGatewayExecPolicy(command: string, policy: GatewayExecPol
 
   const { base, args } = parseCommand(trimmed);
 
+  // Blocklist is consulted first (token-level match): base command or any
+  // arg equal to a blocked token is rejected, even if the command is
+  // otherwise allowlisted. Operator intent for GATEWAY_EXEC_BLOCKED_TOKENS
+  // is "never, period". Bypassed only by full-autonomy mode (which disables
+  // restrictedMode entirely, handled above).
+  for (const token of policy.blockedTokens) {
+    if (base === token || args.some((a) => a === token)) {
+      throw new AppError(
+        'VALIDATION_ERROR',
+        `command contains blocked token: ${token}`,
+        403,
+      );
+    }
+  }
+
   // Check allowlist
   const rule = policy.allowlist.get(base);
   if (!rule) {
@@ -344,7 +377,10 @@ export function enforceGatewayExecAuth(
   config: GatewayExecAuthConfig,
 ): void {
   assertGatewayExecAuthConfigured(config);
-  if (authHeader === `Bearer ${config.authToken}`) {
+  if (
+    typeof authHeader === 'string' &&
+    secureCompare(authHeader, `Bearer ${config.authToken ?? ''}`)
+  ) {
     return;
   }
 

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -39,6 +39,7 @@ import {
   applyCognitiveMode,
   type CognitiveModeContribution,
 } from '../cognitive/mode-dispatch.js';
+import { AppError } from '../core/errors.js';
 import type { RuntimeTelemetry, TokenUsage } from '../core/types.js';
 import { metrics } from '../infra/logging/metrics.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
@@ -836,9 +837,21 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     metrics.recordProviderCall(llm.provider, false, Date.now() - startedAt);
     // Phase 2.1: record outcome for the breaker. A run of failures trips
     // the breaker and subsequent calls fail fast.
+    //
+    // Codex Round 6 P1 (PR #122): only count TRANSIENT provider faults
+    // against the breaker. Validation / 4xx bursts must not trip it.
+    // PROVIDER_TIMEOUT / PROVIDER_UNAVAILABLE / PROVIDER_RATE_LIMIT are
+    // the AppError codes that genuinely indicate provider-side trouble.
     try {
-      const { recordProviderOutcome } = await import('../infra/runtime/circuit-breaker.js');
-      recordProviderOutcome(llm.provider, false, rawEnvWithTier3);
+      const isTransient =
+        error instanceof AppError &&
+        (error.code === 'PROVIDER_TIMEOUT' ||
+          error.code === 'PROVIDER_UNAVAILABLE' ||
+          error.code === 'PROVIDER_RATE_LIMIT');
+      if (isTransient) {
+        const { recordProviderOutcome } = await import('../infra/runtime/circuit-breaker.js');
+        recordProviderOutcome(llm.provider, false, rawEnvWithTier3);
+      }
     } catch {
       /* breaker recording is best-effort */
     }

--- a/src/infra/auth/operator-gate.ts
+++ b/src/infra/auth/operator-gate.ts
@@ -5,7 +5,7 @@
  * Session-cached for 15 minutes (like sudo). Gates destructive operations only.
  */
 import { pbkdf2Sync, randomBytes } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import * as readline from 'node:readline/promises';
 
@@ -97,8 +97,20 @@ export function saveOperatorConfig(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): void {
   const configPath = getOperatorConfigPath(rawEnv);
-  mkdirSync(dirname(configPath), { recursive: true });
-  writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
+  // Fail-closed on permissions. The file holds the PBKDF2 salt + hash of
+  // the operator passphrase and recovery answer — world-readable means any
+  // local user can run an offline dictionary attack (#135). 0o700 on the
+  // dir, 0o600 on the file.
+  mkdirSync(dirname(configPath), { recursive: true, mode: 0o700 });
+  writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+  // writeFileSync's mode only applies on file CREATION — if the file
+  // already existed, its mode is preserved. chmod explicitly every write.
+  try {
+    chmodSync(configPath, 0o600);
+  } catch {
+    // chmod can fail on platforms that don't support it (Windows). The
+    // create-time mode already limited exposure; don't fail the save.
+  }
 }
 
 export function isOperatorConfigured(rawEnv: NodeJS.ProcessEnv = process.env): boolean {

--- a/src/infra/cli/commands/backup.ts
+++ b/src/infra/cli/commands/backup.ts
@@ -266,7 +266,7 @@ function extractFallbackArchive(archivePath: string, targetRoot: string): void {
   }
 }
 
-function listArchiveContents(archivePath: string): string[] {
+export function listArchiveContents(archivePath: string): string[] {
   try {
     return readFallbackArchive(archivePath).entries.map((entry) =>
       entry.kind === 'dir' ? `${entry.path}/` : entry.path,

--- a/src/infra/config/mutability.ts
+++ b/src/infra/config/mutability.ts
@@ -197,6 +197,10 @@ export const FIELD_MUTABILITY: Record<string, MutabilityTier> = {
   MEMPHIS_COST_CAP_GLM_MONTHLY_TOKENS: 'hot',
   MEMPHIS_COST_CAP_OLLAMA_DAILY_TOKENS: 'hot',
   MEMPHIS_COST_CAP_OLLAMA_MONTHLY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_SHARED_LLM_DAILY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_SHARED_LLM_MONTHLY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_DECENTRALIZED_LLM_DAILY_TOKENS: 'hot',
+  MEMPHIS_COST_CAP_DECENTRALIZED_LLM_MONTHLY_TOKENS: 'hot',
 
   // ── Circuit breaker (Phase 2.1 production sprint) ──
   // All hot — operator can re-tune sensitivity at runtime.

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -202,6 +202,13 @@ export const envSchema = z.object({
   MEMPHIS_COST_CAP_GLM_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
   MEMPHIS_COST_CAP_OLLAMA_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
   MEMPHIS_COST_CAP_OLLAMA_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
+  // Codex Round 6 P2 (PR #121): shared-llm + decentralized-llm are
+  // real runtime providers; they must be capable of runtime budget
+  // control the same as the other five.
+  MEMPHIS_COST_CAP_SHARED_LLM_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_SHARED_LLM_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_DECENTRALIZED_LLM_DAILY_TOKENS: z.coerce.number().int().min(1).optional(),
+  MEMPHIS_COST_CAP_DECENTRALIZED_LLM_MONTHLY_TOKENS: z.coerce.number().int().min(1).optional(),
 
   // Phase 2.1 production sprint — per-provider circuit breaker.
   // _DEFAULT_ keys apply to any provider lacking a specific override.

--- a/src/infra/logging/pino.ts
+++ b/src/infra/logging/pino.ts
@@ -22,15 +22,19 @@ const loggerRegistry = new FinalizationRegistry<WeakRef<Logger>>((ref) => {
 
 // Each entry is the streams array returned by pino.multistream — mutating
 // `.level` on each element propagates to the per-stream filter on the
-// next emit. We hold strong references because these arrays are not
-// reachable from the Logger instance itself.
+// next emit.
+//
+// Codex Round 6 P2 (PR #118): the old code wrapped each MultistreamEntry
+// in a WeakRef with no strong retention anywhere else, so the entry
+// could be garbage-collected while the logger was still alive. That
+// silently killed file-stream level updates in long-running processes
+// after a GC cycle. Fix: hold the entry strongly in a WeakMap keyed by
+// the Logger itself — the entry is reachable as long as the logger is,
+// and garbage-collects together with it.
 interface MultistreamEntry {
   streams: Array<{ level?: string | number; stream: DestinationStream }>;
 }
-const liveMultistreams = new Set<WeakRef<MultistreamEntry>>();
-const multistreamRegistry = new FinalizationRegistry<WeakRef<MultistreamEntry>>((ref) => {
-  liveMultistreams.delete(ref);
-});
+const multistreamByLogger = new WeakMap<Logger, MultistreamEntry>();
 
 /**
  * Resolve the local log file path.
@@ -89,10 +93,7 @@ export function createPinoLogger(options?: LoggerOptions): Logger {
     ];
     const multistream = pino.multistream(streamsArray);
     logger = pino(options ?? {}, multistream);
-    const entry: MultistreamEntry = { streams: streamsArray };
-    const msRef = new WeakRef(entry);
-    liveMultistreams.add(msRef);
-    multistreamRegistry.register(logger, msRef);
+    multistreamByLogger.set(logger, { streams: streamsArray });
   } else {
     logger = pino(options ?? {}, stderrStream);
   }
@@ -131,13 +132,16 @@ export function setAllPinoLoggerLevels(level: string): {
       // pino throws on unknown levels — best-effort, skip and continue
     }
   }
+  // Walk the logger registry and look each one up in the multistream
+  // WeakMap. Since the entry is strongly referenced FROM the logger
+  // (via the WeakMap), it can't be GC'd independently — the Codex
+  // Round 6 P2 failure mode.
   let multistreamsUpdated = 0;
-  for (const ref of liveMultistreams) {
-    const entry = ref.deref();
-    if (!entry) {
-      liveMultistreams.delete(ref);
-      continue;
-    }
+  for (const ref of liveLoggers) {
+    const logger = ref.deref();
+    if (!logger) continue;
+    const entry = multistreamByLogger.get(logger);
+    if (!entry) continue;
     for (const streamEntry of entry.streams) {
       streamEntry.level = level;
     }
@@ -149,5 +153,5 @@ export function setAllPinoLoggerLevels(level: string): {
 /** Test-only: clear the registry (does not destroy the loggers themselves). */
 export function __resetPinoRegistryForTests(): void {
   liveLoggers.clear();
-  liveMultistreams.clear();
+  // multistreamByLogger is a WeakMap — entries auto-clear when loggers GC
 }

--- a/src/infra/ops/zombie-cleanup.ts
+++ b/src/infra/ops/zombie-cleanup.ts
@@ -9,6 +9,16 @@ export interface ZombieCleanupResult {
   errors: string[];
 }
 
+/**
+ * Decide whether a ps-aux cmdline belongs to a Memphis process.
+ * Must require `memphis` in the cmdline — a prior version was
+ * `tsx || node && memphis` (precedence: `tsx || (node && memphis)`), which
+ * terminated every tsx process on the host (#133).
+ */
+export function isMemphisProcess(cmd: string): boolean {
+  return (cmd.includes('tsx') || cmd.includes('node')) && cmd.includes('memphis');
+}
+
 function getMemphisProcesses(): Array<{ pid: number; cmd: string }> {
   try {
     const output = execSync('ps aux', { encoding: 'utf8' });
@@ -26,7 +36,7 @@ function getMemphisProcesses(): Array<{ pid: number; cmd: string }> {
       if (isNaN(pid)) continue;
 
       const cmd = parts.slice(10).join(' ');
-      if (cmd.includes('tsx') || cmd.includes('node') && cmd.includes('memphis')) {
+      if (isMemphisProcess(cmd)) {
         processes.push({ pid, cmd });
       }
     }

--- a/src/infra/runtime/circuit-breaker.ts
+++ b/src/infra/runtime/circuit-breaker.ts
@@ -184,7 +184,18 @@ export function recordProviderOutcome(
     return;
   }
 
-  // Failure in CLOSED state
+  // Failure in closed state — maintain the window and maybe trip.
+  // Codex Round 6 P1 fix (PR #122): if we're already OPEN (because
+  // concurrent requests raced past the trip and their failures
+  // landed here AFTER state flipped), we must NOT reset openedAt or
+  // increment totalTrips — otherwise a stampede of stale failures
+  // keeps pushing the cooldown window forward and delays recovery.
+  // lastFailureAt is still useful for diagnostics; we update that.
+  if (rec.state === 'open') {
+    rec.lastFailureAt = now;
+    return;
+  }
+
   rec.failureTimestamps.push(now);
   rec.lastFailureAt = now;
   rec.failureTimestamps = rec.failureTimestamps.filter((t) => now - t < windowMs);

--- a/src/infra/runtime/graceful-shutdown.ts
+++ b/src/infra/runtime/graceful-shutdown.ts
@@ -24,10 +24,18 @@
  */
 
 import { writePulseEvent } from './heartbeat-watchdog.js';
-import { activeTurnCount } from './self-restart.js';
+import { activeTurnCount, signalDrain } from './self-restart.js';
 import type { AppLogger } from '../logging/logger.js';
 import { writeSecurityAudit } from '../logging/security-audit.js';
 import { shutdownOtel } from '../observability/otel.js';
+
+/**
+ * Default per-stopper timeout. Codex Round 6 P1 (PR #119): without a
+ * per-stopper bound, one hung close() (e.g. a Fastify server with open
+ * connections) blocked the entire shutdown sequence forever and we
+ * never reached PULSE/OTel completion or exitFn.
+ */
+export const DEFAULT_STOPPER_TIMEOUT_MS = 5_000;
 
 export const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 15_000;
 
@@ -58,6 +66,11 @@ export interface GracefulShutdownOptions {
    * Failures are logged + swallowed; one stuck loop must not prevent shutdown.
    */
   stopFns?: Array<{ name: string; stop: () => void | Promise<void> }>;
+  /**
+   * Per-stopper timeout. Codex Round 6 P1 (PR #119): a hung stopper
+   * must not block the whole shutdown. Default 5s per stopper.
+   */
+  stopperTimeoutMs?: number;
   /** Optional logger; if absent, structured stderr writes are used. */
   logger?: AppLogger;
 }
@@ -154,7 +167,15 @@ export async function performGracefulShutdown(
     // best-effort
   }
 
-  // 2. Drain in-flight (turn controllers self-abort on signal; we just wait)
+  // 2. Signal every registered turn controller to abort (Codex Round 6
+  //    P2 fix — previously we only polled activeTurnCount, so turns
+  //    that depended on the abort signal to unwind hit the timeout
+  //    unnecessarily. Now we tell them explicitly, then wait.)
+  try {
+    signalDrain(`graceful shutdown (${reason})`);
+  } catch {
+    // signalDrain is best-effort; we proceed with the poll regardless
+  }
   const { drained, remaining } = await waitForDrain(drainTimeoutMs);
   state.remainingAfterDrain = remaining;
   if (!drained) {
@@ -166,12 +187,30 @@ export async function performGracefulShutdown(
     );
   }
 
-  // 3. Stop background loops in parallel
+  // 3. Stop background loops in parallel, each bounded by a timeout
+  //    so one hung close() doesn't block the whole shutdown sequence
+  //    (Codex Round 6 P1 fix on PR #119).
   const stoppers = options.stopFns ?? [];
+  const stopperTimeoutMs =
+    options.stopperTimeoutMs ?? DEFAULT_STOPPER_TIMEOUT_MS;
   await Promise.all(
     stoppers.map(async ({ name, stop }) => {
       try {
-        await stop();
+        await Promise.race([
+          Promise.resolve().then(() => stop()),
+          new Promise<void>((_, reject) => {
+            const timer = setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `stopper '${name}' did not complete within ${stopperTimeoutMs}ms`,
+                  ),
+                ),
+              stopperTimeoutMs,
+            );
+            if (typeof timer === 'object' && 'unref' in timer) timer.unref?.();
+          }),
+        ]);
       } catch (err) {
         logLine(
           options.logger,
@@ -220,8 +259,17 @@ export async function performGracefulShutdown(
   exitFn(exitCode);
 }
 
+const installedHandlers: Array<{ signal: NodeJS.Signals; handler: () => void }> = [];
+
 /**
  * Install signal handlers. Idempotent — re-calling is a no-op.
+ *
+ * Codex Round 6 P1 fix (PR #119): uses `process.on` (persistent)
+ * instead of `process.once` so a SECOND signal during shutdown still
+ * hits our handler (which ignores it via the `shuttingDown` guard)
+ * rather than Node's default "terminate immediately" behavior. The
+ * old code meant an impatient double-Ctrl-C killed the process
+ * mid-drain and defeated the whole point of the graceful path.
  */
 export function installShutdownHandlers(options: GracefulShutdownOptions = {}): void {
   if (installed) return;
@@ -231,8 +279,12 @@ export function installShutdownHandlers(options: GracefulShutdownOptions = {}): 
     void performGracefulShutdown(reason, options);
   };
 
-  process.once('SIGTERM', handler('SIGTERM'));
-  process.once('SIGINT', handler('SIGINT'));
+  const sigterm = handler('SIGTERM');
+  const sigint = handler('SIGINT');
+  process.on('SIGTERM', sigterm);
+  process.on('SIGINT', sigint);
+  installedHandlers.push({ signal: 'SIGTERM', handler: sigterm });
+  installedHandlers.push({ signal: 'SIGINT', handler: sigint });
 }
 
 /** Snapshot for /status payloads. */
@@ -244,4 +296,8 @@ export function getShutdownState(): ShutdownState {
 export function __resetShutdownStateForTests(): void {
   state = { shuttingDown: false };
   installed = false;
+  // Detach any handlers we installed — tests re-install fresh.
+  for (const h of installedHandlers.splice(0)) {
+    process.off(h.signal, h.handler);
+  }
 }

--- a/src/infra/runtime/scheduled-backup.ts
+++ b/src/infra/runtime/scheduled-backup.ts
@@ -116,23 +116,25 @@ function readKeep(rawEnv: NodeJS.ProcessEnv): number {
 }
 
 /**
- * Default restore-drill: extract the archive to a tmp dir and verify
- * the directory structure looks sane. A real production drill would
- * re-run `chain verify` against the extracted chain dir; this one is
- * intentionally fast (a few hundred ms) so it can run frequently.
+ * Default restore-drill: verify the archive is listable + contains at
+ * least one chain block file.
+ *
+ * Codex Round 6 P1 fix (PR #120): the old drill unconditionally ran
+ * `tar -tzf`, but `createBackup` can produce a fallback gzip/JSON
+ * archive when tar is unavailable (EPERM/EACCES path). That made every
+ * drill on those hosts emit a false drill_failed alert. Use the
+ * canonical `listArchiveContents` from backup.ts which already
+ * handles BOTH formats.
  */
 async function defaultDrill(backupPath: string): Promise<void> {
   const drillDir = mkdtempSync(join(tmpdir(), 'memphis-backup-drill-'));
   try {
-    const { execFile } = await import('node:child_process');
-    const { promisify } = await import('node:util');
-    const execFileAsync = promisify(execFile);
-    await execFileAsync('tar', ['-tzf', backupPath]);
-    // Lightweight extraction sanity: the archive must contain at least
-    // one chain block file. We use `tar -tzf` instead of full extract
-    // for speed; a test PR can extend with a real `chain verify` pass.
-    const { stdout } = await execFileAsync('tar', ['-tzf', backupPath]);
-    const hasBlocks = /chains\/.+\.json/.test(stdout);
+    const { listArchiveContents } = await import('../cli/commands/backup.js');
+    const entries = listArchiveContents(backupPath);
+    if (entries.length === 0) {
+      throw new Error('drill failed: archive has no entries');
+    }
+    const hasBlocks = entries.some((e) => /chains\/.+\.json/.test(e));
     if (!hasBlocks) {
       throw new Error('drill failed: archive contains no chain block files');
     }
@@ -152,9 +154,10 @@ export function startScheduledBackupLoop(
   options: ScheduledBackupOptions = {},
 ): ScheduledBackupHandle {
   const rawEnv = options.rawEnv ?? process.env;
+  // Interval is bound at setInterval and can't change post-start.
+  // drillEveryN + keep ARE classified hot in mutability.ts, so we
+  // re-read them on every tick (Codex Round 6 P2 fix on PR #120).
   const interval = options.intervalMs ?? readIntervalFromEnv(rawEnv);
-  const drillEveryN = readDrillEveryN(rawEnv);
-  const keep = readKeep(rawEnv);
   const drillFn = options.drillFn ?? defaultDrill;
 
   const createBackupFn =
@@ -169,8 +172,10 @@ export function startScheduledBackupLoop(
   const cleanFn =
     options.cleanFn ??
     (async () => {
+      // Re-read keep on each clean so /config set MEMPHIS_BACKUP_KEEP
+      // actually takes effect immediately.
       const { cleanBackups } = await import('../cli/commands/backup.js');
-      await cleanBackups({ keep });
+      await cleanBackups({ keep: readKeep(rawEnv) });
     });
 
   let inFlight = false;
@@ -185,6 +190,8 @@ export function startScheduledBackupLoop(
     }
     inFlight = true;
     try {
+      // Re-read on each tick so hot-reload via /config set picks up.
+      const drillEveryN = readDrillEveryN(rawEnv);
       log.info({ event: 'backup.scheduled.start' }, 'scheduled backup starting');
       const result = await createBackupFn();
       state.lastSuccessAt = new Date().toISOString();
@@ -290,7 +297,12 @@ export function startScheduledBackupLoop(
   }
 
   log.info(
-    { event: 'backup.scheduled.loop.started', intervalMs: interval, drillEveryN, keep },
+    {
+      event: 'backup.scheduled.loop.started',
+      intervalMs: interval,
+      drillEveryN: readDrillEveryN(rawEnv),
+      keep: readKeep(rawEnv),
+    },
     'scheduled backup loop started',
   );
 

--- a/src/infra/runtime/self-restart.ts
+++ b/src/infra/runtime/self-restart.ts
@@ -98,11 +98,18 @@ export function activeTurnCount(): number {
   return turnControllers.size;
 }
 
-function signalDrain(): number {
+/**
+ * Signal every registered turn controller to abort. Used by BOTH the
+ * restart flow AND the graceful-shutdown flow (Codex Round 6 P2 fix —
+ * shutdown previously just polled activeTurnCount without telling the
+ * controllers to bail, so turns that depended on the abort signal to
+ * unwind hit the drain timeout unnecessarily).
+ */
+export function signalDrain(reason = 'draining in-flight turn'): number {
   const count = turnControllers.size;
   for (const controller of turnControllers) {
     try {
-      controller.abort(new AppError('VALIDATION_ERROR', 'restart draining in-flight turn', 503));
+      controller.abort(new AppError('VALIDATION_ERROR', reason, 503));
     } catch {
       // abort failures are best-effort — we're tearing down anyway
     }

--- a/src/infra/runtime/turn-admission.ts
+++ b/src/infra/runtime/turn-admission.ts
@@ -84,9 +84,16 @@ function readMaxQueued(rawEnv: NodeJS.ProcessEnv): number {
 
 function admitOne(): void {
   // Called when a slot frees up — pump the queue.
-  if (state.active >= 1 && waitQueue.length === 0) return;
-  // (the active >= 1 check is just paranoid — the only caller already
-  // confirmed we're admitting after a release)
+  // Codex Round 6 P1 fix (PR #123): re-read the cap here so hot
+  // changes to MEMPHIS_MAX_CONCURRENT_TURNS actually take effect
+  // while a backlog exists. Without this, operators could `/config
+  // set MEMPHIS_MAX_CONCURRENT_TURNS=50` and throughput would stay
+  // at the old cap until the queue drained on its own.
+  const maxConcurrent = readMaxConcurrent(process.env);
+  // Respect the current cap — if a release frees a slot but the cap
+  // was just lowered below the active count, DON'T admit the next
+  // waiter. Let the queue drain naturally as more releases happen.
+  if (state.active >= maxConcurrent) return;
   const next = waitQueue.shift();
   if (!next) return;
   state.queued -= 1;
@@ -99,6 +106,12 @@ function admitOne(): void {
     release: makeRelease(acquiredAt),
     acquiredAt,
   });
+  // Cap may have been raised — keep pumping until we reach it or
+  // the queue is empty. This is the "raise 1→10 takes effect
+  // immediately" half of the fix.
+  if (state.active < maxConcurrent && waitQueue.length > 0) {
+    admitOne();
+  }
 }
 
 function makeRelease(acquiredAt: number): () => void {

--- a/src/infra/storage/migrations/runner.ts
+++ b/src/infra/storage/migrations/runner.ts
@@ -12,7 +12,7 @@
  *   - never touches data/ if ANY chain fails in dry-run
  */
 
-import { createHash } from 'node:crypto';
+import * as nodeCrypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
@@ -26,6 +26,7 @@ import type {
 } from './types.js';
 import { getChainPath } from '../../../config/paths.js';
 import { writeSecurityAudit } from '../../logging/security-audit.js';
+import { hashBlock } from '../chain-adapter.js';
 
 const SAFE_CHAIN_NAME = /^[A-Za-z0-9_-]{1,64}$/;
 
@@ -36,40 +37,46 @@ function detectVersion(block: MigratableBlock): number {
   return 1;
 }
 
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== 'object') return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
-  const rec = value as Record<string, unknown>;
-  const keys = Object.keys(rec).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(rec[k])}`).join(',')}}`;
-}
-
-function recomputeHash(block: MigratableBlock): string {
-  const { hash: _unused, ...rest } = block;
-  void _unused;
-  // Keep canonical hash input simple + deterministic (sorted keys).
-  // Any new migration that changes this MUST advance the schema
-  // version so old-vs-new hashes don't collide.
-  return createHash('sha256').update(stableStringify(rest)).digest('hex');
-}
-
+/**
+ * Codex Round 6 P1 fix (PR #126): use the canonical chain-adapter
+ * hashBlock so migrated blocks pass normal integrity checks
+ * (diagnoseChainHashes, checkBlockHashMismatch). The old bespoke
+ * stableStringify hashed the WHOLE block including schemaVersion +
+ * extras, which didn't match the `{index, timestamp, chain, data,
+ * prev_hash}` payload the rest of the system validates against.
+ *
+ * Any migration that wants to CHANGE the canonical hash input needs to
+ * extend chain-adapter's hashBlock under a new schema version rather
+ * than silently diverging here.
+ */
 function applyMigrations(
   block: MigratableBlock,
   migrations: ChainMigration[],
   targetVersion: number,
+  prevHashOverride: string | null,
 ): MigratableBlock {
   let current = block;
   for (const m of migrations) {
     current = m.transformBlock(current);
   }
-  // After all migrations: stamp the version and rehash.
-  const migrated: MigratableBlock = {
-    ...current,
-    schemaVersion: targetVersion,
-    hash: '', // placeholder; recomputeHash excludes hash
+  // If a prior block in this run was migrated, its hash changed; we
+  // MUST update this block's prev_hash to the new predecessor hash so
+  // the chain's prev_hash linkage stays intact. (Codex Round 6 P1 fix.)
+  const linkedPrevHash = prevHashOverride ?? current.prev_hash;
+  const canonicalInput = {
+    index: current.index,
+    timestamp: current.timestamp,
+    chain: current.chain,
+    data: current.data,
+    prev_hash: linkedPrevHash,
   };
-  migrated.hash = recomputeHash(migrated);
-  return migrated;
+  const newHash = hashBlock(canonicalInput, nodeCrypto);
+  return {
+    ...current,
+    prev_hash: linkedPrevHash,
+    schemaVersion: targetVersion,
+    hash: newHash,
+  };
 }
 
 async function listBlockFiles(
@@ -152,7 +159,14 @@ async function migrateChain(
       };
     }
     try {
-      const migrated = applyMigrations(raw, applicable, targetVersion);
+      // Codex Round 6 P1 fix (PR #126): thread the previous converted
+      // block's NEW hash so prev_hash linkage stays intact after
+      // migration. Without this, blocks 2..N still point at the
+      // pre-migration hash of block 1, causing deterministic
+      // prev_hash mismatches in chain verify.
+      const prevHashOverride =
+        converted.length === 0 ? null : converted[converted.length - 1]!.block.hash;
+      const migrated = applyMigrations(raw, applicable, targetVersion, prevHashOverride);
       converted.push({ file: entry.file, block: migrated });
     } catch (err) {
       return {
@@ -177,16 +191,40 @@ async function migrateChain(
   }
 
   // Phase 2: write to tmp dir, then atomically swap.
+  //
+  // Codex Round 6 P2 fix (PR #126): the old code didn't handle the
+  // failure mode where the FIRST rename (chain → backup) succeeds but
+  // the SECOND rename (tmp → chain) fails. In that window the active
+  // chain dir is GONE and reads fail until an operator manually moves
+  // the backup back. The fix: track which renames we performed and
+  // restore the backup if the second rename throws.
   const tmpDir = `${chainDir}.migrating-${process.pid}`;
+  const backupDir = `${chainDir}.pre-migration-${Date.now()}`;
   await fs.mkdir(tmpDir, { recursive: true });
+  let backupMoved = false;
   try {
     for (const { file, block } of converted) {
       await fs.writeFile(path.join(tmpDir, file), JSON.stringify(block), 'utf8');
     }
-    // Backup original then swap
-    const backupDir = `${chainDir}.pre-migration-${Date.now()}`;
     await fs.rename(chainDir, backupDir);
-    await fs.rename(tmpDir, chainDir);
+    backupMoved = true;
+    try {
+      await fs.rename(tmpDir, chainDir);
+    } catch (secondRenameErr) {
+      // Second rename failed — restore backup so reads don't break.
+      try {
+        await fs.rename(backupDir, chainDir);
+        backupMoved = false; // restored
+      } catch (restoreErr) {
+        throw new Error(
+          `phase-2 second rename failed AND restore failed. ` +
+            `original error: ${secondRenameErr instanceof Error ? secondRenameErr.message : String(secondRenameErr)}; ` +
+            `restore error: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}. ` +
+            `Manual recovery: \`mv ${backupDir} ${chainDir}\``,
+        );
+      }
+      throw secondRenameErr;
+    }
     writeSecurityAudit({
       action: 'chain.migration.completed',
       status: 'allowed',
@@ -200,14 +238,14 @@ async function migrateChain(
     });
   } catch (err) {
     // tmpDir still exists; leave it for the operator to inspect. Real
-    // chain dir is untouched.
+    // chain dir is untouched (either never moved, or restored above).
     return {
       chain: chainName,
       fromVersion,
       toVersion: fromVersion,
       blocksConsidered: blockFiles.length,
       blocksMigrated: 0,
-      error: `phase-2 write failed: ${err instanceof Error ? err.message : String(err)}. Active chain is unchanged; tmp at ${tmpDir}`,
+      error: `phase-2 write failed: ${err instanceof Error ? err.message : String(err)}. Active chain ${backupMoved ? 'RESTORED from backup' : 'unchanged'}; tmp at ${tmpDir}`,
     };
   }
 

--- a/src/mcp/tools/code-read.ts
+++ b/src/mcp/tools/code-read.ts
@@ -10,6 +10,7 @@ import { readFileSync, statSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { isInsideMemphisSandbox } from './fs-permission.js';
 import { AppError } from '../../core/errors.js';
 
 export type MemphisCodeReadInput = {
@@ -39,12 +40,14 @@ function resolvePath(inputPath: string): string {
   return expanded;
 }
 
-/** Verify the resolved path lives under ~/memphis/. */
+/**
+ * Verify the resolved path lives under ~/memphis/.
+ * Uses isInsideMemphisSandbox which realpath-resolves symlinks — a prior
+ * version relied on path.normalize only, which let a symlink inside the
+ * sandbox point outward and readFileSync would happily follow it (#132).
+ */
 function assertInMemphisDir(resolvedPath: string): void {
-  const memphisDir = path.join(os.homedir(), 'memphis');
-  const normalized = path.normalize(resolvedPath);
-
-  if (!normalized.startsWith(memphisDir + path.sep) && normalized !== memphisDir) {
+  if (!isInsideMemphisSandbox(resolvedPath)) {
     throw new AppError(
       'VALIDATION_ERROR',
       `Path '${resolvedPath}' is outside the allowed ~/memphis/ directory`,

--- a/src/mcp/tools/fs-permission.ts
+++ b/src/mcp/tools/fs-permission.ts
@@ -67,7 +67,7 @@ function memphisSandboxDir(): string {
  * when no existing ancestor is found (e.g. nonexistent root), which the
  * caller then evaluates against the sandbox prefix as-is.
  */
-function realpathOrNearest(resolvedPath: string): string {
+export function realpathOrNearest(resolvedPath: string): string {
   try {
     return realpathSync(resolvedPath);
   } catch {

--- a/src/mcp/tools/self-modify.ts
+++ b/src/mcp/tools/self-modify.ts
@@ -9,6 +9,7 @@ import { createHash } from 'node:crypto';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
+import { realpathOrNearest } from './fs-permission.js';
 import { RollbackManager } from '../../backup/rollback.js';
 import {
   commitAll,
@@ -61,12 +62,23 @@ export interface SelfModifyDeps {
 
 const FORBIDDEN_SEGMENTS = ['.env', 'vault/', '.git/', 'node_modules/'];
 
-function validateFilePath(filePath: string, projectRoot: string): string {
-  const resolved = resolve(projectRoot, filePath);
-  if (!resolved.startsWith(projectRoot + '/')) {
-    throw new Error(`Path traversal blocked: ${filePath} resolves outside project root`);
+export function validateFilePath(filePath: string, projectRoot: string): string {
+  // Realpath both sides so a symlink inside the project root pointing at an
+  // outside file cannot slip past the prefix check (#136). projectRoot
+  // itself may be a symlink (common on NixOS / containers); realpathOrNearest
+  // handles targets that don't yet exist (create-new case).
+  const realRoot = realpathOrNearest(projectRoot);
+  const realResolved = realpathOrNearest(resolve(projectRoot, filePath));
+
+  if (
+    !realResolved.startsWith(realRoot + '/') &&
+    realResolved !== realRoot
+  ) {
+    throw new Error(
+      `Path traversal blocked: ${filePath} resolves outside project root`,
+    );
   }
-  const relative = resolved.slice(projectRoot.length + 1);
+  const relative = realResolved.slice(realRoot.length + 1);
   if (relative.startsWith('.')) {
     throw new Error(`Dotfile modification blocked: ${filePath}`);
   }
@@ -75,7 +87,7 @@ function validateFilePath(filePath: string, projectRoot: string): string {
       throw new Error(`Forbidden path segment '${seg}' in: ${filePath}`);
     }
   }
-  return resolved;
+  return realResolved;
 }
 
 function errorResult(reason: string): SelfModifyResult {

--- a/src/mcp/tools/test-run.ts
+++ b/src/mcp/tools/test-run.ts
@@ -26,6 +26,8 @@ export type MemphisTestOutput = {
 
 const PROJECT_ROOT = path.join(os.homedir(), 'memphis');
 
+const SAFE_FILTER_RE = /^[A-Za-z0-9_.,/ -]+$/;
+
 const SUITES: Record<string, { command: string; args: string[] }> = {
   ts: { command: 'npx', args: ['vitest', 'run'] },
   rust: { command: 'npm', args: ['run', 'test:rust'] },
@@ -73,6 +75,19 @@ export function runMemphisTest(input: MemphisTestInput): MemphisTestOutput {
 
   const args = [...config.args];
   if (suite === 'ts' && input.filter) {
+    // Restrict filter to a test-name pattern. Anything starting with '-'
+    // would become a vitest CLI flag, and --config=<path> loads arbitrary
+    // JS — chained with fs-write that's a tier-2 → arbitrary-code-exec
+    // elevation (#137).
+    if (!SAFE_FILTER_RE.test(input.filter) || input.filter.startsWith('-')) {
+      return {
+        passed: false,
+        suite,
+        output: '',
+        durationMs: 0,
+        error: `filter must be a plain test-name pattern (letters, digits, _.,/ -); flags are not allowed`,
+      };
+    }
     args.push(input.filter);
   }
 

--- a/src/mcp/tools/web-fetch.ts
+++ b/src/mcp/tools/web-fetch.ts
@@ -1,7 +1,11 @@
+import { lookup } from 'node:dns/promises';
+import net from 'node:net';
+
 import { AppError } from '../../core/errors.js';
 
 const MAX_BODY_CHARS = 4000;
 const FETCH_TIMEOUT_MS = 8000;
+const MAX_REDIRECTS = 5;
 
 export type MemphisWebFetchInput = {
   url: string;
@@ -15,50 +19,219 @@ export type MemphisWebFetchOutput = {
 };
 
 /**
- * Check if a URL is safe to fetch (blocks SSRF to internal networks).
+ * Block list of dangerous IPv4 ranges. Beyond the obvious RFC1918 + localhost,
+ * we also block:
+ *  - 169.254.0.0/16   — link-local / cloud-provider metadata (AWS/GCP/Azure
+ *                       use 169.254.169.254 for instance credentials).
+ *  - 100.64.0.0/10    — CGNAT (RFC 6598).
+ *  - 0.0.0.0/8        — "this host" on many stacks; resolves to localhost.
+ *  - 224.0.0.0/4      — multicast.
+ *  - 255.255.255.255  — limited broadcast.
  */
-function isSafeUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    if (!['http:', 'https:'].includes(parsed.protocol)) return false;
-    if (parsed.search.length > 200) return false;
-
-    const host = parsed.hostname.toLowerCase();
-    if (host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0' || host === '[::1]')
-      return false;
-    if (host.startsWith('192.168.') || host.startsWith('10.') || host.startsWith('172.'))
-      return false;
-    if (host.endsWith('.local') || host.endsWith('.internal')) return false;
-    return true;
-  } catch {
-    return false;
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split('.').map((p) => Number.parseInt(p, 10));
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) {
+    return true; // malformed → treat as unsafe
   }
+  const [a, b] = parts;
+  if (a === 127) return true;                         // loopback
+  if (a === 10) return true;                          // RFC1918
+  if (a === 172 && b >= 16 && b <= 31) return true;   // RFC1918
+  if (a === 192 && b === 168) return true;            // RFC1918
+  if (a === 169 && b === 254) return true;            // link-local / cloud metadata
+  if (a === 100 && b >= 64 && b <= 127) return true;  // CGNAT
+  if (a === 0) return true;                           // 0.0.0.0/8
+  if (a >= 224) return true;                          // multicast + reserved
+  return false;
+}
+
+/**
+ * Block list of dangerous IPv6 ranges:
+ *  - ::1              — loopback
+ *  - fc00::/7         — unique local addresses
+ *  - fe80::/10        — link-local
+ *  - ::ffff:0:0/96    — IPv4-mapped (must re-check against IPv4 blocklist)
+ *  - ::/128, ::/96    — unspecified, compat range
+ */
+function isPrivateIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+  if (normalized === '::' || normalized === '::1') return true;
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true; // fc00::/7
+  if (normalized.startsWith('fe8') || normalized.startsWith('fe9')) return true;
+  if (normalized.startsWith('fea') || normalized.startsWith('feb')) return true; // fe80::/10
+  if (normalized.startsWith('ff')) return true; // multicast
+  // IPv4-mapped: ::ffff:a.b.c.d — extract and re-check
+  const mappedMatch = normalized.match(/^::ffff:([0-9.]+)$/);
+  if (mappedMatch) return isPrivateIPv4(mappedMatch[1]);
+  // IPv4-mapped alt form: ::ffff:X:Y where X:Y is hex
+  const hexMappedMatch = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hexMappedMatch) {
+    const hi = Number.parseInt(hexMappedMatch[1], 16);
+    const lo = Number.parseInt(hexMappedMatch[2], 16);
+    const ipv4 = [(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff].join('.');
+    return isPrivateIPv4(ipv4);
+  }
+  return false;
+}
+
+function isPrivateIp(ip: string): boolean {
+  if (net.isIPv4(ip)) return isPrivateIPv4(ip);
+  if (net.isIPv6(ip)) return isPrivateIPv6(ip);
+  return true; // unknown → unsafe
+}
+
+export interface SafeFetchDeps {
+  /**
+   * DNS resolver used for the pre-fetch host check. Override in tests so
+   * adversarial hosts can be simulated without real DNS lookups.
+   */
+  dnsLookup?: (host: string) => Promise<Array<{ address: string }>>;
+  /**
+   * fetch impl. Override in tests to simulate redirects.
+   */
+  fetch?: typeof fetch;
+}
+
+async function assertHostSafe(
+  host: string,
+  deps: SafeFetchDeps,
+): Promise<void> {
+  const resolver = deps.dnsLookup ?? ((h) => lookup(h, { all: true }));
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await resolver(host);
+  } catch {
+    throw new AppError(
+      'VALIDATION_ERROR',
+      'URL blocked: host could not be resolved',
+      403,
+    );
+  }
+  if (addresses.length === 0) {
+    throw new AppError(
+      'VALIDATION_ERROR',
+      'URL blocked: host resolved to no addresses',
+      403,
+    );
+  }
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      throw new AppError(
+        'VALIDATION_ERROR',
+        `URL blocked: host resolves to private/internal IP (${address})`,
+        403,
+      );
+    }
+  }
+}
+
+/**
+ * First-pass URL sanity — protocol, query-string size, hostname literal IP
+ * checks (catches the case where the URL is a direct private-IP literal
+ * before we even try DNS).
+ */
+function assertUrlShapeSafe(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new AppError('VALIDATION_ERROR', 'URL blocked: invalid URL', 403);
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new AppError(
+      'VALIDATION_ERROR',
+      'URL blocked: only http(s) is allowed',
+      403,
+    );
+  }
+  if (parsed.search.length > 200) {
+    throw new AppError(
+      'VALIDATION_ERROR',
+      'URL blocked: query string too long',
+      403,
+    );
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!host) {
+    throw new AppError('VALIDATION_ERROR', 'URL blocked: empty host', 403);
+  }
+  if (host === 'localhost') {
+    throw new AppError('VALIDATION_ERROR', 'URL blocked: localhost', 403);
+  }
+  if (host.endsWith('.local') || host.endsWith('.internal')) {
+    throw new AppError(
+      'VALIDATION_ERROR',
+      'URL blocked: .local/.internal domain',
+      403,
+    );
+  }
+  // Literal-IP shortcut: if the host is already an IP literal we can check
+  // it directly without DNS. `[::1]` etc. get stripped of brackets by URL.
+  if (net.isIP(host) !== 0) {
+    if (isPrivateIp(host)) {
+      throw new AppError(
+        'VALIDATION_ERROR',
+        `URL blocked: private/internal IP literal (${host})`,
+        403,
+      );
+    }
+  }
+  return parsed;
 }
 
 export async function runMemphisWebFetch(
   input: MemphisWebFetchInput,
+  deps: SafeFetchDeps = {},
 ): Promise<MemphisWebFetchOutput> {
-  if (!isSafeUrl(input.url)) {
+  const fetchImpl = deps.fetch ?? fetch;
+  let currentUrl = input.url;
+  let currentParsed = assertUrlShapeSafe(currentUrl);
+
+  await assertHostSafe(currentParsed.hostname, deps);
+
+  let response: Response | null = null;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    response = await fetchImpl(currentUrl, {
+      method: 'GET',
+      headers: { 'User-Agent': 'Memphis/5.0 MCP-Tool' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      redirect: 'manual',
+    });
+
+    // Follow redirect manually after re-validating the target.
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) break;
+      const next = new URL(location, currentUrl).toString();
+      currentUrl = next;
+      currentParsed = assertUrlShapeSafe(currentUrl);
+      await assertHostSafe(currentParsed.hostname, deps);
+      if (hop === MAX_REDIRECTS) {
+        throw new AppError(
+          'VALIDATION_ERROR',
+          'URL blocked: too many redirects',
+          403,
+        );
+      }
+      continue;
+    }
+    break;
+  }
+
+  if (!response) {
     throw new AppError(
       'VALIDATION_ERROR',
-      'URL blocked: internal/private addresses not allowed',
+      'URL blocked: no response',
       403,
     );
   }
-
-  const response = await fetch(input.url, {
-    method: 'GET',
-    headers: { 'User-Agent': 'Memphis/5.0 MCP-Tool' },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    redirect: 'follow',
-  });
 
   const raw = await response.text();
   const truncated = raw.length > MAX_BODY_CHARS;
   const content = truncated ? raw.slice(0, MAX_BODY_CHARS) : raw;
 
   return {
-    url: input.url,
+    url: currentUrl,
     status: response.status,
     content,
     truncated,

--- a/src/modules/apps/manifest.ts
+++ b/src/modules/apps/manifest.ts
@@ -413,6 +413,30 @@ function interpolateTemplate(template: string, vars: Record<string, string>): st
   return template.replace(/\$\{([A-Z0-9_]+)\}/g, (_match, name: string) => vars[name] ?? '');
 }
 
+/**
+ * Single-quote a value for safe inclusion in a POSIX shell argument.
+ * Wraps in '…' and escapes any embedded single quotes via the standard
+ * '\'' dance. Never use unquoted interpolation in steps that reach
+ * `bash -lc` (#140).
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Interpolate a template whose output is passed to a shell (e.g. bash -lc).
+ * Each substituted value is single-quoted so shell metacharacters inside
+ * the value cannot escape their position.
+ */
+export function interpolateTemplateShell(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(/\$\{([A-Z0-9_]+)\}/g, (_match, name: string) =>
+    shellQuote(vars[name] ?? ''),
+  );
+}
+
 export function guidanceForManagedAppCapabilities(capabilities: ManagedAppCapability[]): string[] {
   const set = new Set(capabilities);
   const guidance: string[] = [];
@@ -900,7 +924,13 @@ export function planManagedAppAction(
   const effectiveEnv = { ...rawEnv, ...secretResolution.injectedEnv };
   const secretFileResolution = resolveActionVaultFiles(action, templateVars, rawEnv);
   const cwd = resolve(interpolateTemplate(action.cwd ?? paths.home, templateVars));
-  const steps = action.steps.map((step) => interpolateTemplate(step, templateVars));
+  // Steps are executed via `bash -lc step` below, so interpolate with
+  // shell-quoting — otherwise a template variable whose value contains a
+  // shell metacharacter escapes its position and can run arbitrary
+  // commands (#140). Non-shell interpolation (paths, env values) still
+  // uses the plain variant because they're already quoted by their
+  // consumer (spawn's argv / env object).
+  const steps = action.steps.map((step) => interpolateTemplateShell(step, templateVars));
   enforceManifestSteps(steps, { manifestId: manifest.id, action: actionName });
   const requirements = [
     ...checkManagedAppRequirements(manifest, rawEnv),

--- a/src/modules/orchestration/service.ts
+++ b/src/modules/orchestration/service.ts
@@ -362,10 +362,37 @@ export class OrchestrationService {
     while (attempt <= this.maxRetries) {
       const started = Date.now();
       try {
+        // Codex Round 6 P1 fix (PR #121): cost-cap + breaker gates
+        // previously only ran in runTurnRuntime, so /v1/chat/generate
+        // with mode: "provider-only" bypassed them entirely. Apply
+        // here so provider-only is subject to the same protection.
+        const [{ checkProviderBudget }, { admitProviderCall }] = await Promise.all([
+          import('../../infra/runtime/cost-cap.js'),
+          import('../../infra/runtime/circuit-breaker.js'),
+        ]);
+        checkProviderBudget(provider.name);
+        admitProviderCall(provider.name);
+
         const out = await provider.generate(input);
         const latencyMs = Date.now() - started;
         metrics.recordProviderCall(provider.name, true, latencyMs);
         this.providerPolicy.markSuccess(provider.name);
+        // Record budget + breaker outcome
+        try {
+          const [{ recordProviderUsage }, { recordProviderOutcome }] = await Promise.all([
+            import('../../infra/runtime/cost-cap.js'),
+            import('../../infra/runtime/circuit-breaker.js'),
+          ]);
+          const usage = (out as { usage?: { inputTokens?: number; outputTokens?: number } }).usage;
+          const inTok = usage?.inputTokens ?? 0;
+          const outTok = usage?.outputTokens ?? 0;
+          if (inTok > 0 || outTok > 0) {
+            recordProviderUsage(provider.name, inTok, outTok);
+          }
+          recordProviderOutcome(provider.name, true);
+        } catch {
+          // best-effort; never break orchestration
+        }
         trace.push({
           attempt: attempt + 1,
           provider: provider.name,
@@ -378,6 +405,22 @@ export class OrchestrationService {
         const latencyMs = Date.now() - started;
         metrics.recordProviderCall(provider.name, false, latencyMs);
         this.providerPolicy.markFailure(provider.name);
+        // Codex Round 6 P1 fix (PR #122): only count TRANSIENT failures
+        // against the breaker. A validation/4xx burst must not trip it
+        // and force unrelated healthy requests to fail fast.
+        // isRetryable already distinguishes PROVIDER_TIMEOUT /
+        // PROVIDER_UNAVAILABLE / PROVIDER_RATE_LIMIT from permanent
+        // errors — reuse that classification.
+        if (isRetryable(error)) {
+          try {
+            const { recordProviderOutcome } = await import(
+              '../../infra/runtime/circuit-breaker.js'
+            );
+            recordProviderOutcome(provider.name, false);
+          } catch {
+            /* best-effort */
+          }
+        }
         trace.push({
           attempt: attempt + 1,
           provider: provider.name,

--- a/tests/unit/apps-manifest-shell-quote.test.ts
+++ b/tests/unit/apps-manifest-shell-quote.test.ts
@@ -1,0 +1,61 @@
+import { execSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  interpolateTemplateShell,
+  shellQuote,
+} from '../../src/modules/apps/manifest.ts';
+
+/**
+ * Regression net for #140. Manifest steps used to interpolate template
+ * vars into a string passed to `bash -lc`. If any var value contained
+ * shell metacharacters, those metacharacters were interpreted by the
+ * shell (injection). Fix: values are single-quoted at interpolation
+ * time.
+ */
+
+describe('apps/manifest — shellQuote (#140)', () => {
+  it('quotes a plain value', () => {
+    expect(shellQuote('hello')).toBe("'hello'");
+  });
+
+  it('neutralizes an embedded single quote', () => {
+    expect(shellQuote("he'llo")).toBe(`'he'\\''llo'`);
+  });
+
+  it('neutralizes shell metacharacters (;, |, &, $, `)', () => {
+    const hostile = `; rm -rf /; |cat /etc/passwd; \`whoami\`; $(id)`;
+    const quoted = shellQuote(hostile);
+    // Round-trip through a real bash invocation via execFileSync (no
+    // parent-shell escaping footguns). bash echo must reproduce the
+    // input verbatim, proving nothing ran.
+    const out = execSync(`echo ${quoted}`, { shell: '/bin/bash' })
+      .toString()
+      .trimEnd();
+    expect(out).toBe(hostile);
+  });
+});
+
+describe('apps/manifest — interpolateTemplateShell (#140)', () => {
+  it('substitutes variables with shell-safe quoting', () => {
+    const out = interpolateTemplateShell('echo ${A} world', { A: 'safe' });
+    expect(out).toBe("echo 'safe' world");
+  });
+
+  it('neutralizes injection in variable values', () => {
+    const hostile = '; touch /tmp/memphis-pwned-marker-zzz';
+    const step = interpolateTemplateShell('echo ${HOSTILE}', { HOSTILE: hostile });
+    const out = execSync(step, { shell: '/bin/bash' }).toString().trimEnd();
+    // Output must literally contain the hostile string — if bash ran it,
+    // the output would be empty and /tmp/memphis-pwned-marker-zzz would
+    // exist (we don't check the file since that would be racy; the
+    // echo-roundtrip is proof enough).
+    expect(out).toBe(hostile);
+  });
+
+  it('empty var substitutes as empty quoted string', () => {
+    const out = interpolateTemplateShell('x=${MISSING}', {});
+    expect(out).toBe("x=''");
+  });
+});

--- a/tests/unit/circuit-breaker.test.ts
+++ b/tests/unit/circuit-breaker.test.ts
@@ -136,4 +136,26 @@ describe('circuit breaker (Phase 2.1 production sprint)', () => {
     const all = getAllBreakerSnapshots({} as NodeJS.ProcessEnv);
     expect(all).toHaveLength(2);
   });
+
+  it('Codex Round 6 P1: failures after breaker is already OPEN do NOT reset cooldown', () => {
+    // Trip the breaker
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '2',
+      MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: '5000',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 2000);
+    const openedAt = getBreakerSnapshot('anthropic', env).openedAt;
+    const trips = getBreakerSnapshot('anthropic', env).totalTrips;
+    expect(trips).toBe(1);
+
+    // More failures land AFTER state flipped (stale concurrent requests)
+    // — cooldown must NOT be extended and totalTrips must stay at 1.
+    recordProviderOutcome('anthropic', false, env, 3000);
+    recordProviderOutcome('anthropic', false, env, 4000);
+    const snap = getBreakerSnapshot('anthropic', env);
+    expect(snap.state).toBe('open');
+    expect(snap.openedAt).toBe(openedAt);
+    expect(snap.totalTrips).toBe(1);
+  });
 });

--- a/tests/unit/gateway-exec-policy.test.ts
+++ b/tests/unit/gateway-exec-policy.test.ts
@@ -128,5 +128,91 @@ describe('gateway exec-policy', () => {
         enforceGatewayExecAuth('Bearer secret', { authToken: 'secret' }),
       ).not.toThrow();
     });
+
+    it('enforceGatewayExecAuth rejects wrong token of same length (constant-time) (#131)', () => {
+      expect(() =>
+        enforceGatewayExecAuth('Bearer wrongx', { authToken: 'secretx' }),
+      ).toThrow();
+      expect(() =>
+        enforceGatewayExecAuth('Bearer secrex', { authToken: 'secrety' }),
+      ).toThrow();
+    });
+  });
+
+  describe('GATEWAY_EXEC_BLOCKED_TOKENS enforcement (#130)', () => {
+    it('rejects command whose base matches a blocked token', () => {
+      const policy = loadGatewayExecPolicy({
+        GATEWAY_EXEC_ALLOWLIST: 'ls,rm',
+        GATEWAY_EXEC_BLOCKED_TOKENS: 'rm,dd',
+      });
+      expect(() => enforceGatewayExecPolicy('rm file.txt', policy)).toThrow(
+        /blocked token/i,
+      );
+    });
+
+    it('rejects command whose arg matches a blocked token exactly', () => {
+      const policy = loadGatewayExecPolicy({
+        GATEWAY_EXEC_ALLOWLIST: 'ls',
+        GATEWAY_EXEC_BLOCKED_TOKENS: 'danger',
+      });
+      expect(() => enforceGatewayExecPolicy('ls danger', policy)).toThrow(
+        /blocked token/i,
+      );
+    });
+
+    it('allows command when no blocked token matches', () => {
+      const policy = loadGatewayExecPolicy({
+        GATEWAY_EXEC_BLOCKED_TOKENS: 'rm,dd',
+      });
+      expect(() => enforceGatewayExecPolicy('ls -la', policy)).not.toThrow();
+    });
+
+    it('full-autonomy mode bypasses blocked tokens (documented)', () => {
+      const policy = loadGatewayExecPolicy({
+        MEMPHIS_AUTONOMY_MODE: 'full',
+        GATEWAY_EXEC_BLOCKED_TOKENS: 'rm',
+      });
+      expect(() => enforceGatewayExecPolicy('rm -rf /', policy)).not.toThrow();
+    });
+  });
+
+  describe('curl/wget --output flag blocked (#134)', () => {
+    it('blocks curl --output=/path', () => {
+      const policy = loadGatewayExecPolicy({ GATEWAY_EXEC_ALLOWLIST: 'curl' });
+      expect(() =>
+        enforceGatewayExecPolicy('curl --output=/tmp/x http://example.com', policy),
+      ).toThrow();
+    });
+
+    it('blocks curl -o /path', () => {
+      const policy = loadGatewayExecPolicy({ GATEWAY_EXEC_ALLOWLIST: 'curl' });
+      expect(() =>
+        enforceGatewayExecPolicy('curl -o /tmp/x http://example.com', policy),
+      ).toThrow();
+    });
+
+    it('blocks wget --output-document=/path', () => {
+      const policy = loadGatewayExecPolicy({ GATEWAY_EXEC_ALLOWLIST: 'wget' });
+      expect(() =>
+        enforceGatewayExecPolicy(
+          'wget --output-document=/tmp/x http://example.com',
+          policy,
+        ),
+      ).toThrow();
+    });
+
+    it('blocks wget -O /path', () => {
+      const policy = loadGatewayExecPolicy({ GATEWAY_EXEC_ALLOWLIST: 'wget' });
+      expect(() =>
+        enforceGatewayExecPolicy('wget -O /tmp/x http://example.com', policy),
+      ).toThrow();
+    });
+
+    it('allows curl with safe read-only flags', () => {
+      const policy = loadGatewayExecPolicy({ GATEWAY_EXEC_ALLOWLIST: 'curl' });
+      expect(() =>
+        enforceGatewayExecPolicy('curl --silent http://example.com', policy),
+      ).not.toThrow();
+    });
   });
 });

--- a/tests/unit/mcp-code-read-symlink.test.ts
+++ b/tests/unit/mcp-code-read-symlink.test.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runMemphisCodeRead } from '../../src/mcp/tools/code-read.js';
+
+/**
+ * Regression net for #132: memphis_code_read used path.normalize-only for
+ * its sandbox check, so a symlink inside ~/memphis pointing at /etc (or any
+ * outside path) passed validation and readFileSync followed it. The fix
+ * reuses isInsideMemphisSandbox from fs-permission.ts, which realpaths.
+ */
+
+interface TestEnv {
+  tmpHome: string;
+  sandboxDir: string;
+  origHome: string | undefined;
+}
+
+function setup(): TestEnv {
+  const tmpHome = mkdtempSync(path.join(os.tmpdir(), 'memphis-code-read-'));
+  const sandboxDir = path.join(tmpHome, 'memphis');
+  mkdirSync(sandboxDir, { recursive: true });
+  const origHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  return { tmpHome, sandboxDir, origHome };
+}
+
+function tearDown(env: TestEnv): void {
+  if (env.origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = env.origHome;
+  rmSync(env.tmpHome, { recursive: true, force: true });
+}
+
+describe('mcp code-read — symlink escape protection (#132)', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('reads a regular file inside the sandbox', () => {
+    const target = path.join(env.sandboxDir, 'legit.ts');
+    writeFileSync(target, 'export const x = 1;\n', 'utf8');
+    const result = runMemphisCodeRead({ path: target });
+    expect(result.error).toBeUndefined();
+    expect(result.content).toContain('export const x = 1');
+  });
+
+  it('refuses to read through a symlink pointing outside the sandbox', () => {
+    const outsideDir = mkdtempSync(path.join(os.tmpdir(), 'memphis-escape-'));
+    try {
+      const secretFile = path.join(outsideDir, 'secret.txt');
+      writeFileSync(secretFile, 'SENSITIVE', 'utf8');
+
+      const linkPath = path.join(env.sandboxDir, 'escape.ts');
+      symlinkSync(secretFile, linkPath);
+
+      expect(() => runMemphisCodeRead({ path: linkPath })).toThrow(
+        /outside the allowed/i,
+      );
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to descend through a symlink-directory to an outside file', () => {
+    const outsideDir = mkdtempSync(path.join(os.tmpdir(), 'memphis-escape-dir-'));
+    try {
+      const inner = path.join(outsideDir, 'payload.txt');
+      writeFileSync(inner, 'SENSITIVE', 'utf8');
+
+      const linkDir = path.join(env.sandboxDir, 'esc-dir');
+      symlinkSync(outsideDir, linkDir);
+
+      expect(() =>
+        runMemphisCodeRead({ path: path.join(linkDir, 'payload.txt') }),
+      ).toThrow(/outside the allowed/i);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/mcp-native-transport-loopback.test.ts
+++ b/tests/unit/mcp-native-transport-loopback.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { startNativeMcpTransport } from '../../src/bridges/mcp-native-transport.ts';
+
+/**
+ * Regression net for #139. Native MCP transport has no auth by design
+ * (local trust). Must fail-closed on non-loopback bind so a future caller
+ * can't silently expose unauthenticated MCP on the network.
+ */
+
+describe('native MCP transport — loopback enforcement (#139)', () => {
+  it('rejects binding to 0.0.0.0', async () => {
+    await expect(
+      startNativeMcpTransport(async () => ({ jsonrpc: '2.0', id: 1, result: {} }), {
+        host: '0.0.0.0',
+      }),
+    ).rejects.toThrow(/non-loopback/);
+  });
+
+  it('rejects binding to a public IP', async () => {
+    await expect(
+      startNativeMcpTransport(async () => ({ jsonrpc: '2.0', id: 1, result: {} }), {
+        host: '1.2.3.4',
+      }),
+    ).rejects.toThrow(/non-loopback/);
+  });
+
+  it('accepts 127.0.0.1', async () => {
+    const t = await startNativeMcpTransport(
+      async () => ({ jsonrpc: '2.0', id: 1, result: {} }),
+      { host: '127.0.0.1', port: 0 },
+    );
+    await t.close();
+    expect(t.host).toBe('127.0.0.1');
+  });
+
+  it('accepts ::1', async () => {
+    const t = await startNativeMcpTransport(
+      async () => ({ jsonrpc: '2.0', id: 1, result: {} }),
+      { host: '::1', port: 0 },
+    );
+    await t.close();
+    expect(t.host).toBe('::1');
+  });
+
+  it('default (no host option) still binds to loopback', async () => {
+    const t = await startNativeMcpTransport(
+      async () => ({ jsonrpc: '2.0', id: 1, result: {} }),
+      { port: 0 },
+    );
+    await t.close();
+    expect(t.host).toBe('127.0.0.1');
+  });
+});

--- a/tests/unit/mcp-test-run-filter.test.ts
+++ b/tests/unit/mcp-test-run-filter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { runMemphisTest } from '../../src/mcp/tools/test-run.js';
+
+/**
+ * Regression net for #137: memphis_test.filter was pushed raw into the
+ * vitest argv. Any flag starting with '-' became a vitest CLI option, and
+ * --config=<path> loads and executes the file as JS — chained with
+ * fs-write that's arbitrary code execution via a tier-2 tool. Fix: restrict
+ * filter to a plain test-name pattern.
+ */
+
+describe('memphis_test filter validation (#137)', () => {
+  it('rejects filter starting with --', () => {
+    const result = runMemphisTest({ suite: 'ts', filter: '--config=/tmp/x.ts' });
+    expect(result.passed).toBe(false);
+    expect(result.error).toMatch(/flags are not allowed/);
+  });
+
+  it('rejects short-flag filter (-c path)', () => {
+    const result = runMemphisTest({ suite: 'ts', filter: '-c /tmp/x.ts' });
+    expect(result.passed).toBe(false);
+    expect(result.error).toMatch(/flags are not allowed/);
+  });
+
+  it('rejects filter containing shell metacharacters', () => {
+    const result = runMemphisTest({ suite: 'ts', filter: 'name; touch /tmp/x' });
+    expect(result.passed).toBe(false);
+    expect(result.error).toMatch(/must be a plain test-name pattern/);
+  });
+
+  it('rejects filter with equals (--config= form)', () => {
+    const result = runMemphisTest({ suite: 'ts', filter: '--config=x.ts' });
+    expect(result.passed).toBe(false);
+    expect(result.error).toMatch(/flags are not allowed/);
+  });
+
+  // Sanity: allowed characters in a real test-name pattern should still
+  // pass validation — we stop before actually running vitest because the
+  // test runner itself is out of scope for this unit.
+  it('accepts alphanumeric test-name pattern (does not reject at validation)', () => {
+    // We can't easily run vitest inside vitest; we verify the validator
+    // didn't reject by ensuring the error message is absent from the
+    // first 200ms of execution. Keeping the assertion narrow.
+    const result = runMemphisTest({ suite: 'ts', filter: 'my-test_name' });
+    // Either it ran (passed or failed based on tests) OR it's an actual
+    // test-gate failure — but NOT a validation rejection.
+    if (result.error !== undefined) {
+      expect(result.error).not.toMatch(/must be a plain test-name pattern/);
+      expect(result.error).not.toMatch(/flags are not allowed/);
+    }
+  });
+});

--- a/tests/unit/mcp-web-fetch.test.ts
+++ b/tests/unit/mcp-web-fetch.test.ts
@@ -2,21 +2,46 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { runMemphisWebFetch } from '../../src/mcp/tools/web-fetch.js';
 
+/**
+ * SSRF regression net for #128. The old isSafeUrl:
+ *  - missed 169.254/16 (cloud metadata), IPv6 private ranges,
+ *    IPv4-mapped IPv6
+ *  - fetched with redirect: 'follow', so a public URL could 302 to any
+ *    internal address and the fetch executed
+ * New runMemphisWebFetch: blocks those ranges, resolves DNS and re-checks
+ * every returned IP, follows redirects manually with per-hop re-validation.
+ */
+
+const PUBLIC_LOOKUP = async () => [{ address: '93.184.216.34' }]; // example.com
+
+function mockFetch(impl: (url: string) => Partial<Response>): typeof fetch {
+  return ((url: string) => {
+    const r = impl(url);
+    const headers = new Headers((r.headers as HeadersInit) ?? {});
+    return Promise.resolve({
+      status: r.status ?? 200,
+      headers,
+      text: r.text ?? (async () => ''),
+    } as Response);
+  }) as typeof fetch;
+}
+
 describe('mcp tools — web-fetch', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
   it('fetches a public URL successfully', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        status: 200,
-        text: async () => 'Hello World',
-      }),
+    const result = await runMemphisWebFetch(
+      { url: 'https://example.com' },
+      {
+        dnsLookup: PUBLIC_LOOKUP,
+        fetch: mockFetch(() => ({
+          status: 200,
+          text: async () => 'Hello World',
+        })),
+      },
     );
-
-    const result = await runMemphisWebFetch({ url: 'https://example.com' });
     expect(result.status).toBe(200);
     expect(result.content).toBe('Hello World');
     expect(result.truncated).toBe(false);
@@ -24,15 +49,13 @@ describe('mcp tools — web-fetch', () => {
 
   it('truncates responses over 4000 chars', async () => {
     const longContent = 'x'.repeat(5000);
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        status: 200,
-        text: async () => longContent,
-      }),
+    const result = await runMemphisWebFetch(
+      { url: 'https://example.com/long' },
+      {
+        dnsLookup: PUBLIC_LOOKUP,
+        fetch: mockFetch(() => ({ status: 200, text: async () => longContent })),
+      },
     );
-
-    const result = await runMemphisWebFetch({ url: 'https://example.com/long' });
     expect(result.truncated).toBe(true);
     expect(result.content.length).toBe(4000);
   });
@@ -82,5 +105,89 @@ describe('mcp tools — web-fetch', () => {
 
   it('blocks invalid URLs', async () => {
     await expect(runMemphisWebFetch({ url: 'not-a-url' })).rejects.toThrow('URL blocked');
+  });
+
+  // ── New coverage for #128 ────────────────────────────────────────────
+
+  it('blocks 169.254.169.254 (cloud metadata endpoint)', async () => {
+    await expect(
+      runMemphisWebFetch({ url: 'http://169.254.169.254/latest/meta-data/' }),
+    ).rejects.toThrow(/URL blocked/);
+  });
+
+  it('blocks IPv6 loopback [::1]', async () => {
+    await expect(runMemphisWebFetch({ url: 'http://[::1]/' })).rejects.toThrow(
+      /URL blocked/,
+    );
+  });
+
+  it('blocks IPv6 ULA [fc00::1]', async () => {
+    await expect(runMemphisWebFetch({ url: 'http://[fc00::1]/' })).rejects.toThrow(
+      /URL blocked/,
+    );
+  });
+
+  it('blocks IPv6 link-local [fe80::1]', async () => {
+    await expect(runMemphisWebFetch({ url: 'http://[fe80::1]/' })).rejects.toThrow(
+      /URL blocked/,
+    );
+  });
+
+  it('blocks IPv4-mapped IPv6 [::ffff:127.0.0.1]', async () => {
+    await expect(
+      runMemphisWebFetch({ url: 'http://[::ffff:127.0.0.1]/' }),
+    ).rejects.toThrow(/URL blocked/);
+  });
+
+  it('blocks hostname that resolves to a private IP (DNS pre-check)', async () => {
+    await expect(
+      runMemphisWebFetch(
+        { url: 'http://ssrf-bait.example.com/' },
+        {
+          // Attacker registers a public hostname pointing at cloud metadata.
+          dnsLookup: async () => [{ address: '169.254.169.254' }],
+        },
+      ),
+    ).rejects.toThrow(/private\/internal IP/);
+  });
+
+  it('blocks redirect to an internal IP (the real #128 bypass)', async () => {
+    await expect(
+      runMemphisWebFetch(
+        { url: 'https://example.com/redirect-trap' },
+        {
+          dnsLookup: PUBLIC_LOOKUP,
+          fetch: mockFetch((url) => {
+            if (url.includes('redirect-trap')) {
+              return {
+                status: 302,
+                headers: { location: 'http://169.254.169.254/latest/' },
+              };
+            }
+            return { status: 200, text: async () => 'unreachable' };
+          }),
+        },
+      ),
+    ).rejects.toThrow(/private\/internal IP/);
+  });
+
+  it('caps redirect chain at 5 hops', async () => {
+    let hopCount = 0;
+    await expect(
+      runMemphisWebFetch(
+        { url: 'https://example.com/hop' },
+        {
+          dnsLookup: PUBLIC_LOOKUP,
+          fetch: mockFetch(() => {
+            hopCount += 1;
+            return {
+              status: 302,
+              headers: { location: 'https://example.com/next' },
+            };
+          }),
+        },
+      ),
+    ).rejects.toThrow(/too many redirects/);
+    expect(hopCount).toBeGreaterThanOrEqual(5);
   });
 });

--- a/tests/unit/operator-gate-file-mode.test.ts
+++ b/tests/unit/operator-gate-file-mode.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { saveOperatorConfig } from '../../src/infra/auth/operator-gate.ts';
+
+/**
+ * Regression net for #135: operator.json contains the PBKDF2 salt + hash
+ * of the operator passphrase (and recovery answer). It MUST be 0o600 so
+ * no other local user can crack it offline.
+ */
+
+describe('operator-gate — file mode (#135)', () => {
+  let tmpDir: string;
+  let origEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'memphis-opergate-'));
+    origEnv = { ...process.env };
+    process.env.MEMPHIS_DATA_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes operator.json with mode 0o600', () => {
+    const config = {
+      schemaVersion: 1,
+      passphraseHash: 'deadbeef'.repeat(8),
+      salt: 'cafebabe'.repeat(4),
+      createdAt: '2026-04-16T00:00:00.000Z',
+      updatedAt: '2026-04-16T00:00:00.000Z',
+      recoveryQuestionHint: 'q',
+      recoveryHash: 'deadbeef'.repeat(8),
+    };
+
+    saveOperatorConfig(config);
+
+    const filePath = path.join(tmpDir, 'config', 'operator.json');
+    const mode = statSync(filePath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('directory is created with mode 0o700', () => {
+    const config = {
+      schemaVersion: 1,
+      passphraseHash: 'deadbeef'.repeat(8),
+      salt: 'cafebabe'.repeat(4),
+      createdAt: '2026-04-16T00:00:00.000Z',
+      updatedAt: '2026-04-16T00:00:00.000Z',
+      recoveryQuestionHint: 'q',
+      recoveryHash: 'deadbeef'.repeat(8),
+    };
+
+    saveOperatorConfig(config);
+
+    const dirPath = path.join(tmpDir, 'config');
+    const mode = statSync(dirPath).mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+});

--- a/tests/unit/self-modify-path-validation.test.ts
+++ b/tests/unit/self-modify-path-validation.test.ts
@@ -1,0 +1,85 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { validateFilePath } from '../../src/mcp/tools/self-modify.js';
+
+/**
+ * Regression net for #136: self-modify's validateFilePath used path.resolve
+ * only (pure string manipulation — doesn't follow symlinks), so a symlink
+ * inside the project root pointing at an outside target passed validation,
+ * and the subsequent writeFileSync happily followed the link. Fix reuses
+ * realpathOrNearest from fs-permission.ts to resolve symlinks before the
+ * prefix check.
+ */
+
+interface Env {
+  tmpRoot: string;
+  outsideDir: string;
+}
+
+function setup(): Env {
+  const tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'memphis-selfmod-'));
+  const outsideDir = mkdtempSync(path.join(os.tmpdir(), 'memphis-selfmod-outside-'));
+  mkdirSync(path.join(tmpRoot, 'src'), { recursive: true });
+  return { tmpRoot, outsideDir };
+}
+
+function tearDown(env: Env): void {
+  rmSync(env.tmpRoot, { recursive: true, force: true });
+  rmSync(env.outsideDir, { recursive: true, force: true });
+}
+
+describe('self-modify — validateFilePath', () => {
+  let env: Env;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('accepts a normal path inside project root', () => {
+    const out = validateFilePath('src/app.ts', env.tmpRoot);
+    expect(out).toBe(path.join(env.tmpRoot, 'src', 'app.ts'));
+  });
+
+  it('rejects a dotfile at the root (.env)', () => {
+    expect(() => validateFilePath('.env', env.tmpRoot)).toThrow(/Dotfile/);
+  });
+
+  it('rejects paths containing .git/', () => {
+    expect(() => validateFilePath('.git/HEAD', env.tmpRoot)).toThrow();
+  });
+
+  it('rejects path traversal out of project root', () => {
+    expect(() => validateFilePath('../escape.ts', env.tmpRoot)).toThrow(
+      /Path traversal/,
+    );
+  });
+
+  it('rejects a symlink inside the root whose target is outside (#136)', () => {
+    const outsideTarget = path.join(env.outsideDir, 'evil.ts');
+    writeFileSync(outsideTarget, 'malicious', 'utf8');
+
+    const linkInsideRoot = path.join(env.tmpRoot, 'src', 'sneaky.ts');
+    symlinkSync(outsideTarget, linkInsideRoot);
+
+    expect(() => validateFilePath('src/sneaky.ts', env.tmpRoot)).toThrow(
+      /Path traversal/,
+    );
+  });
+
+  it('rejects a symlinked directory inside root pointing outside (#136)', () => {
+    const linkDir = path.join(env.tmpRoot, 'src', 'linked');
+    symlinkSync(env.outsideDir, linkDir);
+
+    expect(() => validateFilePath('src/linked/payload.ts', env.tmpRoot)).toThrow(
+      /Path traversal/,
+    );
+  });
+});

--- a/tests/unit/turn-admission.test.ts
+++ b/tests/unit/turn-admission.test.ts
@@ -128,6 +128,71 @@ describe('turn admission control (Phase 2.2 production sprint)', () => {
     for (const t of tickets) t.release();
   });
 
+  it('Codex Round 6 P1: raising MEMPHIS_MAX_CONCURRENT_TURNS drains queue to new cap', async () => {
+    const savedMax = process.env.MEMPHIS_MAX_CONCURRENT_TURNS;
+    process.env.MEMPHIS_MAX_CONCURRENT_TURNS = '1';
+    try {
+      // Acquire 1 (cap) + queue 3
+      const a = await acquireTurnSlot(process.env);
+      const p1 = acquireTurnSlot(process.env);
+      const p2 = acquireTurnSlot(process.env);
+      const p3 = acquireTurnSlot(process.env);
+      await Promise.resolve();
+      expect(getAdmissionState().queued).toBe(3);
+
+      // Raise cap mid-flight
+      process.env.MEMPHIS_MAX_CONCURRENT_TURNS = '4';
+
+      // Release a — admitOne should now pump ALL queued callers
+      // immediately because the new cap allows it.
+      a.release();
+      const r1 = await p1;
+      const r2 = await p2;
+      const r3 = await p3;
+      expect(getAdmissionState().active).toBe(3);
+      expect(getAdmissionState().queued).toBe(0);
+
+      r1.release();
+      r2.release();
+      r3.release();
+    } finally {
+      if (savedMax !== undefined) process.env.MEMPHIS_MAX_CONCURRENT_TURNS = savedMax;
+      else delete process.env.MEMPHIS_MAX_CONCURRENT_TURNS;
+    }
+  });
+
+  it('Codex Round 6 P1: lowering MEMPHIS_MAX_CONCURRENT_TURNS stops admission until active drains', async () => {
+    const savedMax = process.env.MEMPHIS_MAX_CONCURRENT_TURNS;
+    process.env.MEMPHIS_MAX_CONCURRENT_TURNS = '3';
+    try {
+      const a = await acquireTurnSlot(process.env);
+      const b = await acquireTurnSlot(process.env);
+      const c = await acquireTurnSlot(process.env);
+      const p1 = acquireTurnSlot(process.env);
+      await Promise.resolve();
+      expect(getAdmissionState().queued).toBe(1);
+
+      // Operator lowers cap to 1 — but 3 are already active.
+      process.env.MEMPHIS_MAX_CONCURRENT_TURNS = '1';
+
+      // Release one — admitOne must NOT admit the queued caller
+      // because active (2) is still above the new cap (1).
+      a.release();
+      await Promise.resolve();
+      expect(getAdmissionState().queued).toBe(1);
+
+      // Release the rest — once active drops below 1 again, queue admits.
+      b.release();
+      c.release();
+      const r1 = await p1;
+      expect(getAdmissionState().active).toBe(1);
+      r1.release();
+    } finally {
+      if (savedMax !== undefined) process.env.MEMPHIS_MAX_CONCURRENT_TURNS = savedMax;
+      else delete process.env.MEMPHIS_MAX_CONCURRENT_TURNS;
+    }
+  });
+
   it('totalAdmitted and totalQueued counters track lifetime traffic', async () => {
     const env = { MEMPHIS_MAX_CONCURRENT_TURNS: '1' } as NodeJS.ProcessEnv;
     const a = await acquireTurnSlot(env);

--- a/tests/unit/web-dashboard-xss.test.ts
+++ b/tests/unit/web-dashboard-xss.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { WebDashboard, type DashboardData } from '../../src/dashboard/web-dashboard.ts';
+
+/**
+ * Regression net for #138. Dashboard HTML used to interpolate
+ * AI-generated predictions, insights, actions, quick-wins, and tag names
+ * directly into template literals with no escaping — a stored XSS vector
+ * for any input that reaches the dashboard (via federation sync, via
+ * prompt injection into the insight pipeline, etc.). Fix: esc() wraps
+ * every dynamic field.
+ */
+
+function buildHostileData(): DashboardData {
+  const payload = '<img src=x onerror="alert(1)">';
+  return {
+    stats: {
+      totalBlocks: 1,
+      totalChains: 1,
+      oldestBlock: '2026-01-01',
+      newestBlock: '2026-04-16',
+      topTags: [{ tag: payload, count: 1 }],
+      blocksPerChain: [{ chain: 'main', count: 1 }],
+    },
+    insights: [
+      { type: 'pattern', title: payload, description: payload, confidence: 0.8 },
+    ],
+    predictions: [{ title: payload, confidence: 0.9, reasoning: payload }],
+    mood: 'productive',
+    quickWins: [payload],
+    nextActions: [payload],
+  };
+}
+
+describe('web-dashboard HTML escaping (#138)', () => {
+  const dashboard = new WebDashboard(
+    { port: 0, host: '127.0.0.1', refreshIntervalMs: 30_000 },
+    async () => buildHostileData(),
+  );
+
+  it('escapes hostile payload in predictions', () => {
+    const html = dashboard.renderDashboard(buildHostileData());
+    expect(html).not.toContain('<img src=x onerror="alert(1)">');
+    expect(html).toContain('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
+  });
+
+  it('escapes in insights, actions, wins, tags', () => {
+    const html = dashboard.renderDashboard(buildHostileData());
+    // At least 5 occurrences (predictions.title, predictions.reasoning,
+    // insights.title, insights.description, nextActions, quickWins, tag) —
+    // assert ≥ 5 to be resilient to template reordering.
+    const matches = html.match(/&lt;img src=x onerror=&quot;alert\(1\)&quot;&gt;/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('preserves safe content unchanged', () => {
+    const data = buildHostileData();
+    data.predictions[0].title = 'Normal prediction title';
+    data.predictions[0].reasoning = 'Because reasons';
+    const html = dashboard.renderDashboard(data);
+    expect(html).toContain('Normal prediction title');
+    expect(html).toContain('Because reasons');
+  });
+});

--- a/tests/unit/zombie-cleanup.test.ts
+++ b/tests/unit/zombie-cleanup.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { isMemphisProcess } from '../../src/infra/ops/zombie-cleanup.ts';
+
+/**
+ * Regression net for #133. The old filter was
+ *   if (cmd.includes('tsx') || cmd.includes('node') && cmd.includes('memphis'))
+ * which parsed as `tsx || (node && memphis)` — ANY tsx process on the host
+ * was killed, including unrelated dev work.
+ */
+
+describe('zombie-cleanup — isMemphisProcess (#133)', () => {
+  it('matches node + memphis cmdline', () => {
+    expect(isMemphisProcess('node /home/user/memphis/dist/index.js')).toBe(true);
+  });
+
+  it('matches tsx + memphis cmdline', () => {
+    expect(isMemphisProcess('tsx /home/user/memphis/src/index.ts')).toBe(true);
+  });
+
+  it('does NOT match unrelated tsx process (regression)', () => {
+    expect(isMemphisProcess('tsx /tmp/some-script.ts')).toBe(false);
+    expect(isMemphisProcess('node /home/user/other-project/app.js')).toBe(false);
+  });
+
+  it('does NOT match non-tsx/node processes even if they contain "memphis"', () => {
+    expect(isMemphisProcess('vim /home/user/memphis/README.md')).toBe(false);
+    expect(isMemphisProcess('less /home/user/memphis/docs/api.md')).toBe(false);
+  });
+
+  it('does NOT match empty/garbage strings', () => {
+    expect(isMemphisProcess('')).toBe(false);
+    expect(isMemphisProcess('   ')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Bundled fixes for the 13 issues surfaced by a two-phase security scan:
**Phase A** — 9 parallel-agent scan clusters over the top-30 attack-surface files, plus manual code-read verification.
**Phase B** — one fix per issue with a PoC test that fails on current code and goes green on the fix.

Result: **13 issues closed, 8 new test files (+53 tests → 2037/2037), 0 regressions.**

Stacks on top of `hotfix/codex-round-6` (unmerged). When that lands, this PR auto-rebases to show only the security-scan commit.

## Closes

- HIGH   #128  SSRF bypass in `memphis_web_fetch` (redirect + IPv6 + metadata)
- HIGH   #129  `npm audit` — fastify / hono / @hono/node-server upgrade + CI audit step
- HIGH   #134  `curl/wget --output=` arbitrary file write via exec allowlist
- HIGH   #135  `operator.json` PBKDF2 salt+hash world-readable (file mode 0o600 + dir 0o700)
- MED    #130  `GATEWAY_EXEC_BLOCKED_TOKENS` enforced (token-level match)
- MED    #132  `memphis_code_read` reuses `isInsideMemphisSandbox` (realpath-based)
- MED    #136  `memphis_self_modify` realpaths both root and target
- MED    #137  `memphis_test` filter restricted to test-name pattern (no CLI flags)
- MED    #138  Dashboard HTML-escapes dynamic fields
- LOW    #131  `/exec` auth compare uses `secureCompare`
- LOW    #133  `zombie-cleanup` operator-precedence fix + first test coverage
- LOW    #139  Native MCP transport fails-closed on non-loopback host
- LOW    #140  `apps/manifest` steps use `shellQuote` before `bash -lc`

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 2037 / 2037 passing (+53 new)
- [x] `npm audit --omit=dev --audit-level=high` — 0 advisories
- [x] `cargo check --workspace` — clean

## Methodology

Scan used the XBOW-style playbook: attack-surface ranking → parallel agents → manual code verification → exploit-as-severity-oracle. ~45 raw candidates → 7 confirmed new (+ original 6) → 38 culled as false-positive / out-of-scope / by-design. See individual issues #128–#140 for per-finding PoC sketches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)