### PR TITLE
chore(ci): bump telegram-smoke actions v4 → v5

### DIFF
--- a/.github/workflows/telegram-smoke.yml
+++ b/.github/workflows/telegram-smoke.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Short-circuit when secrets are not configured
         id: check-secrets
@@ -46,7 +46,7 @@ jobs:
             echo "skipped=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: steps.check-secrets.outputs.skipped != 'true'
         with:
           # Codex Round 6 P2 fix (PR #125): project declares


### PR DESCRIPTION
## Summary

Repo-hygiene scan during 2026-04-19 sprint surfaced one workflow still pinning v4 of `actions/checkout` + `actions/setup-node` while the other ten workflows already use v5. This aligns the stragglers.

## Other findings from the same scan (no fix needed today)

- 0 \`.only\` / \`.skip\` in tests/ — clean
- 1 TODO in src/soul/memory.ts:290 (vault-encrypt memory archive) — documented future work, not blocking
- 8 minor npm bumps available (@types/node, better-sqlite3, dotenv, prettier, typedoc, typescript-eslint, vitest, @opentelemetry/resources) — deferred to a separate dependency-bump PR
- 5 major npm bumps available (@anthropic-ai/sdk 0.78→0.90, discord.js 13→14, typescript 5→6, eslint 9→10, ollama 0.5→0.6) — each needs its own review

## Verification

- [x] `npm run lint` — clean (pre-commit hook)
- [x] No other workflow file affected (grep confirmed only telegram-smoke.yml had v4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)