### PR TITLE
fix(bootstrap): make json_field tolerant of logs/warnings before JSON

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -68,10 +68,26 @@ json_field() {
   local field="$1"
   node -e "
     const fs = require('node:fs');
-    const payload = JSON.parse(fs.readFileSync(0, 'utf8'));
-    const value = payload[process.argv[1]];
-    if (value !== undefined && value !== null) {
-      process.stdout.write(String(value));
+    const raw = fs.readFileSync(0, 'utf8');
+    // \`memphis service <cmd> --json\` may prefix logs/warnings before the
+    // JSON line (e.g. pino logs, deprecation warnings). Scan backwards for
+    // the last line that parses as a JSON object; fall back to whole-input
+    // parse for the happy single-JSON case; emit nothing on total failure.
+    const lines = raw.split('\n');
+    let payload = null;
+    for (let i = lines.length - 1; i >= 0 && !payload; i--) {
+      const line = lines[i].trim();
+      if (!line.startsWith('{')) continue;
+      try { payload = JSON.parse(line); } catch {}
+    }
+    if (!payload) {
+      try { payload = JSON.parse(raw); } catch {}
+    }
+    if (payload) {
+      const value = payload[process.argv[1]];
+      if (value !== undefined && value !== null) {
+        process.stdout.write(String(value));
+      }
     }
   " "$field"
 }


### PR DESCRIPTION
## Summary

`scripts/bootstrap.sh:67` crashed on WSL fresh install when `memphis service install --json` emitted Node deprecation warnings before its JSON line:

```
SyntaxError: Unexpected non-whitespace character after JSON at position 570 (line 15 column 1)
    at JSON.parse (<anonymous>)
    at [eval]:3:26
```

Repro (user, 2026-04-20, post-#183):
```
memphis@memphis:~/memphis$ npm run bootstrap
[memphis-bootstrap] Deferring first-run state formation to memphis init
(node:28722) [DEP0040] DeprecationWarning: The `punycode` module is deprecated.
^
SyntaxError: Unexpected non-whitespace character after JSON at position 570
```

## Root cause

`json_field()` helper did `JSON.parse(fs.readFileSync(0, 'utf8'))` — parsed **full** stdout as one JSON document. Any log line, deprecation warning, or stray stderr-redirected noise before the JSON payload broke the parse.

## Fix

Scan stdout backwards for the last line that starts with `{` and parses as JSON. Fall back to whole-input parse (happy single-JSON case). Emit nothing on total failure — callers already handle empty output (`SYSTEMD_SERVICE_STATUS` defaults to "service install command failed").

```js
const lines = raw.split('\n');
let payload = null;
for (let i = lines.length - 1; i >= 0 && !payload; i--) {
  const line = lines[i].trim();
  if (!line.startsWith('{')) continue;
  try { payload = JSON.parse(line); } catch {}
}
if (!payload) { try { payload = JSON.parse(raw); } catch {} }
```

## Test plan

Smoke-tested four scenarios in isolated bash subshell:

- [x] Pure JSON → field extracted
- [x] Log prefix + JSON → field extracted (bug repro resolved)
- [x] Garbage input → empty output, no crash
- [x] Multiple JSON lines → last wins
- [ ] CI `quality-gate` green (shell-only change)

## Why no auto-fix for upstream `--json` output

The real root cause is `memphis service <cmd> --json` mixing logs with JSON on stdout. Fixing that requires refactoring the pino logger config + audit emission paths in `src/infra/cli/commands/service.ts` and similar — bigger scope, touches every `--json` subcommand. This PR unblocks the user now and de-risks `json_field` for any future `--json` emission regressions.

Follow-up (separate PR, not blocking): route warnings/logs to stderr in `--json` mode for all CLI subcommands; keep stdout pure-JSON contract.

## After merge

User (WSL) reruns:
```bash
cd ~/memphis
git pull --ff-only     # now includes #183 + this fix
npm run bootstrap      # no more SyntaxError; service install proceeds
memphis init
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)