### PR TITLE
fix(tests): repair test-suite contracts after docs/ reorg #169

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,15 @@ Index of all docs after the 2026-04-19 reorganization (PR #169 + sprint).
 - **Debug:** [`operator/debug.en.md`](./operator/debug.en.md) · [`operator/debug.pl.md`](./operator/debug.pl.md)
 - **Current roadmap:** [`ROADMAP-CURRENT.md`](./ROADMAP-CURRENT.md)
 
+## Status & Planning
+
+Canonical status stack for "where is Memphis right now":
+
+- **Project Status:** [`historical/PROJECT-STATUS.md`](./historical/PROJECT-STATUS.md) — maturity snapshot
+- **Publish Status:** [`historical/PUBLISH-STATUS.md`](./historical/PUBLISH-STATUS.md) — latest released tag
+- **Clean Install:** [`operator/CLEAN-INSTALL.md`](./operator/CLEAN-INSTALL.md) — canonical source-checkout path
+- **Execution Plan:** [`historical/EXECUTION-PLAN.md`](./historical/EXECUTION-PLAN.md) — recent sprint plan
+
 ## By audience
 
 ### `operator/` — for users running Memphis

--- a/src/infra/cli/commands/setup-matrix.ts
+++ b/src/infra/cli/commands/setup-matrix.ts
@@ -270,7 +270,7 @@ export async function runMatrixSetup(options: MatrixSetupOptions): Promise<Matri
 
   let content = readFileSync(SYNAPSE_TEMPLATE_PATH, 'utf8');
   content = content
-    .replace(/^server_name:\s*".*"$/m, `server_name: "${result.serverName}"`)
+    .replace(/^server_name:.*$/m, `server_name: "${result.serverName}"`)
     .replace('${SYNAPSE_REGISTRATION_SHARED_SECRET}', registrationSecret)
     .replace('${SYNAPSE_MACAROON_SECRET_KEY}', macaroonSecret)
     .replace('${SYNAPSE_SERVER_NAME}', result.serverName);

--- a/tests/ops/install-support-matrix-docs-contract.test.ts
+++ b/tests/ops/install-support-matrix-docs-contract.test.ts
@@ -10,20 +10,20 @@ const repoRoot = path.resolve(thisDir, '..', '..');
 const node22Docs = [
   'README.md',
   'INSTALL.md',
-  'docs/GETTING-STARTED.md',
-  'docs/INSTALLATION.md',
-  'docs/OPERATIONS-MANUAL.md',
-  'docs/TROUBLESHOOTING.md',
-  'docs/RE-INSTALL.md',
+  'docs/operator/GETTING-STARTED.md',
+  'docs/operator/INSTALLATION.md',
+  'docs/operator/OPERATIONS-MANUAL.md',
+  'docs/operator/TROUBLESHOOTING.md',
+  'docs/operator/RE-INSTALL.md',
 ];
 
 const sourceFirstDocs = [
   'README.md',
   'INSTALL.md',
-  'docs/GETTING-STARTED.md',
-  'docs/INSTALLATION.md',
-  'docs/PACKAGE-PUBLISH.md',
-  'docs/RELEASE-PROCESS.md',
+  'docs/operator/GETTING-STARTED.md',
+  'docs/operator/INSTALLATION.md',
+  'docs/historical/PACKAGE-PUBLISH.md',
+  'docs/historical/RELEASE-PROCESS.md',
 ];
 
 const workflowPaths = [
@@ -66,13 +66,13 @@ describe('install/release support matrix contract', () => {
       expect(markdown).toMatch(/bootstrap/i);
     }
 
-    const packagePublish = read('docs/PACKAGE-PUBLISH.md');
+    const packagePublish = read('docs/historical/PACKAGE-PUBLISH.md');
     expect(packagePublish).toMatch(/bounded CLI\/distribution path/i);
     expect(packagePublish).not.toMatch(/package-first/i);
   });
 
   it('keeps the production brief explicitly non-canonical and current-tooling aware', () => {
-    const brief = read('PRODUCTION-BRIEF.md');
+    const brief = read('docs/archive/2026-04-19-root-cleanup/PRODUCTION-BRIEF.md');
 
     expect(brief).toContain('Non-canonical planning note.');
     expect(brief).toContain('docs/EXECUTION-PLAN.md');

--- a/tests/ops/matrix-pilot-docs-contract.test.ts
+++ b/tests/ops/matrix-pilot-docs-contract.test.ts
@@ -14,8 +14,8 @@ function readDoc(relativePath: string): string {
 describe('matrix pilot docs contract', () => {
   it('documents setup matrix in operator entrypoint docs', () => {
     const readme = readDoc('README.md');
-    const gettingStarted = readDoc(path.join('docs', 'GETTING-STARTED.md'));
-    const cliReference = readDoc(path.join('docs', 'CLI-REFERENCE.md'));
+    const gettingStarted = readDoc(path.join('docs', 'operator', 'GETTING-STARTED.md'));
+    const cliReference = readDoc(path.join('docs', 'operator', 'CLI-REFERENCE.md'));
 
     expect(readme).toContain('setup matrix');
     expect(gettingStarted).toContain('setup matrix');
@@ -23,8 +23,8 @@ describe('matrix pilot docs contract', () => {
   });
 
   it('documents vault-backed matrix token configuration instead of fake plaintext access-token output', () => {
-    const configuration = readDoc(path.join('docs', 'CONFIGURATION.md'));
-    const vaultCli = readDoc(path.join('docs', 'VAULT-CLI.md'));
+    const configuration = readDoc(path.join('docs', 'operator', 'CONFIGURATION.md'));
+    const vaultCli = readDoc(path.join('docs', 'operator', 'VAULT-CLI.md'));
 
     expect(configuration).toContain('MEMPHIS_MATRIX_ACCESS_TOKEN');
     expect(configuration).toContain('VAULT:MEMPHIS_MATRIX_ACCESS_TOKEN');
@@ -32,10 +32,10 @@ describe('matrix pilot docs contract', () => {
   });
 
   it('keeps matrix pilot positioning bounded and trusted-pilot only', () => {
-    const federation = readDoc(path.join('docs', 'FEDERATION-KEY-EXCHANGE.md'));
-    const releaseProcess = readDoc(path.join('docs', 'RELEASE-PROCESS.md'));
-    const releaseChecklist = readDoc(path.join('docs', 'RELEASE-CHECKLIST.md'));
-    const testing = readDoc(path.join('docs', 'TESTING-VERIFICATION.md'));
+    const federation = readDoc(path.join('docs', 'dev', 'FEDERATION-KEY-EXCHANGE.md'));
+    const releaseProcess = readDoc(path.join('docs', 'historical', 'RELEASE-PROCESS.md'));
+    const releaseChecklist = readDoc(path.join('docs', 'historical', 'RELEASE-CHECKLIST.md'));
+    const testing = readDoc(path.join('docs', 'dev', 'TESTING-VERIFICATION.md'));
 
     expect(federation).toContain('trusted-pilot');
     expect(federation).toContain('memphis setup matrix');

--- a/tests/ops/onboarding-docs-truth-contract.test.ts
+++ b/tests/ops/onboarding-docs-truth-contract.test.ts
@@ -15,12 +15,12 @@ describe('onboarding docs truth contract', () => {
   it('keeps active first-run docs on the bootstrap -> init story', () => {
     for (const docPath of [
       'README.md',
-      'docs/GETTING-STARTED.md',
-      'docs/INSTALLATION.md',
-      'docs/GUIDE-FIRST-BOOTSTRAP.md',
-      'docs/ONBOARDING-INSTALL.md',
-      'docs/USER-QUICKSTART-GITHUB.md',
-      'docs/POST-INSTALLATION.md',
+      'docs/operator/GETTING-STARTED.md',
+      'docs/operator/INSTALLATION.md',
+      'docs/operator/GUIDE-FIRST-BOOTSTRAP.md',
+      'docs/operator/ONBOARDING-INSTALL.md',
+      'docs/operator/USER-QUICKSTART-GITHUB.md',
+      'docs/operator/POST-INSTALLATION.md',
     ]) {
       const markdown = read(docPath);
       expect(markdown).toMatch(/bootstrap/i);
@@ -30,7 +30,7 @@ describe('onboarding docs truth contract', () => {
 
   it('keeps generated and user-facing CLI docs off legacy onboarding command lists', () => {
     const apiCli = read(path.join('docs', 'api', 'cli.md'));
-    const cliReference = read(path.join('docs', 'CLI-REFERENCE.md'));
+    const cliReference = read(path.join('docs', 'operator', 'CLI-REFERENCE.md'));
 
     expect(apiCli).toContain('- `memphis init`');
     expect(apiCli).toContain('- `memphis setup matrix`');

--- a/tests/ops/openclaw-docs-truth-contract.test.ts
+++ b/tests/ops/openclaw-docs-truth-contract.test.ts
@@ -13,8 +13,8 @@ function read(relativePath: string): string {
 
 describe('OpenClaw docs truth contract', () => {
   it('keeps active operator docs off deprecated OpenClaw install paths', () => {
-    const postInstall = read(path.join('docs', 'POST-INSTALLATION.md'));
-    const reinstall = read(path.join('docs', 'RE-INSTALL.md'));
+    const postInstall = read(path.join('docs', 'operator', 'POST-INSTALLATION.md'));
+    const reinstall = read(path.join('docs', 'operator', 'RE-INSTALL.md'));
 
     expect(postInstall).not.toContain('OPENCLAW-INTEGRATION.md');
     expect(postInstall).toContain('not part of the active');

--- a/tests/ops/public-status-docs-contract.test.ts
+++ b/tests/ops/public-status-docs-contract.test.ts
@@ -15,8 +15,8 @@ describe('public status and license docs contract', () => {
   it('keeps README on the current release truth with canonical status and roadmap links', () => {
     const readme = read('README.md');
 
-    expect(readme).toContain('`v1.2.1`');
-    expect(readme).toContain('operational but not yet broadly stable');
+    expect(readme).toContain('`v1.4.0`');
+    expect(readme).toContain('production-ready for first install');
     expect(readme).toContain('docs/PROJECT-STATUS.md');
     expect(readme).toContain('docs/ROADMAP-CURRENT.md');
     expect(readme).toContain('docs/CLEAN-INSTALL.md');
@@ -25,15 +25,15 @@ describe('public status and license docs contract', () => {
 
   it('keeps the docs index and release docs aligned with the new canonical status stack', () => {
     const docsIndex = read(path.join('docs', 'README.md'));
-    const cleanInstall = read(path.join('docs', 'CLEAN-INSTALL.md'));
-    const projectStatus = read(path.join('docs', 'PROJECT-STATUS.md'));
+    const cleanInstall = read(path.join('docs', 'operator', 'CLEAN-INSTALL.md'));
+    const projectStatus = read(path.join('docs', 'historical', 'PROJECT-STATUS.md'));
     const roadmap = read(path.join('docs', 'ROADMAP-CURRENT.md'));
-    const publishStatus = read(path.join('docs', 'PUBLISH-STATUS.md'));
-    const executionPlan = read(path.join('docs', 'EXECUTION-PLAN.md'));
+    const publishStatus = read(path.join('docs', 'historical', 'PUBLISH-STATUS.md'));
+    const executionPlan = read(path.join('docs', 'historical', 'EXECUTION-PLAN.md'));
     const changelog = read('CHANGELOG.md');
 
     expect(docsIndex).toContain('Project Status');
-    expect(docsIndex).toContain('Current Roadmap');
+    expect(docsIndex).toContain('Current roadmap');
     expect(docsIndex).toContain('Clean Install');
     expect(cleanInstall).toContain('git clone https://github.com/Memphis-Chains/memphis.git');
     expect(cleanInstall).toContain('npm run bootstrap');

--- a/tests/ops/published-package-files-contract.test.ts
+++ b/tests/ops/published-package-files-contract.test.ts
@@ -15,6 +15,8 @@ describe('published package files contract', () => {
 
     expect(Array.isArray(pkg.files)).toBe(true);
     expect(pkg.files).not.toContain('docs/OPENCLAW-INTEGRATION.md');
-    expect(pkg.files).toContain('docs/GETTING-STARTED.md');
+    // v1.4.0 release deliberately dropped docs/ from the npm package
+    // (see release commit f551665: "minimal files array — drop docs/").
+    expect(pkg.files).not.toContain('docs/GETTING-STARTED.md');
   });
 });

--- a/tests/ops/rc-release-truth-contract.test.ts
+++ b/tests/ops/rc-release-truth-contract.test.ts
@@ -14,7 +14,7 @@ function read(relativePath: string): string {
 describe('rc release truth contract', () => {
   it('keeps README and TUI guide aligned with the shipped Rust console', () => {
     const readme = read('README.md');
-    const tuiGuide = read(path.join('docs', 'TUI-OPERATOR-GUIDE.md'));
+    const tuiGuide = read(path.join('docs', 'operator', 'TUI-OPERATOR-GUIDE.md'));
 
     expect(readme).toContain('Native operator cockpit with live chat streaming');
     expect(readme).toContain(
@@ -49,8 +49,8 @@ describe('rc release truth contract', () => {
   });
 
   it('keeps runtime and architecture docs aligned with memphis-operator ownership', () => {
-    const runtimeSecurity = read(path.join('docs', 'RUNTIME-SECURITY-ARCHITECTURE.md'));
-    const canonicalArchitecture = read(path.join('docs', 'CANONICAL-ARCHITECTURE.md'));
+    const runtimeSecurity = read(path.join('docs', 'dev', 'RUNTIME-SECURITY-ARCHITECTURE.md'));
+    const canonicalArchitecture = read(path.join('docs', 'dev', 'CANONICAL-ARCHITECTURE.md'));
 
     expect(runtimeSecurity).toContain('### Rust operator layer');
     expect(runtimeSecurity).not.toContain('MCP, gateway, HTTP, CLI, and TUI adapters.');
@@ -64,13 +64,13 @@ describe('rc release truth contract', () => {
   });
 
   it('keeps release docs on the RC drill and deprecated-install truth', () => {
-    const releaseProcess = read(path.join('docs', 'RELEASE-PROCESS.md'));
-    const releaseChecklist = read(path.join('docs', 'RELEASE-CHECKLIST.md'));
-    const packagePublish = read(path.join('docs', 'PACKAGE-PUBLISH.md'));
-    const testing = read(path.join('docs', 'TESTING-VERIFICATION.md'));
-    const smoke = read(path.join('docs', 'MUST-PASS-SMOKE.md'));
-    const fullInstallGuide = read(path.join('docs', 'FULL_INSTALL_GUIDE.md'));
-    const releaseSchedule = read(path.join('docs', 'RELEASE-SCHEDULE.md'));
+    const releaseProcess = read(path.join('docs', 'historical', 'RELEASE-PROCESS.md'));
+    const releaseChecklist = read(path.join('docs', 'historical', 'RELEASE-CHECKLIST.md'));
+    const packagePublish = read(path.join('docs', 'historical', 'PACKAGE-PUBLISH.md'));
+    const testing = read(path.join('docs', 'dev', 'TESTING-VERIFICATION.md'));
+    const smoke = read(path.join('docs', 'historical', 'MUST-PASS-SMOKE.md'));
+    const fullInstallGuide = read(path.join('docs', 'operator', 'FULL_INSTALL_GUIDE.md'));
+    const releaseSchedule = read(path.join('docs', 'historical', 'RELEASE-SCHEDULE.md'));
     const tuiCancelDrill = read(path.join('docs', 'runbooks', 'TUI_CANCEL_DRILL.md'));
     const releaseGates = read(path.join('scripts', 'run-release-gates.sh'));
     const releaseScript = read(path.join('scripts', 'release.sh'));

--- a/tests/ops/release-candidate-path-contract.test.ts
+++ b/tests/ops/release-candidate-path-contract.test.ts
@@ -13,7 +13,7 @@ function read(relativePath: string): string {
 
 describe('release candidate path contract', () => {
   it('keeps RC prep and final GA release paths explicitly separated', () => {
-    const releaseProcess = read(path.join('docs', 'RELEASE-PROCESS.md'));
+    const releaseProcess = read(path.join('docs', 'historical', 'RELEASE-PROCESS.md'));
     const releaseRunbook = read(path.join('docs', 'runbooks', 'RELEASE.md'));
     const readme = read('README.md');
 


### PR DESCRIPTION
## Summary

Closes the test debt that accumulated when `docs/` was reorganized into `operator/`, `dev/`, and `historical/` buckets (PR #169). Release `v1.4.0` (#175) merged with these tests already red via **admin bypass**; this PR unblocks the quality-gate so future PRs can't need `--admin` again.

## Why this PR exists (culture note)

Memphis culture: test-as-truth, one-PR-one-concern, no admin bypass. #175 shipped on bypass because the docs reorg surfaced as red tests rather than merge blockers. That dug a hole in main that this PR fills before #179 (bundled hotfix 666) can merge cleanly.

## Changes

### Path remaps (docs moved to buckets, tests didn't follow)
- `tests/ops/matrix-pilot-docs-contract.test.ts`
- `tests/ops/openclaw-docs-truth-contract.test.ts`
- `tests/ops/rc-release-truth-contract.test.ts`
- `tests/ops/release-candidate-path-contract.test.ts`
- `tests/ops/install-support-matrix-docs-contract.test.ts`
- `tests/ops/onboarding-docs-truth-contract.test.ts`

### Content drift (frozen at v1.2.1, reality moved to v1.4.0)
- `tests/ops/public-status-docs-contract.test.ts` — README assertions updated to current release truth (`v1.2.1` → `v1.4.0`, `"operational but not yet broadly stable"` → `"production-ready for first install"`). Historical snapshots (`PROJECT-STATUS`, `PUBLISH-STATUS`) keep their frozen `v1.2.1` strings — that's the point of historical docs.
- `tests/ops/published-package-files-contract.test.ts` — invert `docs/GETTING-STARTED.md` assertion. v1.4.0 release commit `f551665` (`minimal files array — drop docs/ from npm package`) deliberately removed `docs/` from `files[]`; the contract now matches the release intent.

### Source bug fix (blocker for `tests/unit/setup-matrix.test.ts`)
- `src/infra/cli/commands/setup-matrix.ts` — `server_name` regex only accepted double-quoted values. Template ships single-quoted `'memphis.local'`. Regex silently left `server_name` untouched in generated `homeserver.yaml`. Relaxed regex matches any trailing value — works with both quote styles.

### Docs index completeness
- `docs/README.md` — add **Status & Planning** section with the canonical status stack (Project Status, Publish Status, Clean Install, Execution Plan). `public-status-docs-contract` test 2 asserts this structure exists in the index.

## Test plan

- [x] `npm run -s test:ts` local → **2075 passed (2075), 0 failed**
- [x] `npm run -s lint` via pre-commit hook → clean
- [ ] CI `quality-gate` → green
- [ ] Merge into `main` → main becomes green again (currently red on these 9 tests)

## After merge

PR #179 (bundled hotfix 666) rebases naturally on top of this. The `install-support-matrix` / `onboarding-docs-truth` path-remap overlap deduplicates cleanly at rebase. Once #180 lands on `main`, #179 CI flips green without further edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)