### PR TITLE
docs: 7 crate READMEs + new docs/README.md index

### DIFF
--- a/crates/memphis-case-index/README.md
+++ b/crates/memphis-case-index/README.md
@@ -1,0 +1,27 @@
+# memphis-case-index
+
+Indexed lookup over the `cases` chain. Backs the `memphis_case_query` MCP tool.
+
+## Public surface
+
+- Index a case block by actor / target / case-type / timestamp
+- Query by composite filter (e.g. all "DECISION" blocks involving actor X)
+- Rebuild index from canonical chain blocks
+- Verify index hash matches chain truth
+
+## Build
+
+```bash
+cargo build -p memphis-case-index
+cargo test -p memphis-case-index --lib
+```
+
+13 tests passing as of v1.3.0 (case-block validation, query composition, hash verification).
+
+## Layer
+
+L1 storage adjunct — pure derivative of the canonical `cases` chain. Index can always be rebuilt from chain truth via `rebuild_from_blocks`.
+
+## Status
+
+Skeleton (single `lib.rs`). Will grow as Memphis's case-based reasoning capabilities expand. The case-block schema (8 grammatical cases — nominative, genitive, dative, accusative, instrumental, locative, vocative, ablative) is the core abstraction.

--- a/crates/memphis-core/README.md
+++ b/crates/memphis-core/README.md
@@ -1,0 +1,35 @@
+# memphis-core
+
+Chain integrity, block hashing, ed25519 signing/verification. The bedrock crate — every signed block in Memphis travels through here.
+
+## Public surface
+
+- `chain.rs` — append-only chain primitives (`append_strict`, `append_precomputed`)
+- `block.rs` — block schema + serde
+- `hash.rs` — SHA-256 hashing of blocks (deterministic by content)
+- `signature.rs` — ed25519 sign/verify, signer allowlist
+- `harness.rs` — replay harness for test fixtures
+- `loop_engine.rs` — bounded loop primitive (max-tool-calls enforcement)
+
+## Build
+
+```bash
+cargo build -p memphis-core
+cargo test -p memphis-core --lib
+```
+
+Sanitizers (Phase A3, weekly CI):
+
+```bash
+cargo +nightly test -p memphis-core --lib -Z sanitizer=address
+cargo +nightly test -p memphis-core --lib -Z sanitizer=undefined
+cargo +nightly test -p memphis-core --lib -Z sanitizer=thread
+```
+
+## Layer
+
+L1 (Storage) primitives. Used by `memphis-napi` to expose chain operations to the TS runtime, by `memphis-vault` for signing vault state changes, and by `memphis-case-index` for case-block validation.
+
+## Stability
+
+Stable since v1.0.0. Block schema is forwards-compatible (additive fields only). Signature primitive is `ed25519`; post-quantum migration would be a separate major version.

--- a/crates/memphis-embed/README.md
+++ b/crates/memphis-embed/README.md
@@ -1,0 +1,27 @@
+# memphis-embed
+
+Embedding pipeline + cache + chain integration. Central to Memphis's RAG and semantic-recall paths.
+
+## Public surface
+
+- `pipeline.rs` — embedding generation (Ollama / OpenAI / hash-fallback)
+- `store.rs` — vector store (cosine similarity, top-k retrieval)
+- `cache.rs` — embed-result cache (content-addressed)
+- `chain_integration.rs` — extract embeddable text from chain blocks; rebuild flow
+
+## Build
+
+```bash
+cargo build -p memphis-embed
+cargo test -p memphis-embed --lib
+```
+
+## Layer
+
+L1+L2 boundary. Owns the embedding store (storage L1) and the cascade decision logic (runtime L2). Exposed to TS via `memphis-napi` (`embed_store`, `embed_search`).
+
+## Sovereign-RAG cascade (M6 plan)
+
+Currently: hash-based fallback ⊕ Ollama (`nomic-embed-text` default) ⊕ OpenAI.
+
+Planned (M6 in `docs/ROADMAP-CURRENT.md`): add `OnnxLocalProvider` as Tier 0 (always-available CPU embeddings via `ort` + pre-shipped `multilingual-e5-small` ONNX model). This makes Memphis fully sovereign — semantic search works on a 2011 CPU without GPU and without internet (proven on Intel i3-2120, 2026-04-19, 68 docs / 797 chunks / cross-lingual EN→PL search).

