### PR TITLE
chore(format): prettier --write on 13 sprint-added files (supersedes #166)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,15 +36,15 @@ team can coordinate without losing context between conversations.
 
 ### Workspaces (7)
 
-| Workspace | Purpose |
-| --- | --- |
-| `core-memphis`  | Architecture, system design, runtime docs |
-| `strategy`      | Vision, roadmaps, business, market, Watra brand |
-| `research`      | External inspirations, links, tech stacks, literature |
-| `ops`           | Runbooks, CLI/API reference, install, release notes |
-| `decisions`     | ADRs, plans, meta-decisions, memory |
-| `agent-notes`   | Inter-agent scratchpad, handoffs, TODOs |
-| `inbox-human`   | LAN drop-zone: humans upload raw material for agents to analyse |
+| Workspace      | Purpose                                                         |
+| -------------- | --------------------------------------------------------------- |
+| `core-memphis` | Architecture, system design, runtime docs                       |
+| `strategy`     | Vision, roadmaps, business, market, Watra brand                 |
+| `research`     | External inspirations, links, tech stacks, literature           |
+| `ops`          | Runbooks, CLI/API reference, install, release notes             |
+| `decisions`    | ADRs, plans, meta-decisions, memory                             |
+| `agent-notes`  | Inter-agent scratchpad, handoffs, TODOs                         |
+| `inbox-human`  | LAN drop-zone: humans upload raw material for agents to analyse |
 
 Workspace IDs are in `_Watra/workspaces.json` on this host (gitignored).
 
@@ -53,30 +53,34 @@ Workspace IDs are in `_Watra/workspaces.json` on this host (gitignored).
 Each agent has its own synjar user. Credentials live in
 `_Watra/agent-credentials.json` (gitignored, local-only):
 
-| Agent | Email | Role | Intended responsibilities |
-| --- | --- | --- | --- |
-| `claude-code`     | `claude-code@agents.local`     | ADMIN  | Full read/write — implementation work |
+| Agent             | Email                          | Role   | Intended responsibilities                      |
+| ----------------- | ------------------------------ | ------ | ---------------------------------------------- |
+| `claude-code`     | `claude-code@agents.local`     | ADMIN  | Full read/write — implementation work          |
 | `codex`           | `codex@agents.local`           | MEMBER | Reviews; writes to `decisions` + `agent-notes` |
-| `hermes`          | `hermes@agents.local`          | MEMBER | Messaging / orchestration notes |
-| `openclaw`        | `openclaw@agents.local`        | MEMBER | Tooling / external-agent exchanges |
-| `memphis-runtime` | `memphis-runtime@agents.local` | MEMBER | Runtime reads (future: MCP tool bridge) |
-| `marcin`          | `marcin@watra.local`           | OWNER  | Operator, final arbiter |
+| `hermes`          | `hermes@agents.local`          | MEMBER | Messaging / orchestration notes                |
+| `openclaw`        | `openclaw@agents.local`        | MEMBER | Tooling / external-agent exchanges             |
+| `memphis-runtime` | `memphis-runtime@agents.local` | MEMBER | Runtime reads (future: MCP tool bridge)        |
+| `marcin`          | `marcin@watra.local`           | OWNER  | Operator, final arbiter                        |
 
 Login to get a JWT:
+
 ```bash
 curl -sS -X POST http://localhost:6200/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email":"<email>","password":"<pass>"}'
 ```
+
 Access tokens expire in 15 min; use the `refreshToken` or re-login.
 
 ### Handoff protocol — how agents exchange notes
 
 **Reading:** every agent, at the start of a task, searches `agent-notes` for
 documents tagged `to:<self>` with no `closed:*` tag. Example:
+
 ```bash
 GET /workspaces/<agent-notes-id>/documents?tags=to:claude-code
 ```
+
 Unread notes are the agent's inbox.
 
 **Writing:** when an agent needs to hand work to another agent, it creates a
@@ -98,26 +102,31 @@ makes a simple "what changed" audit trail possible.
 ### Search
 
 Semantic RAG search across any workspace the agent is a member of:
+
 ```
 POST /workspaces/<id>/search   { "query": "..." }
 ```
+
 Cross-workspace search at `/search` (global) — respects RLS, so only
 workspaces the caller is a member of are searched.
 
 ### Frontmatter convention for ingested documents
 
 All bootstrap-ingested docs carry:
+
 - `source:bootstrap` — initial 2026-04-18 ingest from local filesystem
 - `ingested:<YYYY-MM-DD>` — date of first ingest
 - `hash:<sha256[:12]>` — content hash for idempotent re-ingest
 
 Agents writing new docs should add at minimum:
+
 - `source:<agent-name>` (instead of `source:bootstrap`)
 - `topic:<keyword>` (searchable domain)
 
 ### Scripts
 
 Utility scripts live in `/home/memphis/synjar/scripts/`:
+
 - `ingest.py` — single-file ingest with polling + idempotent hash tag
 - `run-bootstrap-ingest.sh` — iterates `bootstrap-manifest.tsv` for bulk ingest
 - `bootstrap-manifest.tsv` — source-of-truth mapping (file → workspace + tags)
@@ -176,4 +185,3 @@ curl -sS -X POST http://localhost:6200/auth/login \
   -d '{"email":"marcin@watra.local","password":"WatraAdmin!2026"}' \
   | python3 -c 'import sys,json;print(json.load(sys.stdin)["accessToken"])'
 ```
-

--- a/MEMPHIS_ARCHITECTURE_LAYERS.md
+++ b/MEMPHIS_ARCHITECTURE_LAYERS.md
@@ -26,18 +26,18 @@ Ten dokument to narada przed kampanią. Nie gwarantuje zwycięstwa, ale gwarantu
 
 ## Teren — stan na 2026-04-18
 
-| Co mamy zielone | Co puste, co trzeba dobudować |
-| --- | --- |
-| Identity (DID, ed25519) | Skill registry |
-| Chain storage + multi-chain | Command registry |
-| Vault 2FA + recovery | Blueprint registry (config) |
-| MCP tool executor + surface policy | Memphis GUI (Tauri) |
-| Gateway HTTP + auth | Agora tier + trust graph |
-| TUI, web-dashboard, Telegram | Własna aptka (starter) |
-| Sync-manager (private tier) | Federation mutual auth / revocation / QR |
-| Provider cascade + cost-cap | Local-LLM CI invariant |
-| Circuit breaker + safe mode | Trust.chain + trusted.chain |
-| Test suite 2054/2054 | Blueprint codegen (skills/tools/config→GUI+TUI+CLI+MCP) |
+| Co mamy zielone                    | Co puste, co trzeba dobudować                           |
+| ---------------------------------- | ------------------------------------------------------- |
+| Identity (DID, ed25519)            | Skill registry                                          |
+| Chain storage + multi-chain        | Command registry                                        |
+| Vault 2FA + recovery               | Blueprint registry (config)                             |
+| MCP tool executor + surface policy | Memphis GUI (Tauri)                                     |
+| Gateway HTTP + auth                | Agora tier + trust graph                                |
+| TUI, web-dashboard, Telegram       | Własna aptka (starter)                                  |
+| Sync-manager (private tier)        | Federation mutual auth / revocation / QR                |
+| Provider cascade + cost-cap        | Local-LLM CI invariant                                  |
+| Circuit breaker + safe mode        | Trust.chain + trusted.chain                             |
+| Test suite 2054/2054               | Blueprint codegen (skills/tools/config→GUI+TUI+CLI+MCP) |
 
 Mamy ~70% fundamentu. Brakujące 30% to **rejestry deklaratywne** — to, co
 sprawi że system scala się w coś spójnego, nie w luźną kupę modułów.
@@ -90,6 +90,7 @@ Slack bot) bez dotykania L2.
 trafia tutaj, żeby zostać podpisana albo zweryfikowana.
 
 **Co jest (Rust crates — primitive crypto):**
+
 - `crates/memphis-vault/src/did.rs` — DID z ed25519
 - `crates/memphis-vault/src/keyring.rs` — Argon2id KDF (64 MB, 3 iter, p=4)
 - `crates/memphis-vault/src/two_factor.rs` — Q&A 2FA (po #144 zwraca Result)
@@ -98,6 +99,7 @@ trafia tutaj, żeby zostać podpisana albo zweryfikowana.
 - `crates/memphis-core/src/hash.rs` — chain block hashing
 
 **Co jest (TS boundary — 11 plików `src/security/`):**
+
 - `constant-time.ts` — `secureCompare` (line 58, verified 2026-04-19)
 - `auth-fail-closed.ts` — fail-closed authentication defaults
 - `content-scan.ts` — risk classification dla web-fetched content
@@ -123,6 +125,7 @@ gdy NIST coś ogłosi. W międzyczasie cisza.
 Multi-chain support (różne chains dla różnych celów).
 
 **Co jest:**
+
 - `src/infra/storage/chain-adapter.ts` — TS strona
 - `src/infra/storage/rust-chain-adapter.ts` — NAPI bridge do Rusta
 - `crates/memphis-core/src/chain.rs`, `block.rs`, `hash.rs` — Rust logic
@@ -130,6 +133,7 @@ Multi-chain support (różne chains dla różnych celów).
 - Vault entries persistence
 
 **Co do dobudowania:**
+
 - `withAppendLockAcrossChains` (Phase T #151) — atomic writes across 2 chains
 - nowe chain types: `trust.chain`, `trusted.chain`, `agora.*` (Phase T + Agora)
 
@@ -145,7 +149,8 @@ własnym), używane przez surface'y pośrednio przez L3/L4.
 
 **Co jest (wszystko sprawdzone w produkcji):**
 
-*Core runtime services (`src/`):*
+_Core runtime services (`src/`):_
+
 - Gateway HTTP (`src/gateway/server.ts`) — pojedynczy API surface dla L5
 - Provider cascade (`src/providers/`) — local-first, fallback'y
 - Memory/recall (`src/memory/`, `src/soul/`)
@@ -158,7 +163,8 @@ własnym), używane przez surface'y pośrednio przez L3/L4.
 - Cache layer (`src/cache/`) — runtime cache
 - Agent runtime (`src/agent/`) — agent profiles + execution
 
-*Infra services (`src/infra/`):*
+_Infra services (`src/infra/`):_
+
 - Scheduler (`runtime/scheduler.ts`)
 - Circuit breaker (`runtime/circuit-breaker.ts`) — po #141 Codex-P1 fix
 - Cost-cap + budget (`runtime/cost-cap.ts`)
@@ -173,6 +179,7 @@ własnym), używane przez surface'y pośrednio przez L3/L4.
 - TUI host (`tui-host/`) — Rust TUI ↔ TS runtime bridge
 
 **Co do dobudowania:**
+
 - Peer transport auth (Phase P #148)
 - Per-peer rate limiter (Phase P #148)
 - QR invite bootstrap (Phase P #148)
@@ -185,7 +192,7 @@ Nic bezpośrednio importowanego przez L5.
 
 ---
 
-## L3 — Capability Registries  ← **tu jest klucz całej spójności**
+## L3 — Capability Registries ← **tu jest klucz całej spójności**
 
 **Co robi:** **jedyny layer który wie co Memphis UMIE**. Wszystkie surface'y
 (L5) tylko czytają tu. Dodajesz tool/skill/command raz, pojawia się
@@ -194,6 +201,7 @@ wszędzie.
 **Cztery rejestry:**
 
 ### a) Tool Registry (MCP tools — już istnieje częściowo)
+
 ```ts
 interface ToolDescriptor {
   id: 'memphis_fs_write' | 'memphis_exec' | ...;
@@ -302,6 +310,7 @@ wymaga.
 L5.
 
 **Co jest:**
+
 - Tier system (tier-1, tier-2, tier-3) — `src/security/tier3-session.ts`
 - Autonomy modes (restricted, balanced, full) — env-var driven
 - Exec policy (`src/gateway/exec-policy.ts`) — allowlist/blocklist commands
@@ -311,10 +320,11 @@ L5.
 - Security audit (`src/infra/logging/security-audit.ts`)
 
 **Co do dobudowania:**
+
 - Rozszerzenie surface-policy żeby obejmowało także skills + commands
   (obecnie obejmuje tylko tools)
 - Policy evaluator nad rejestrami L3: `canUseOnSurface(capability, surface,
-  tier, autonomy) -> allow | deny | elevate-required`
+tier, autonomy) -> allow | deny | elevate-required`
 
 **Interfejs wyżej:** "czy mogę użyć tego capability z tego surface'u w
 obecnym tier'ze?". Idempotentne, pure, observable (audit-log).
@@ -327,6 +337,7 @@ obecnym tier'ze?". Idempotentne, pure, observable (audit-log).
 Każdy surface = deklaratywny konsument L3 + L4.
 
 **Co jest (główne surface'y):**
+
 - **TUI** — `crates/memphis-tui/` — pełny ratatui dashboard
 - **Web dashboard** — `src/dashboard/web-dashboard.ts` — z auth token po #143 + XSS-escape po #138
 - **Telegram bot** — `src/infra/cli/handlers/telegram.handler.ts`
@@ -336,12 +347,14 @@ Każdy surface = deklaratywny konsument L3 + L4.
 - **Gateway HTTP** — `src/gateway/server.ts` (API dla custom app'ek)
 
 **Adaptery / wewnętrzne komponenty surface'ów (NIE same surface'y):**
+
 - `src/bridges/` — bridges między surface'ami (np. MCP-native bridge)
 - `src/app/` — app-level entry points
 - `src/gateway/voice/` — voice surface adapter (audio in/out)
 - `src/gateway/channels/` — multi-channel routing
 
 **Co do dobudowania:**
+
 - **Memphis GUI** (Tauri) — Phase G #152 — szósty surface, ale **najważniejszy**
   dla docelowego UX
 - **Starter custom app** — zupełnie basic HTTP client (Python script? React
@@ -359,15 +372,17 @@ wyciągać z L3 przez L4 gate. Surface jest **renderer'em** stanu +
 **Co robi:** jak instancje Memphis rozmawiają między sobą.
 
 **Co jest:**
+
 - **Private tier** — sync-manager w L2, + signature gate po #142, + peer
   allowlist via `MEMPHIS_SYNC_PEERS`
 - **Trust chains** — w L1, pin/revoke via operator sign
 
 **Co do dobudowania:**
+
 - Phase P #148 — mutual auth, revocation, rate limits, QR bootstrap
 - Phase T #151 — trust.chain + trusted.chain dual-write
 - Phase 0-5 — public tier (Agora: attestations + stake + reviews + discovery
-  + marketplace)
+  - marketplace)
 
 **Interfejs wyżej:** sync-manager i attestation engine wystawione jako
 internal API do L2 i dalej przez gateway.
@@ -379,6 +394,7 @@ internal API do L2 i dalej przez gateway.
 **Co robi:** mosty do świata poza Memphisem.
 
 **Co jest (częściowo):**
+
 - MCP client dla zewnętrznych LLMów (outbound) — `src/providers/*`
 - Telegram adapter — ale to jest **surface** (L5), nie external — Telegram
   użytkownik interaktuje przez Telegram, Memphis działa po swojej stronie
@@ -386,6 +402,7 @@ internal API do L2 i dalej przez gateway.
   osobny repo, kandydat na integrację w Phase 3b
 
 **Co do dobudowania (deferred):**
+
 - Payment adapters (Lightning, Monero, wallet-in-vault) — Phase 3c #156
 - ML-as-contract-language — Phase 3b #156
 - Future: dodatkowe MCP clients, model APIs
@@ -394,15 +411,15 @@ internal API do L2 i dalej przez gateway.
 
 ## Crates Rust — kompletny inwentarz (7 crates)
 
-| Crate | Pliki | Rola | Warstwa |
-|---|---|---|---|
-| `memphis-core` | `chain.rs`, `block.rs`, `hash.rs`, `signature.rs` | Chain logic, block hashing, signature verify | L0 + L1 |
-| `memphis-vault` | `did.rs`, `keyring.rs`, `crypto.rs`, `vault.rs`, `two_factor.rs` | DID, Argon2id KDF, vault encryption, Q&A 2FA | L0 |
-| `memphis-embed` | `cache.rs`, `chain_integration.rs`, `pipeline.rs`, `store.rs` | Embedding pipeline + cache + chain integration. **Central dla M6** sovereign-RAG cascade. | L1 + L2 |
-| `memphis-napi` | bindings | TS↔Rust bridge, exposes core/vault/embed do TS surface'ów | L2 (bridge) |
-| `memphis-operator` | `chat.rs`, `config.rs`, `provider.rs`, `runtime.rs` | Rust operator console (replaces TS TUI per ROADMAP-CURRENT.md M1) | L5 |
-| `memphis-tui` | full ratatui app | Active native TUI dashboard | L5 |
-| `memphis-case-index` | `lib.rs` (szkielet) | Chain indexing dla `memphis_case_query` tool | L1 |
+| Crate                | Pliki                                                            | Rola                                                                                      | Warstwa     |
+| -------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| `memphis-core`       | `chain.rs`, `block.rs`, `hash.rs`, `signature.rs`                | Chain logic, block hashing, signature verify                                              | L0 + L1     |
+| `memphis-vault`      | `did.rs`, `keyring.rs`, `crypto.rs`, `vault.rs`, `two_factor.rs` | DID, Argon2id KDF, vault encryption, Q&A 2FA                                              | L0          |
+| `memphis-embed`      | `cache.rs`, `chain_integration.rs`, `pipeline.rs`, `store.rs`    | Embedding pipeline + cache + chain integration. **Central dla M6** sovereign-RAG cascade. | L1 + L2     |
+| `memphis-napi`       | bindings                                                         | TS↔Rust bridge, exposes core/vault/embed do TS surface'ów                                 | L2 (bridge) |
+| `memphis-operator`   | `chat.rs`, `config.rs`, `provider.rs`, `runtime.rs`              | Rust operator console (replaces TS TUI per ROADMAP-CURRENT.md M1)                         | L5          |
+| `memphis-tui`        | full ratatui app                                                 | Active native TUI dashboard                                                               | L5          |
+| `memphis-case-index` | `lib.rs` (szkielet)                                              | Chain indexing dla `memphis_case_query` tool                                              | L1          |
 
 **Out-of-tree:** `memphis-ml` (osobny repo `Memphis-Chains/memphis-ml`) — kandydat na Agora contract language (Phase 3b, conditional na Phase 3-spike #160).
 
@@ -427,6 +444,7 @@ Dodaję nowy tool / skill / command / config:
 ```
 
 Warunki by to działało w praktyce:
+
 1. **Każdy surface czyta z rejestrów, nie z plików w src/mcp/tools/.**
 2. **Każdy descriptor ma pełną Zod schema na inputy.** Zero free-form
    parsingu w surface'ach.
@@ -444,21 +462,22 @@ Koszt jednorazowy. Zwrot przez kolejne N lat każdej featurowej pracy.
 
 Każde GitHub issue (#148–#158) mapuję na warstwy które zmienia.
 
-| Kampania | L0 | L1 | L2 | L3 | L4 | L5 | L6 | L7 |
-| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-| #148 Phase P — private tier hardening | | | ✓ | | ✓ | | ✓ | |
-| #149 Phase L — offline invariant test | | | | | | | | |
-| #151 Phase T — trust chains | | ✓ | ✓ | ✓ cmd | ✓ | ✓ cli | ✓ | |
-| #150 Phase B — Blueprint system | | | | ✓ cfg | | ✓ all | | |
-| #152 Phase G — Tauri GUI | | | | | | ✓ GUI | | |
-| #153 Phase 0 — Agora design | | | | | | | ✓ design | |
-| #154 Phase 1 — attestations | | ✓ | ✓ | ✓ cmd | ✓ | | ✓ | |
-| #155 Phase 2 — reviews | | ✓ | ✓ | | | | ✓ | |
-| #156 Phase 3 — stake + ML + pay | | ✓ | ✓ | | ✓ | | ✓ | ✓ |
-| #157 Phase 4 — discovery | | | ✓ | | | | ✓ | |
-| #158 Phase 5 — marketplace UX | | | | | | ✓ GUI | | |
+| Kampania                              | L0  | L1  | L2  |  L3   | L4  |  L5   |    L6    | L7  |
+| ------------------------------------- | :-: | :-: | :-: | :---: | :-: | :---: | :------: | :-: |
+| #148 Phase P — private tier hardening |     |     |  ✓  |       |  ✓  |       |    ✓     |     |
+| #149 Phase L — offline invariant test |     |     |     |       |     |       |          |     |
+| #151 Phase T — trust chains           |     |  ✓  |  ✓  | ✓ cmd |  ✓  | ✓ cli |    ✓     |     |
+| #150 Phase B — Blueprint system       |     |     |     | ✓ cfg |     | ✓ all |          |     |
+| #152 Phase G — Tauri GUI              |     |     |     |       |     | ✓ GUI |          |     |
+| #153 Phase 0 — Agora design           |     |     |     |       |     |       | ✓ design |     |
+| #154 Phase 1 — attestations           |     |  ✓  |  ✓  | ✓ cmd |  ✓  |       |    ✓     |     |
+| #155 Phase 2 — reviews                |     |  ✓  |  ✓  |       |     |       |    ✓     |     |
+| #156 Phase 3 — stake + ML + pay       |     |  ✓  |  ✓  |       |  ✓  |       |    ✓     |  ✓  |
+| #157 Phase 4 — discovery              |     |     |  ✓  |       |     |       |    ✓     |     |
+| #158 Phase 5 — marketplace UX         |     |     |     |       |     | ✓ GUI |          |     |
 
 **Obserwacja:**
+
 - Phase P, T, 1 wielowarstwowe — pracochłonne
 - Phase L, 0 jedno/zero-warstwowe — małe, tanie wygrane
 - Phase G, 5 tylko L5 — widoczne, ale niedotykają fundamentu

--- a/ROADMAP_FOR_SORT_BRANCHES.md
+++ b/ROADMAP_FOR_SORT_BRANCHES.md
@@ -22,6 +22,7 @@ instance on one device. Hermetic (nothing leaves without explicit consent),
 observable (every decision visible at creation + code + UX).
 
 Current state on `main` post-PR #146:
+
 - 33 security + reliability fixes merged (PR #127, #141, #146)
 - Signed-block peer sync enforced (#142)
 - Dashboard auth-token support (#143)
@@ -40,21 +41,21 @@ the existing vault-2FA (operator passphrase + recovery Q&A) gate.
 
 ## Locked decisions
 
-| Decision | Choice |
-| --- | --- |
-| Repo layout | **Single `memphis` monorepo** (not split into 3 repos) |
-| GUI framework | Tauri 2 |
-| Target OS | Ubuntu (primary), any systemd+glibc Linux (secondary), WSL2 (compat) |
-| GUI design language | Zed × VSCode × Tailscale hybrid |
-| Install modes | Appliance (GUI-as-shell) / Desktop (normal + app) / Server (headless) |
-| Agora trust model | All 4 layers composed |
-| Payment rail | Free for demo/test → vault-secret wallets later via pluggable adapter |
-| Slash multisig | Configurable 2-of-N, min 2, max 10 |
-| Local-LLM fallback | Unconditional invariant, CI-enforced |
-| Attestation TTL | Both persistent + expiring, configurable via Blueprint |
-| Trust anchors | Dual chain: `trust.chain` (current) + `trusted.chain` (forensic audit) |
-| Config surface | Blueprint system (Zod → codegen GUI + validator + MCP + docs) |
-| memphis-ml role | Candidate Agora contract language (Phase 3 — conditional on market validation) |
+| Decision            | Choice                                                                         |
+| ------------------- | ------------------------------------------------------------------------------ |
+| Repo layout         | **Single `memphis` monorepo** (not split into 3 repos)                         |
+| GUI framework       | Tauri 2                                                                        |
+| Target OS           | Ubuntu (primary), any systemd+glibc Linux (secondary), WSL2 (compat)           |
+| GUI design language | Zed × VSCode × Tailscale hybrid                                                |
+| Install modes       | Appliance (GUI-as-shell) / Desktop (normal + app) / Server (headless)          |
+| Agora trust model   | All 4 layers composed                                                          |
+| Payment rail        | Free for demo/test → vault-secret wallets later via pluggable adapter          |
+| Slash multisig      | Configurable 2-of-N, min 2, max 10                                             |
+| Local-LLM fallback  | Unconditional invariant, CI-enforced                                           |
+| Attestation TTL     | Both persistent + expiring, configurable via Blueprint                         |
+| Trust anchors       | Dual chain: `trust.chain` (current) + `trusted.chain` (forensic audit)         |
+| Config surface      | Blueprint system (Zod → codegen GUI + validator + MCP + docs)                  |
+| memphis-ml role     | Candidate Agora contract language (Phase 3 — conditional on market validation) |
 
 ## Architecture stack (final target)
 
@@ -86,21 +87,21 @@ the existing vault-2FA (operator passphrase + recovery Q&A) gate.
 
 ## Vision: 11-phase plan
 
-| # | Phase | Branch name | Est. | Dep | Outcome |
-| --- | --- | --- | --- | --- | --- |
-| P | Private tier hardening | `feat/phase-P-private-tier` | 1 wk | — | mutual auth, revocation, rate limits, QR bootstrap |
-| L | Local-LLM invariant test | `feat/phase-L-local-llm-invariant` | 0.5d | — | CI-enforced offline operability |
-| B | Blueprint Config System | `feat/phase-B-blueprint-config` | 0.5–1 wk | — | DSL + codegen + pilot migration |
-| T | Trust chains | `feat/phase-T-trust-chains` | 1 wk | P, B | `trust.chain` + `trusted.chain` dual-write, operator CLI |
-| G | Tauri GUI skeleton | `feat/phase-G-gui-skeleton` | 2 wk | B | monorepo `apps/memphis-gui/`, Chat+Memory+Agents views |
-| 0 | Agora design doc | `feat/phase-0-agora-design-doc` | 0.5 wk | T | locked schemas, thresholds, protocols |
-| 1 | L1 Attestations | `feat/phase-1-attestations` | 1 wk | T, 0 | attestation blocks, trust-graph BFS |
-| 2 | L3 Reviews | `feat/phase-2-reviews` | 0.5 wk | 1 | review blocks, weighted-PageRank reputation |
-| 3 | L2 Stake + ML contracts | `feat/phase-3-stake-ml-contracts` | 2–3 wk | 1, 2 | escrow + ML-as-offer-language + payment adapter stub |
-| 4 | L4 Discovery | `feat/phase-4-discovery` | 1 wk | 3 | DHT or gossip + ranked offer discovery |
-| 5 | Marketplace UX | `feat/phase-5-marketplace-ux` | 1–2 wk | 3, 4, G | publish/sign/review flows in GUI |
-| 3-spike | memphis-ml viability spike (TIMEBOX 1 wk) | `feat/phase-3-spike-ml-viability` | 1 wk | 0 | go/no-go gate przed Phase 3a (utworzony jako #160) |
-| 4.5 | Agora adversarial sim (sybil + wash + collusion) | `feat/phase-4.5-agora-adversarial-sim` | 1 wk | 4 | gate BEFORE Phase 5 ship (utworzony jako #161) |
+| #       | Phase                                            | Branch name                            | Est.     | Dep     | Outcome                                                  |
+| ------- | ------------------------------------------------ | -------------------------------------- | -------- | ------- | -------------------------------------------------------- |
+| P       | Private tier hardening                           | `feat/phase-P-private-tier`            | 1 wk     | —       | mutual auth, revocation, rate limits, QR bootstrap       |
+| L       | Local-LLM invariant test                         | `feat/phase-L-local-llm-invariant`     | 0.5d     | —       | CI-enforced offline operability                          |
+| B       | Blueprint Config System                          | `feat/phase-B-blueprint-config`        | 0.5–1 wk | —       | DSL + codegen + pilot migration                          |
+| T       | Trust chains                                     | `feat/phase-T-trust-chains`            | 1 wk     | P, B    | `trust.chain` + `trusted.chain` dual-write, operator CLI |
+| G       | Tauri GUI skeleton                               | `feat/phase-G-gui-skeleton`            | 2 wk     | B       | monorepo `apps/memphis-gui/`, Chat+Memory+Agents views   |
+| 0       | Agora design doc                                 | `feat/phase-0-agora-design-doc`        | 0.5 wk   | T       | locked schemas, thresholds, protocols                    |
+| 1       | L1 Attestations                                  | `feat/phase-1-attestations`            | 1 wk     | T, 0    | attestation blocks, trust-graph BFS                      |
+| 2       | L3 Reviews                                       | `feat/phase-2-reviews`                 | 0.5 wk   | 1       | review blocks, weighted-PageRank reputation              |
+| 3       | L2 Stake + ML contracts                          | `feat/phase-3-stake-ml-contracts`      | 2–3 wk   | 1, 2    | escrow + ML-as-offer-language + payment adapter stub     |
+| 4       | L4 Discovery                                     | `feat/phase-4-discovery`               | 1 wk     | 3       | DHT or gossip + ranked offer discovery                   |
+| 5       | Marketplace UX                                   | `feat/phase-5-marketplace-ux`          | 1–2 wk   | 3, 4, G | publish/sign/review flows in GUI                         |
+| 3-spike | memphis-ml viability spike (TIMEBOX 1 wk)        | `feat/phase-3-spike-ml-viability`      | 1 wk     | 0       | go/no-go gate przed Phase 3a (utworzony jako #160)       |
+| 4.5     | Agora adversarial sim (sybil + wash + collusion) | `feat/phase-4.5-agora-adversarial-sim` | 1 wk     | 4       | gate BEFORE Phase 5 ship (utworzony jako #161)           |
 
 **Full-plan total:** 8–12 weeks of focused solo work (optimistic).
 
@@ -115,6 +116,7 @@ written, as a counterweight against solo-dev over-estimation. It reflects
 honest risk assessment, not delivery pessimism.
 
 ### What's genuinely solid
+
 1. **Core Memphis** (runtime, vault, chains, sync, MCP) — architectonicznie sound, production-feasible.
 2. **Phases P + L + T** — realistic, each has clear acceptance criteria, each is a measurable security/reliability win.
 3. **TDD PoC-first pattern** — established by PR #141 + #146, should be preserved.
@@ -152,6 +154,7 @@ want normal-desktop-plus-Memphis-app.
 of work on its own. Not a "Phase D bullet point".
 
 ### Solo-dev pace reality
+
 - PR #141 + #146 shipped ~27 items in ~8–10h of focused work **with Claude
   writing 90% of the code**.
 - True solo pace = 200–500 "good" lines/day, 1–2k/week.
@@ -159,6 +162,7 @@ of work on its own. Not a "Phase D bullet point".
   of solo velocity, assuming 100% focus, zero life interruptions, zero rework.
 
 ### Likely outcomes if plan runs as-is
+
 - (a) Burnout at week 8, Memphis frozen half-built
 - (b) Everything at 60% complete, nothing production-ready
 - (c) Refactor paralysis ("need Blueprint before Settings before GUI before ship")
@@ -173,6 +177,7 @@ with a hard decision gate between them.
 ### Horizon 1 — 2–3 weeks, measurable wins
 
 Sprint goals:
+
 1. **Phase P** (3–4 d) — private tier hardening (mutual auth, revocation, rate limits, QR bootstrap)
 2. **Phase L** (½ d) — local-LLM invariant CI test
 3. **Phase T** (2–3 d) — trust chains dual-write + operator CLI commands
@@ -180,6 +185,7 @@ Sprint goals:
 **Ship `v1.4.0`.** Write down what you learned.
 
 **Skip (for now):**
+
 - Phase B (Blueprint) — defer until pain is acute
 - Phase 0 (Agora design) — defer until H2 passes
 - All Phases 1–5 (Agora) — defer
@@ -193,6 +199,7 @@ Sprint goals:
 ### Decision gate
 
 After ~6 weeks of H1 + H2:
+
 - Does anyone use Memphis on desktop?
 - What actually hurts them?
 - Did anyone ask for a marketplace?
@@ -204,16 +211,16 @@ before investing in economic layer.
 
 ### Rzeczy do odłożenia (for now)
 
-| Defer | Reason |
-| --- | --- |
-| Blueprint Config System | Build when it hurts (5+ manual copy-paste of form boilerplate) |
-| memphis-ml integration | Defer until Agora demand proven |
-| DHT/gossip discovery | Start with explicit peer-list if Agora ships |
-| Payment adapter | Symbolic numbers on chain suffice for MVP |
-| Appliance-as-default-shell | Keep as opt-in, NOT default |
-| WSL2 custom distro APPX | `wsl --install Ubuntu` + `apt install memphis` sufficient |
-| Live ISO | `.deb` on Ubuntu is enough as first distribution |
-| ML-as-contract-language | JSON schema offers suffice for MVP |
+| Defer                      | Reason                                                         |
+| -------------------------- | -------------------------------------------------------------- |
+| Blueprint Config System    | Build when it hurts (5+ manual copy-paste of form boilerplate) |
+| memphis-ml integration     | Defer until Agora demand proven                                |
+| DHT/gossip discovery       | Start with explicit peer-list if Agora ships                   |
+| Payment adapter            | Symbolic numbers on chain suffice for MVP                      |
+| Appliance-as-default-shell | Keep as opt-in, NOT default                                    |
+| WSL2 custom distro APPX    | `wsl --install Ubuntu` + `apt install memphis` sufficient      |
+| Live ISO                   | `.deb` on Ubuntu is enough as first distribution               |
+| ML-as-contract-language    | JSON schema offers suffice for MVP                             |
 
 ---
 
@@ -230,22 +237,22 @@ hotfix/security-scan-<date>            # bundled security-scan hotfix
 
 ### Phase → branch map (as issues get worked)
 
-| Issue | Branch | Status |
-| --- | --- | --- |
-| Meta roadmap | N/A (tracking only) | open |
-| Phase P | `feat/phase-P-private-tier` | pending |
-| Phase L | `feat/phase-L-local-llm-invariant` | pending |
-| Phase B | `feat/phase-B-blueprint-config` | **deferred** (see brutal truth) |
-| Phase T | `feat/phase-T-trust-chains` | pending |
-| Phase G | `feat/phase-G-gui-skeleton` | pending (after H1 passes) |
-| Phase 0 | `feat/phase-0-agora-design-doc` | **deferred** (after H2 validation) |
-| Phase 1 | `feat/phase-1-attestations` | deferred |
-| Phase 2 | `feat/phase-2-reviews` | deferred |
-| Phase 3 | `feat/phase-3-stake-ml-contracts` | deferred (2027 candidate) |
-| Phase 4 | `feat/phase-4-discovery` | deferred |
-| Phase 5 | `feat/phase-5-marketplace-ux` | deferred |
-| Phase 3-spike | `feat/phase-3-spike-ml-viability` | open as #160 (TIMEBOX 1 wk before Phase 3a) |
-| Phase 4.5 | `feat/phase-4.5-agora-adversarial-sim` | open as #161 (gate BEFORE Phase 5) |
+| Issue         | Branch                                 | Status                                      |
+| ------------- | -------------------------------------- | ------------------------------------------- |
+| Meta roadmap  | N/A (tracking only)                    | open                                        |
+| Phase P       | `feat/phase-P-private-tier`            | pending                                     |
+| Phase L       | `feat/phase-L-local-llm-invariant`     | pending                                     |
+| Phase B       | `feat/phase-B-blueprint-config`        | **deferred** (see brutal truth)             |
+| Phase T       | `feat/phase-T-trust-chains`            | pending                                     |
+| Phase G       | `feat/phase-G-gui-skeleton`            | pending (after H1 passes)                   |
+| Phase 0       | `feat/phase-0-agora-design-doc`        | **deferred** (after H2 validation)          |
+| Phase 1       | `feat/phase-1-attestations`            | deferred                                    |
+| Phase 2       | `feat/phase-2-reviews`                 | deferred                                    |
+| Phase 3       | `feat/phase-3-stake-ml-contracts`      | deferred (2027 candidate)                   |
+| Phase 4       | `feat/phase-4-discovery`               | deferred                                    |
+| Phase 5       | `feat/phase-5-marketplace-ux`          | deferred                                    |
+| Phase 3-spike | `feat/phase-3-spike-ml-viability`      | open as #160 (TIMEBOX 1 wk before Phase 3a) |
+| Phase 4.5     | `feat/phase-4.5-agora-adversarial-sim` | open as #161 (gate BEFORE Phase 5)          |
 
 ---
 
@@ -292,19 +299,23 @@ Performance budget (where relevant)
 ## Cross-cutting concerns
 
 ### Blueprint usage policy (post-Phase B)
+
 Every new config option MUST be added as a Blueprint. No new `MEMPHIS_*` env
 var merges without an accompanying Blueprint.
 
 ### Local-LLM invariant enforcement (post-Phase L)
+
 The `offline-invariant.test.ts` gate is non-negotiable. Any PR that makes
 Memphis require a remote call for a core operation (chat, chain, vault, tool)
 is rejected.
 
 ### Chain audit discipline
+
 Every operator-initiated state change → chain block. Every finance decision →
 vault-2FA modal → chain block. No silent state mutations.
 
 ### memphis-ml preconditions (before Phase 3b)
+
 - Fix or remove `ml-vm` from workspace (currently broken)
 - Replace `ml-p2p` raw-TCP transport with memphis sync-manager adapter
 - Add determinism-tracing hooks so arbiters can replay (core interpreter IS
@@ -317,18 +328,19 @@ vault-2FA modal → chain block. No silent state mutations.
 Blockers still needing user input before specific phases begin.
 
 **Already locked** (zob. `review.md` Część III sekcja A):
+
 - Tauri frontend stack → **React+shadcn/ui** (locked w review.md A.1)
 - System tray → **Yes, systemd --user + tray** (locked w review.md A.1)
 - memphis-ml ml-vm handling → **Phase 3-spike #160 decyduje** (1-week TIMEBOX, locked w review.md A.2)
 
 **Still open:**
 
-| Decision | Blocks | Default if unspecified |
-| --- | --- | --- |
-| Blueprint codegen timing (build-time vs runtime) | Phase B start | **Hybrid** (types build-time, form runtime) |
-| Agora DHT choice (libp2p vs Nostr vs custom) | Phase 0 outcome | **libp2p Kademlia** (most mature) |
-| Distribution forms (.deb / ISO / Docker / APPX) | Phase D | **.deb first, rest deferred** |
-| Appliance mode as default install | Phase D | **Opt-in, not default** |
+| Decision                                         | Blocks          | Default if unspecified                      |
+| ------------------------------------------------ | --------------- | ------------------------------------------- |
+| Blueprint codegen timing (build-time vs runtime) | Phase B start   | **Hybrid** (types build-time, form runtime) |
+| Agora DHT choice (libp2p vs Nostr vs custom)     | Phase 0 outcome | **libp2p Kademlia** (most mature)           |
+| Distribution forms (.deb / ISO / Docker / APPX)  | Phase D         | **.deb first, rest deferred**               |
+| Appliance mode as default install                | Phase D         | **Opt-in, not default**                     |
 
 ---
 
@@ -337,11 +349,13 @@ Blockers still needing user input before specific phases begin.
 All three tracks can run in parallel:
 
 **Track 1 — Phase L (½ day):**
+
 - `tests/integration/offline-invariant.test.ts`
 - Add step to `.github/workflows/ci.yml`
 - Ships as 1 PR, ~150 LOC
 
 **Track 2 — Phase P (3–4 days):**
+
 - **Day 0 (audit pre-work):** `src/sync/` ma już 12 plików (`agent-registry`, `chain-diff`, `conflict-resolver`, `ipfs`, `network-chain`, `protocol`, `signature-verify`, `sync-manager`, `trade`, `transport`, `types`, `websocket-transport`). PR #142 dodał już `signature-verify.ts` i wymusił signed-block gate. Przed pisaniem nowego kodu — zidentyfikuj co rozszerzyć (`protocol.ts`, `signature-verify.ts`, `transport.ts`) vs co nowe (mutual auth, revocation, rate-limit, QR bootstrap).
 - `src/sync/peer-auth.ts` (NEW) → `enforcePeerTransportAuth`
 - `src/sync/revocation.ts` (NEW) → revocation flow
@@ -351,6 +365,7 @@ All three tracks can run in parallel:
 - Ships as 3 stacked PRs
 
 **Track 3 — Phase T (2–3 days) after P lands:**
+
 - `src/trust/anchor.ts` → `pinTrustAnchor`, `revokeTrustAnchor`
 - Extend `src/infra/storage/chain-adapter.ts` with `withAppendLockAcrossChains`
 - Operator CLI commands: `memphis trust pin/revoke/list/history`
@@ -373,6 +388,7 @@ npm run test:offline                    # after Phase L lands
 ```
 
 For Phase G:
+
 ```bash
 cd apps/memphis-gui && cargo tauri dev    # local smoke
 cargo tauri build --target x86_64-unknown-linux-gnu  # .deb artifact

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -4,15 +4,15 @@ Surfaced by the production-1st-install sprint (2026-04-19) — every dependency 
 
 ## System packages (auto-installed by `scripts/install.sh`)
 
-| Package | Why | Install path |
-|---|---|---|
-| `git` | Repo clone + version pinning | apt/dnf/yum/pacman/zypper/brew |
-| `curl` (or `wget` or `python3`) | Downloader for installer scripts (NodeSource, rustup, ollama) | apt/dnf/yum/pacman/zypper/brew |
-| `build-essential` (apt) / `Development Tools` (dnf/yum) / `base-devel` (pacman) / `devel_C_C++` (zypper) / Xcode CLT (macOS) | C/C++ toolchain for `better-sqlite3` + NAPI bridge native build | distro package manager |
-| `pkg-config` / `pkgconf` | Library discovery for native builds | distro package manager |
-| `libssl-dev` (apt) / `openssl-devel` (dnf/yum) / `openssl` (brew/pacman) / `libopenssl-devel` (zypper) | OpenSSL headers for crypto-bearing native modules | distro package manager |
-| `python3` | Required by `node-gyp` for native module builds | distro package manager |
-| `sudo` | System package install (auto-skipped if running as root) | system |
+| Package                                                                                                                      | Why                                                             | Install path                   |
+| ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------ |
+| `git`                                                                                                                        | Repo clone + version pinning                                    | apt/dnf/yum/pacman/zypper/brew |
+| `curl` (or `wget` or `python3`)                                                                                              | Downloader for installer scripts (NodeSource, rustup, ollama)   | apt/dnf/yum/pacman/zypper/brew |
+| `build-essential` (apt) / `Development Tools` (dnf/yum) / `base-devel` (pacman) / `devel_C_C++` (zypper) / Xcode CLT (macOS) | C/C++ toolchain for `better-sqlite3` + NAPI bridge native build | distro package manager         |
+| `pkg-config` / `pkgconf`                                                                                                     | Library discovery for native builds                             | distro package manager         |
+| `libssl-dev` (apt) / `openssl-devel` (dnf/yum) / `openssl` (brew/pacman) / `libopenssl-devel` (zypper)                       | OpenSSL headers for crypto-bearing native modules               | distro package manager         |
+| `python3`                                                                                                                    | Required by `node-gyp` for native module builds                 | distro package manager         |
+| `sudo`                                                                                                                       | System package install (auto-skipped if running as root)        | system                         |
 
 **Memphis does not install:** systemd (used as system service if present, but the runtime works without it via `memphis service stop` + manual `memphis serve`).
 
@@ -37,6 +37,7 @@ Source: `https://ollama.com/install.sh`.
 Why optional: Memphis has a `local-fallback` provider that returns minimal echo responses without a real LLM, so the runtime is operational even without Ollama. Real chat needs either Ollama (local) or a remote provider (Anthropic/OpenAI/MiniMax/GLM/DeepSeek with vault-stored API key).
 
 Default models pulled by installer:
+
 - `nomic-embed-text` — embeddings (137M params, ~85 MB)
 - `cogito:3b` — chat (~2 GB)
 
@@ -47,37 +48,46 @@ The sovereign-RAG proof (2026-04-19) used `all-minilm` (22M params, ~23 MB) inst
 Captured from `package.json` at v1.3.0. Listed by category, not alphabetically.
 
 ### HTTP + transport
+
 - `fastify` — gateway HTTP server
 - `hono` + `@hono/node-server` — secondary HTTP layer (dashboards, MCP HTTP transport)
 - `pino` + `pino-pretty` — structured logging
 
 ### Storage
+
 - `better-sqlite3` — SQLite native bindings (exact-search FTS5 + KV)
 - `@memphis-chains/memphis` (self) — npm package metadata
 
 ### Provider SDKs
+
 - `@anthropic-ai/sdk` — Anthropic provider (native + OAuth)
 - `openai` — used for OpenAI-compatible endpoints (DeepSeek/Z.AI etc reuse this client shape)
 - `ollama` — Ollama HTTP client
 
 ### Telegram
+
 - `node-telegram-bot-api` — Telegram bot SDK
 - `discord.js` — Discord (gated; v13 — see below)
 
 ### Validation + types
+
 - `zod` — schema validation (config, MCP tool inputs, surface inputs)
 
 ### MCP
+
 - `@modelcontextprotocol/sdk` — MCP server + client
 - `eventsource` — SSE transport
 
 ### Voice (optional)
+
 - `@google-cloud/text-to-speech` — TTS fallback for Telegram voice messages
 
 ### OpenTelemetry (opt-in)
+
 - `@opentelemetry/api` + `@opentelemetry/sdk-node` + `@opentelemetry/exporter-trace-otlp-http` + `@opentelemetry/resources` + `@opentelemetry/semantic-conventions` — OTel tracing (no-op when `MEMPHIS_OTEL_ENDPOINT` unset)
 
 ### Misc runtime
+
 - `dotenv` — `.env` file loading (vault-first; .env is fallback)
 - `tsx` — TypeScript runner (used by `npm run dev` and `bin/memphis.js`)
 
@@ -107,6 +117,7 @@ Captured from `package.json` at v1.3.0. Listed by category, not alphabetically.
 As of `npm outdated` on 2026-04-19:
 
 ### Safe minor / patch (no breaking changes expected)
+
 - `@types/node` 25.5.2 → 25.6.0
 - `@opentelemetry/resources` 2.6.1 → 2.7.0
 - `better-sqlite3` 12.8.0 → 12.9.0
@@ -117,6 +128,7 @@ As of `npm outdated` on 2026-04-19:
 - `vitest` 4.1.2 → 4.1.4
 
 ### Major bumps (each requires its own review)
+
 - `@anthropic-ai/sdk` 0.78.0 → 0.90.0
 - `discord.js` 13.x → 14.x (breaking — major API rewrite)
 - `typescript` 5.9.3 → 6.0.3
@@ -128,6 +140,7 @@ The minor bumps are safe to do as a single dependency-bump PR; major bumps each 
 ## Disk + memory footprint
 
 After a clean install (no chains, no vault entries):
+
 - `~/memphis/` (repo + node_modules + cargo target + dist) — ~1.7 GB
 - `~/.memphis/` (state, empty) — ~50 KB
 - Ollama models (cogito:3b + nomic-embed-text) — ~2.1 GB

--- a/docs/operator/debug.en.md
+++ b/docs/operator/debug.en.md
@@ -33,93 +33,93 @@ If `memphis health` returns `status: ok` and `memphis doctor` shows all green, y
 
 ### Daemon won't start
 
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| `memphis service start` exits with no output | systemd not enabled | `systemctl --user enable memphis` then retry |
-| `Connection refused on :3000` after start | daemon crashed early | `memphis service logs -n 200` → look for first ERROR |
-| `EADDRINUSE: address already in use :3000` | another process bound :3000 | `lsof -i :3000` → kill rogue process or change `MEMPHIS_HTTP_PORT` |
+| Symptom                                          | Diagnosis                                 | Fix                                                                                                                                |
+| ------------------------------------------------ | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `memphis service start` exits with no output     | systemd not enabled                       | `systemctl --user enable memphis` then retry                                                                                       |
+| `Connection refused on :3000` after start        | daemon crashed early                      | `memphis service logs -n 200` → look for first ERROR                                                                               |
+| `EADDRINUSE: address already in use :3000`       | another process bound :3000               | `lsof -i :3000` → kill rogue process or change `MEMPHIS_HTTP_PORT`                                                                 |
 | `Loop detected: boot-failure threshold exceeded` | runtime crashed 5×; auto-revert kicked in | `memphis service logs -n 500` → diagnose; `memphis evolve --help` for self-modify rollback options if a recent evolution caused it |
-| Daemon starts but immediately exits | unhandled exception during init | `MEMPHIS_DEBUG=1 memphis service start` for verbose trace |
+| Daemon starts but immediately exits              | unhandled exception during init           | `MEMPHIS_DEBUG=1 memphis service start` for verbose trace                                                                          |
 
 ### Vault won't unlock
 
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| `vault unlock failed: invalid passphrase` | typo or wrong passphrase | retry; if forgotten use recovery |
-| `recovery answer mismatch` | answer hashed differently than at init | answers are case-sensitive after Argon2id; try variations. Recovery flow: see `memphis vault --help` for recovery-related subcommands |
-| `vault corrupt: checksum mismatch` | disk error | restore from backup — see `memphis backup --help` for restore flags |
-| `vault not initialized` | `memphis init` never ran | run `memphis init` |
-| `vault locked after rotation` | tmp files not fsynced (pre-#145 bug) | upgrade to v1.3.0+; `memphis vault rotate` retry |
+| Symptom                                   | Diagnosis                              | Fix                                                                                                                                   |
+| ----------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `vault unlock failed: invalid passphrase` | typo or wrong passphrase               | retry; if forgotten use recovery                                                                                                      |
+| `recovery answer mismatch`                | answer hashed differently than at init | answers are case-sensitive after Argon2id; try variations. Recovery flow: see `memphis vault --help` for recovery-related subcommands |
+| `vault corrupt: checksum mismatch`        | disk error                             | restore from backup — see `memphis backup --help` for restore flags                                                                   |
+| `vault not initialized`                   | `memphis init` never ran               | run `memphis init`                                                                                                                    |
+| `vault locked after rotation`             | tmp files not fsynced (pre-#145 bug)   | upgrade to v1.3.0+; `memphis vault rotate` retry                                                                                      |
 
 ### Chain integrity errors
 
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| `chain hash mismatch at block N` | block content edited or disk error | `memphis repair runtime --fix` for derived state; for canonical chain corruption restore from backup |
-| `chain integrity degraded` | one or more invalid blocks detected | Use `memphis chain --help` to find the audit/repair subcommands available in your version (chain audit + chain repair are typical) |
-| `signature verification failed` | unsigned block where `RUST_CHAIN_REQUIRE_SIGNATURES=true` | check `RUST_CHAIN_SIGNER_KEY_HEX` is set; or set `MEMPHIS_SYNC_ACCEPT_UNSIGNED=true` for legacy migration |
-| `append-lock timeout` | another process holds the lock | `lsof ~/.memphis/chains/.append.lock` → kill blocker; lock auto-releases on process exit |
+| Symptom                          | Diagnosis                                                 | Fix                                                                                                                                |
+| -------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `chain hash mismatch at block N` | block content edited or disk error                        | `memphis repair runtime --fix` for derived state; for canonical chain corruption restore from backup                               |
+| `chain integrity degraded`       | one or more invalid blocks detected                       | Use `memphis chain --help` to find the audit/repair subcommands available in your version (chain audit + chain repair are typical) |
+| `signature verification failed`  | unsigned block where `RUST_CHAIN_REQUIRE_SIGNATURES=true` | check `RUST_CHAIN_SIGNER_KEY_HEX` is set; or set `MEMPHIS_SYNC_ACCEPT_UNSIGNED=true` for legacy migration                          |
+| `append-lock timeout`            | another process holds the lock                            | `lsof ~/.memphis/chains/.append.lock` → kill blocker; lock auto-releases on process exit                                           |
 
 ### Provider / chat issues
 
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| `Rate limit exceeded` (429) | provider quota | wait `retryAfterMs` from response, or switch provider: `memphis config set DEFAULT_PROVIDER local-fallback` |
-| `Provider unauthorized` (401) | API key missing or invalid | `memphis vault add <PROVIDER>_API_KEY` (vault-first) or set env var |
-| `Ollama unreachable` | daemon not running | `ollama serve &` or `systemctl --user start ollama` |
-| `Model not found: cogito:3b` | model not pulled | `ollama pull cogito:3b` |
-| `Circuit breaker tripped: <provider>` | 5+ consecutive failures | Restart the daemon (`memphis service restart`) to reset the breaker; verify state via `memphis providers list --json`; check provider status page |
-| `Cost cap reached` | budget exhausted | `memphis config show COST_CAP_*` then adjust, or wait for reset window |
+| Symptom                               | Diagnosis                  | Fix                                                                                                                                               |
+| ------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Rate limit exceeded` (429)           | provider quota             | wait `retryAfterMs` from response, or switch provider: `memphis config set DEFAULT_PROVIDER local-fallback`                                       |
+| `Provider unauthorized` (401)         | API key missing or invalid | `memphis vault add <PROVIDER>_API_KEY` (vault-first) or set env var                                                                               |
+| `Ollama unreachable`                  | daemon not running         | `ollama serve &` or `systemctl --user start ollama`                                                                                               |
+| `Model not found: cogito:3b`          | model not pulled           | `ollama pull cogito:3b`                                                                                                                           |
+| `Circuit breaker tripped: <provider>` | 5+ consecutive failures    | Restart the daemon (`memphis service restart`) to reset the breaker; verify state via `memphis providers list --json`; check provider status page |
+| `Cost cap reached`                    | budget exhausted           | `memphis config show COST_CAP_*` then adjust, or wait for reset window                                                                            |
 
 ### Search / recall issues
 
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| `memphis recall` returns nothing | embeddings not built | `memphis search rebuild` |
-| Empty results for known content | exact-search index drift | `memphis repair --help` for rebuild-search options |
-| `embedding dimension mismatch` | model changed without rebuild | rebuild via `memphis search --help` (rebuild subcommand) or `memphis embed --help` |
-| Slow search (>10s) | unindexed corpus | rebuild search index; verify `RUST_EMBED_MODE=local` for ONNX path |
+| Symptom                          | Diagnosis                     | Fix                                                                                |
+| -------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------- |
+| `memphis recall` returns nothing | embeddings not built          | `memphis search rebuild`                                                           |
+| Empty results for known content  | exact-search index drift      | `memphis repair --help` for rebuild-search options                                 |
+| `embedding dimension mismatch`   | model changed without rebuild | rebuild via `memphis search --help` (rebuild subcommand) or `memphis embed --help` |
+| Slow search (>10s)               | unindexed corpus              | rebuild search index; verify `RUST_EMBED_MODE=local` for ONNX path                 |
 
 ### Telegram surface
 
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| Bot doesn't respond | bot token missing or wrong | `memphis vault add MEMPHIS_TELEGRAM_BOT_TOKEN`; restart |
-| `User ID not in allowlist` | sender not authorized | add user ID to `MEMPHIS_TELEGRAM_ALLOWED_USER_IDS` |
-| Voice messages fail | TTS/STT not configured | check Google Cloud TTS env or use text mode |
-| Smoke test fails in CI | bot token expired | regenerate via @BotFather; update CI secret `MEMPHIS_TELEGRAM_SMOKE_BOT_TOKEN` |
+| Symptom                    | Diagnosis                  | Fix                                                                            |
+| -------------------------- | -------------------------- | ------------------------------------------------------------------------------ |
+| Bot doesn't respond        | bot token missing or wrong | `memphis vault add MEMPHIS_TELEGRAM_BOT_TOKEN`; restart                        |
+| `User ID not in allowlist` | sender not authorized      | add user ID to `MEMPHIS_TELEGRAM_ALLOWED_USER_IDS`                             |
+| Voice messages fail        | TTS/STT not configured     | check Google Cloud TTS env or use text mode                                    |
+| Smoke test fails in CI     | bot token expired          | regenerate via @BotFather; update CI secret `MEMPHIS_TELEGRAM_SMOKE_BOT_TOKEN` |
 
 ### Self-modification
 
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| `tier-3 session required` | running tier-3 op without elevation | Tier-3 elevation is prompted automatically when invoking a tier-3 tool. For non-interactive flows set `MEMPHIS_OPERATOR_PASSPHRASE` env var. See `memphis operator --help` for related commands. |
-| `Test gate failed` | self-modify branch tests didn't pass | review proposed diff, fix tests, retry |
-| `Boot-failure auto-revert triggered` | post-self-modify boot crashed | last self-modify was reverted; inspect history via `memphis evolve --help` |
-| `path validation failed: outside sandbox` | self-modify tried to write outside `~/memphis/` | by design — operator passphrase + tier-3 won't bypass |
+| Symptom                                   | Diagnosis                                       | Fix                                                                                                                                                                                              |
+| ----------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `tier-3 session required`                 | running tier-3 op without elevation             | Tier-3 elevation is prompted automatically when invoking a tier-3 tool. For non-interactive flows set `MEMPHIS_OPERATOR_PASSPHRASE` env var. See `memphis operator --help` for related commands. |
+| `Test gate failed`                        | self-modify branch tests didn't pass            | review proposed diff, fix tests, retry                                                                                                                                                           |
+| `Boot-failure auto-revert triggered`      | post-self-modify boot crashed                   | last self-modify was reverted; inspect history via `memphis evolve --help`                                                                                                                       |
+| `path validation failed: outside sandbox` | self-modify tried to write outside `~/memphis/` | by design — operator passphrase + tier-3 won't bypass                                                                                                                                            |
 
 ### Performance
 
-| Symptom | Diagnosis | Fix |
-|---|---|---|
-| Slow startup (>30s) | first build cold | second start should be <5s; if not, check `cargo target/` cache integrity |
-| High CPU on idle | embedding rebuild loop | force one-shot rebuild (see `memphis search --help`) then `memphis service restart` |
-| Memory growth over hours | known: vitest test harness leak (not prod) | n/a in production |
-| Slow chat response | non-streaming provider | use streaming provider (Ollama, Anthropic) |
+| Symptom                  | Diagnosis                                  | Fix                                                                                 |
+| ------------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Slow startup (>30s)      | first build cold                           | second start should be <5s; if not, check `cargo target/` cache integrity           |
+| High CPU on idle         | embedding rebuild loop                     | force one-shot rebuild (see `memphis search --help`) then `memphis service restart` |
+| Memory growth over hours | known: vitest test harness leak (not prod) | n/a in production                                                                   |
+| Slow chat response       | non-streaming provider                     | use streaming provider (Ollama, Anthropic)                                          |
 
 ---
 
 ## Log locations
 
-| Log | Path | Format |
-|---|---|---|
-| Daemon stdout/stderr | `journalctl --user -u memphis` (systemd) or `~/.memphis/logs/daemon.log` | pino JSON |
-| Security audit | `~/.memphis/data/security-audit.jsonl` | JSONL, append-only |
-| Chain blocks | `~/.memphis/chains/<name>/<index>.json` | JSON, append-only |
-| Boot failures | `~/.memphis/state/boot-failures.json` | JSON state |
-| Vault state | `~/.memphis/vault/vault-state.json` | encrypted JSON |
-| Vault entries | `~/.memphis/vault/vault-entries.json` | encrypted JSON |
-| TUI state | `~/.config/memphis/tui-state.json` | JSON |
+| Log                  | Path                                                                     | Format             |
+| -------------------- | ------------------------------------------------------------------------ | ------------------ |
+| Daemon stdout/stderr | `journalctl --user -u memphis` (systemd) or `~/.memphis/logs/daemon.log` | pino JSON          |
+| Security audit       | `~/.memphis/data/security-audit.jsonl`                                   | JSONL, append-only |
+| Chain blocks         | `~/.memphis/chains/<name>/<index>.json`                                  | JSON, append-only  |
+| Boot failures        | `~/.memphis/state/boot-failures.json`                                    | JSON state         |
+| Vault state          | `~/.memphis/vault/vault-state.json`                                      | encrypted JSON     |
+| Vault entries        | `~/.memphis/vault/vault-entries.json`                                    | encrypted JSON     |
+| TUI state            | `~/.config/memphis/tui-state.json`                                       | JSON               |
 
 To follow live: `journalctl --user -u memphis -f` (Linux) or `tail -F ~/.memphis/logs/daemon.log`.
 
@@ -140,6 +140,7 @@ memphis --version > memphis-version.txt
 ```
 
 **Sanitize before sharing publicly:**
+
 - Remove API keys (grep -E 'sk-|api_key|token|password')
 - Remove vault entries content (encrypted but content metadata can leak)
 - Remove personal identifiers from chain blocks if present

--- a/docs/operator/debug.pl.md
+++ b/docs/operator/debug.pl.md
@@ -33,93 +33,93 @@ Jeśli `memphis health` zwraca `status: ok` i `memphis doctor` jest zielony — 
 
 ### Daemon nie startuje
 
-| Symptom | Diagnoza | Naprawa |
-|---|---|---|
-| `memphis service start` kończy bez output'u | systemd nie włączony | `systemctl --user enable memphis` i ponów |
-| `Connection refused on :3000` po starcie | daemon się rozsypał wcześnie | `memphis service logs -n 200` → szukaj pierwszego ERROR |
-| `EADDRINUSE: address already in use :3000` | inny proces zajmuje :3000 | `lsof -i :3000` → zabij rogue proces lub zmień `MEMPHIS_HTTP_PORT` |
+| Symptom                                          | Diagnoza                          | Naprawa                                                                                                                  |
+| ------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `memphis service start` kończy bez output'u      | systemd nie włączony              | `systemctl --user enable memphis` i ponów                                                                                |
+| `Connection refused on :3000` po starcie         | daemon się rozsypał wcześnie      | `memphis service logs -n 200` → szukaj pierwszego ERROR                                                                  |
+| `EADDRINUSE: address already in use :3000`       | inny proces zajmuje :3000         | `lsof -i :3000` → zabij rogue proces lub zmień `MEMPHIS_HTTP_PORT`                                                       |
 | `Loop detected: boot-failure threshold exceeded` | runtime crashował 5×; auto-revert | `memphis service logs -n 500` → diagnoza; `memphis evolve --help` dla opcji rollback self-modify jeśli niedawna ewolucja |
-| Daemon startuje i od razu kończy | nieobsłużony wyjątek przy init | `MEMPHIS_DEBUG=1 memphis service start` dla verbose stack |
+| Daemon startuje i od razu kończy                 | nieobsłużony wyjątek przy init    | `MEMPHIS_DEBUG=1 memphis service start` dla verbose stack                                                                |
 
 ### Sejf się nie otwiera
 
-| Symptom | Diagnoza | Naprawa |
-|---|---|---|
-| `vault unlock failed: invalid passphrase` | literówka lub złe hasło | ponów; jeśli zapomniane — odzyskiwanie |
-| `recovery answer mismatch` | odpowiedź zhashowana inaczej niż przy init | odpowiedzi case-sensitive po Argon2id; spróbuj wariantów. Flow odzyskiwania: `memphis vault --help` |
-| `vault corrupt: checksum mismatch` | błąd dysku | przywróć z backupu — `memphis backup --help` dla flag restore |
-| `vault not initialized` | `memphis init` nigdy nie uruchomione | uruchom `memphis init` |
-| `vault locked after rotation` | tmp files nie fsynced (bug pre-#145) | upgrade do v1.3.0+; `memphis vault rotate` ponów |
+| Symptom                                   | Diagnoza                                   | Naprawa                                                                                             |
+| ----------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `vault unlock failed: invalid passphrase` | literówka lub złe hasło                    | ponów; jeśli zapomniane — odzyskiwanie                                                              |
+| `recovery answer mismatch`                | odpowiedź zhashowana inaczej niż przy init | odpowiedzi case-sensitive po Argon2id; spróbuj wariantów. Flow odzyskiwania: `memphis vault --help` |
+| `vault corrupt: checksum mismatch`        | błąd dysku                                 | przywróć z backupu — `memphis backup --help` dla flag restore                                       |
+| `vault not initialized`                   | `memphis init` nigdy nie uruchomione       | uruchom `memphis init`                                                                              |
+| `vault locked after rotation`             | tmp files nie fsynced (bug pre-#145)       | upgrade do v1.3.0+; `memphis vault rotate` ponów                                                    |
 
 ### Błędy integralności łańcucha
 
-| Symptom | Diagnoza | Naprawa |
-|---|---|---|
-| `chain hash mismatch at block N` | blok edytowany lub błąd dysku | `memphis repair runtime --fix` dla pochodnych; dla canonical chain — przywróć z backupu |
-| `chain integrity degraded` | jeden lub więcej niepoprawnych bloków | `memphis chain --help` dla dostępnych w Twojej wersji subcommandów audit/repair |
-| `signature verification failed` | niepodpisany blok przy `RUST_CHAIN_REQUIRE_SIGNATURES=true` | sprawdź `RUST_CHAIN_SIGNER_KEY_HEX`; lub `MEMPHIS_SYNC_ACCEPT_UNSIGNED=true` dla migracji legacy |
-| `append-lock timeout` | inny proces trzyma lock | `lsof ~/.memphis/chains/.append.lock` → zabij blockera; lock uwalnia się przy exit |
+| Symptom                          | Diagnoza                                                    | Naprawa                                                                                          |
+| -------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `chain hash mismatch at block N` | blok edytowany lub błąd dysku                               | `memphis repair runtime --fix` dla pochodnych; dla canonical chain — przywróć z backupu          |
+| `chain integrity degraded`       | jeden lub więcej niepoprawnych bloków                       | `memphis chain --help` dla dostępnych w Twojej wersji subcommandów audit/repair                  |
+| `signature verification failed`  | niepodpisany blok przy `RUST_CHAIN_REQUIRE_SIGNATURES=true` | sprawdź `RUST_CHAIN_SIGNER_KEY_HEX`; lub `MEMPHIS_SYNC_ACCEPT_UNSIGNED=true` dla migracji legacy |
+| `append-lock timeout`            | inny proces trzyma lock                                     | `lsof ~/.memphis/chains/.append.lock` → zabij blockera; lock uwalnia się przy exit               |
 
 ### Provider / chat
 
-| Symptom | Diagnoza | Naprawa |
-|---|---|---|
-| `Rate limit exceeded` (429) | quota providera | poczekaj `retryAfterMs`, lub przełącz: `memphis config set DEFAULT_PROVIDER local-fallback` |
-| `Provider unauthorized` (401) | API key brak lub niepoprawny | `memphis vault add <PROVIDER>_API_KEY` (vault-first) lub env var |
-| `Ollama unreachable` | daemon nie działa | `ollama serve &` lub `systemctl --user start ollama` |
-| `Model not found: cogito:3b` | model nie pobrany | `ollama pull cogito:3b` |
-| `Circuit breaker tripped: <provider>` | 5+ błędów z rzędu | Restart daemona (`memphis service restart`) resetuje breaker; weryfikacja: `memphis providers list --json`; sprawdź status providera |
-| `Cost cap reached` | budżet wyczerpany | `memphis config show COST_CAP_*` i dostosuj, lub czekaj na reset |
+| Symptom                               | Diagnoza                     | Naprawa                                                                                                                              |
+| ------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `Rate limit exceeded` (429)           | quota providera              | poczekaj `retryAfterMs`, lub przełącz: `memphis config set DEFAULT_PROVIDER local-fallback`                                          |
+| `Provider unauthorized` (401)         | API key brak lub niepoprawny | `memphis vault add <PROVIDER>_API_KEY` (vault-first) lub env var                                                                     |
+| `Ollama unreachable`                  | daemon nie działa            | `ollama serve &` lub `systemctl --user start ollama`                                                                                 |
+| `Model not found: cogito:3b`          | model nie pobrany            | `ollama pull cogito:3b`                                                                                                              |
+| `Circuit breaker tripped: <provider>` | 5+ błędów z rzędu            | Restart daemona (`memphis service restart`) resetuje breaker; weryfikacja: `memphis providers list --json`; sprawdź status providera |
+| `Cost cap reached`                    | budżet wyczerpany            | `memphis config show COST_CAP_*` i dostosuj, lub czekaj na reset                                                                     |
 
 ### Wyszukiwanie / recall
 
-| Symptom | Diagnoza | Naprawa |
-|---|---|---|
-| `memphis recall` zwraca pusto | embeddingi nie zbudowane | `memphis search rebuild` |
-| Pusto przy znanej zawartości | drift indeksu exact-search | `memphis repair --help` dla opcji rebuild-search |
+| Symptom                        | Diagnoza                    | Naprawa                                                                               |
+| ------------------------------ | --------------------------- | ------------------------------------------------------------------------------------- |
+| `memphis recall` zwraca pusto  | embeddingi nie zbudowane    | `memphis search rebuild`                                                              |
+| Pusto przy znanej zawartości   | drift indeksu exact-search  | `memphis repair --help` dla opcji rebuild-search                                      |
 | `embedding dimension mismatch` | zmieniono model bez rebuild | rebuild przez `memphis search --help` (subcommand rebuild) lub `memphis embed --help` |
-| Wolne wyszukiwanie (>10s) | nieindeksowany korpus | rebuild indeksu search; zweryfikuj `RUST_EMBED_MODE=local` dla ścieżki ONNX |
+| Wolne wyszukiwanie (>10s)      | nieindeksowany korpus       | rebuild indeksu search; zweryfikuj `RUST_EMBED_MODE=local` dla ścieżki ONNX           |
 
 ### Surface Telegram
 
-| Symptom | Diagnoza | Naprawa |
-|---|---|---|
-| Bot nie odpowiada | brak lub złego token | `memphis vault add MEMPHIS_TELEGRAM_BOT_TOKEN`; restart |
-| `User ID not in allowlist` | nadawca nieautoryzowany | dodaj user ID do `MEMPHIS_TELEGRAM_ALLOWED_USER_IDS` |
-| Wiadomości głosowe nie działają | TTS/STT nie skonfigurowane | sprawdź Google Cloud TTS env lub używaj tekst |
-| Smoke test fail w CI | bot token wygasł | regeneruj przez @BotFather; update CI secret `MEMPHIS_TELEGRAM_SMOKE_BOT_TOKEN` |
+| Symptom                         | Diagnoza                   | Naprawa                                                                         |
+| ------------------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| Bot nie odpowiada               | brak lub złego token       | `memphis vault add MEMPHIS_TELEGRAM_BOT_TOKEN`; restart                         |
+| `User ID not in allowlist`      | nadawca nieautoryzowany    | dodaj user ID do `MEMPHIS_TELEGRAM_ALLOWED_USER_IDS`                            |
+| Wiadomości głosowe nie działają | TTS/STT nie skonfigurowane | sprawdź Google Cloud TTS env lub używaj tekst                                   |
+| Smoke test fail w CI            | bot token wygasł           | regeneruj przez @BotFather; update CI secret `MEMPHIS_TELEGRAM_SMOKE_BOT_TOKEN` |
 
 ### Self-modyfikacja
 
-| Symptom | Diagnoza | Naprawa |
-|---|---|---|
-| `tier-3 session required` | tier-3 op bez elewacji | Tier-3 elewacja jest pytana automatycznie przy wywołaniu tier-3 toola. Dla flow non-interactive ustaw `MEMPHIS_OPERATOR_PASSPHRASE`. Patrz `memphis operator --help`. |
-| `Test gate failed` | branch self-modify nie zdał testów | review diff, popraw testy, ponów |
-| `Boot-failure auto-revert triggered` | post-self-modify boot crashował | ostatni self-modify cofnięty; historia przez `memphis evolve --help` |
-| `path validation failed: outside sandbox` | self-modify próbował zapisać poza `~/memphis/` | by design — hasło operatora + tier-3 nie obejdzie |
+| Symptom                                   | Diagnoza                                       | Naprawa                                                                                                                                                               |
+| ----------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tier-3 session required`                 | tier-3 op bez elewacji                         | Tier-3 elewacja jest pytana automatycznie przy wywołaniu tier-3 toola. Dla flow non-interactive ustaw `MEMPHIS_OPERATOR_PASSPHRASE`. Patrz `memphis operator --help`. |
+| `Test gate failed`                        | branch self-modify nie zdał testów             | review diff, popraw testy, ponów                                                                                                                                      |
+| `Boot-failure auto-revert triggered`      | post-self-modify boot crashował                | ostatni self-modify cofnięty; historia przez `memphis evolve --help`                                                                                                  |
+| `path validation failed: outside sandbox` | self-modify próbował zapisać poza `~/memphis/` | by design — hasło operatora + tier-3 nie obejdzie                                                                                                                     |
 
 ### Wydajność
 
-| Symptom | Diagnoza | Naprawa |
-|---|---|---|
-| Wolny start (>30s) | pierwszy build na zimno | drugi start <5s; jeśli nie — sprawdź cache `cargo target/` |
-| Wysokie CPU na idle | pętla rebuild embeddings | wymuś jednorazowy rebuild (patrz `memphis search --help`) potem `memphis service restart` |
-| Wzrost pamięci po godzinach | znane: leak vitest test harness (nie prod) | n/d w produkcji |
-| Wolna odpowiedź chat | provider nie-streaming | użyj streaming providera (Ollama, Anthropic) |
+| Symptom                     | Diagnoza                                   | Naprawa                                                                                   |
+| --------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| Wolny start (>30s)          | pierwszy build na zimno                    | drugi start <5s; jeśli nie — sprawdź cache `cargo target/`                                |
+| Wysokie CPU na idle         | pętla rebuild embeddings                   | wymuś jednorazowy rebuild (patrz `memphis search --help`) potem `memphis service restart` |
+| Wzrost pamięci po godzinach | znane: leak vitest test harness (nie prod) | n/d w produkcji                                                                           |
+| Wolna odpowiedź chat        | provider nie-streaming                     | użyj streaming providera (Ollama, Anthropic)                                              |
 
 ---
 
 ## Lokalizacje logów
 
-| Log | Ścieżka | Format |
-|---|---|---|
-| Daemon stdout/stderr | `journalctl --user -u memphis` (systemd) lub `~/.memphis/logs/daemon.log` | pino JSON |
-| Security audit | `~/.memphis/data/security-audit.jsonl` | JSONL, append-only |
-| Chain blocks | `~/.memphis/chains/<nazwa>/<indeks>.json` | JSON, append-only |
-| Boot failures | `~/.memphis/state/boot-failures.json` | JSON state |
-| Vault state | `~/.memphis/vault/vault-state.json` | encrypted JSON |
-| Vault entries | `~/.memphis/vault/vault-entries.json` | encrypted JSON |
-| TUI state | `~/.config/memphis/tui-state.json` | JSON |
+| Log                  | Ścieżka                                                                   | Format             |
+| -------------------- | ------------------------------------------------------------------------- | ------------------ |
+| Daemon stdout/stderr | `journalctl --user -u memphis` (systemd) lub `~/.memphis/logs/daemon.log` | pino JSON          |
+| Security audit       | `~/.memphis/data/security-audit.jsonl`                                    | JSONL, append-only |
+| Chain blocks         | `~/.memphis/chains/<nazwa>/<indeks>.json`                                 | JSON, append-only  |
+| Boot failures        | `~/.memphis/state/boot-failures.json`                                     | JSON state         |
+| Vault state          | `~/.memphis/vault/vault-state.json`                                       | encrypted JSON     |
+| Vault entries        | `~/.memphis/vault/vault-entries.json`                                     | encrypted JSON     |
+| TUI state            | `~/.config/memphis/tui-state.json`                                        | JSON               |
 
 Live follow: `journalctl --user -u memphis -f` (Linux) lub `tail -F ~/.memphis/logs/daemon.log`.
 
@@ -140,6 +140,7 @@ memphis --version > memphis-version.txt
 ```
 
 **Zanim wyślesz publicznie — sanityzacja:**
+
 - Usuń API keys (`grep -E 'sk-|api_key|token|password'`)
 - Usuń zawartość vault entries (zaszyfrowane, ale metadata może wyciec)
 - Usuń identyfikatory osobiste z chain blocks

--- a/docs/operator/example-installation/05-health-snapshot.json
+++ b/docs/operator/example-installation/05-health-snapshot.json
@@ -43,7 +43,15 @@
       "system": 4,
       "proactive": 1
     },
-    "activeChains": ["journal", "decisions", "reflections", "patterns", "cases", "system", "proactive"],
+    "activeChains": [
+      "journal",
+      "decisions",
+      "reflections",
+      "patterns",
+      "cases",
+      "system",
+      "proactive"
+    ],
     "integrity": {
       "status": "ready",
       "checked": 11,

--- a/docs/operator/example-installation/README.md
+++ b/docs/operator/example-installation/README.md
@@ -8,18 +8,19 @@
 
 ## What's in this directory
 
-| File | What it shows |
-|---|---|
-| `01-fresh-install.md` | One-liner installer run on a clean Ubuntu 24.04 box, with timing |
-| `02-first-run.md` | `memphis init` interactive session — what to type, what to expect |
-| `03-first-chat.md` | First chat through Telegram + CLI, vault prompt for tier-2 tools |
-| `04-vault-setup.md` | Adding API keys to vault, listing vault, recovery flow |
-| `05-health-snapshot.json` | Sample sanitized output of `memphis health --json` on a healthy install |
-| `06-timing-baseline.txt` | Step-by-step timing on Intel i3-2120 (2011, no GPU, 4 cores) — Memphis's lower hardware bound |
+| File                      | What it shows                                                                                 |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| `01-fresh-install.md`     | One-liner installer run on a clean Ubuntu 24.04 box, with timing                              |
+| `02-first-run.md`         | `memphis init` interactive session — what to type, what to expect                             |
+| `03-first-chat.md`        | First chat through Telegram + CLI, vault prompt for tier-2 tools                              |
+| `04-vault-setup.md`       | Adding API keys to vault, listing vault, recovery flow                                        |
+| `05-health-snapshot.json` | Sample sanitized output of `memphis health --json` on a healthy install                       |
+| `06-timing-baseline.txt`  | Step-by-step timing on Intel i3-2120 (2011, no GPU, 4 cores) — Memphis's lower hardware bound |
 
 ## Discipline
 
 Everything in here is **sanitized sample data**:
+
 - No real API keys
 - No real DID
 - No real chain content

--- a/docs/operator/install.en.md
+++ b/docs/operator/install.en.md
@@ -36,16 +36,16 @@ That's it. If anything goes wrong, see [`debug.en.md`](./debug.en.md).
 
 ## Prerequisites
 
-| Requirement | Why | Auto-installed by `install.sh`? |
-|---|---|---|
-| Linux / macOS / WSL2 | Native Windows shells unsupported | n/a |
-| `git` | Repo clone + version pinning | yes (apt/dnf/brew/pacman/zypper) |
-| `curl` or `wget` or `python3` | Downloader | yes |
-| `sudo` (or root) | System package install | required |
-| Node.js ≥ v22 | Memphis runtime | yes (NodeSource on Linux, brew on macOS) |
-| Rust stable | NAPI bridge + crates | yes (rustup) |
-| Build toolchain (cc, make, pkg-config, openssl, python3) | better-sqlite3 + NAPI native modules | yes |
-| Ollama (optional but recommended) | Local LLM + embeddings | yes if you confirm |
+| Requirement                                              | Why                                  | Auto-installed by `install.sh`?          |
+| -------------------------------------------------------- | ------------------------------------ | ---------------------------------------- |
+| Linux / macOS / WSL2                                     | Native Windows shells unsupported    | n/a                                      |
+| `git`                                                    | Repo clone + version pinning         | yes (apt/dnf/brew/pacman/zypper)         |
+| `curl` or `wget` or `python3`                            | Downloader                           | yes                                      |
+| `sudo` (or root)                                         | System package install               | required                                 |
+| Node.js ≥ v22                                            | Memphis runtime                      | yes (NodeSource on Linux, brew on macOS) |
+| Rust stable                                              | NAPI bridge + crates                 | yes (rustup)                             |
+| Build toolchain (cc, make, pkg-config, openssl, python3) | better-sqlite3 + NAPI native modules | yes                                      |
+| Ollama (optional but recommended)                        | Local LLM + embeddings               | yes if you confirm                       |
 
 **Disk:** ~2 GB for Memphis + dependencies. **RAM:** 2 GB minimum, 8 GB recommended. **CPU:** any x86_64 from 2013+ (AVX). The sovereign-RAG stack is proven on Intel i3-2120 (2011) without GPU and without internet access — that's the lower bound.
 
@@ -101,6 +101,7 @@ memphis init
 ```
 
 Interactive prompts:
+
 1. **Operator passphrase** — used to elevate to tier 2 (write/execute tools). Choose a strong passphrase; you'll be asked for it on every elevation. Memphis never logs it.
 2. **Vault passphrase** — encrypts your secrets vault (AES-256-GCM + Argon2id KDF). Different from the operator passphrase.
 3. **Recovery question + answer** — used if you ever lose the vault passphrase. Write both down somewhere safe. The answer is hashed; we cannot recover the original.
@@ -145,17 +146,17 @@ If all green, your installation is **production-ready for first test**.
 
 ## Common errors → fix
 
-| Error | Diagnosis | Fix |
-|---|---|---|
-| `Node.js v22+ required, found v20` | Outdated Node | Re-run installer; or `nvm install 22 && nvm use 22` |
-| `rustc not found` | Rust not in PATH | `source $HOME/.cargo/env` (add to `~/.bashrc`) |
-| `better-sqlite3` install fails | Missing build toolchain | `sudo apt-get install build-essential python3` |
-| `Cannot find module '@memphis-chains/memphis'` | `npm link` not run | `cd ~/memphis && npm link` |
-| `memphis: command not found` after npm link | Linker path | Add `$(npm prefix -g)/bin` to PATH |
-| `vault unlock failed: invalid passphrase` | Typo or wrong passphrase | Use recovery question/answer if forgotten |
-| `Connection refused on :3000` | Daemon not started | `memphis service start` |
-| `Ollama unreachable` | Ollama not running | `ollama serve &` (or skip — local-fallback handles it) |
-| `Chain corrupt` | Disk error mid-write | `memphis repair runtime --fix` |
+| Error                                          | Diagnosis                | Fix                                                    |
+| ---------------------------------------------- | ------------------------ | ------------------------------------------------------ |
+| `Node.js v22+ required, found v20`             | Outdated Node            | Re-run installer; or `nvm install 22 && nvm use 22`    |
+| `rustc not found`                              | Rust not in PATH         | `source $HOME/.cargo/env` (add to `~/.bashrc`)         |
+| `better-sqlite3` install fails                 | Missing build toolchain  | `sudo apt-get install build-essential python3`         |
+| `Cannot find module '@memphis-chains/memphis'` | `npm link` not run       | `cd ~/memphis && npm link`                             |
+| `memphis: command not found` after npm link    | Linker path              | Add `$(npm prefix -g)/bin` to PATH                     |
+| `vault unlock failed: invalid passphrase`      | Typo or wrong passphrase | Use recovery question/answer if forgotten              |
+| `Connection refused on :3000`                  | Daemon not started       | `memphis service start`                                |
+| `Ollama unreachable`                           | Ollama not running       | `ollama serve &` (or skip — local-fallback handles it) |
+| `Chain corrupt`                                | Disk error mid-write     | `memphis repair runtime --fix`                         |
 
 For a full troubleshooting tree, see [`debug.en.md`](./debug.en.md).
 

--- a/docs/operator/install.pl.md
+++ b/docs/operator/install.pl.md
@@ -36,16 +36,16 @@ Tyle. Jeśli coś nie zadziała, zajrzyj do [`debug.pl.md`](./debug.pl.md).
 
 ## Wymagania wstępne
 
-| Wymaganie | Po co | Auto-instalowane przez `install.sh`? |
-|---|---|---|
-| Linux / macOS / WSL2 | Natywny Windows nie jest wspierany | n/d |
-| `git` | Klonowanie repo + pinowanie wersji | tak (apt/dnf/brew/pacman/zypper) |
-| `curl` lub `wget` lub `python3` | Pobieranie | tak |
-| `sudo` (lub root) | Instalacja pakietów systemowych | wymagane |
-| Node.js ≥ v22 | Runtime Memphis | tak (NodeSource na Linux, brew na macOS) |
-| Rust stable | Mostek NAPI + cratey | tak (rustup) |
-| Toolchain budowy (cc, make, pkg-config, openssl, python3) | better-sqlite3 + natywne moduły NAPI | tak |
-| Ollama (opcjonalne, ale zalecane) | Lokalny LLM + embeddingi | tak, jeśli potwierdzisz |
+| Wymaganie                                                 | Po co                                | Auto-instalowane przez `install.sh`?     |
+| --------------------------------------------------------- | ------------------------------------ | ---------------------------------------- |
+| Linux / macOS / WSL2                                      | Natywny Windows nie jest wspierany   | n/d                                      |
+| `git`                                                     | Klonowanie repo + pinowanie wersji   | tak (apt/dnf/brew/pacman/zypper)         |
+| `curl` lub `wget` lub `python3`                           | Pobieranie                           | tak                                      |
+| `sudo` (lub root)                                         | Instalacja pakietów systemowych      | wymagane                                 |
+| Node.js ≥ v22                                             | Runtime Memphis                      | tak (NodeSource na Linux, brew na macOS) |
+| Rust stable                                               | Mostek NAPI + cratey                 | tak (rustup)                             |
+| Toolchain budowy (cc, make, pkg-config, openssl, python3) | better-sqlite3 + natywne moduły NAPI | tak                                      |
+| Ollama (opcjonalne, ale zalecane)                         | Lokalny LLM + embeddingi             | tak, jeśli potwierdzisz                  |
 
 **Dysk:** ~2 GB na Memphis + zależności. **RAM:** minimum 2 GB, zalecane 8 GB. **CPU:** dowolny x86_64 od 2013+ (AVX). Stack sovereign-RAG działa na Intel i3-2120 (2011) bez GPU i bez internetu — to dolna granica sprzętowa.
 
@@ -101,6 +101,7 @@ memphis init
 ```
 
 Interaktywne pytania:
+
 1. **Hasło operatora** — używane do podniesienia uprawnień do tier 2 (narzędzia write/execute). Wybierz mocne; będzie pytane przy każdym podniesieniu. Memphis nigdy go nie loguje.
 2. **Hasło sejfu** — szyfruje sejf z sekretami (AES-256-GCM + Argon2id KDF). Inne niż hasło operatora.
 3. **Pytanie + odpowiedź odzyskiwania** — używane gdy zapomnisz hasła sejfu. Zapisz oba w bezpiecznym miejscu. Odpowiedź jest hashowana, nie da się odzyskać oryginału.
@@ -145,17 +146,17 @@ Jeśli wszystko zielone — instalacja jest **gotowa do pierwszego testu produkc
 
 ## Częste błędy → rozwiązanie
 
-| Błąd | Diagnoza | Naprawa |
-|---|---|---|
-| `Node.js v22+ required, found v20` | Stary Node | Uruchom instalator ponownie; lub `nvm install 22 && nvm use 22` |
-| `rustc not found` | Rust nie w PATH | `source $HOME/.cargo/env` (dodaj do `~/.bashrc`) |
-| `better-sqlite3` instalacja fail | Brak toolchain budowy | `sudo apt-get install build-essential python3` |
-| `Cannot find module '@memphis-chains/memphis'` | Nie wykonano `npm link` | `cd ~/memphis && npm link` |
-| `memphis: command not found` po `npm link` | Ścieżka linkera | Dodaj `$(npm prefix -g)/bin` do PATH |
-| `vault unlock failed: invalid passphrase` | Literówka lub złe hasło | Użyj pytania/odpowiedzi odzyskiwania |
-| `Connection refused on :3000` | Daemon nie wystartował | `memphis service start` |
-| `Ollama unreachable` | Ollama nie działa | `ollama serve &` (lub pomiń — local-fallback to obsłuży) |
-| `Chain corrupt` | Błąd dysku w trakcie zapisu | `memphis repair runtime --fix` |
+| Błąd                                           | Diagnoza                    | Naprawa                                                         |
+| ---------------------------------------------- | --------------------------- | --------------------------------------------------------------- |
+| `Node.js v22+ required, found v20`             | Stary Node                  | Uruchom instalator ponownie; lub `nvm install 22 && nvm use 22` |
+| `rustc not found`                              | Rust nie w PATH             | `source $HOME/.cargo/env` (dodaj do `~/.bashrc`)                |
+| `better-sqlite3` instalacja fail               | Brak toolchain budowy       | `sudo apt-get install build-essential python3`                  |
+| `Cannot find module '@memphis-chains/memphis'` | Nie wykonano `npm link`     | `cd ~/memphis && npm link`                                      |
+| `memphis: command not found` po `npm link`     | Ścieżka linkera             | Dodaj `$(npm prefix -g)/bin` do PATH                            |
+| `vault unlock failed: invalid passphrase`      | Literówka lub złe hasło     | Użyj pytania/odpowiedzi odzyskiwania                            |
+| `Connection refused on :3000`                  | Daemon nie wystartował      | `memphis service start`                                         |
+| `Ollama unreachable`                           | Ollama nie działa           | `ollama serve &` (lub pomiń — local-fallback to obsłuży)        |
+| `Chain corrupt`                                | Błąd dysku w trakcie zapisu | `memphis repair runtime --fix`                                  |
 
 Pełne drzewo troubleshootingu: [`debug.pl.md`](./debug.pl.md).
 

--- a/review.md
+++ b/review.md
@@ -18,6 +18,7 @@ Plan jest solidny — function evaluation template to mocna dyscyplina, Blueprin
 ### 2. Phase 3 (memphis-ml integration) jest niedoszacowana
 
 Estimate: 5–6 PRs / ~2k src + ~1.5k test. Realnie:
+
 - `ml-vm` jest broken (potwierdzone w Phase 1 research)
 - swap `ml-p2p` raw-TCP → memphis sync-manager adapter
 - nowy `ml-hw-memphis-llm` backend
@@ -48,6 +49,7 @@ Phase 0 pisze `docs/AGORA-DESIGN.md` z threat modelem (sybil, wash-trading, slas
 ### 6. Vault-unlock lifecycle w Tauri — nie zaadresowane
 
 Każda finance/trust op → vault-2FA modal. Ale plan nie mówi **jak Tauri trzyma stan "unlocked" między operacjami**:
+
 - Per-op prompt → UX okropny (operator klika 5× w trakcie jednego flow)
 - Session z timeoutem → security risk (kradzież device w stanie unlocked)
 - Hybrid: per-op dla finance, krótki session dla reszty → kompromis
@@ -194,6 +196,7 @@ decyzję + mechanikę, nie dalsze rozważania.
 jako runtime model.
 
 Powody po skrócie:
+
 - shadcn to state-of-art dla estetyki Zed/VSCode, react-hook-form + zod
   idealnie pasuje jako konsument L3 Blueprint schema
 - React ma największą community = najszybszy turnaround AI-assisted development
@@ -209,14 +212,15 @@ always-on).
 
 **Zamknięte: nowa Phase 3-spike przed Phase 3a**, 1 tydzień TIMEBOX.
 
-| Dzień | Zadanie |
-| --- | --- |
-| D1–D2 | Fix OR remove `ml-vm` z workspace'u. Jeśli fix > 2 dni → rip out. |
-| D3–D4 | Prototype ml-p2p → sync-manager adapter, proof-of-concept. |
+| Dzień | Zadanie                                                                              |
+| ----- | ------------------------------------------------------------------------------------ |
+| D1–D2 | Fix OR remove `ml-vm` z workspace'u. Jeśli fix > 2 dni → rip out.                    |
+| D3–D4 | Prototype ml-p2p → sync-manager adapter, proof-of-concept.                           |
 | D5–D6 | Prototype virtualized clock (Luka 4) + determinism tracing, record/replay roundtrip. |
-| D7 | Write 100-line ML sample Agora offer, verify replay deterministic. |
+| D7    | Write 100-line ML sample Agora offer, verify replay deterministic.                   |
 
 **Decyzja po spike'u:**
+
 - Wszystkie 4 kroki zielone → proceed Phase 3b jak w planie (memphis-ml jako contract language)
 - Jakiekolwiek > 2× budget → **abort ML integration**, offers jako JSON schema + endpoint URL (Option A w issue #156)
 
@@ -247,9 +251,9 @@ Startup recovery scan:
 ```
 
 **Update Phase T (#151)** — dodać do Function Evaluation nową sekcję
-**"Crash recovery"** z I5: *Restart po kill -9 między fsync → recovery
+**"Crash recovery"** z I5: _Restart po kill -9 między fsync → recovery
 scan przywraca spójność; `listCurrentTrustAnchors()` i `trusted.chain`
-zgodne.*
+zgodne._
 
 **Nowy test (regresja):** `kill -9` po kroku 6, restart, `listCurrentTrustAnchors`
 nie widzi did'a, `trusted.chain` też nie — albo obie widzą. Nigdy jedna+druga.
@@ -260,6 +264,7 @@ nie widzi did'a, `trusted.chain` też nie — albo obie widzą. Nigdy jedna+drug
 non-deterministic sources dostępne TYLKO przez injected providers.
 
 Sources do wirtualizacji:
+
 - `Clock::now_ms()` zamiast `Date.now()`/`SystemTime::now()`
 - `Rng::bytes(n)` zamiast `Math.random()`/`thread_rng()`
 - `Sensor::read()` (już tak się dzieje w ml-hal)
@@ -279,8 +284,8 @@ struct ReplayEnv   { journal: Journal }  // reads recorded values
 ```
 
 **Update Phase 3b (#156) prereq section** — dodać punkt:
-*"All non-deterministic access goes via `MLEnv` trait; direct OS time/RNG/I/O
-rejected przy AST validation time."*
+_"All non-deterministic access goes via `MLEnv` trait; direct OS time/RNG/I/O
+rejected przy AST validation time."_
 
 #### Luka 5 → Phase 4.5 adversarial simulation
 
@@ -289,16 +294,17 @@ nie startuje przed zielonym 4.5.
 
 Obowiązkowe scenariusze ataku (symulacja na testnecie):
 
-| Atak | Oczekiwane zachowanie | Warunek zielony |
-| --- | --- | --- |
-| **Sybil swarm** — 1000 atakujących DIDs | Oferty niewidoczne dla uczciwego operatora bez attestation path lub stake | `discoverOffers()` filter dla operatora X zwraca 0 ofert sybilowego kręgu |
-| **Wash trading** — fake contracts w ramach kliki | Reputation nie nabiera masy bo weighting × attestation-distance zeruje | `reputationOf(sybil) → { score, confidence: low }` |
-| **Slash-vote collusion** — attacker + N kumpli próbują slash innocent | selectArbiters PRF z reputation-weighted pool → attacker nie gwarantuje wyboru swojej grupy | > 90% prób slash-vote collusion kończy się odmową wykonania slash |
-| **Attestation cycle** — A→B→C→A loop | BFS visited-set terminuje cykl → distance = Infinity poza tree | `trustPathFromAnchor` zwraca `Infinity` dla loop'a |
-| **Stake-grief** — attacker lock'uje stake i prowokuje slash ofiary | Arbiter k-of-n majority → single attacker nie wygrywa głosowania | > 95% prób stake-grief kończy się release dla ofiary |
+| Atak                                                                  | Oczekiwane zachowanie                                                                       | Warunek zielony                                                           |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Sybil swarm** — 1000 atakujących DIDs                               | Oferty niewidoczne dla uczciwego operatora bez attestation path lub stake                   | `discoverOffers()` filter dla operatora X zwraca 0 ofert sybilowego kręgu |
+| **Wash trading** — fake contracts w ramach kliki                      | Reputation nie nabiera masy bo weighting × attestation-distance zeruje                      | `reputationOf(sybil) → { score, confidence: low }`                        |
+| **Slash-vote collusion** — attacker + N kumpli próbują slash innocent | selectArbiters PRF z reputation-weighted pool → attacker nie gwarantuje wyboru swojej grupy | > 90% prób slash-vote collusion kończy się odmową wykonania slash         |
+| **Attestation cycle** — A→B→C→A loop                                  | BFS visited-set terminuje cykl → distance = Infinity poza tree                              | `trustPathFromAnchor` zwraca `Infinity` dla loop'a                        |
+| **Stake-grief** — attacker lock'uje stake i prowokuje slash ofiary    | Arbiter k-of-n majority → single attacker nie wygrywa głosowania                            | > 95% prób stake-grief kończy się release dla ofiary                      |
 
 **Deliverable:** `docs/AGORA-ATTACKS.md` + runnable simulator w `tests/sim/`
-+ przebieg każdego scenariusza na testnecie z reportem.
+
+- przebieg każdego scenariusza na testnecie z reportem.
 
 **Nowy GH issue: #160 `phase-4.5-agora-adversarial-sim`.**
 
@@ -306,13 +312,14 @@ Obowiązkowe scenariusze ataku (symulacja na testnecie):
 
 **Zamknięte: 3-tier auth model** z jawną state-machine.
 
-| Tier | Kiedy działa | Auto-lock triggers |
-| --- | --- | --- |
-| **Session auth** (15 min idle TTL) | chat, read chains, list peers, run safe tools | idle > 15 min · suspend/sleep · explicit lock button |
+| Tier                                  | Kiedy działa                                                                                                           | Auto-lock triggers                                    |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| **Session auth** (15 min idle TTL)    | chat, read chains, list peers, run safe tools                                                                          | idle > 15 min · suspend/sleep · explicit lock button  |
 | **Fresh auth** (per-op, never cached) | stake.lock, stake.slash, wallet.unlock, wallet.send, trust.revoke, trust.anchor.pin, tier3.elevate, self-modify.commit | każda taka op prompt'uje niezależnie od session state |
-| **Recovery auth** | passphrase-forgot path | Q&A recovery answer, nie session |
+| **Recovery auth**                     | passphrase-forgot path                                                                                                 | Q&A recovery answer, nie session                      |
 
 **Mockup modal fresh auth:**
+
 ```
 ┌──────────────────────────────────────────────────┐
 │  🔐 Fresh auth required for: stake.lock          │
@@ -435,7 +442,7 @@ nie znika z historii.
 ```
 Dev pisze:
   src/mcp/tools/ghunt.ts
-  
+
   export const ghuntTool: ToolDescriptor = {
     id: 'memphis_osint_ghunt',
     title: 'GHunt — investigate Google account',
@@ -471,14 +478,14 @@ Zakładki z Części II uporządkowane według roli w architekturze.
 
 #### L2 — Local LLM serving (provider cascade)
 
-| Zakładka | Rola dla Memphis |
-| --- | --- |
+| Zakładka                                                   | Rola dla Memphis                                                                       |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | #15 **NVIDIA PersonaPlex 7B** (audio-to-audio, Moshi arch) | TTS/STT stack dla voice surface'u (Phase G+). Low-latency speech z persistent persona. |
-| #17 **arcee-ai org** (Small Language Models) | "Small-by-default" ethos — kandydat na lokalne modele gdy user nie chce Ollama/30GB |
-| #21 **TheTom/turboquant_plus** (MLX quantization) | Apple Silicon users — kwantyzacja dla lokalnego Memphis na Macu |
-| #23 **danveloper/flash-moe** (MoE na słabym laptopie) | PC3 / low-resource fallback ścieżka |
-| #32 **airllm** (405B na 8GB VRAM) | Extreme low-resource dla power-userów z 405B aspiracjami |
-| #33 (tylko jako info) | joke easter egg, nie produkcja |
+| #17 **arcee-ai org** (Small Language Models)               | "Small-by-default" ethos — kandydat na lokalne modele gdy user nie chce Ollama/30GB    |
+| #21 **TheTom/turboquant_plus** (MLX quantization)          | Apple Silicon users — kwantyzacja dla lokalnego Memphis na Macu                        |
+| #23 **danveloper/flash-moe** (MoE na słabym laptopie)      | PC3 / low-resource fallback ścieżka                                                    |
+| #32 **airllm** (405B na 8GB VRAM)                          | Extreme low-resource dla power-userów z 405B aspiracjami                               |
+| #33 (tylko jako info)                                      | joke easter egg, nie produkcja                                                         |
 
 **Decyzja stack'owa:** Ollama jako primary. Phase G dodać `WebGPUProviderAdapter`
 inspirowany #30 bonsai-webgpu (z Części I linków), dla zero-install
@@ -487,20 +494,20 @@ ships own-model distribution.
 
 #### L3 — Capability inspiracje (tools + skills)
 
-| Zakładka | Rola |
-| --- | --- |
-| #18 **skills.sh** (Claude Code Agent Skills catalog) | Reference dla Memphis skill registry design + Agora Phase 5 marketplace UX |
-| #20 **paoloanzn/free-code** | Reference for "unrestricted coding assistant" — ale NIE adoptujemy bo telemetria-less + security-stripped = anti-pattern dla sovereign |
-| #22 **claw-code** / #29 **claurst** (Claude Code w Rust) | Jeśli kiedyś migracja TS→Rust dla Memphis core, zobaczyć ich approach |
-| #30 **Liquid4All cookbook — audio-car-cockpit** | Wzorzec voice-workflow: STT + function-calling LLM + TTS. Model do Phase G voice surface. |
-| #36 **Git-on-my-level/codex-autorunner** | Reference dla scheduler-driven autonomous tool chains |
+| Zakładka                                                 | Rola                                                                                                                                   |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| #18 **skills.sh** (Claude Code Agent Skills catalog)     | Reference dla Memphis skill registry design + Agora Phase 5 marketplace UX                                                             |
+| #20 **paoloanzn/free-code**                              | Reference for "unrestricted coding assistant" — ale NIE adoptujemy bo telemetria-less + security-stripped = anti-pattern dla sovereign |
+| #22 **claw-code** / #29 **claurst** (Claude Code w Rust) | Jeśli kiedyś migracja TS→Rust dla Memphis core, zobaczyć ich approach                                                                  |
+| #30 **Liquid4All cookbook — audio-car-cockpit**          | Wzorzec voice-workflow: STT + function-calling LLM + TTS. Model do Phase G voice surface.                                              |
+| #36 **Git-on-my-level/codex-autorunner**                 | Reference dla scheduler-driven autonomous tool chains                                                                                  |
 
 **Decyzja:** L3 registry design bazuje na skills.sh conceptually (skill = declarative folder z SKILL.md + metadata). Liquid4All cockbook daje wzorzec dla voice surface (Phase G v2).
 
 #### L1 — Memory infrastructure
 
-| Zakładka | Rola |
-| --- | --- |
+| Zakładka                                                                   | Rola                                                                                                                                                                                |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | #27 **memvid/memvid** (memory layer for AI agents, single-file serverless) | **Konkurent Memphis chains.** Warto przeanalizować ich approach, ale NIE integrujemy — Memphis ma własny signed-block chain design z audit-trail, memvid jest bardziej RAG-oriented |
 
 **Decyzja:** Memphis trzyma się signed-chain model. Memvid jako "warto
@@ -508,11 +515,11 @@ wiedzieć czego nie robić albo co robić inaczej".
 
 #### L5 — Surface patterns
 
-| Zakładka | Rola |
-| --- | --- |
-| #28 **alibaba/page-agent** (JS in-page GUI agent) | Reference dla potencjalnego browser-extension surface Memphis v3 (odroczone) |
-| #34 **BasedHardware/omi** (open-source AI wearable) | Hardware companion Memphis v3 (odroczone, ale ekosystemowo interesujące) |
-| #35 **Brax BraX3** (privacy-friendly smartphone) | Target hardware dla Memphis mobile companion v3 |
+| Zakładka                                            | Rola                                                                         |
+| --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| #28 **alibaba/page-agent** (JS in-page GUI agent)   | Reference dla potencjalnego browser-extension surface Memphis v3 (odroczone) |
+| #34 **BasedHardware/omi** (open-source AI wearable) | Hardware companion Memphis v3 (odroczone, ale ekosystemowo interesujące)     |
+| #35 **Brax BraX3** (privacy-friendly smartphone)    | Target hardware dla Memphis mobile companion v3                              |
 
 **Decyzja:** surface'y v1 = TUI + GUI + Telegram + CLI + MCP + custom-app.
 Surface'y v2 (post-v1.5.0) = voice (Phase G+ z Liquid4All wzorcem), browser-ext.
@@ -520,21 +527,21 @@ Surface'y v3 (2027+) = wearable, mobile-as-companion.
 
 #### L7 — External integration i ecosystem research
 
-| Zakładka | Rola |
-| --- | --- |
-| #43 **warproxxx/poly_data** (Polymarket data) | Future MCP tool dla market-data retrieval — Phase 3 Agora context, albo standalone tool w Phase G+ |
-| #26 **ResearAI/DeepScientist** | Reference dla potencjalnego "research skill" w Phase G+ |
-| #31 **Kronos** (foundation model dla market data) | Inspired dla sektorowych skills — finance-aware skill |
+| Zakładka                                          | Rola                                                                                               |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| #43 **warproxxx/poly_data** (Polymarket data)     | Future MCP tool dla market-data retrieval — Phase 3 Agora context, albo standalone tool w Phase G+ |
+| #26 **ResearAI/DeepScientist**                    | Reference dla potencjalnego "research skill" w Phase G+                                            |
+| #31 **Kronos** (foundation model dla market data) | Inspired dla sektorowych skills — finance-aware skill                                              |
 
 #### Polski kontekst ekosystemowy
 
-| Zakładka | Rola |
-| --- | --- |
-| #19 **Innovations Hub Foundation** | Lokalny ecosystem — Memphis jako europejska suwerenna alternatywa, framing dla grantów |
-| #25 **mSzyfr APK** (NASK polski Matrix rządowy) | Reference dla government-grade security standardów |
-| #40 **SPIN Małopolskie Centra Transferu Wiedzy** | Finansowanie: transfer wiedzy z uczelni |
-| #41 **Akces NCBR** | Akceleracja startupów |
-| #42 **Akces NCBR HPN Impakt** (świeżo ogłoszony) | **KRYTYCZNE** — nabór dla technologii impaktowych TRL 3-8. Memphis kwalifikuje się. |
+| Zakładka                                         | Rola                                                                                   |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| #19 **Innovations Hub Foundation**               | Lokalny ecosystem — Memphis jako europejska suwerenna alternatywa, framing dla grantów |
+| #25 **mSzyfr APK** (NASK polski Matrix rządowy)  | Reference dla government-grade security standardów                                     |
+| #40 **SPIN Małopolskie Centra Transferu Wiedzy** | Finansowanie: transfer wiedzy z uczelni                                                |
+| #41 **Akces NCBR**                               | Akceleracja startupów                                                                  |
+| #42 **Akces NCBR HPN Impakt** (świeżo ogłoszony) | **KRYTYCZNE** — nabór dla technologii impaktowych TRL 3-8. Memphis kwalifikuje się.    |
 
 **Decyzja strategiczna:** **HPN Impakt application** jako równoległy track
 obok technical development. Aplikacja wymaga opisu TRL 3-8 + komercjalizacji

--- a/tests/integration/offline-invariant.test.ts
+++ b/tests/integration/offline-invariant.test.ts
@@ -64,9 +64,7 @@ describe('offline-invariant gate (Phase L)', () => {
     };
     const status = getChainAdapterStatus(env);
     if (!status.rustBridgeLoaded) {
-      console.warn(
-        'Rust bridge not loaded — skipping offline-invariant chain-append assertion',
-      );
+      console.warn('Rust bridge not loaded — skipping offline-invariant chain-append assertion');
       return;
     }
 

--- a/tests/unit/tool-registry-schema.test.ts
+++ b/tests/unit/tool-registry-schema.test.ts
@@ -61,7 +61,9 @@ describe('tool registry — inputSchema (pilot 5 tools)', () => {
 
     it('accepts valid input', () => {
       expect(() => schema.parse({ query: 'meaning of life' })).not.toThrow();
-      expect(() => schema.parse({ query: 'q', limit: 10, tags: ['t'], chain: 'journal' })).not.toThrow();
+      expect(() =>
+        schema.parse({ query: 'q', limit: 10, tags: ['t'], chain: 'journal' }),
+      ).not.toThrow();
     });
 
     it('rejects missing query', () => {


### PR DESCRIPTION
Post-merge format pass — 13 files I authored during 2026-04-19 sprint had whitespace drift. Supersedes PR #166 (which was 328-file diff against pre-sprint main; obsolete after sprint merges). `npm run format:check` is green after this.