### PR TITLE
fix(doctor): header verdict aligns with visible summary.fail counter

### DIFF
--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1609,8 +1609,13 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
 export function printDoctorHumanV2(report: DoctorReport): void {
   const icon = (l: DoctorCheckLevel): string => (l === 'pass' ? '✓' : l === 'warn' ? '⚠' : '✗');
   const border = '═'.repeat(76);
+  // Header aligns with the visible summary counters below. `report.ok`
+  // tracks an internal `requiredFailures` metric that can diverge from
+  // the public `summary.fail` count — operators read the two visible
+  // numbers and expect them to match the header verdict.
+  const passed = report.summary.fail === 0;
   console.log(`╔${border}╗`);
-  console.log(`║ ${`MEMPHIS DOCTOR v2.0 ${report.ok ? 'PASS' : 'FAIL'}`.padEnd(75)}║`);
+  console.log(`║ ${`MEMPHIS DOCTOR v2.0 ${passed ? 'PASS' : 'FAIL'}`.padEnd(75)}║`);
   console.log(`╚${border}╝`);
 
   for (const tier of [1, 2, 3, 4, 5, 6, 'A'] as const) {


### PR DESCRIPTION
## Summary

Fixes confusing `memphis doctor` header contradiction reported on 2026-04-20 WSL run:

```
║ MEMPHIS DOCTOR v2.0 FAIL                                                   ║
...
Summary: total=50 pass=34 warn=16 fail=0
```

Header says FAIL, summary says fail=0. Operators read both and get confused — is it broken or not?

## Root cause

Header at `src/infra/cli/utils/doctor-v2.ts:1613` used `report.ok`, which is computed from an internal `requiredFailures` counter:

```typescript
ok: summary.requiredFailures === 0
```

`requiredFailures` can diverge from the public `summary.fail` count (some warning-level checks are marked "required" and bump the internal counter without bumping the visible `fail` counter). This internal metric is never exposed in the summary line, so the header looks inconsistent with everything the operator can actually see.

## Fix

One-line change: derive header boolean from the visible counter instead.

```typescript
const passed = report.summary.fail === 0;
console.log(`║ ${`MEMPHIS DOCTOR v2.0 ${passed ? 'PASS' : 'FAIL'}`.padEnd(75)}║`);
```

Header now says PASS iff zero failures are listed in the visible summary.

## Test plan

- [x] `npm run -s test:ts` — **1533/1533 passed** locally (no doctor test snapshots the header line; existing tests assert structured report fields and continue to pass)
- [x] Lint via pre-commit hook → clean
- [ ] CI `quality-gate` green
- [ ] Manual on WSL after merge: user's identical 16-warn / 0-fail state → now shows `MEMPHIS DOCTOR v2.0 PASS`

## Out of scope

- Surfacing `requiredFailures` in the summary line (Option B in the plan) — not recommended, adds a new user-visible concept for a value that's still private internally. Defer until `requiredFailures` itself becomes a first-class operator-facing metric.
- Refactoring the 1,643-LOC `doctor-v2.ts` file — different concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)