--- a/crates/memphis-napi/README.md
+++ b/crates/memphis-napi/README.md
@@ -1,0 +1,34 @@
+# memphis-napi
+
+The TypeScript ↔ Rust bridge. Exposes `memphis-core`, `memphis-vault`, `memphis-embed` to the Node.js runtime via N-API.
+
+## Public surface
+
+NAPI exports (consumed from `src/infra/storage/rust-*-adapter.ts`):
+
+- Chain: `chain_init`, `chain_append_strict`, `chain_append_precomputed`, `chain_validate`, `chain_query_blocks`
+- Vault: `vault_*` (encrypt, decrypt, list, rotate)
+- Embed: `embed_store`, `embed_search`, `embed_rebuild`
+- Cases: `case_*` index ops
+- Harness: replay primitives
+
+The pre-built native module is committed at `index.node` so `npm install` works without a Rust toolchain on consumer machines. Rebuild with:
+
+```bash
+npm run build:napi      # or: cargo build -p memphis-napi --release
+```
+
+## Build
+
+```bash
+cargo build -p memphis-napi
+cargo check -p memphis-napi
+```
+
+## Layer
+
+L2 bridge. Pure plumbing — no business logic lives here, only NAPI argument marshalling and error translation between Rust `Result` and JS exceptions.
+
+## Stability contract
+
+NAPI surface is documented in `docs/dev/NAPI-CONTRACT-V1.md`. Breaking changes require a major version bump on the npm package.

--- a/crates/memphis-operator/README.md
+++ b/crates/memphis-operator/README.md
@@ -1,0 +1,27 @@
+# memphis-operator
+
+Native Rust operator console — chat runtime + provider adapters + config. Replaces the legacy TypeScript TUI as the active operator surface (per `docs/ROADMAP-CURRENT.md` M1).
+
+## Public surface
+
+- `chat.rs` — chat loop (streaming, tool dispatch, approval gates)
+- `config.rs` — runtime config resolver (vault-first secret resolution)
+- `provider.rs` — provider adapters (Ollama, Anthropic, MiniMax, GLM, DeepSeek, OpenAI)
+- `runtime.rs` — top-level runtime orchestration
+
+## Build
+
+```bash
+cargo build -p memphis-operator
+cargo test -p memphis-operator --lib
+```
+
+## Layer
+
+L5 surface (operator console). Used by `memphis-tui` as the native chat backend; also dispatched via `memphis-napi` so the TS gateway can use the same provider cascade.
+
+## Provider cascade
+
+Default order: `local-fallback` → `ollama` → operator-configured remote. Each provider implements the same trait (`provider.rs`). Cost-cap, circuit-breaker, and tier-gates apply uniformly across providers.
+
+`sanitize_for_json()` (post-v1.2.3 fix) handles invalid `\xNN` escapes that DeepSeek's API rejected — applied before every outbound request.

--- a/crates/memphis-tui/README.md
+++ b/crates/memphis-tui/README.md
@@ -1,0 +1,33 @@
+# memphis-tui
+
+Native ratatui-based terminal cockpit. The active operator console (replaces the legacy TypeScript TUI archived under `docs/archive/`).
+
+## Public surface
+
+`cargo run -p memphis-tui` (or via the CLI: `memphis tui`).
+
+Tabs: Overview · Chat · Memory · Sessions · Vault · Cases · System.
+
+Status bar shows: cognitive mode (A-E), provider/model, PULSE health, session id.
+
+## Build
+
+```bash
+cargo build -p memphis-tui
+cargo run -p memphis-tui
+```
+
+For check-only smoke (used by CI):
+
+```bash
+memphis tui --check-only --json
+```
+
+## Layer
+
+L5 surface. Talks to `memphis-operator` (chat backend) and `memphis-napi` bridge (chain/vault ops). No business logic — pure renderer + input dispatcher.
+
+## Reference docs
+
+- Migration history from TS TUI: `docs/dev/TUI-RATATUI-MIGRATION-SEAM.md`
+- Operator usage: `docs/operator/TUI-OPERATOR-GUIDE.md`

