### PR TITLE
fix(install): add zstd to build-essentials — Ollama needs it

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,18 +206,18 @@ ensure_build_essentials() {
 
   if have apt-get; then
     run_sudo apt-get update -y
-    run_sudo apt-get install -y build-essential pkg-config libssl-dev python3
+    run_sudo apt-get install -y build-essential pkg-config libssl-dev python3 zstd
   elif have dnf; then
     run_sudo dnf groupinstall -y "Development Tools"
-    run_sudo dnf install -y pkgconf-pkg-config openssl-devel python3
+    run_sudo dnf install -y pkgconf-pkg-config openssl-devel python3 zstd
   elif have yum; then
     run_sudo yum groupinstall -y "Development Tools"
-    run_sudo yum install -y pkgconfig openssl-devel python3
+    run_sudo yum install -y pkgconfig openssl-devel python3 zstd
   elif have pacman; then
-    run_sudo pacman -Sy --noconfirm base-devel pkgconf openssl python
+    run_sudo pacman -Sy --noconfirm base-devel pkgconf openssl python zstd
   elif have zypper; then
     run_sudo zypper install -y -t pattern devel_C_C++
-    run_sudo zypper install -y pkg-config libopenssl-devel python3
+    run_sudo zypper install -y pkg-config libopenssl-devel python3 zstd
   else
     warn "No supported package manager found for build essentials — proceeding anyway"
   fi


### PR DESCRIPTION
Real install bug surfaced by Docker capture on clean Ubuntu 24.04. Ollama's installer requires `zstd` for binary extraction; install.sh didn't pull it. Adds `zstd` to apt/dnf/yum/pacman/zypper package lists. macOS unaffected (brew installs transitively). Verified via re-run on same Docker image.