### PR TITLE
fix(install): auto-stash dirty worktree before pull on upgrade

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -409,7 +409,30 @@ resolve_repo() {
   if [[ -d "$TARGET_DIR/.git" ]]; then
     log "Updating existing repo: $TARGET_DIR"
     git -C "$TARGET_DIR" fetch --all --prune
-    git -C "$TARGET_DIR" pull --ff-only
+
+    # Detect dirty state so the upgrade never aborts on local changes.
+    # Auto-stash with a labeled entry — user recovers explicitly via
+    # `git stash list | grep memphis-install-autostash`. No auto-pop:
+    # surprise merges inside a curl|bash installer are unacceptable.
+    local dirty_tracked=0
+    local dirty_untracked=0
+    git -C "$TARGET_DIR" diff --quiet HEAD -- 2>/dev/null || dirty_tracked=1
+    if [[ -n "$(git -C "$TARGET_DIR" ls-files --others --exclude-standard 2>/dev/null)" ]]; then
+      dirty_untracked=1
+    fi
+
+    if (( dirty_tracked == 1 || dirty_untracked == 1 )); then
+      local stash_label="memphis-install-autostash-$(date -u +%Y%m%dT%H%M%SZ)"
+      warn "Worktree has local changes — auto-stashing as '$stash_label'."
+      warn "Restore later with: git -C $TARGET_DIR stash list | grep $stash_label"
+      if ! git -C "$TARGET_DIR" stash push --include-untracked --message "$stash_label" >/dev/null; then
+        fail "Auto-stash failed. Clean $TARGET_DIR manually (git status) and re-run installer."
+      fi
+    fi
+
+    if ! git -C "$TARGET_DIR" pull --ff-only; then
+      fail "Pull failed even after auto-stash. Inspect $TARGET_DIR manually."
+    fi
   else
     if [[ -d "$TARGET_DIR" ]] && [[ -n "$(ls -A "$TARGET_DIR" 2>/dev/null || true)" ]]; then
       fail "Target directory exists and is not empty: $TARGET_DIR"


### PR DESCRIPTION
## Summary

Installer one-liner (`curl | bash scripts/install.sh`) aborts on upgrade when target worktree is dirty. User-reported blocker.

## Repro (user, WSL, 2026-04-20)

```
[memphis-install] Updating existing repo: /home/memphis/memphis
error: Your local changes to the following files would be overwritten by merge:
        package-lock.json
error: The following untracked working tree files would be overwritten by merge:
        review.md
Aborting
[memphis-install][error] Installer failed near line 412.
```

## Root cause

`scripts/install.sh:412` ran `git pull --ff-only` unconditionally. `git pull` aborts if:
- any tracked file has uncommitted modifications (here: `package-lock.json`), or
- the incoming commit adds a file that already exists untracked (here: upstream now tracks `review.md`).

No recovery path in installer → user stuck.

## Fix

Before pull: detect dirty state, auto-stash with labeled entry, then pull. **No auto-pop** — user recovers explicitly.

```bash
dirty_tracked=0; dirty_untracked=0
git diff --quiet HEAD -- || dirty_tracked=1
[[ -n "$(git ls-files --others --exclude-standard)" ]] && dirty_untracked=1

if (( dirty_tracked || dirty_untracked )); then
  stash_label="memphis-install-autostash-$(date -u +%Y%m%dT%H%M%SZ)"
  warn "Worktree has local changes — auto-stashing as '$stash_label'."
  warn "Restore later with: git stash list | grep $stash_label"
  git stash push --include-untracked --message "$stash_label"
fi

git pull --ff-only || fail "Pull failed even after auto-stash."
```

## Behavior matrix

| Worktree state | Before | After |
|---|---|---|
| Clean | Pull succeeds | Pull succeeds (unchanged) |
| Tracked modified | **Aborts** | Auto-stashed + pull succeeds |
| Untracked collides | **Aborts** | Auto-stashed (untracked incl.) + pull succeeds |
| Both dirty | **Aborts** | One stash entry + pull succeeds |
| Pull would still fail (non-ff) | Aborts vague | Aborts with "even after auto-stash" context |

**No data loss** — every local change lives in a labeled stash. **No auto-pop** — surprise merges inside a curl|bash installer are unacceptable UX; explicit recovery matches memphis culture.

## Why no auto-pop

1. If upstream changed the same file, auto-pop would trigger interactive conflict resolution inside `curl | bash` — terrible UX.
2. User may actually want to discard local changes; auto-pop would resurrect them.
3. Labeled stash (`memphis-install-autostash-<timestamp>`) makes recovery trivial and auditable:
   ```
   git stash list | grep memphis-install-autostash
   git stash pop stash@{N}
   ```

## Test plan

Manual (CI can't easily reproduce — worktree state depends on runtime):

- [x] `bash -n scripts/install.sh` → clean syntax
- [x] Clean worktree upgrade → pull succeeds (regression check)
- [x] Tracked-modified (`package-lock.json` dirty) → stash + pull
- [x] Untracked-collision (`review.md` local) → stash + pull
- [x] Both dirty → one stash, pull
- [x] `git stash list` shows labeled entries, recoverable via `stash pop`
- [ ] CI `quality-gate` → green (shell-only diff, should be unaffected)

## After merge

User reruns `curl -fsSL https://raw.githubusercontent.com/Memphis-Chains/memphis/main/scripts/install.sh | bash` on WSL → succeeds; any prior local changes land in a labeled stash.

## Out of scope

- Preventing original dirty state (`.gitignore` for `package-lock.json` — no, it's a contract file).
- Installer re-design for package-checkout mode (different code path, not touched).
- Auto-pop on successful pull (deliberately skipped, see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)