--- a/crates/memphis-vault/README.md
+++ b/crates/memphis-vault/README.md
@@ -1,0 +1,38 @@
+# memphis-vault
+
+DID, vault encryption, KDF, 2FA recovery. Everything secret-bearing in Memphis lives here.
+
+## Public surface
+
+- `did.rs` — Decentralized Identifier (`did:mph:...`) with ed25519 keys
+- `keyring.rs` — Argon2id KDF (default 64 MiB / 3 iter / p=4); v1→v2 salt migration
+- `crypto.rs` — AES-256-GCM with 12-byte nonce (random per encryption)
+- `vault.rs` — vault entry persistence + master-key rotation (with fsync, post-#145)
+- `two_factor.rs` — Q&A recovery (Argon2id over answer + HKDF combine; `Result`-returning since #144)
+- `error.rs` — `VaultError` taxonomy
+
+## Build
+
+```bash
+cargo build -p memphis-vault
+cargo test -p memphis-vault --lib
+```
+
+ASan (weekly CI, Phase A3):
+
+```bash
+cargo +nightly test -p memphis-vault --lib -Z sanitizer=address
+```
+
+31/31 tests passing as of v1.3.0.
+
+## Layer
+
+L0 (Identity & Crypto). Used by `memphis-napi` (vault NAPI bindings), `memphis-operator` (Rust operator console resolves API keys here), and `memphis-core` (signature key resolution from vault).
+
+## Security notes
+
+- Vault state on-disk is `0o600` mode; vault dir is `0o700` (post-#135).
+- Argon2id parameters are env-configurable (`MEMPHIS_VAULT_KDF_*`); defaults tuned to ~1.5s on Intel i3-2120 reference.
+- Master-key rotation is atomic with fsync between writes (post-#145).
+- 2FA recovery answer never stored in plaintext — hashed via Argon2id, combined with master key via HKDF.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,72 +1,143 @@
 # Memphis Documentation
 
-This index separates canonical docs from operational planning and historical material.
+Index of all docs after the 2026-04-19 reorganization (PR #169 + sprint).
 
-## Start Here
+## Start here
 
-- [README](../README.md) - operator-first entrypoint
-- [Project Status](./PROJECT-STATUS.md) - current truth after `v1.2.1`
-- [Current Roadmap](./ROADMAP-CURRENT.md) - active roadmap from current state forward
-- [Clean Install](./CLEAN-INSTALL.md) - shortest fresh-install path from GitHub
-- [Getting Started](./GETTING-STARTED.md) - canonical local runtime path
-- [Configuration](./CONFIGURATION.md) - runtime config and env reference
-- [Troubleshooting](./TROUBLESHOOTING.md) - common runtime failures and fixes
-- [API Reference](./API-REFERENCE.md) - current HTTP and gateway endpoints
+- **Install:** [`operator/install.en.md`](./operator/install.en.md) · [`operator/install.pl.md`](./operator/install.pl.md)
+- **First steps:** [`operator/example-installation/`](./operator/example-installation/)
+- **Debug:** [`operator/debug.en.md`](./operator/debug.en.md) · [`operator/debug.pl.md`](./operator/debug.pl.md)
+- **Current roadmap:** [`ROADMAP-CURRENT.md`](./ROADMAP-CURRENT.md)
 
-## Canonical Product Docs
+## By audience
 
-- [Canonical Architecture](./CANONICAL-ARCHITECTURE.md) - verified architecture source of truth
-- [Project Status](./PROJECT-STATUS.md) - current product maturity and known gaps
-- [Current Roadmap](./ROADMAP-CURRENT.md) - active roadmap and historical summary
-- [Runtime State Model](./RUNTIME-STATE-MODEL.md) - canonical runtime roots, cleanup semantics, and fresh-install contract
-- [Runtime Security Architecture](./RUNTIME-SECURITY-ARCHITECTURE.md) - runtime dependency graph, trust boundaries, and security model
-- [Execution Plan](./EXECUTION-PLAN.md) - canonical `v1.0.0` delivery record and post-GA baseline, including legacy sprint mapping
-- [NAPI Contract](./NAPI-CONTRACT-V1.md) - Rust <-> TypeScript bridge contract
+### `operator/` — for users running Memphis
 
-## Governance
+47 docs. Install, run, troubleshoot, vault, chains, providers, TUI, CLI, upgrades, deployment, runbooks. The bilingual install + debug guides above are the canonical entry points; the rest is reference.
 
-Canonical product truth lives in this repository:
+### `dev/` — for developers contributing to Memphis
 
-- `README.md`
-- `docs/PROJECT-STATUS.md`
-- `docs/ROADMAP-CURRENT.md`
-- `docs/CANONICAL-ARCHITECTURE.md`
-- `docs/RUNTIME-STATE-MODEL.md`
-- `docs/EXECUTION-PLAN.md`
-- `docs/NAPI-CONTRACT-V1.md`
-- runtime/public contract docs such as `docs/API-REFERENCE.md`, `docs/CONFIGURATION.md`, and `docs/RELEASE-PROCESS.md`
+28 docs. Architecture (canonical, runtime, security, evolution), cognitive models, embedding pipeline, NAPI contract, vault internals, federation key exchange, testing, surface parity, performance tuning.
 
-Repo-local `memory/` notes, overnight reports, and operator handoff snapshots are useful context,
-but they are not canonical product truth unless explicitly linked from the list above.
+### `agents/` — for AI agents working on Memphis
 
-Operational planning lives in the external workspace layer and is not canonical product truth:
+Coordination protocol for Claude / Memphis-runtime / OpenClaw. Includes inter-agent handoff, tool registry conventions, and the OpenClaw integration spec.
 
-- `../.openclaw/workspace/SPRINT_STATUS.md`
-- `../.openclaw/workspace/SPRINT-PLAN-UPDATED.md`
-- `../.openclaw/workspace/ROADMAP-COMPLETE.md`
-- `../.openclaw/workspace/NEXT_CODER_TASKS.md`
+### `historical/` — sprint logs, release process, planning
 
-Historical roadmap material remains for auditability:
+15 docs. Old execution plans, project status snapshots, release schedules, observability rollouts, alert policies. Useful for understanding how Memphis got here, not what to do next.
 
-- [ROADMAP-FULL-SPRINT3-TO-M8](./archive/2026-04-14-post-roadmap-cleanup/ROADMAP-FULL-SPRINT3-TO-M8.md) - historical roadmap (archived), superseded and mapped into [Execution Plan](./EXECUTION-PLAN.md)
-- [`../ROADMAP.md`](../ROADMAP.md) - repo-root historical roadmap pointer, superseded
-- [`../ROADMAP-MASTER-QUEUE.md`](../ROADMAP-MASTER-QUEUE.md) - historical queue artifact, superseded
-- [`../SPRINT_STATUS.md`](../SPRINT_STATUS.md) - repo-root historical sprint board pointer, superseded
+### `archive/` — older archived planning material
 
-## Operations and Release
+Two prior cleanup waves (PR #108 in 2026-04-14, PR #168 in 2026-04-19) plus older V5 / pre-V5 planning artifacts. Retained for audit; not authoritative for current behavior.
 
-- [Package Publish](./PACKAGE-PUBLISH.md)
-- [Release Process](./RELEASE-PROCESS.md)
-- [Operations Manual](./OPERATIONS-MANUAL.md)
-- [Testing and Verification](./TESTING-VERIFICATION.md)
+## By subject
 
-## Advisory / Downstream References
+### Architecture & internals
 
-- [Hotel Deployment Reference](./HOTEL-DEPLOYMENT-REFERENCE.md) - optional hotel, Synjar, and PMS deployment patterns
-- [Federation Key Exchange](./FEDERATION-KEY-EXCHANGE.md) - Matrix pilot and deferred public-federation hardening note
-- [Soul Guide](./SOUL_GUIDE.md) - advisory reference for `soul-*` identity/memory surfaces; not the canonical product definition
+- `dev/CANONICAL-ARCHITECTURE.md`
+- `dev/RUNTIME-SECURITY-ARCHITECTURE.md`
+- `dev/RUNTIME-STATE-MODEL.md`
+- `dev/EVOLUTION-ARCHITECTURE.md`
+- `dev/COGNITIVE-ARCHITECTURE.md` + `dev/COGNITIVE-MODELS.md`
+- `dev/EMBEDDING-ARCHITECTURE.md` + `dev/EMBED-PIPELINE.md`
+- `dev/rust-crates-architecture.md`
 
-## Legacy and Historical Material
+### API contracts
 
-Several docs in this directory remain for historical context, audits, or earlier design iterations.
-Use the canonical documents above first. Treat older `v4` / `v5` strategy, release, architecture, and superseded roadmap docs as reference only.
+- `api/` — REST endpoints
+- `dev/API-REFERENCE.md` — top-level
+- `dev/NAPI-CONTRACT-V1.md` — TS↔Rust bridge
+- `dev/VAULT-API.md`
+- `dev/MEMORY-FILE-FORMAT.md`
+
+### Security
+
+- `dev/SECURITY-GUIDE.md`
+- `dev/key-lifecycle.md` + `dev/KEY-ROTATION-DESIGN.md` + `dev/VAULT-PEPPER-LIFECYCLE.md`
+- `dev/GATEWAY-EXEC-HARDENING.md`
+- `operator/tier3-runbook.md`
+
+### Operations
+
+- `runbooks/` — incident playbooks
+- `operator/OPERATIONS-MANUAL.md`
+- `operator/disaster-recovery.md`
+- `operator/DB-BACKUP-BASELINE.md`
+- `operator/DEPLOYMENT-CHECKLIST.md`
+- `historical/RELEASE-PROCESS.md` + `historical/RELEASE-CHECKLIST.md`
+
+### Federation & sync
+
+- `dev/FEDERATION-KEY-EXCHANGE.md`
+- `MEMPHIS-FEDERATION-DESIGN.md` (root) — design doc
+- `agents/OPENCLAW-INTEGRATION.md`
+
+### CLI / TUI
+
+- `operator/CLI-REFERENCE.md`
+- `operator/CLI-COMMAND-MATRIX.md`
+- `operator/TUI-OPERATOR-GUIDE.md`
+- `operator/voice.md`
+
+### Vault
+
+- `dev/VAULT-API.md` (internals)
+- `operator/VAULT-CLI.md` (CLI surface)
+- `dev/VAULT-PEPPER-LIFECYCLE.md`
+
+### Chains
+
+- `operator/chain-integrity.md`
+- `operator/CHAIN-EXPORT.md` + `operator/CHAIN-IMPORT-JSON.md`
+
+### Providers / LLMs
+
+- `operator/OLLAMA-SETUP.md` + `operator/OLLAMA-BRIDGE-RUNBOOK.md`
+- `operator/GUIDE-CUSTOM-LLM.md`
+
+### Observability
+
+- `observability/` — Grafana dashboards, OTel config
+- `historical/observability.md` (rollout plan)
+- `historical/slo-baseline.md`
+- `historical/NIGHTLY-CRYSTAL.md`
+
+### Cognitive
+
+- `dev/COGNITIVE-MODELS.md` (5 models A-E)
+- `dev/cognitive-modes.md`
+- `dev/cognitive-frames.md`
+- `operator/SOUL_GUIDE.md`
+
+### Self-modification
+
+- `operator/self-modify.md` (root, see also `dev/EVOLUTION-ARCHITECTURE.md`)
+- `operator/self-restart.md`
+- `operator/self-update.md`
+
+### Roadmap
+
+- `ROADMAP-CURRENT.md` — current canonical roadmap (this file)
+- `historical/EXECUTION-PLAN.md` — archived planning
+- `PROPOSALS/` — WIP design proposals not yet promoted
+
+## Conventions
+
+- **Markdown.** Every doc is `.md` for grep-ability and rendering on GitHub.
+- **Bilingual** for entry-point operator docs (install, debug). Internals + dev docs stay English-only.
+- **Filenames** are lowercase-kebab-case for new docs; legacy ALL-CAPS preserved where moves would break external links.
+- **Cross-links** use relative paths so the docs work browsed on GitHub or via `mkdocs serve` locally.
+
+## How to add a doc
+
+1. Pick the right bucket: operator (user-facing) / dev (architecture/code) / agents (Claude/Memphis-runtime/OpenClaw context) / historical (point-in-time records).
+2. Use lowercase-kebab-case filename.
+3. Open with one-sentence purpose + audience.
+4. Cross-link to related docs at the bottom.
+5. Add a date stamp at the bottom: `_Last verified: YYYY-MM-DD against vN.N.N._`
+6. Update this index if your doc opens a new subject area.
+
+---
+
+_Last verified: 2026-04-19 against Memphis v1.3.0._


### PR DESCRIPTION
## Summary

Surfaced by Wodzu's deep-review (2026-04-19): **zero crate-level READMEs** across 7 Rust crates, and \`docs/README.md\` was a stale 72-line index predating the 4-bucket reorganization (PR #169).

## New (8 files)

| File | Purpose |
|---|---|
| \`crates/memphis-core/README.md\` | chain integrity + ed25519 bedrock |
| \`crates/memphis-vault/README.md\` | DID + Argon2id + AES-GCM |
| \`crates/memphis-embed/README.md\` | embedding pipeline (M6 host) |
| \`crates/memphis-napi/README.md\` | TS↔Rust bridge contract |
| \`crates/memphis-operator/README.md\` | native chat runtime |
| \`crates/memphis-tui/README.md\` | ratatui cockpit |
| \`crates/memphis-case-index/README.md\` | cases chain index |
| \`docs/README.md\` | full index after PR #169 reorg (replaces 72-line stale version) |

Each crate README is intentionally one screen: role, public surface, build commands, layer position, stability/sanitizer notes.

\`docs/README.md\` indexes everything by audience (operator/dev/agents/historical) AND by subject (architecture/security/operations/cli/vault/chains/providers/observability/cognitive/self-modify/roadmap).

## What this PR does NOT do

Root \`README.md\` and \`AGENTS.md\` intentionally NOT touched — they have in-flight changes in PR #167 (version sync). Updating them here would conflict on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)