### PR TITLE
fix(tests): add listCliCompletionCommands to cli-router integration mock

### DIFF
--- a/tests/integration/cli-router.integration.test.ts
+++ b/tests/integration/cli-router.integration.test.ts
@@ -72,6 +72,7 @@ async function importDispatcherWithMock() {
   vi.resetModules();
   vi.doMock('../../src/infra/cli/registry.js', () => ({
     getCliCommandRegistrations: (command?: string) => buildRegistryMock(command),
+    listCliCompletionCommands: () => [],
   }));
 
   const [{ executeCommand }, { parseCommand }] = await Promise.all([


### PR DESCRIPTION
## Summary

Closes the mock-completeness gap that made `main` CI red after PR #180 merged. One-line fix.

## What happened

Commit **b77aaad** ("Centralize CLI registry with lazy loading", 2026-04-08) added:
- Export `listCliCompletionCommands()` → `src/infra/cli/registry.ts:326`
- Module-level call site → `src/infra/cli/utils/render.ts:35`
  ```typescript
  const CLI_TOP_LEVEL_COMPLETION_OPTIONS = listCliCompletionCommands().join(' ');
  ```

The integration test's `vi.doMock` at `tests/integration/cli-router.integration.test.ts:73` was **not** updated — it only returned `getCliCommandRegistrations`. When `importDispatcherWithMock()` imports `dispatcher.js` / `parser.js`, the transitive import reaches `render.ts:35` at module init, hits the unfulfilled mock export, and vitest throws:

```
Error: [vitest] No "listCliCompletionCommands" export is defined on
       the "../../src/infra/cli/registry.js" mock.
```

**Why only push trigger caught it**: PR #180's `pull_request` trigger passed by mock-hoisting luck; `main`'s `push` trigger reliably hit the unfulfilled mock (run [24674499454](https://github.com/Memphis-Chains/memphis/actions/runs/24674499454)).

## The fix

```diff
   vi.doMock('../../src/infra/cli/registry.js', () => ({
     getCliCommandRegistrations: (command?: string) => buildRegistryMock(command),
+    listCliCompletionCommands: () => [],
   }));
```

**Why `() => []`**: `render.ts:35` calls `.join(' ')` on the result → empty array yields empty string. The test doesn't assert on `CLI_TOP_LEVEL_COMPLETION_OPTIONS`, so a realistic stub would be over-reach for a mock-completeness fix.

## Test plan

- [x] `vitest run tests/integration/cli-router.integration.test.ts` → **3/3 passed** locally
- [x] `npm run -s lint` via pre-commit hook → clean
- [ ] CI `quality-gate` → green
- [ ] Merge into `main` → `main` becomes green; **PR #179 can then merge** without further edits (its PR CI is already green)

## Follow-ups (separate PRs if wanted)

1. Refactor integration test to import real `registry.js` instead of mocking (avoids this class of bug).
2. Add a meta-test that verifies mock completeness (e.g. compares mock keys against real module's exported keys).
3. Investigate `pull_request` vs `push` CI trigger divergence — symptom is gone after this fix, but the timing-dependent mock-hoisting is still latent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)