### PR TITLE
fix: security scan round 2 + Codex follow-ups (7 items)

### DIFF
--- a/bin/memphis.js
+++ b/bin/memphis.js
@@ -41,6 +41,11 @@ function recordBootAttemptEarly() {
     record.failures.push({ at: new Date().toISOString() });
     record.failures = record.failures.slice(-50);
     writeFileSync(statePath, JSON.stringify(record), 'utf8');
+    // Signal to bootstrap.ts that we already recorded this attempt so
+    // it can skip its own call — otherwise a crashing serve launch
+    // double-counts, exceeding the auto-revert threshold after a single
+    // real failure (#141 Codex P1).
+    process.env.MEMPHIS_BOOT_ATTEMPT_RECORDED = '1';
   } catch {
     /* best-effort — never break CLI because of bookkeeping */
   }

--- a/crates/memphis-vault/src/two_factor.rs
+++ b/crates/memphis-vault/src/two_factor.rs
@@ -60,18 +60,30 @@ pub fn derive_vault_key_with_2fa_v1(master_key: &[u8; 32], qa_answer: &str) -> [
 }
 
 /// HKDF-based 2FA derivation (v2). Uses master_key as IKM and QA answer hash as salt.
-pub fn derive_vault_key_with_2fa_v2(master_key: &[u8; 32], qa_answer: &str) -> [u8; 32] {
+///
+/// Returns Result — production code should never panic on key derivation. Prior
+/// versions used `.expect()` on both the hex decode and the HKDF expand; the
+/// panics were only reachable via internal-logic corruption (#144), but
+/// non-panicking error propagation is table-stakes for the crypto layer.
+pub fn derive_vault_key_with_2fa_v2(
+    master_key: &[u8; 32],
+    qa_answer: &str,
+) -> Result<[u8; 32], VaultError> {
     let qa_hash = hash_answer(qa_answer);
-    let qa_bytes = hex::decode(&qa_hash).expect("valid hex");
+    let qa_bytes = hex::decode(&qa_hash)
+        .map_err(|e| VaultError::KeyDerivation(format!("2fa qa_hash decode: {e}")))?;
     let hk = Hkdf::<Sha256>::new(Some(&qa_bytes), master_key);
     let mut vault_key = [0u8; 32];
     hk.expand(b"memphis-vault-2fa-v2", &mut vault_key)
-        .expect("32 bytes is valid for HKDF-SHA256");
-    vault_key
+        .map_err(|e| VaultError::KeyDerivation(format!("2fa HKDF expand: {e}")))?;
+    Ok(vault_key)
 }
 
 /// Default 2FA derivation — uses v2 (HKDF).
-pub fn derive_vault_key_with_2fa(master_key: &[u8; 32], qa_answer: &str) -> [u8; 32] {
+pub fn derive_vault_key_with_2fa(
+    master_key: &[u8; 32],
+    qa_answer: &str,
+) -> Result<[u8; 32], VaultError> {
     derive_vault_key_with_2fa_v2(master_key, qa_answer)
 }
 
@@ -115,16 +127,16 @@ mod tests {
     #[test]
     fn test_derive_vault_key_v2_deterministic() {
         let master_key = [42u8; 32];
-        let key1 = derive_vault_key_with_2fa_v2(&master_key, "answer1");
-        let key2 = derive_vault_key_with_2fa_v2(&master_key, "answer1");
+        let key1 = derive_vault_key_with_2fa_v2(&master_key, "answer1").unwrap();
+        let key2 = derive_vault_key_with_2fa_v2(&master_key, "answer1").unwrap();
         assert_eq!(key1, key2);
     }
 
     #[test]
     fn test_derive_vault_key_v2_different_answers() {
         let master_key = [42u8; 32];
-        let key1 = derive_vault_key_with_2fa_v2(&master_key, "answer1");
-        let key2 = derive_vault_key_with_2fa_v2(&master_key, "answer2");
+        let key1 = derive_vault_key_with_2fa_v2(&master_key, "answer1").unwrap();
+        let key2 = derive_vault_key_with_2fa_v2(&master_key, "answer2").unwrap();
         assert_ne!(key1, key2);
     }
 
@@ -133,7 +145,7 @@ mod tests {
     fn test_v1_and_v2_produce_different_keys() {
         let master_key = [42u8; 32];
         let v1 = derive_vault_key_with_2fa_v1(&master_key, "answer1");
-        let v2 = derive_vault_key_with_2fa_v2(&master_key, "answer1");
+        let v2 = derive_vault_key_with_2fa_v2(&master_key, "answer1").unwrap();
         assert_ne!(
             v1, v2,
             "v1 and v2 must produce different keys for same input"
@@ -143,8 +155,22 @@ mod tests {
     #[test]
     fn test_default_uses_v2() {
         let master_key = [42u8; 32];
-        let default_key = derive_vault_key_with_2fa(&master_key, "answer1");
-        let v2_key = derive_vault_key_with_2fa_v2(&master_key, "answer1");
+        let default_key = derive_vault_key_with_2fa(&master_key, "answer1").unwrap();
+        let v2_key = derive_vault_key_with_2fa_v2(&master_key, "answer1").unwrap();
         assert_eq!(default_key, v2_key);
+    }
+
+    // Regression net for #144: production code paths must return Result, not
+    // panic. hash_answer always produces valid hex today, so the error path
+    // is only reachable via internal-logic corruption — we can't easily
+    // trigger it without mocking hash_answer. This test instead asserts the
+    // Ok-path contract: valid input always yields Ok(...), the function
+    // signature is Result, and a caller can use `?`-propagation.
+    #[test]
+    fn test_derive_vault_key_v2_returns_result() {
+        let master_key = [1u8; 32];
+        let result: Result<[u8; 32], VaultError> =
+            derive_vault_key_with_2fa_v2(&master_key, "sample-answer");
+        assert!(result.is_ok(), "valid input must produce Ok(_)");
     }
 }

--- a/crates/memphis-vault/src/vault.rs
+++ b/crates/memphis-vault/src/vault.rs
@@ -60,7 +60,7 @@ impl Vault {
         let qa_challenge = QAChallenge::new(config.qa_question, &config.qa_answer)?;
 
         // 3. Derive vault key with 2FA
-        let vault_key = derive_vault_key_with_2fa(&master_key, &config.qa_answer);
+        let vault_key = derive_vault_key_with_2fa(&master_key, &config.qa_answer)?;
 
         // 4. Generate DID
         let (did, private_key) = MemphisDid::generate()?;

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -52,8 +52,8 @@ import {
 import { writeSecurityCriticalEvent } from '../infra/runtime/security-critical.js';
 import {
   evaluateAutoRevert,
+  maybeRecordBootAttempt,
   performAutoRevert,
-  recordBootAttempt,
   recordBootSuccess,
 } from '../infra/runtime/self-modify-revert.js';
 import {
@@ -88,7 +88,14 @@ export async function bootstrap(): Promise<void> {
   // Phase 2.3 production sprint: bump the boot-attempt counter BEFORE
   // any risky init. If we crash mid-init, the next process sees the
   // failure and may auto-revert a recent self-modify commit.
-  recordBootAttempt(process.env);
+  //
+  // Codex P1 follow-up on PR #141: the production entry `bin/memphis.js`
+  // now records the boot attempt EARLY (before importing dist so import-
+  // time crashes still bump the counter) and sets MEMPHIS_BOOT_ATTEMPT_RECORDED.
+  // `maybeRecordBootAttempt` skips the bump when the env var is set,
+  // preventing double-counting in production. Non-production entries
+  // (tsx dev, tests) bypass bin/memphis.js and still record here.
+  maybeRecordBootAttempt(process.env);
 
   // Then evaluate whether the prior crashes warrant a revert. If yes,
   // perform it and continue boot — the just-reverted code is what we'll

--- a/src/dashboard/web-dashboard.ts
+++ b/src/dashboard/web-dashboard.ts
@@ -11,6 +11,7 @@
 import * as http from 'http';
 
 import { createLogger } from '../infra/logging/logger.js';
+import { secureCompare } from '../security/constant-time.js';
 
 const logger = createLogger('info', 'text', { component: 'WebDashboard' });
 
@@ -35,7 +36,17 @@ export interface DashboardConfig {
   port: number;
   host: string;
   refreshIntervalMs: number;
+  /**
+   * Optional Bearer token for /api/data and the HTML dashboard.
+   * When set, requests must include `Authorization: Bearer <token>`.
+   * Default (undefined) preserves the historic localhost-no-auth
+   * behavior. If host is non-loopback and no token is set, start()
+   * logs a loud warning (#143).
+   */
+  authToken?: string;
 }
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '::ffff:127.0.0.1']);
 
 export interface DashboardData {
   stats: {
@@ -69,11 +80,34 @@ export class WebDashboard {
 
   constructor(dataProvider: () => Promise<DashboardData>, config: Partial<DashboardConfig> = {}) {
     this.config = {
-      port: config.port || 3131,
-      host: config.host || 'localhost',
-      refreshIntervalMs: config.refreshIntervalMs || 30000,
+      port: config.port ?? 3131,
+      host: config.host ?? 'localhost',
+      refreshIntervalMs: config.refreshIntervalMs ?? 30000,
+      authToken: config.authToken,
     };
     this.dataProvider = dataProvider;
+  }
+
+  /**
+   * Constant-time compare of the incoming Authorization header against
+   * the configured token. Returns true when:
+   *  - no token is configured (historic no-auth path), or
+   *  - the header matches "Bearer <token>" byte-for-byte.
+   */
+  private isAuthorized(authHeader: string | undefined): boolean {
+    if (!this.config.authToken) return true;
+    if (typeof authHeader !== 'string') return false;
+    return secureCompare(authHeader, `Bearer ${this.config.authToken}`);
+  }
+
+  private serveUnauthorized(res: http.ServerResponse): void {
+    res.writeHead(401, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        error: 'unauthorized',
+        message: 'dashboard requires Authorization: Bearer <token>',
+      }),
+    );
   }
 
   /**
@@ -83,12 +117,20 @@ export class WebDashboard {
     return new Promise((resolve, reject) => {
       this.server = http.createServer(async (req, res) => {
         try {
+          // /api/health is always public (monitoring probes).
+          if (req.url === '/api/health') {
+            this.serveHealth(res);
+            return;
+          }
+          // Everything else enforces the optional Bearer token (#143).
+          if (!this.isAuthorized(req.headers.authorization)) {
+            this.serveUnauthorized(res);
+            return;
+          }
           if (req.url === '/' || req.url === '/index.html') {
             await this.serveDashboard(res);
           } else if (req.url === '/api/data') {
             await this.serveData(res);
-          } else if (req.url === '/api/health') {
-            this.serveHealth(res);
           } else {
             this.serve404(res);
           }
@@ -98,7 +140,24 @@ export class WebDashboard {
       });
 
       this.server.listen(this.config.port, this.config.host, () => {
-        logger.info('Memphis Dashboard started', { host: this.config.host, port: this.config.port });
+        logger.info('Memphis Dashboard started', {
+          host: this.config.host,
+          port: this.config.port,
+          authEnforced: !!this.config.authToken,
+        });
+        // Loud warning when host is exposed beyond loopback with no auth
+        // configured. Default remains "localhost + no auth" for
+        // backwards compat; operators who set a non-loopback host get
+        // nudged to set authToken too (#143).
+        if (
+          !LOOPBACK_HOSTS.has(this.config.host) &&
+          !this.config.authToken
+        ) {
+          logger.warn(
+            'Memphis Dashboard is bound to a non-loopback host with NO auth token — any LAN client can read dashboard data. Set DashboardConfig.authToken to require a Bearer token.',
+            { host: this.config.host },
+          );
+        }
         resolve();
       });
 

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -842,16 +842,24 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
     // against the breaker. Validation / 4xx bursts must not trip it.
     // PROVIDER_TIMEOUT / PROVIDER_UNAVAILABLE / PROVIDER_RATE_LIMIT are
     // the AppError codes that genuinely indicate provider-side trouble.
+    //
+    // Codex P1 follow-up (on PR #141): the prior revision SKIPPED the
+    // breaker call entirely for non-transient errors, which stranded
+    // the halfOpenProbeInFlight flag set by admitProviderCall — every
+    // subsequent call then failed fast as "probe in flight" until
+    // process restart. Now we always settle the probe flag; the
+    // countAsTrip flag distinguishes transient (counts) from
+    // non-transient (settles probe without tripping).
     try {
       const isTransient =
         error instanceof AppError &&
         (error.code === 'PROVIDER_TIMEOUT' ||
           error.code === 'PROVIDER_UNAVAILABLE' ||
           error.code === 'PROVIDER_RATE_LIMIT');
-      if (isTransient) {
-        const { recordProviderOutcome } = await import('../infra/runtime/circuit-breaker.js');
-        recordProviderOutcome(llm.provider, false, rawEnvWithTier3);
-      }
+      const { recordProviderOutcome } = await import('../infra/runtime/circuit-breaker.js');
+      recordProviderOutcome(llm.provider, false, rawEnvWithTier3, Date.now(), {
+        countAsTrip: isTransient,
+      });
     } catch {
       /* breaker recording is best-effort */
     }

--- a/src/infra/runtime/circuit-breaker.ts
+++ b/src/infra/runtime/circuit-breaker.ts
@@ -35,6 +35,7 @@ export interface BreakerSnapshot {
   lastFailureAt?: string;
   openedAt?: string;
   halfOpenAt?: string;
+  halfOpenProbeInFlight: boolean;
   totalTrips: number;
   totalRecoveries: number;
 }
@@ -149,15 +150,24 @@ export function admitProviderCall(
 /**
  * Record the outcome of a provider call. Failures may trip the breaker;
  * a half-open success closes it; a half-open failure re-opens.
+ *
+ * Codex Round 6 follow-up: `countAsTrip` distinguishes transient provider
+ * faults (timeouts, rate limits, 5xx — should count against the trip
+ * threshold) from non-transient errors (validation, 4xx, caller bugs —
+ * must NOT count, but MUST still settle the half-open probe flag so
+ * subsequent calls aren't locked out forever). Prior behavior skipped
+ * the entire call on non-transient errors, stranding the probe flag.
  */
 export function recordProviderOutcome(
   provider: string,
   ok: boolean,
   rawEnv: NodeJS.ProcessEnv = process.env,
   now: number = Date.now(),
+  opts: { countAsTrip?: boolean } = {},
 ): void {
   const rec = getOrCreate(provider);
   const { failureThreshold, windowMs } = envThresholds(provider, rawEnv);
+  const countAsTrip = opts.countAsTrip ?? true;
 
   if (rec.state === 'half-open') {
     rec.halfOpenProbeInFlight = false;
@@ -168,12 +178,17 @@ export function recordProviderOutcome(
       rec.openedAt = undefined;
       rec.halfOpenAt = undefined;
       rec.totalRecoveries += 1;
-    } else {
-      // Probe failed — back to open with a fresh cooldown
+    } else if (countAsTrip) {
+      // Transient probe failure — back to open with a fresh cooldown
       rec.state = 'open';
       rec.openedAt = now;
       rec.lastFailureAt = now;
       rec.totalTrips += 1;
+    } else {
+      // Non-transient failure during probe: provider state is still
+      // unknown, so stay half-open. Probe flag is cleared above; next
+      // admitProviderCall will admit another probe.
+      rec.lastFailureAt = now;
     }
     return;
   }
@@ -181,6 +196,13 @@ export function recordProviderOutcome(
   if (ok) {
     // Successful call in CLOSED state — drop stale failures
     rec.failureTimestamps = rec.failureTimestamps.filter((t) => now - t < windowMs);
+    return;
+  }
+
+  // Non-transient errors in the closed state don't count toward the
+  // trip threshold (validation errors, caller-side 4xx, etc.).
+  if (!countAsTrip) {
+    rec.lastFailureAt = now;
     return;
   }
 
@@ -224,6 +246,7 @@ export function getBreakerSnapshot(
       : undefined,
     openedAt: rec.openedAt ? new Date(rec.openedAt).toISOString() : undefined,
     halfOpenAt: rec.halfOpenAt ? new Date(rec.halfOpenAt).toISOString() : undefined,
+    halfOpenProbeInFlight: rec.halfOpenProbeInFlight,
     totalTrips: rec.totalTrips,
     totalRecoveries: rec.totalRecoveries,
   };

--- a/src/infra/runtime/self-modify-revert.ts
+++ b/src/infra/runtime/self-modify-revert.ts
@@ -109,6 +109,25 @@ export function recordBootAttempt(rawEnv: NodeJS.ProcessEnv = process.env): void
 }
 
 /**
+ * Record a boot attempt UNLESS the pre-bootstrap CLI wrapper already did.
+ *
+ * Production: `bin/memphis.js` records early (before dist imports) so
+ * import-time crashes still bump the counter, and sets
+ * MEMPHIS_BOOT_ATTEMPT_RECORDED=1 so we don't double-count here.
+ *
+ * Dev (tsx/test): the wrapper isn't in the path, so this records
+ * normally. Prevents the "1 real crash = 2 counted attempts" bug that
+ * would cross the auto-revert threshold one crash too early (Codex P1
+ * on PR #141).
+ */
+export function maybeRecordBootAttempt(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): void {
+  if (rawEnv.MEMPHIS_BOOT_ATTEMPT_RECORDED === '1') return;
+  recordBootAttempt(rawEnv);
+}
+
+/**
  * Called at the END of successful bootstrap. Clears the failure
  * counter — we made it through.
  */

--- a/src/infra/storage/chain-adapter.ts
+++ b/src/infra/storage/chain-adapter.ts
@@ -187,6 +187,8 @@ export async function appendPrecomputedBlock(
     hash: string;
     prev_hash: string;
     data: Record<string, unknown>;
+    signer?: string;
+    signature?: string;
   },
   _rawEnv: NodeJS.ProcessEnv = process.env,
 ): Promise<{ index: number; hash: string; chain: string; timestamp: string }> {
@@ -209,6 +211,8 @@ export async function appendPrecomputedBlock(
     data: block.data,
     prev_hash: block.prev_hash,
     hash: block.hash,
+    ...(block.signer !== undefined ? { signer: block.signer } : {}),
+    ...(block.signature !== undefined ? { signature: block.signature } : {}),
   };
 
   const filename = path.join(chainsDir, `${String(block.index).padStart(6, '0')}.json`);

--- a/src/infra/storage/rust-vault-adapter.ts
+++ b/src/infra/storage/rust-vault-adapter.ts
@@ -1,9 +1,12 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes, scryptSync } from 'node:crypto';
 import {
   chmodSync,
+  closeSync,
   copyFileSync,
   existsSync,
+  fsyncSync,
   mkdirSync,
+  openSync,
   readFileSync,
   renameSync,
   unlinkSync,
@@ -21,6 +24,31 @@ import {
 import { parseBool } from '../../core/env.js';
 import { errorTemplates } from '../../core/errors.js';
 import { writeSecurityAudit } from '../logging/security-audit.js';
+
+/**
+ * fsync a file so writes are durable on disk. Used between
+ * writeFileSync(tmp) and renameSync(tmp, live) during vault rotation
+ * (#145). Silently tolerates platforms/filesystems where fsync isn't
+ * available — the rename itself is still the primary durability
+ * barrier, fsync just closes the crash-between-write-and-rename window.
+ */
+function fsyncFile(path: string): void {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, 'r+');
+    fsyncSync(fd);
+  } catch {
+    // Best-effort; proceed with the rename even if fsync isn't supported.
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // noop
+      }
+    }
+  }
+}
 
 export interface RustVaultAdapterStatus {
   rustEnabled: boolean;
@@ -734,6 +762,14 @@ export function rotateVaultMasterKey(
     } catch {
       // chmod non-fatal
     }
+
+    // Fsync both tmp files before the first rename (#145). writeFileSync
+    // doesn't guarantee durability until the buffer is flushed to disk —
+    // a crash between writeFileSync and renameSync could leave a torn
+    // tmp that the catch-block rollback then restores from a half-written
+    // state. Explicit fsync here closes that window.
+    fsyncFile(tmpState);
+    fsyncFile(tmpEntries);
 
     renameSync(tmpState, statePath);
     try {

--- a/src/mcp/tools/web-fetch.ts
+++ b/src/mcp/tools/web-fetch.ts
@@ -80,6 +80,11 @@ function isPrivateIp(ip: string): boolean {
   return true; // unknown → unsafe
 }
 
+/** URL.hostname includes brackets for IPv6 literals — strip them. */
+function stripIpv6Brackets(host: string): string {
+  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+}
+
 export interface SafeFetchDeps {
   /**
    * DNS resolver used for the pre-fetch host check. Override in tests so
@@ -151,7 +156,11 @@ function assertUrlShapeSafe(rawUrl: string): URL {
       403,
     );
   }
-  const host = parsed.hostname.toLowerCase();
+  // URL.hostname keeps the brackets on IPv6 literals (e.g. "[::1]"),
+  // which would make net.isIP return 0 and skip the private-IP check,
+  // and would poison dns.lookup with a non-resolvable bracketed string.
+  // Strip the brackets before any host-classification logic.
+  const host = stripIpv6Brackets(parsed.hostname.toLowerCase());
   if (!host) {
     throw new AppError('VALIDATION_ERROR', 'URL blocked: empty host', 403);
   }
@@ -166,7 +175,7 @@ function assertUrlShapeSafe(rawUrl: string): URL {
     );
   }
   // Literal-IP shortcut: if the host is already an IP literal we can check
-  // it directly without DNS. `[::1]` etc. get stripped of brackets by URL.
+  // it directly without DNS.
   if (net.isIP(host) !== 0) {
     if (isPrivateIp(host)) {
       throw new AppError(
@@ -187,7 +196,7 @@ export async function runMemphisWebFetch(
   let currentUrl = input.url;
   let currentParsed = assertUrlShapeSafe(currentUrl);
 
-  await assertHostSafe(currentParsed.hostname, deps);
+  await assertHostSafe(stripIpv6Brackets(currentParsed.hostname), deps);
 
   let response: Response | null = null;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
@@ -205,7 +214,7 @@ export async function runMemphisWebFetch(
       const next = new URL(location, currentUrl).toString();
       currentUrl = next;
       currentParsed = assertUrlShapeSafe(currentUrl);
-      await assertHostSafe(currentParsed.hostname, deps);
+      await assertHostSafe(stripIpv6Brackets(currentParsed.hostname), deps);
       if (hop === MAX_REDIRECTS) {
         throw new AppError(
           'VALIDATION_ERROR',

--- a/src/memory/chain.ts
+++ b/src/memory/chain.ts
@@ -8,4 +8,8 @@ export interface Block {
     tags?: string[];
     [key: string]: unknown;
   };
+  /** Hex-encoded ed25519 public key of the signer. */
+  signer?: string;
+  /** Hex-encoded ed25519 signature over the canonical block hash. */
+  signature?: string;
 }

--- a/src/sync/signature-verify.ts
+++ b/src/sync/signature-verify.ts
@@ -1,0 +1,47 @@
+import { createPinoLogger } from '../infra/logging/pino.js';
+import { NapiChainAdapter } from '../infra/storage/rust-chain-adapter.js';
+import type { Block } from '../memory/chain.js';
+
+const logger = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+
+/**
+ * Verify an ed25519 signature on a peer-origin chain block.
+ *
+ * Routes through the Rust `chain_validate` NAPI so the canonical-hash
+ * computation and signature verification are identical to what the
+ * local append path enforces. Returns:
+ *   - true:  signature is cryptographically valid
+ *   - false: signature is malformed, missing, or verification failed
+ *
+ * Failures are logged (not thrown) so the caller can decide whether to
+ * reject the block vs fall back to MEMPHIS_SYNC_ACCEPT_UNSIGNED.
+ */
+export async function verifyChainBlockSignature(block: Block): Promise<boolean> {
+  if (!block.signer || !block.signature) return false;
+  try {
+    const adapter = new NapiChainAdapter(process.env);
+    // The Rust bridge's validateBlock re-computes the canonical hash
+    // and verifies the ed25519 signature if signer/signature are
+    // present. When REQUIRE_SIGNATURES is off, validateBlock still
+    // verifies whenever signer+signature are supplied — which is
+    // exactly what we want here.
+    const result = adapter.validateBlock(block);
+    if (result.valid) return true;
+    logger.warn({
+      event: 'sync.block.signature_invalid',
+      chain: block.chain,
+      index: block.index,
+      signer: block.signer,
+      errors: result.errors,
+    });
+    return false;
+  } catch (error) {
+    logger.warn({
+      event: 'sync.block.signature_verify_error',
+      chain: block.chain,
+      index: block.index,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}

--- a/src/sync/sync-manager.ts
+++ b/src/sync/sync-manager.ts
@@ -207,55 +207,59 @@ export class SyncManager {
   }
 
   private async writeChain(chain: string, blocks: Block[]): Promise<void> {
+    // #142 — signature/policy check runs BEFORE we touch the filesystem
+    // (before acquiring the append lock). Unsigned peer blocks are
+    // rejected unless MEMPHIS_SYNC_ACCEPT_UNSIGNED=true. Blocks with
+    // signer+signature are verified via the Rust chain_validate bridge.
+    // Doing the check up front means a rejection never leaves a half-
+    // created lock file behind and never requires the chain dir to
+    // exist.
+    const { verifyChainBlockSignature } = await import('./signature-verify.js');
+    const acceptUnsigned =
+      (process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED ?? '').toLowerCase() === 'true';
+
+    for (const block of blocks) {
+      if (block.index === undefined || block.timestamp === undefined || block.hash === undefined) {
+        throw new Error('cannot write block with missing index/timestamp/hash');
+      }
+      const hasSig =
+        typeof block.signer === 'string' && typeof block.signature === 'string';
+      if (!hasSig) {
+        if (!acceptUnsigned) {
+          throw new Error(
+            `refusing to accept unsigned peer block (chain=${chain}, index=${String(
+              block.index,
+            )}): set MEMPHIS_SYNC_ACCEPT_UNSIGNED=true to opt in`,
+          );
+        }
+      } else {
+        const valid = await verifyChainBlockSignature(block);
+        if (!valid) {
+          throw new Error(
+            `refusing peer block with invalid signature (chain=${chain}, index=${String(
+              block.index,
+            )}, signer=${block.signer ?? '<none>'})`,
+          );
+        }
+      }
+    }
+
     const chainsDir = resolveChainDir(chain, {
       homedir: homedir(),
       resolve: path.resolve,
       sep: path.sep,
     });
-
-    // Import lazily so the sync manager doesn't force the Rust bridge
-    // to load just for status queries that never hit writeChain.
-    const { verifyChainBlockSignature } = await import('./signature-verify.js');
-    const acceptUnsigned =
-      (process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED ?? '').toLowerCase() === 'true';
+    // Ensure the chain dir exists so withAppendLock can take the lock
+    // even on a fresh install where no local blocks have been written
+    // yet (common in CI).
+    await fsP.mkdir(chainsDir, { recursive: true });
 
     await withAppendLock(chainsDir, fsP, path, async () => {
       for (const block of blocks) {
-        if (block.index === undefined || block.timestamp === undefined || block.hash === undefined) {
-          throw new Error('cannot write block with missing index/timestamp/hash');
-        }
-
-        // #142 — signature check on remote-origin blocks. The TS sync
-        // path used to accept anything the peer returned because no
-        // verify_block_signature call existed here. Now we require a
-        // verified signature on every block, unless the operator
-        // explicitly opts in to MEMPHIS_SYNC_ACCEPT_UNSIGNED (for
-        // legacy migration — logged loudly by the verifier).
-        const hasSig =
-          typeof block.signer === 'string' && typeof block.signature === 'string';
-        if (!hasSig) {
-          if (!acceptUnsigned) {
-            throw new Error(
-              `refusing to accept unsigned peer block (chain=${chain}, index=${String(
-                block.index,
-              )}): set MEMPHIS_SYNC_ACCEPT_UNSIGNED=true to opt in`,
-            );
-          }
-        } else {
-          const valid = await verifyChainBlockSignature(block);
-          if (!valid) {
-            throw new Error(
-              `refusing peer block with invalid signature (chain=${chain}, index=${String(
-                block.index,
-              )}, signer=${block.signer ?? '<none>'})`,
-            );
-          }
-        }
-
         await appendPrecomputedBlock(chain, {
-          index: block.index,
-          timestamp: block.timestamp,
-          hash: block.hash,
+          index: block.index as number,
+          timestamp: block.timestamp as string,
+          hash: block.hash as string,
           prev_hash: '', // not used when appending precomputed blocks
           data: block.data ?? {},
           ...(block.signer !== undefined ? { signer: block.signer } : {}),

--- a/src/sync/sync-manager.ts
+++ b/src/sync/sync-manager.ts
@@ -24,6 +24,8 @@ interface ChainBlock {
   data: Record<string, unknown>;
   prev_hash: string;
   hash: string;
+  signer?: string;
+  signature?: string;
 }
 
 export class SyncManager {
@@ -211,17 +213,53 @@ export class SyncManager {
       sep: path.sep,
     });
 
+    // Import lazily so the sync manager doesn't force the Rust bridge
+    // to load just for status queries that never hit writeChain.
+    const { verifyChainBlockSignature } = await import('./signature-verify.js');
+    const acceptUnsigned =
+      (process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED ?? '').toLowerCase() === 'true';
+
     await withAppendLock(chainsDir, fsP, path, async () => {
       for (const block of blocks) {
         if (block.index === undefined || block.timestamp === undefined || block.hash === undefined) {
           throw new Error('cannot write block with missing index/timestamp/hash');
         }
+
+        // #142 — signature check on remote-origin blocks. The TS sync
+        // path used to accept anything the peer returned because no
+        // verify_block_signature call existed here. Now we require a
+        // verified signature on every block, unless the operator
+        // explicitly opts in to MEMPHIS_SYNC_ACCEPT_UNSIGNED (for
+        // legacy migration — logged loudly by the verifier).
+        const hasSig =
+          typeof block.signer === 'string' && typeof block.signature === 'string';
+        if (!hasSig) {
+          if (!acceptUnsigned) {
+            throw new Error(
+              `refusing to accept unsigned peer block (chain=${chain}, index=${String(
+                block.index,
+              )}): set MEMPHIS_SYNC_ACCEPT_UNSIGNED=true to opt in`,
+            );
+          }
+        } else {
+          const valid = await verifyChainBlockSignature(block);
+          if (!valid) {
+            throw new Error(
+              `refusing peer block with invalid signature (chain=${chain}, index=${String(
+                block.index,
+              )}, signer=${block.signer ?? '<none>'})`,
+            );
+          }
+        }
+
         await appendPrecomputedBlock(chain, {
           index: block.index,
           timestamp: block.timestamp,
           hash: block.hash,
           prev_hash: '', // not used when appending precomputed blocks
           data: block.data ?? {},
+          ...(block.signer !== undefined ? { signer: block.signer } : {}),
+          ...(block.signature !== undefined ? { signature: block.signature } : {}),
         });
       }
     });

--- a/tests/unit/circuit-breaker.test.ts
+++ b/tests/unit/circuit-breaker.test.ts
@@ -158,4 +158,61 @@ describe('circuit breaker (Phase 2.1 production sprint)', () => {
     expect(snap.openedAt).toBe(openedAt);
     expect(snap.totalTrips).toBe(1);
   });
+
+  // Codex P1 follow-up on PR #141. Prior revision of turn-runtime.ts
+  // skipped recordProviderOutcome entirely on non-transient errors.
+  // admitProviderCall had already set halfOpenProbeInFlight=true, so
+  // the next call saw "probe in flight" and failed fast forever.
+  it('non-transient failure during half-open probe clears the probe flag (no stranded probe)', () => {
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '2',
+      MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: '1000',
+    } as NodeJS.ProcessEnv;
+
+    // Trip the breaker open
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 1100);
+    expect(getBreakerSnapshot('anthropic', env).state).toBe('open');
+
+    // Wait past cooldown, admit the probe → halfOpenProbeInFlight=true
+    admitProviderCall('anthropic', env, 3000);
+    expect(getBreakerSnapshot('anthropic', env).state).toBe('half-open');
+    expect(getBreakerSnapshot('anthropic', env).halfOpenProbeInFlight).toBe(true);
+
+    // Non-transient failure: countAsTrip=false — probe flag MUST clear,
+    // state stays half-open (don't re-open for validation errors).
+    recordProviderOutcome('anthropic', false, env, 3100, { countAsTrip: false });
+    const snap = getBreakerSnapshot('anthropic', env);
+    expect(snap.halfOpenProbeInFlight).toBe(false);
+    expect(snap.state).toBe('half-open'); // still half-open, not re-opened
+
+    // Next call must be admitted (as another probe), not fail fast.
+    expect(() => admitProviderCall('anthropic', env, 3200)).not.toThrow();
+  });
+
+  it('transient failure during half-open probe re-opens (countAsTrip default)', () => {
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '2',
+      MEMPHIS_BREAKER_DEFAULT_COOLDOWN_MS: '1000',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000);
+    recordProviderOutcome('anthropic', false, env, 1100);
+    admitProviderCall('anthropic', env, 3000);
+    recordProviderOutcome('anthropic', false, env, 3100); // default countAsTrip=true
+    const snap = getBreakerSnapshot('anthropic', env);
+    expect(snap.state).toBe('open');
+    expect(snap.halfOpenProbeInFlight).toBe(false);
+  });
+
+  it('non-transient failure in closed state does not count toward trip', () => {
+    const env = {
+      MEMPHIS_BREAKER_DEFAULT_FAILURES: '2',
+    } as NodeJS.ProcessEnv;
+    recordProviderOutcome('anthropic', false, env, 1000, { countAsTrip: false });
+    recordProviderOutcome('anthropic', false, env, 1100, { countAsTrip: false });
+    recordProviderOutcome('anthropic', false, env, 1200, { countAsTrip: false });
+    const snap = getBreakerSnapshot('anthropic', env);
+    expect(snap.state).toBe('closed');
+    expect(snap.totalTrips).toBe(0);
+  });
 });

--- a/tests/unit/mcp-web-fetch.test.ts
+++ b/tests/unit/mcp-web-fetch.test.ts
@@ -171,6 +171,43 @@ describe('mcp tools — web-fetch', () => {
     ).rejects.toThrow(/private\/internal IP/);
   });
 
+  // ── IPv6 bracket handling (Codex review on PR #141) ────────────────
+
+  it('accepts a public IPv6 literal (bracket-strip)', async () => {
+    // A public IPv6 like 2001:4860:4860::8888 (Google DNS). Previously
+    // URL.hostname returned "[2001:...]" with brackets so net.isIP
+    // returned 0 and the literal-IP path was skipped — then DNS lookup
+    // got the bracketed string and failed, blocking all legit IPv6.
+    const result = await runMemphisWebFetch(
+      { url: 'http://[2001:4860:4860::8888]/' },
+      {
+        dnsLookup: async () => [{ address: '2001:4860:4860::8888' }],
+        fetch: mockFetch(() => ({ status: 200, text: async () => 'ok' })),
+      },
+    );
+    expect(result.status).toBe(200);
+  });
+
+  it('still blocks private IPv6 literal via the IP-literal shortcut', async () => {
+    // Regression — the existing test passes via the DNS path, but
+    // with bracket-strip in place this should now trip the IP-literal
+    // check and reject BEFORE DNS is consulted.
+    let dnsCalled = false;
+    await expect(
+      runMemphisWebFetch(
+        { url: 'http://[fc00::1]/' },
+        {
+          dnsLookup: async () => {
+            dnsCalled = true;
+            return [{ address: '93.184.216.34' }];
+          },
+          fetch: mockFetch(() => ({ status: 200, text: async () => 'ok' })),
+        },
+      ),
+    ).rejects.toThrow(/private\/internal IP literal/);
+    expect(dnsCalled).toBe(false);
+  });
+
   it('caps redirect chain at 5 hops', async () => {
     let hopCount = 0;
     await expect(

--- a/tests/unit/self-modify-revert.test.ts
+++ b/tests/unit/self-modify-revert.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   __resetSelfModifyRevertForTests,
   evaluateAutoRevert,
+  maybeRecordBootAttempt,
   performAutoRevert,
   recordBootAttempt,
   recordBootSuccess,
@@ -181,5 +182,61 @@ describe('self-modify boot-failure auto-revert (Phase 2.3)', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/git: bad ref/);
+  });
+
+  // Codex P1 follow-up on PR #141. bin/memphis.js records the boot
+  // attempt early (pre-import) so import-time crashes still bump the
+  // counter, and signals that to bootstrap.ts via
+  // MEMPHIS_BOOT_ATTEMPT_RECORDED. maybeRecordBootAttempt must respect
+  // that flag or each boot double-counts — one real crash would cross
+  // the default 3-failure threshold after a single crash.
+  it('maybeRecordBootAttempt records when the env flag is NOT set', () => {
+    maybeRecordBootAttempt(env);
+    const afterOne = evaluateAutoRevert({
+      ...env,
+      MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES: '1',
+    } as NodeJS.ProcessEnv);
+    // With a marker present we'd shouldRevert; here we only assert the
+    // counter advanced by inspecting performAutoRevert's detail count
+    // indirectly — the simplest signal is that no-failures is false.
+    expect(afterOne.reason).not.toBe('no-failures');
+  });
+
+  it('maybeRecordBootAttempt skips the bump when MEMPHIS_BOOT_ATTEMPT_RECORDED=1 (#141 Codex P1)', () => {
+    const flagged = {
+      ...env,
+      MEMPHIS_BOOT_ATTEMPT_RECORDED: '1',
+    } as NodeJS.ProcessEnv;
+    maybeRecordBootAttempt(flagged);
+    // No file, no counter — evaluateAutoRevert must see no-failures.
+    recordSelfModifyCommit(
+      { commitHash: 'abc', previousHash: 'def', intent: 'test' },
+      env,
+    );
+    const decision = evaluateAutoRevert(env);
+    expect(decision.reason).toBe('no-failures');
+  });
+
+  it('maybeRecordBootAttempt + recordBootAttempt do not double-count for one boot', () => {
+    // Production path: bin/memphis.js calls recordBootAttempt directly
+    // via the early path (simulated here) and sets the env flag. Then
+    // bootstrap calls maybeRecordBootAttempt which should be a no-op.
+    recordBootAttempt(env); // stand-in for bin/memphis.js early record
+    const flagged = {
+      ...env,
+      MEMPHIS_BOOT_ATTEMPT_RECORDED: '1',
+    } as NodeJS.ProcessEnv;
+    maybeRecordBootAttempt(flagged); // bootstrap.ts call — must skip
+
+    recordSelfModifyCommit(
+      { commitHash: 'abc', previousHash: 'def', intent: 'test' },
+      env,
+    );
+    // Threshold 2 must NOT trigger after just one real boot attempt.
+    const decision = evaluateAutoRevert({
+      ...env,
+      MEMPHIS_SELF_MODIFY_REVERT_AFTER_BOOT_FAILURES: '2',
+    } as NodeJS.ProcessEnv);
+    expect(decision.shouldRevert).toBe(false);
   });
 });

--- a/tests/unit/sync-manager-signature-reject.test.ts
+++ b/tests/unit/sync-manager-signature-reject.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import { SyncManager } from '../../src/sync/sync-manager.ts';
+
+/**
+ * Regression net for #142. SyncManager.writeChain used to forward peer
+ * blocks into the chain via appendPrecomputedBlock with no signature
+ * check. Now unsigned remote blocks are rejected unless
+ * MEMPHIS_SYNC_ACCEPT_UNSIGNED=true. Blocks with signer+signature go
+ * through the Rust chain_validate bridge.
+ *
+ * These tests exercise only the sync-side policy — the Rust bridge
+ * path is covered by tests/integration/signed-block-gate.test.ts.
+ */
+
+describe('SyncManager — unsigned peer block rejection (#142)', () => {
+  it('rejects an unsigned peer block when MEMPHIS_SYNC_ACCEPT_UNSIGNED is NOT set', async () => {
+    const prior = process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED;
+    delete process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED;
+    try {
+      const manager = new SyncManager('did:memphis:self');
+      const unsigned = [
+        {
+          index: 0,
+          timestamp: '2026-04-17T00:00:00Z',
+          hash: 'a'.repeat(64),
+          chain: 'journal',
+          data: { content: 'hostile-unsigned', tags: [] },
+        },
+      ];
+      // writeChain is private; we reach it through the internal test
+      // seam. The test passes iff the promise rejects with the
+      // "refusing to accept unsigned" message.
+      await expect(
+        (
+          manager as unknown as {
+            writeChain: (c: string, b: unknown[]) => Promise<void>;
+          }
+        ).writeChain('journal', unsigned),
+      ).rejects.toThrow(/unsigned/i);
+    } finally {
+      if (prior === undefined) delete process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED;
+      else process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED = prior;
+    }
+  });
+
+  it('does NOT reject unsigned blocks when MEMPHIS_SYNC_ACCEPT_UNSIGNED=true (escape hatch)', async () => {
+    const prior = process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED;
+    const priorDataDir = process.env.MEMPHIS_DATA_DIR;
+    process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED = 'true';
+    // Isolate the actual append side-effect — point at a tmpdir.
+    const { mkdtempSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    process.env.MEMPHIS_DATA_DIR = mkdtempSync(join(tmpdir(), 'memphis-sync-accept-unsigned-'));
+    try {
+      const manager = new SyncManager('did:memphis:self');
+      const unsigned = [
+        {
+          index: 0,
+          timestamp: '2026-04-17T00:00:00Z',
+          hash: 'b'.repeat(64),
+          chain: 'journal',
+          data: { content: 'legacy-unsigned', tags: [] },
+        },
+      ];
+      // With the escape hatch set, the signature check must pass. The
+      // actual append may still fail because the test doesn't stand up
+      // a full chain dir — that's fine, we just need to prove the
+      // signature policy didn't reject.
+      let signatureRejected = false;
+      try {
+        await (
+          manager as unknown as {
+            writeChain: (c: string, b: unknown[]) => Promise<void>;
+          }
+        ).writeChain('journal', unsigned);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // Match the specific sync-policy rejection phrasing. The tmp
+        // path itself contains "unsigned" so a looser regex false-
+        // positives on unrelated ENOENT errors.
+        if (/refusing to accept unsigned|refusing peer block with invalid/i.test(msg)) {
+          signatureRejected = true;
+        }
+      }
+      expect(signatureRejected).toBe(false);
+    } finally {
+      if (prior === undefined) delete process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED;
+      else process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED = prior;
+      if (priorDataDir === undefined) delete process.env.MEMPHIS_DATA_DIR;
+      else process.env.MEMPHIS_DATA_DIR = priorDataDir;
+    }
+  });
+
+  it('rejects a block with signer+signature that fails verification', async () => {
+    const prior = process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED;
+    delete process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED;
+    try {
+      const manager = new SyncManager('did:memphis:self');
+      // 32-byte hex signer + 64-byte hex signature — well-formed,
+      // cryptographically invalid for the content.
+      const bogus = [
+        {
+          index: 0,
+          timestamp: '2026-04-17T00:00:00Z',
+          hash: 'c'.repeat(64),
+          chain: 'journal',
+          data: { content: 'bogus-signed', tags: [] },
+          signer: 'a'.repeat(64),
+          signature: 'f'.repeat(128),
+        },
+      ];
+      await expect(
+        (
+          manager as unknown as {
+            writeChain: (c: string, b: unknown[]) => Promise<void>;
+          }
+        ).writeChain('journal', bogus),
+      ).rejects.toThrow(/invalid signature|unsigned|rust chain bridge unavailable/i);
+      // The rust-bridge-unavailable fallback is allowed because on CI
+      // without the Rust binary verifyChainBlockSignature returns false
+      // via the catch branch, which still fails the signature check
+      // and surfaces as "invalid signature".
+    } finally {
+      if (prior === undefined) delete process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED;
+      else process.env.MEMPHIS_SYNC_ACCEPT_UNSIGNED = prior;
+    }
+  });
+});

--- a/tests/unit/web-dashboard-auth.test.ts
+++ b/tests/unit/web-dashboard-auth.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { WebDashboard, type DashboardData } from '../../src/dashboard/web-dashboard.ts';
+
+/**
+ * Regression net for #143. Dashboard /api/data and the HTML dashboard
+ * used to be unauthenticated. Default bind is localhost so the default
+ * case is safe, but there was no way for an operator to enforce auth
+ * when binding non-loopback. This test verifies the optional Bearer
+ * token enforcement works end-to-end.
+ */
+
+function emptyData(): DashboardData {
+  return {
+    stats: {
+      totalBlocks: 0,
+      totalChains: 0,
+      oldestBlock: '',
+      newestBlock: '',
+      topTags: [],
+      blocksPerChain: [],
+    },
+    insights: [],
+    predictions: [],
+    mood: 'productive',
+    quickWins: [],
+    nextActions: [],
+  };
+}
+
+describe('web-dashboard auth token (#143)', () => {
+  let dashboard: WebDashboard;
+  let port: number;
+
+  beforeEach(async () => {
+    dashboard = new WebDashboard(async () => emptyData(), {
+      port: 0,
+      host: '127.0.0.1',
+      authToken: 's3cret-token',
+    });
+    await dashboard.start();
+    // Pull the assigned port from the internal server.
+    const server = (dashboard as unknown as { server: { address: () => { port: number } } }).server;
+    port = server.address().port;
+  });
+
+  afterEach(async () => {
+    await dashboard.stop();
+  });
+
+  it('/api/data with no Authorization returns 401', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/data`);
+    expect(res.status).toBe(401);
+  });
+
+  it('/api/data with wrong Bearer token returns 401', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/data`, {
+      headers: { Authorization: 'Bearer nope' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('/api/data with correct Bearer token returns 200 + JSON', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/data`, {
+      headers: { Authorization: 'Bearer s3cret-token' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as DashboardData;
+    expect(body.stats.totalBlocks).toBe(0);
+  });
+
+  it('/ (HTML dashboard) also requires the token', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(res.status).toBe(401);
+
+    const authed = await fetch(`http://127.0.0.1:${port}/`, {
+      headers: { Authorization: 'Bearer s3cret-token' },
+    });
+    expect(authed.status).toBe(200);
+    expect(authed.headers.get('content-type') ?? '').toMatch(/text\/html/);
+  });
+
+  it('/api/health stays public (for monitoring)', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/health`);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('web-dashboard default (no auth) backward-compat', () => {
+  let dashboard: WebDashboard;
+  let port: number;
+
+  beforeEach(async () => {
+    dashboard = new WebDashboard(async () => emptyData(), {
+      port: 0,
+      host: '127.0.0.1',
+      // authToken: undefined — default path, no auth required
+    });
+    await dashboard.start();
+    const server = (dashboard as unknown as { server: { address: () => { port: number } } }).server;
+    port = server.address().port;
+  });
+
+  afterEach(async () => {
+    await dashboard.stop();
+  });
+
+  it('/api/data is accessible without auth when no token configured', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/data`);
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Second bundled hotfix following PR #141's methodology. 7 fixes total: 4 planned (sync-signature, dashboard auth, 2FA Result, vault fsync) + 3 Codex follow-ups on #141.

**PoC-test-first pattern preserved:** every fix ships with a regression test. +17 new tests → **2054/2054 passing**.

## Closes

Planned:
- **HIGH   #142** — sync-manager rejects unsigned peer blocks; Rust `chain_validate` verifies signer/signature; `MEMPHIS_SYNC_ACCEPT_UNSIGNED` escape hatch for legacy migration
- **MED    #143** — Dashboard optional Bearer token via `secureCompare`; warns at startup on non-loopback + no token
- **LOW    #144** — `derive_vault_key_with_2fa_v2` returns `Result<[u8;32], VaultError>` instead of `.expect()`
- **LOW    #145** — Vault rotation fsyncs tmp files before first rename

Codex follow-ups on PR #141:
- **P1 (turn-runtime)** — non-transient errors during half-open probe now settle `halfOpenProbeInFlight` via new `countAsTrip` param. Prior behavior stranded the probe flag, locking the provider until restart.
- **P1 (bin/memphis.js + bootstrap)** — `recordBootAttempt` double-counted each boot. Added `MEMPHIS_BOOT_ATTEMPT_RECORDED` env flag + new `maybeRecordBootAttempt` that dedups in the production path.
- **P2 (web-fetch IPv6 brackets)** — `URL.hostname` keeps brackets on IPv6 literals, so `net.isIP` returned 0 and every public IPv6 URL was blocked. Added `stripIpv6Brackets` before IP check + DNS.

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 2054/2054 (+17 new)
- [x] `cargo test -p memphis-vault --lib` — 31/31
- [x] `cargo check --workspace` — clean
- [x] `npm audit --omit=dev --audit-level=high` — 0 advisories

## Notes

- Extends Block schema with optional `signer` / `signature` fields so they round-trip through sync.
- `appendPrecomputedBlock` now preserves signer / signature when present.
- New file: `src/sync/signature-verify.ts` — routes through NAPI `chain_validate` for consistency with local append-path signature enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)