### PR TITLE
feat(L3): inputSchema (Zod) on ToolMeta + pilot 5 tools

### DIFF
--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -5,6 +5,8 @@
  * Replaces the static KNOWN_TOOLS list in soul/manifest.ts.
  */
 
+import { z } from 'zod';
+
 import type { MemphisFeatureFlag } from '../infra/features/flags.js';
 import { isFeatureFlagEnabled } from '../infra/features/flags.js';
 
@@ -17,6 +19,17 @@ export interface ToolMeta {
   capabilities: ToolCapability[];
   description: string;
   featureFlag?: MemphisFeatureFlag;
+  /**
+   * Optional Zod schema describing the tool's input shape.
+   *
+   * When present, surfaces (TUI, GUI, MCP server, custom apps) can use it
+   * to render forms, validate input before dispatch, and generate JSON
+   * schema for LLM tool-call signatures. Pilot rollout: 5 tier-0 tools
+   * (memphis_journal, memphis_recall, memphis_search, memphis_decide,
+   * memphis_health). Migration of remaining 32 tool handlers is intentionally
+   * deferred to keep the diff isolated to the registry.
+   */
+  inputSchema?: z.ZodTypeAny;
 }
 
 export const TOOL_REGISTRY: Record<string, ToolMeta> = {
@@ -25,30 +38,59 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
     tier: 0,
     capabilities: ['write'],
     description: 'Save entries to journal chain',
+    inputSchema: z
+      .object({
+        content: z.string().min(1, 'content is required'),
+        tags: z.array(z.string()).optional(),
+      })
+      .strict(),
   },
   memphis_recall: {
     name: 'memphis_recall',
     tier: 0,
     capabilities: ['read'],
     description: 'Semantic search across chains',
+    inputSchema: z
+      .object({
+        query: z.string().min(1, 'query is required'),
+        limit: z.number().int().positive().max(100).optional(),
+        tags: z.array(z.string()).optional(),
+        chain: z.string().optional(),
+      })
+      .strict(),
   },
   memphis_search: {
     name: 'memphis_search',
     tier: 0,
     capabilities: ['read'],
     description: 'Exact phrase search across indexed memory',
+    inputSchema: z
+      .object({
+        query: z.string().min(1, 'query is required'),
+        limit: z.number().int().positive().max(100).optional(),
+        chain: z.string().optional(),
+      })
+      .strict(),
   },
   memphis_decide: {
     name: 'memphis_decide',
     tier: 0,
     capabilities: ['write'],
     description: 'Record decisions',
+    inputSchema: z
+      .object({
+        title: z.string().min(1, 'title is required'),
+        choice: z.string().min(1, 'choice is required'),
+        context: z.string().optional(),
+      })
+      .strict(),
   },
   memphis_health: {
     name: 'memphis_health',
     tier: 0,
     capabilities: ['read'],
     description: 'Check runtime health',
+    inputSchema: z.object({}).strict(),
   },
   memphis_repair: {
     name: 'memphis_repair',

--- a/tests/unit/tool-registry-schema.test.ts
+++ b/tests/unit/tool-registry-schema.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the optional `inputSchema` extension to ToolMeta
+ * (L3 Capability Registry — incremental polish, ROADMAP-CURRENT.md M6 / Phase L3).
+ *
+ * Pilot: 5 tier-0 tools carry a Zod schema describing their input shape.
+ * Surfaces (TUI, GUI, MCP, custom apps) can use these schemata to render
+ * forms, validate input before dispatch, and generate JSON schemas for LLM
+ * tool-call signatures.
+ *
+ * The remaining 32 tool handlers in src/mcp/tools/ are intentionally NOT
+ * touched in this PR — schema migration is incremental.
+ */
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { TOOL_REGISTRY } from '../../src/gateway/tool-registry.js';
+
+const PILOT_TOOLS_WITH_SCHEMA = [
+  'memphis_journal',
+  'memphis_recall',
+  'memphis_search',
+  'memphis_decide',
+  'memphis_health',
+] as const;
+
+describe('tool registry — inputSchema (pilot 5 tools)', () => {
+  it('every pilot tool exposes a Zod inputSchema', () => {
+    for (const name of PILOT_TOOLS_WITH_SCHEMA) {
+      const meta = TOOL_REGISTRY[name];
+      expect(meta, `${name} must be in TOOL_REGISTRY`).toBeDefined();
+      expect(meta.inputSchema, `${name}.inputSchema must be present`).toBeDefined();
+      // ZodSchema instances expose a `.parse` method
+      expect(typeof meta.inputSchema!.parse).toBe('function');
+    }
+  });
+
+  describe('memphis_journal schema', () => {
+    const schema = TOOL_REGISTRY.memphis_journal.inputSchema!;
+
+    it('accepts valid input', () => {
+      expect(() => schema.parse({ content: 'hello world' })).not.toThrow();
+      expect(() => schema.parse({ content: 'hi', tags: ['note', 'test'] })).not.toThrow();
+    });
+
+    it('rejects missing content', () => {
+      expect(() => schema.parse({})).toThrow();
+      expect(() => schema.parse({ tags: ['x'] })).toThrow();
+    });
+
+    it('rejects empty content', () => {
+      expect(() => schema.parse({ content: '' })).toThrow();
+    });
+
+    it('rejects unknown fields (strict)', () => {
+      expect(() => schema.parse({ content: 'hi', extra: 'reject me' })).toThrow();
+    });
+  });
+
+  describe('memphis_recall schema', () => {
+    const schema = TOOL_REGISTRY.memphis_recall.inputSchema!;
+
+    it('accepts valid input', () => {
+      expect(() => schema.parse({ query: 'meaning of life' })).not.toThrow();
+      expect(() => schema.parse({ query: 'q', limit: 10, tags: ['t'], chain: 'journal' })).not.toThrow();
+    });
+
+    it('rejects missing query', () => {
+      expect(() => schema.parse({})).toThrow();
+    });
+
+    it('rejects negative or zero limit', () => {
+      expect(() => schema.parse({ query: 'q', limit: 0 })).toThrow();
+      expect(() => schema.parse({ query: 'q', limit: -1 })).toThrow();
+    });
+
+    it('rejects limit above 100', () => {
+      expect(() => schema.parse({ query: 'q', limit: 101 })).toThrow();
+    });
+  });
+
+  describe('memphis_search schema', () => {
+    const schema = TOOL_REGISTRY.memphis_search.inputSchema!;
+
+    it('accepts valid input', () => {
+      expect(() => schema.parse({ query: 'phrase' })).not.toThrow();
+      expect(() => schema.parse({ query: 'p', limit: 5, chain: 'decisions' })).not.toThrow();
+    });
+
+    it('rejects missing query', () => {
+      expect(() => schema.parse({})).toThrow();
+    });
+  });
+
+  describe('memphis_decide schema', () => {
+    const schema = TOOL_REGISTRY.memphis_decide.inputSchema!;
+
+    it('accepts valid input', () => {
+      expect(() => schema.parse({ title: 'Choice A', choice: 'A' })).not.toThrow();
+      expect(() => schema.parse({ title: 't', choice: 'c', context: 'why' })).not.toThrow();
+    });
+
+    it('rejects missing required fields', () => {
+      expect(() => schema.parse({ title: 'no choice' })).toThrow();
+      expect(() => schema.parse({ choice: 'no title' })).toThrow();
+    });
+  });
+
+  describe('memphis_health schema', () => {
+    const schema = TOOL_REGISTRY.memphis_health.inputSchema!;
+
+    it('accepts empty input', () => {
+      expect(() => schema.parse({})).not.toThrow();
+    });
+
+    it('rejects any field (strict)', () => {
+      expect(() => schema.parse({ foo: 'bar' })).toThrow();
+    });
+  });
+
+  describe('non-pilot tools intentionally lack inputSchema', () => {
+    it('keeps schema migration incremental', () => {
+      const withSchema = Object.values(TOOL_REGISTRY).filter((m) => m.inputSchema !== undefined);
+      // Only the 5 pilot tools should have a schema in this PR.
+      expect(withSchema).toHaveLength(PILOT_TOOLS_WITH_SCHEMA.length);
+      const names = withSchema.map((m) => m.name).sort();
+      expect(names).toEqual([...PILOT_TOOLS_WITH_SCHEMA].sort());
+    });
+  });
+
+  describe('schema is structurally compatible with z.ZodTypeAny', () => {
+    it('all pilot schemata return safeParse with success boolean', () => {
+      for (const name of PILOT_TOOLS_WITH_SCHEMA) {
+        const schema = TOOL_REGISTRY[name].inputSchema!;
+        const result = schema.safeParse(undefined);
+        expect(typeof result.success).toBe('boolean');
+        expect(result.success).toBe(false);
+      }
+    });
+
+    it('schema has a stable identity (same reference across reads)', () => {
+      // Surface adapters may cache schema references — assert identity is stable.
+      const a = TOOL_REGISTRY.memphis_journal.inputSchema;
+      const b = TOOL_REGISTRY.memphis_journal.inputSchema;
+      expect(a).toBe(b);
+    });
+
+    it('z import is functional in this test (sanity)', () => {
+      const local = z.object({ x: z.string() });
+      expect(() => local.parse({ x: 'ok' })).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Incremental polish of the centralized tool registry. Adds optional `inputSchema?: z.ZodTypeAny` to `ToolMeta`, populated for 5 pilot tier-0 tools. Surfaces (TUI, GUI, MCP server, custom apps) can now use these schemata to render forms, validate input before dispatch, and generate JSON schemas for LLM tool-call signatures.

## Why incremental, not big-bang

The plan in \`MEMPHIS_ARCHITECTURE_LAYERS.md\` (L3 Capability Registries section) describes the goal as "unification of 37 handlers + 37 schemata into one declarative descriptor". Code verification on 2026-04-19 surfaced that the registry is already partially there — \`src/gateway/tool-registry.ts:22\` has the centralized metadata for 37 tools (name, tier, capabilities, description, featureFlag). What's missing is just the input schema reference + handler reference.

This PR adds **only the schema field**, populated for 5 pilot tools. Handlers stay where they are (\`src/mcp/tools/*.ts\`). This keeps the diff narrow, preserves runtime behavior (37/37 existing registry tests still pass), and unblocks surface adapters that want to pre-validate inputs.

## Pilot tools

Input shapes derived from the existing TS handler types in \`src/mcp/tools/\`:

| Tool | Schema |
|---|---|
| \`memphis_journal\` | content: string, tags?: string[] |
| \`memphis_recall\` | query: string, limit?: 1..100, tags?, chain? |
| \`memphis_search\` | query: string, limit?: 1..100, chain? |
| \`memphis_decide\` | title, choice: string, context?: string |
| \`memphis_health\` | no input — strict empty object |

Every schema uses \`.strict()\` so surfaces catch typos and unknown fields before dispatch.

## What this does NOT do

- Does not migrate the other 32 tool handlers (intentional)
- Does not change handler dispatch in \`src/gateway/tool-orchestration.ts\`
- Does not change the surface contract — schema is **optional** on \`ToolMeta\`, surfaces that don't know about it keep working unchanged
- Does not pre-empt the larger SkillRegistry / CommandRegistry / BlueprintRegistry effort (those are separate, deferred)

## Verification

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean (pre-commit hook)
- [x] \`npx vitest run tests/unit/tool-registry.test.ts tests/unit/tool-registry-schema.test.ts\` — 31/31 in 749ms
  - 12 existing tests in \`tool-registry.test.ts\` still pass (no behavior change)
  - 19 new tests in \`tool-registry-schema.test.ts\` cover: presence, happy-path, rejection of missing/empty/unknown fields, identity stability, incremental-migration invariant
- [x] \`npm audit --omit=dev --audit-level=high\` — 0 advisories

## Function evaluation (per ROADMAP_FOR_SORT_BRANCHES.md template)

### \`ToolMeta.inputSchema?: z.ZodTypeAny\`

**Contract**
- inputs: optional Zod schema attached to a tool's metadata entry
- consumers: gateway, surface adapters, MCP server, GUI form renderer
- guarantee: when present, parsing succeeds for valid inputs and throws/returns failure for invalid ones

**Invariants**
- I1. Schema is optional — non-pilot tools work unchanged
- I2. Pilot tools always have schema (asserted in test)
- I3. Schema reference is stable across reads (caching-safe)
- I4. Migration progress trackable: \`Object.values(TOOL_REGISTRY).filter(m => m.inputSchema).length\` is the count of migrated tools

**Observable success signal**
- CI: green tool-registry-schema test
- Future: surface adapters consuming the schema for form/JSON generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)