### PR TITLE
docs(operator): bilingual debug playbook (EN + PL)

### DIFF
--- a/docs/operator/debug.en.md
+++ b/docs/operator/debug.en.md
@@ -4,6 +4,12 @@
 > Polish version: [`debug.pl.md`](./debug.pl.md).
 > Install issues: see [`install.en.md`](./install.en.md).
 
+> ⚠️ **Verify exact subcommand syntax.** Top-level commands (`memphis health`,
+> `memphis vault`, `memphis chain`, etc.) are confirmed against the v1.3.0
+> CLI dispatcher (`src/infra/cli/registry.ts`). Subcommand forms shown
+> below reflect common usage patterns and may differ — always cross-check
+> with `memphis <command> --help`.
+
 ---
 
 ## First-line tools
@@ -14,7 +20,6 @@ Run these first; they catch most issues:
 memphis health                     # is the daemon up + reachable?
 memphis health --json              # machine-readable; includes offline mode
 memphis doctor                     # full pre-flight check
-memphis doctor --fix               # attempt safe auto-repair
 memphis service status             # systemd service state
 memphis service logs -n 100        # recent daemon logs
 memphis tui --check-only --json    # TUI cockpit boot-test
@@ -33,7 +38,7 @@ If `memphis health` returns `status: ok` and `memphis doctor` shows all green, y
 | `memphis service start` exits with no output | systemd not enabled | `systemctl --user enable memphis` then retry |
 | `Connection refused on :3000` after start | daemon crashed early | `memphis service logs -n 200` → look for first ERROR |
 | `EADDRINUSE: address already in use :3000` | another process bound :3000 | `lsof -i :3000` → kill rogue process or change `MEMPHIS_HTTP_PORT` |
-| `Loop detected: boot-failure threshold exceeded` | runtime crashed 5×; auto-revert kicked in | `memphis service logs --boot-failures` → diagnose; `memphis self-modify rollback` if recent self-modify caused it |
+| `Loop detected: boot-failure threshold exceeded` | runtime crashed 5×; auto-revert kicked in | `memphis service logs -n 500` → diagnose; `memphis evolve --help` for self-modify rollback options if a recent evolution caused it |
 | Daemon starts but immediately exits | unhandled exception during init | `MEMPHIS_DEBUG=1 memphis service start` for verbose trace |
 
 ### Vault won't unlock
@@ -41,8 +46,8 @@ If `memphis health` returns `status: ok` and `memphis doctor` shows all green, y
 | Symptom | Diagnosis | Fix |
 |---|---|---|
 | `vault unlock failed: invalid passphrase` | typo or wrong passphrase | retry; if forgotten use recovery |
-| `recovery answer mismatch` | answer hashed differently than at init | answers are case-sensitive after Argon2id; try variations |
-| `vault corrupt: checksum mismatch` | disk error | restore from backup: `memphis backup restore --vault` |
+| `recovery answer mismatch` | answer hashed differently than at init | answers are case-sensitive after Argon2id; try variations. Recovery flow: see `memphis vault --help` for recovery-related subcommands |
+| `vault corrupt: checksum mismatch` | disk error | restore from backup — see `memphis backup --help` for restore flags |
 | `vault not initialized` | `memphis init` never ran | run `memphis init` |
 | `vault locked after rotation` | tmp files not fsynced (pre-#145 bug) | upgrade to v1.3.0+; `memphis vault rotate` retry |
 
@@ -51,7 +56,7 @@ If `memphis health` returns `status: ok` and `memphis doctor` shows all green, y
 | Symptom | Diagnosis | Fix |
 |---|---|---|
 | `chain hash mismatch at block N` | block content edited or disk error | `memphis repair runtime --fix` for derived state; for canonical chain corruption restore from backup |
-| `chain integrity degraded` | one or more invalid blocks detected | `memphis chain audit --json` → identify; `memphis chain repair <chain>` |
+| `chain integrity degraded` | one or more invalid blocks detected | Use `memphis chain --help` to find the audit/repair subcommands available in your version (chain audit + chain repair are typical) |
 | `signature verification failed` | unsigned block where `RUST_CHAIN_REQUIRE_SIGNATURES=true` | check `RUST_CHAIN_SIGNER_KEY_HEX` is set; or set `MEMPHIS_SYNC_ACCEPT_UNSIGNED=true` for legacy migration |
 | `append-lock timeout` | another process holds the lock | `lsof ~/.memphis/chains/.append.lock` → kill blocker; lock auto-releases on process exit |
 
@@ -63,7 +68,7 @@ If `memphis health` returns `status: ok` and `memphis doctor` shows all green, y
 | `Provider unauthorized` (401) | API key missing or invalid | `memphis vault add <PROVIDER>_API_KEY` (vault-first) or set env var |
 | `Ollama unreachable` | daemon not running | `ollama serve &` or `systemctl --user start ollama` |
 | `Model not found: cogito:3b` | model not pulled | `ollama pull cogito:3b` |
-| `Circuit breaker tripped: <provider>` | 5+ consecutive failures | `memphis providers reset-breaker <provider>`; also check provider status page |
+| `Circuit breaker tripped: <provider>` | 5+ consecutive failures | Restart the daemon (`memphis service restart`) to reset the breaker; verify state via `memphis providers list --json`; check provider status page |
 | `Cost cap reached` | budget exhausted | `memphis config show COST_CAP_*` then adjust, or wait for reset window |
 
 ### Search / recall issues
@@ -71,9 +76,9 @@ If `memphis health` returns `status: ok` and `memphis doctor` shows all green, y
 | Symptom | Diagnosis | Fix |
 |---|---|---|
 | `memphis recall` returns nothing | embeddings not built | `memphis search rebuild` |
-| Empty results for known content | exact-search index drift | `memphis repair runtime --rebuild-search` |
-| `embedding dimension mismatch` | model changed without rebuild | `memphis search rebuild --force` |
-| Slow search (>10s) | unindexed corpus | `memphis search rebuild`; verify `RUST_EMBED_MODE=local` for ONNX path |
+| Empty results for known content | exact-search index drift | `memphis repair --help` for rebuild-search options |
+| `embedding dimension mismatch` | model changed without rebuild | rebuild via `memphis search --help` (rebuild subcommand) or `memphis embed --help` |
+| Slow search (>10s) | unindexed corpus | rebuild search index; verify `RUST_EMBED_MODE=local` for ONNX path |
 
 ### Telegram surface
 
@@ -88,9 +93,9 @@ If `memphis health` returns `status: ok` and `memphis doctor` shows all green, y
 
 | Symptom | Diagnosis | Fix |
 |---|---|---|
-| `tier-3 session required` | running tier-3 op without elevation | `memphis tier3 elevate` (operator passphrase prompt) |
+| `tier-3 session required` | running tier-3 op without elevation | Tier-3 elevation is prompted automatically when invoking a tier-3 tool. For non-interactive flows set `MEMPHIS_OPERATOR_PASSPHRASE` env var. See `memphis operator --help` for related commands. |
 | `Test gate failed` | self-modify branch tests didn't pass | review proposed diff, fix tests, retry |
-| `Boot-failure auto-revert triggered` | post-self-modify boot crashed | last self-modify was reverted; check `memphis evolve log` |
+| `Boot-failure auto-revert triggered` | post-self-modify boot crashed | last self-modify was reverted; inspect history via `memphis evolve --help` |
 | `path validation failed: outside sandbox` | self-modify tried to write outside `~/memphis/` | by design — operator passphrase + tier-3 won't bypass |
 
 ### Performance
@@ -98,7 +103,7 @@ If `memphis health` returns `status: ok` and `memphis doctor` shows all green, y
 | Symptom | Diagnosis | Fix |
 |---|---|---|
 | Slow startup (>30s) | first build cold | second start should be <5s; if not, check `cargo target/` cache integrity |
-| High CPU on idle | embedding rebuild loop | `memphis search rebuild --once` then `memphis service restart` |
+| High CPU on idle | embedding rebuild loop | force one-shot rebuild (see `memphis search --help`) then `memphis service restart` |
 | Memory growth over hours | known: vitest test harness leak (not prod) | n/a in production |
 | Slow chat response | non-streaming provider | use streaming provider (Ollama, Anthropic) |
 
@@ -122,15 +127,16 @@ To follow live: `journalctl --user -u memphis -f` (Linux) or `tail -F ~/.memphis
 
 ## Diagnostic dumps
 
-For filing an issue, attach:
+For filing an issue, attach (some commands may need slight subcommand
+adjustments — verify with `memphis <command> --help`):
 
 ```bash
 memphis health --json > memphis-health.json
 memphis doctor --json > memphis-doctor.json
-memphis chain audit --json > memphis-chain-audit.json
 memphis service logs -n 500 > memphis-logs.txt
 memphis providers list --json > memphis-providers.json
 memphis --version > memphis-version.txt
+# Plus any chain / audit dumps via `memphis chain --help` and `memphis audit --help`
 ```
 
 **Sanitize before sharing publicly:**
@@ -183,4 +189,4 @@ cp -r ~/.memphis/chains ~/memphis-chains-backup-$(date -Idate)
 
 ---
 
-_Last verified: 2026-04-19 against Memphis v1.3.0 runtime behavior._
+_Last verified: 2026-04-19 against Memphis v1.3.0 runtime behavior + `src/infra/cli/registry.ts` dispatcher. Top-level commands confirmed real (in registry as of v1.3.0): `health`, `doctor`, `service`, `tui`, `chat`, `ask`, `vault`, `chain`, `search`, `embed`, `evolve`, `providers`, `repair`, `init`, `mcp`, `telegram`, `trust`, `audit`, `worker`, `secret`, `schedule`, `kill-zombies`, `backup`, `self-update`, `restart`, `setup`, `configure`, `deploy`, `operator`. Subcommand syntax may evolve — verify with `memphis <command> --help`._

--- a/docs/operator/debug.en.md
+++ b/docs/operator/debug.en.md
@@ -1,0 +1,186 @@
+# Memphis Debug Playbook (EN)
+
+> Symptom → Diagnosis → Fix tree for Memphis runtime issues.
+> Polish version: [`debug.pl.md`](./debug.pl.md).
+> Install issues: see [`install.en.md`](./install.en.md).
+
+---
+
+## First-line tools
+
+Run these first; they catch most issues:
+
+```bash
+memphis health                     # is the daemon up + reachable?
+memphis health --json              # machine-readable; includes offline mode
+memphis doctor                     # full pre-flight check
+memphis doctor --fix               # attempt safe auto-repair
+memphis service status             # systemd service state
+memphis service logs -n 100        # recent daemon logs
+memphis tui --check-only --json    # TUI cockpit boot-test
+```
+
+If `memphis health` returns `status: ok` and `memphis doctor` shows all green, you don't have a runtime problem — check application-layer issues (vault, chains, providers).
+
+---
+
+## Symptom → diagnosis → fix
+
+### Daemon won't start
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `memphis service start` exits with no output | systemd not enabled | `systemctl --user enable memphis` then retry |
+| `Connection refused on :3000` after start | daemon crashed early | `memphis service logs -n 200` → look for first ERROR |
+| `EADDRINUSE: address already in use :3000` | another process bound :3000 | `lsof -i :3000` → kill rogue process or change `MEMPHIS_HTTP_PORT` |
+| `Loop detected: boot-failure threshold exceeded` | runtime crashed 5×; auto-revert kicked in | `memphis service logs --boot-failures` → diagnose; `memphis self-modify rollback` if recent self-modify caused it |
+| Daemon starts but immediately exits | unhandled exception during init | `MEMPHIS_DEBUG=1 memphis service start` for verbose trace |
+
+### Vault won't unlock
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `vault unlock failed: invalid passphrase` | typo or wrong passphrase | retry; if forgotten use recovery |
+| `recovery answer mismatch` | answer hashed differently than at init | answers are case-sensitive after Argon2id; try variations |
+| `vault corrupt: checksum mismatch` | disk error | restore from backup: `memphis backup restore --vault` |
+| `vault not initialized` | `memphis init` never ran | run `memphis init` |
+| `vault locked after rotation` | tmp files not fsynced (pre-#145 bug) | upgrade to v1.3.0+; `memphis vault rotate` retry |
+
+### Chain integrity errors
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `chain hash mismatch at block N` | block content edited or disk error | `memphis repair runtime --fix` for derived state; for canonical chain corruption restore from backup |
+| `chain integrity degraded` | one or more invalid blocks detected | `memphis chain audit --json` → identify; `memphis chain repair <chain>` |
+| `signature verification failed` | unsigned block where `RUST_CHAIN_REQUIRE_SIGNATURES=true` | check `RUST_CHAIN_SIGNER_KEY_HEX` is set; or set `MEMPHIS_SYNC_ACCEPT_UNSIGNED=true` for legacy migration |
+| `append-lock timeout` | another process holds the lock | `lsof ~/.memphis/chains/.append.lock` → kill blocker; lock auto-releases on process exit |
+
+### Provider / chat issues
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `Rate limit exceeded` (429) | provider quota | wait `retryAfterMs` from response, or switch provider: `memphis config set DEFAULT_PROVIDER local-fallback` |
+| `Provider unauthorized` (401) | API key missing or invalid | `memphis vault add <PROVIDER>_API_KEY` (vault-first) or set env var |
+| `Ollama unreachable` | daemon not running | `ollama serve &` or `systemctl --user start ollama` |
+| `Model not found: cogito:3b` | model not pulled | `ollama pull cogito:3b` |
+| `Circuit breaker tripped: <provider>` | 5+ consecutive failures | `memphis providers reset-breaker <provider>`; also check provider status page |
+| `Cost cap reached` | budget exhausted | `memphis config show COST_CAP_*` then adjust, or wait for reset window |
+
+### Search / recall issues
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `memphis recall` returns nothing | embeddings not built | `memphis search rebuild` |
+| Empty results for known content | exact-search index drift | `memphis repair runtime --rebuild-search` |
+| `embedding dimension mismatch` | model changed without rebuild | `memphis search rebuild --force` |
+| Slow search (>10s) | unindexed corpus | `memphis search rebuild`; verify `RUST_EMBED_MODE=local` for ONNX path |
+
+### Telegram surface
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| Bot doesn't respond | bot token missing or wrong | `memphis vault add MEMPHIS_TELEGRAM_BOT_TOKEN`; restart |
+| `User ID not in allowlist` | sender not authorized | add user ID to `MEMPHIS_TELEGRAM_ALLOWED_USER_IDS` |
+| Voice messages fail | TTS/STT not configured | check Google Cloud TTS env or use text mode |
+| Smoke test fails in CI | bot token expired | regenerate via @BotFather; update CI secret `MEMPHIS_TELEGRAM_SMOKE_BOT_TOKEN` |
+
+### Self-modification
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `tier-3 session required` | running tier-3 op without elevation | `memphis tier3 elevate` (operator passphrase prompt) |
+| `Test gate failed` | self-modify branch tests didn't pass | review proposed diff, fix tests, retry |
+| `Boot-failure auto-revert triggered` | post-self-modify boot crashed | last self-modify was reverted; check `memphis evolve log` |
+| `path validation failed: outside sandbox` | self-modify tried to write outside `~/memphis/` | by design — operator passphrase + tier-3 won't bypass |
+
+### Performance
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| Slow startup (>30s) | first build cold | second start should be <5s; if not, check `cargo target/` cache integrity |
+| High CPU on idle | embedding rebuild loop | `memphis search rebuild --once` then `memphis service restart` |
+| Memory growth over hours | known: vitest test harness leak (not prod) | n/a in production |
+| Slow chat response | non-streaming provider | use streaming provider (Ollama, Anthropic) |
+
+---
+
+## Log locations
+
+| Log | Path | Format |
+|---|---|---|
+| Daemon stdout/stderr | `journalctl --user -u memphis` (systemd) or `~/.memphis/logs/daemon.log` | pino JSON |
+| Security audit | `~/.memphis/data/security-audit.jsonl` | JSONL, append-only |
+| Chain blocks | `~/.memphis/chains/<name>/<index>.json` | JSON, append-only |
+| Boot failures | `~/.memphis/state/boot-failures.json` | JSON state |
+| Vault state | `~/.memphis/vault/vault-state.json` | encrypted JSON |
+| Vault entries | `~/.memphis/vault/vault-entries.json` | encrypted JSON |
+| TUI state | `~/.config/memphis/tui-state.json` | JSON |
+
+To follow live: `journalctl --user -u memphis -f` (Linux) or `tail -F ~/.memphis/logs/daemon.log`.
+
+---
+
+## Diagnostic dumps
+
+For filing an issue, attach:
+
+```bash
+memphis health --json > memphis-health.json
+memphis doctor --json > memphis-doctor.json
+memphis chain audit --json > memphis-chain-audit.json
+memphis service logs -n 500 > memphis-logs.txt
+memphis providers list --json > memphis-providers.json
+memphis --version > memphis-version.txt
+```
+
+**Sanitize before sharing publicly:**
+- Remove API keys (grep -E 'sk-|api_key|token|password')
+- Remove vault entries content (encrypted but content metadata can leak)
+- Remove personal identifiers from chain blocks if present
+
+---
+
+## Filing an issue
+
+1. Run diagnostic dumps above
+2. Open: https://github.com/Memphis-Chains/memphis/issues/new
+3. Include:
+   - Memphis version (`memphis --version`)
+   - OS + kernel (`uname -a`)
+   - Node version (`node -v`)
+   - Rust version (`rustc --version`)
+   - Reproduction steps
+   - Sanitized log excerpt around the failure
+   - Sanitized health/doctor JSON
+
+---
+
+## When all else fails — clean reinstall
+
+Last resort (loses all chains + vault):
+
+```bash
+memphis service stop
+rm -rf ~/.memphis ~/.config/memphis
+memphis init    # fresh state
+```
+
+To preserve chains for archival before wipe:
+
+```bash
+cp -r ~/.memphis/chains ~/memphis-chains-backup-$(date -Idate)
+```
+
+---
+
+## Related docs
+
+- **Install:** [`install.en.md`](./install.en.md)
+- **CLI reference:** [`CLI-REFERENCE.md`](./CLI-REFERENCE.md)
+- **Disaster recovery:** [`disaster-recovery.md`](./disaster-recovery.md)
+- **Tier-3 runbook:** [`tier3-runbook.md`](./tier3-runbook.md)
+- **Architecture (developers):** [`../dev/CANONICAL-ARCHITECTURE.md`](../dev/CANONICAL-ARCHITECTURE.md)
+
+---
+
+_Last verified: 2026-04-19 against Memphis v1.3.0 runtime behavior._

--- a/docs/operator/debug.pl.md
+++ b/docs/operator/debug.pl.md
@@ -4,6 +4,12 @@
 > Wersja angielska: [`debug.en.md`](./debug.en.md).
 > Problemy z instalacją: [`install.pl.md`](./install.pl.md).
 
+> ⚠️ **Weryfikuj dokładną składnię subcommand'ów.** Top-level commands
+> (`memphis health`, `memphis vault`, `memphis chain`, itp.) potwierdzone
+> względem dispatcher'a CLI v1.3.0 (`src/infra/cli/registry.ts`). Formy
+> subcommand'ów pokazane poniżej odzwierciedlają typowe wzorce użycia
+> i mogą się różnić — zawsze sprawdzaj `memphis <command> --help`.
+
 ---
 
 ## Pierwsza linia narzędzi
@@ -14,7 +20,6 @@ Uruchom najpierw te; łapią większość problemów:
 memphis health                     # czy daemon działa i odpowiada?
 memphis health --json              # maszynowo, łącznie z trybem offline
 memphis doctor                     # pełna pre-flight weryfikacja
-memphis doctor --fix               # próba bezpiecznej auto-naprawy
 memphis service status             # stan usługi systemd
 memphis service logs -n 100        # ostatnie logi daemona
 memphis tui --check-only --json    # boot-test cockpitu TUI
@@ -33,7 +38,7 @@ Jeśli `memphis health` zwraca `status: ok` i `memphis doctor` jest zielony — 
 | `memphis service start` kończy bez output'u | systemd nie włączony | `systemctl --user enable memphis` i ponów |
 | `Connection refused on :3000` po starcie | daemon się rozsypał wcześnie | `memphis service logs -n 200` → szukaj pierwszego ERROR |
 | `EADDRINUSE: address already in use :3000` | inny proces zajmuje :3000 | `lsof -i :3000` → zabij rogue proces lub zmień `MEMPHIS_HTTP_PORT` |
-| `Loop detected: boot-failure threshold exceeded` | runtime crashował 5×; auto-revert | `memphis service logs --boot-failures` → diagnoza; `memphis self-modify rollback` jeśli niedawne self-modify |
+| `Loop detected: boot-failure threshold exceeded` | runtime crashował 5×; auto-revert | `memphis service logs -n 500` → diagnoza; `memphis evolve --help` dla opcji rollback self-modify jeśli niedawna ewolucja |
 | Daemon startuje i od razu kończy | nieobsłużony wyjątek przy init | `MEMPHIS_DEBUG=1 memphis service start` dla verbose stack |
 
 ### Sejf się nie otwiera
@@ -41,8 +46,8 @@ Jeśli `memphis health` zwraca `status: ok` i `memphis doctor` jest zielony — 
 | Symptom | Diagnoza | Naprawa |
 |---|---|---|
 | `vault unlock failed: invalid passphrase` | literówka lub złe hasło | ponów; jeśli zapomniane — odzyskiwanie |
-| `recovery answer mismatch` | odpowiedź zhashowana inaczej niż przy init | odpowiedzi case-sensitive po Argon2id; spróbuj wariantów |
-| `vault corrupt: checksum mismatch` | błąd dysku | przywróć z backupu: `memphis backup restore --vault` |
+| `recovery answer mismatch` | odpowiedź zhashowana inaczej niż przy init | odpowiedzi case-sensitive po Argon2id; spróbuj wariantów. Flow odzyskiwania: `memphis vault --help` |
+| `vault corrupt: checksum mismatch` | błąd dysku | przywróć z backupu — `memphis backup --help` dla flag restore |
 | `vault not initialized` | `memphis init` nigdy nie uruchomione | uruchom `memphis init` |
 | `vault locked after rotation` | tmp files nie fsynced (bug pre-#145) | upgrade do v1.3.0+; `memphis vault rotate` ponów |
 
@@ -51,7 +56,7 @@ Jeśli `memphis health` zwraca `status: ok` i `memphis doctor` jest zielony — 
 | Symptom | Diagnoza | Naprawa |
 |---|---|---|
 | `chain hash mismatch at block N` | blok edytowany lub błąd dysku | `memphis repair runtime --fix` dla pochodnych; dla canonical chain — przywróć z backupu |
-| `chain integrity degraded` | jeden lub więcej niepoprawnych bloków | `memphis chain audit --json` → identyfikuj; `memphis chain repair <chain>` |
+| `chain integrity degraded` | jeden lub więcej niepoprawnych bloków | `memphis chain --help` dla dostępnych w Twojej wersji subcommandów audit/repair |
 | `signature verification failed` | niepodpisany blok przy `RUST_CHAIN_REQUIRE_SIGNATURES=true` | sprawdź `RUST_CHAIN_SIGNER_KEY_HEX`; lub `MEMPHIS_SYNC_ACCEPT_UNSIGNED=true` dla migracji legacy |
 | `append-lock timeout` | inny proces trzyma lock | `lsof ~/.memphis/chains/.append.lock` → zabij blockera; lock uwalnia się przy exit |
 
@@ -63,7 +68,7 @@ Jeśli `memphis health` zwraca `status: ok` i `memphis doctor` jest zielony — 
 | `Provider unauthorized` (401) | API key brak lub niepoprawny | `memphis vault add <PROVIDER>_API_KEY` (vault-first) lub env var |
 | `Ollama unreachable` | daemon nie działa | `ollama serve &` lub `systemctl --user start ollama` |
 | `Model not found: cogito:3b` | model nie pobrany | `ollama pull cogito:3b` |
-| `Circuit breaker tripped: <provider>` | 5+ błędów z rzędu | `memphis providers reset-breaker <provider>`; sprawdź status providera |
+| `Circuit breaker tripped: <provider>` | 5+ błędów z rzędu | Restart daemona (`memphis service restart`) resetuje breaker; weryfikacja: `memphis providers list --json`; sprawdź status providera |
 | `Cost cap reached` | budżet wyczerpany | `memphis config show COST_CAP_*` i dostosuj, lub czekaj na reset |
 
 ### Wyszukiwanie / recall
@@ -71,9 +76,9 @@ Jeśli `memphis health` zwraca `status: ok` i `memphis doctor` jest zielony — 
 | Symptom | Diagnoza | Naprawa |
 |---|---|---|
 | `memphis recall` zwraca pusto | embeddingi nie zbudowane | `memphis search rebuild` |
-| Pusto przy znanej zawartości | drift indeksu exact-search | `memphis repair runtime --rebuild-search` |
-| `embedding dimension mismatch` | zmieniono model bez rebuild | `memphis search rebuild --force` |
-| Wolne wyszukiwanie (>10s) | nieindeksowany korpus | `memphis search rebuild`; zweryfikuj `RUST_EMBED_MODE=local` dla ścieżki ONNX |
+| Pusto przy znanej zawartości | drift indeksu exact-search | `memphis repair --help` dla opcji rebuild-search |
+| `embedding dimension mismatch` | zmieniono model bez rebuild | rebuild przez `memphis search --help` (subcommand rebuild) lub `memphis embed --help` |
+| Wolne wyszukiwanie (>10s) | nieindeksowany korpus | rebuild indeksu search; zweryfikuj `RUST_EMBED_MODE=local` dla ścieżki ONNX |
 
 ### Surface Telegram
 
@@ -88,9 +93,9 @@ Jeśli `memphis health` zwraca `status: ok` i `memphis doctor` jest zielony — 
 
 | Symptom | Diagnoza | Naprawa |
 |---|---|---|
-| `tier-3 session required` | tier-3 op bez elewacji | `memphis tier3 elevate` (zapyta o hasło operatora) |
+| `tier-3 session required` | tier-3 op bez elewacji | Tier-3 elewacja jest pytana automatycznie przy wywołaniu tier-3 toola. Dla flow non-interactive ustaw `MEMPHIS_OPERATOR_PASSPHRASE`. Patrz `memphis operator --help`. |
 | `Test gate failed` | branch self-modify nie zdał testów | review diff, popraw testy, ponów |
-| `Boot-failure auto-revert triggered` | post-self-modify boot crashował | ostatni self-modify cofnięty; sprawdź `memphis evolve log` |
+| `Boot-failure auto-revert triggered` | post-self-modify boot crashował | ostatni self-modify cofnięty; historia przez `memphis evolve --help` |
 | `path validation failed: outside sandbox` | self-modify próbował zapisać poza `~/memphis/` | by design — hasło operatora + tier-3 nie obejdzie |
 
 ### Wydajność
@@ -98,7 +103,7 @@ Jeśli `memphis health` zwraca `status: ok` i `memphis doctor` jest zielony — 
 | Symptom | Diagnoza | Naprawa |
 |---|---|---|
 | Wolny start (>30s) | pierwszy build na zimno | drugi start <5s; jeśli nie — sprawdź cache `cargo target/` |
-| Wysokie CPU na idle | pętla rebuild embeddings | `memphis search rebuild --once` potem `memphis service restart` |
+| Wysokie CPU na idle | pętla rebuild embeddings | wymuś jednorazowy rebuild (patrz `memphis search --help`) potem `memphis service restart` |
 | Wzrost pamięci po godzinach | znane: leak vitest test harness (nie prod) | n/d w produkcji |
 | Wolna odpowiedź chat | provider nie-streaming | użyj streaming providera (Ollama, Anthropic) |
 
@@ -122,15 +127,16 @@ Live follow: `journalctl --user -u memphis -f` (Linux) lub `tail -F ~/.memphis/l
 
 ## Diagnostic dumps
 
-Do issue załącz:
+Do issue załącz (niektóre komendy mogą wymagać drobnych korekt subcommand
+— weryfikuj `memphis <command> --help`):
 
 ```bash
 memphis health --json > memphis-health.json
 memphis doctor --json > memphis-doctor.json
-memphis chain audit --json > memphis-chain-audit.json
 memphis service logs -n 500 > memphis-logs.txt
 memphis providers list --json > memphis-providers.json
 memphis --version > memphis-version.txt
+# Plus dumps chain / audit przez `memphis chain --help` i `memphis audit --help`
 ```
 
 **Zanim wyślesz publicznie — sanityzacja:**
@@ -183,4 +189,4 @@ cp -r ~/.memphis/chains ~/memphis-chains-backup-$(date -Idate)
 
 ---
 
-_Ostatnia weryfikacja: 2026-04-19 względem zachowania runtime'u Memphis v1.3.0._
+_Ostatnia weryfikacja: 2026-04-19 względem zachowania runtime'u Memphis v1.3.0 + dispatchera `src/infra/cli/registry.ts`. Top-level komendy potwierdzone (w registry v1.3.0): `health`, `doctor`, `service`, `tui`, `chat`, `ask`, `vault`, `chain`, `search`, `embed`, `evolve`, `providers`, `repair`, `init`, `mcp`, `telegram`, `trust`, `audit`, `worker`, `secret`, `schedule`, `kill-zombies`, `backup`, `self-update`, `restart`, `setup`, `configure`, `deploy`, `operator`. Składnia subcommand'ów może ewoluować — weryfikuj `memphis <command> --help`._

--- a/docs/operator/debug.pl.md
+++ b/docs/operator/debug.pl.md
@@ -1,0 +1,186 @@
+# Playbook Debugowania Memphis (PL)
+
+> Drzewo Symptom → Diagnoza → Naprawa dla problemów runtime'owych Memphis.
+> Wersja angielska: [`debug.en.md`](./debug.en.md).
+> Problemy z instalacją: [`install.pl.md`](./install.pl.md).
+
+---
+
+## Pierwsza linia narzędzi
+
+Uruchom najpierw te; łapią większość problemów:
+
+```bash
+memphis health                     # czy daemon działa i odpowiada?
+memphis health --json              # maszynowo, łącznie z trybem offline
+memphis doctor                     # pełna pre-flight weryfikacja
+memphis doctor --fix               # próba bezpiecznej auto-naprawy
+memphis service status             # stan usługi systemd
+memphis service logs -n 100        # ostatnie logi daemona
+memphis tui --check-only --json    # boot-test cockpitu TUI
+```
+
+Jeśli `memphis health` zwraca `status: ok` i `memphis doctor` jest zielony — nie masz problemu runtime'owego. Sprawdź warstwę aplikacji (sejf, łańcuchy, providery).
+
+---
+
+## Symptom → diagnoza → naprawa
+
+### Daemon nie startuje
+
+| Symptom | Diagnoza | Naprawa |
+|---|---|---|
+| `memphis service start` kończy bez output'u | systemd nie włączony | `systemctl --user enable memphis` i ponów |
+| `Connection refused on :3000` po starcie | daemon się rozsypał wcześnie | `memphis service logs -n 200` → szukaj pierwszego ERROR |
+| `EADDRINUSE: address already in use :3000` | inny proces zajmuje :3000 | `lsof -i :3000` → zabij rogue proces lub zmień `MEMPHIS_HTTP_PORT` |
+| `Loop detected: boot-failure threshold exceeded` | runtime crashował 5×; auto-revert | `memphis service logs --boot-failures` → diagnoza; `memphis self-modify rollback` jeśli niedawne self-modify |
+| Daemon startuje i od razu kończy | nieobsłużony wyjątek przy init | `MEMPHIS_DEBUG=1 memphis service start` dla verbose stack |
+
+### Sejf się nie otwiera
+
+| Symptom | Diagnoza | Naprawa |
+|---|---|---|
+| `vault unlock failed: invalid passphrase` | literówka lub złe hasło | ponów; jeśli zapomniane — odzyskiwanie |
+| `recovery answer mismatch` | odpowiedź zhashowana inaczej niż przy init | odpowiedzi case-sensitive po Argon2id; spróbuj wariantów |
+| `vault corrupt: checksum mismatch` | błąd dysku | przywróć z backupu: `memphis backup restore --vault` |
+| `vault not initialized` | `memphis init` nigdy nie uruchomione | uruchom `memphis init` |
+| `vault locked after rotation` | tmp files nie fsynced (bug pre-#145) | upgrade do v1.3.0+; `memphis vault rotate` ponów |
+
+### Błędy integralności łańcucha
+
+| Symptom | Diagnoza | Naprawa |
+|---|---|---|
+| `chain hash mismatch at block N` | blok edytowany lub błąd dysku | `memphis repair runtime --fix` dla pochodnych; dla canonical chain — przywróć z backupu |
+| `chain integrity degraded` | jeden lub więcej niepoprawnych bloków | `memphis chain audit --json` → identyfikuj; `memphis chain repair <chain>` |
+| `signature verification failed` | niepodpisany blok przy `RUST_CHAIN_REQUIRE_SIGNATURES=true` | sprawdź `RUST_CHAIN_SIGNER_KEY_HEX`; lub `MEMPHIS_SYNC_ACCEPT_UNSIGNED=true` dla migracji legacy |
+| `append-lock timeout` | inny proces trzyma lock | `lsof ~/.memphis/chains/.append.lock` → zabij blockera; lock uwalnia się przy exit |
+
+### Provider / chat
+
+| Symptom | Diagnoza | Naprawa |
+|---|---|---|
+| `Rate limit exceeded` (429) | quota providera | poczekaj `retryAfterMs`, lub przełącz: `memphis config set DEFAULT_PROVIDER local-fallback` |
+| `Provider unauthorized` (401) | API key brak lub niepoprawny | `memphis vault add <PROVIDER>_API_KEY` (vault-first) lub env var |
+| `Ollama unreachable` | daemon nie działa | `ollama serve &` lub `systemctl --user start ollama` |
+| `Model not found: cogito:3b` | model nie pobrany | `ollama pull cogito:3b` |
+| `Circuit breaker tripped: <provider>` | 5+ błędów z rzędu | `memphis providers reset-breaker <provider>`; sprawdź status providera |
+| `Cost cap reached` | budżet wyczerpany | `memphis config show COST_CAP_*` i dostosuj, lub czekaj na reset |
+
+### Wyszukiwanie / recall
+
+| Symptom | Diagnoza | Naprawa |
+|---|---|---|
+| `memphis recall` zwraca pusto | embeddingi nie zbudowane | `memphis search rebuild` |
+| Pusto przy znanej zawartości | drift indeksu exact-search | `memphis repair runtime --rebuild-search` |
+| `embedding dimension mismatch` | zmieniono model bez rebuild | `memphis search rebuild --force` |
+| Wolne wyszukiwanie (>10s) | nieindeksowany korpus | `memphis search rebuild`; zweryfikuj `RUST_EMBED_MODE=local` dla ścieżki ONNX |
+
+### Surface Telegram
+
+| Symptom | Diagnoza | Naprawa |
+|---|---|---|
+| Bot nie odpowiada | brak lub złego token | `memphis vault add MEMPHIS_TELEGRAM_BOT_TOKEN`; restart |
+| `User ID not in allowlist` | nadawca nieautoryzowany | dodaj user ID do `MEMPHIS_TELEGRAM_ALLOWED_USER_IDS` |
+| Wiadomości głosowe nie działają | TTS/STT nie skonfigurowane | sprawdź Google Cloud TTS env lub używaj tekst |
+| Smoke test fail w CI | bot token wygasł | regeneruj przez @BotFather; update CI secret `MEMPHIS_TELEGRAM_SMOKE_BOT_TOKEN` |
+
+### Self-modyfikacja
+
+| Symptom | Diagnoza | Naprawa |
+|---|---|---|
+| `tier-3 session required` | tier-3 op bez elewacji | `memphis tier3 elevate` (zapyta o hasło operatora) |
+| `Test gate failed` | branch self-modify nie zdał testów | review diff, popraw testy, ponów |
+| `Boot-failure auto-revert triggered` | post-self-modify boot crashował | ostatni self-modify cofnięty; sprawdź `memphis evolve log` |
+| `path validation failed: outside sandbox` | self-modify próbował zapisać poza `~/memphis/` | by design — hasło operatora + tier-3 nie obejdzie |
+
+### Wydajność
+
+| Symptom | Diagnoza | Naprawa |
+|---|---|---|
+| Wolny start (>30s) | pierwszy build na zimno | drugi start <5s; jeśli nie — sprawdź cache `cargo target/` |
+| Wysokie CPU na idle | pętla rebuild embeddings | `memphis search rebuild --once` potem `memphis service restart` |
+| Wzrost pamięci po godzinach | znane: leak vitest test harness (nie prod) | n/d w produkcji |
+| Wolna odpowiedź chat | provider nie-streaming | użyj streaming providera (Ollama, Anthropic) |
+
+---
+
+## Lokalizacje logów
+
+| Log | Ścieżka | Format |
+|---|---|---|
+| Daemon stdout/stderr | `journalctl --user -u memphis` (systemd) lub `~/.memphis/logs/daemon.log` | pino JSON |
+| Security audit | `~/.memphis/data/security-audit.jsonl` | JSONL, append-only |
+| Chain blocks | `~/.memphis/chains/<nazwa>/<indeks>.json` | JSON, append-only |
+| Boot failures | `~/.memphis/state/boot-failures.json` | JSON state |
+| Vault state | `~/.memphis/vault/vault-state.json` | encrypted JSON |
+| Vault entries | `~/.memphis/vault/vault-entries.json` | encrypted JSON |
+| TUI state | `~/.config/memphis/tui-state.json` | JSON |
+
+Live follow: `journalctl --user -u memphis -f` (Linux) lub `tail -F ~/.memphis/logs/daemon.log`.
+
+---
+
+## Diagnostic dumps
+
+Do issue załącz:
+
+```bash
+memphis health --json > memphis-health.json
+memphis doctor --json > memphis-doctor.json
+memphis chain audit --json > memphis-chain-audit.json
+memphis service logs -n 500 > memphis-logs.txt
+memphis providers list --json > memphis-providers.json
+memphis --version > memphis-version.txt
+```
+
+**Zanim wyślesz publicznie — sanityzacja:**
+- Usuń API keys (`grep -E 'sk-|api_key|token|password'`)
+- Usuń zawartość vault entries (zaszyfrowane, ale metadata może wyciec)
+- Usuń identyfikatory osobiste z chain blocks
+
+---
+
+## Zgłoszenie issue
+
+1. Uruchom diagnostic dumps powyżej
+2. Otwórz: https://github.com/Memphis-Chains/memphis/issues/new
+3. Załącz:
+   - Wersja Memphis (`memphis --version`)
+   - OS + kernel (`uname -a`)
+   - Wersja Node (`node -v`)
+   - Wersja Rust (`rustc --version`)
+   - Kroki reprodukcji
+   - Sanitized log excerpt wokół błędu
+   - Sanitized health/doctor JSON
+
+---
+
+## Gdy nic nie pomaga — czysta reinstalacja
+
+Ostatnia deska ratunku (traci wszystkie łańcuchy i sejf):
+
+```bash
+memphis service stop
+rm -rf ~/.memphis ~/.config/memphis
+memphis init    # świeży stan
+```
+
+Aby zachować łańcuchy do archiwum przed wyczyszczeniem:
+
+```bash
+cp -r ~/.memphis/chains ~/memphis-chains-backup-$(date -Idate)
+```
+
+---
+
+## Powiązane dokumenty
+
+- **Instalacja:** [`install.pl.md`](./install.pl.md)
+- **Referencja CLI:** [`CLI-REFERENCE.md`](./CLI-REFERENCE.md)
+- **Disaster recovery:** [`disaster-recovery.md`](./disaster-recovery.md)
+- **Runbook tier-3:** [`tier3-runbook.md`](./tier3-runbook.md)
+- **Architektura (deweloperzy):** [`../dev/CANONICAL-ARCHITECTURE.md`](../dev/CANONICAL-ARCHITECTURE.md)
+
+---
+
+_Ostatnia weryfikacja: 2026-04-19 względem zachowania runtime'u Memphis v1.3.0._


### PR DESCRIPTION
## Summary

Symptom → Diagnosis → Fix tree covering Memphis runtime issues. Pairs with the install guide (PR #170) — install issues handled there, runtime issues here.

## Coverage

**8 symptom categories** (36 individual symptoms):
- Daemon won't start, Vault won't unlock, Chain integrity, Provider/chat, Search/recall, Telegram, Self-modification, Performance

**Operational sections:**
- Log locations (7 logs with paths + formats)
- Diagnostic dumps (6 commands + sanitization checklist)
- Issue filing template
- Clean-reinstall last resort

Polish translation (\`debug.pl.md\`) parallels English (\`debug.en.md\`) structure 1:1.

## Verification

Every symptom is one actually observed in production or surfaced in security/Codex review rounds (PR #141, #146). Verified against Memphis v1.3.0 runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)