### PR TITLE
fix(gateway): add Tool discipline preamble; stop journal-as-reply pattern

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -79,12 +79,22 @@ function formatBlockTypes(): string {
 
 // ── Tool-Use Instructions ────────────────────────────────────────────────────
 
+const TOOL_DISCIPLINE_PREAMBLE = `## Tool discipline
+
+Tools save or retrieve state. They are NEVER how you reply to the user.
+After executing any tool call(s), you MUST produce a plain text response
+to the user. Do not package your reply as the argument to a tool.
+memphis_journal saves context for FUTURE sessions — it is not the channel
+for the response to the current message.`;
+
 function buildToolInstructions(tools: string[]): string {
-  const sections: string[] = [];
+  const sections: string[] = [TOOL_DISCIPLINE_PREAMBLE];
 
   if (tools.includes('memphis_journal')) {
     sections.push(`<tool name="memphis_journal">
-PURPOSE: Write to the journal chain. This is your persistent memory.
+PURPOSE: Save context you want to recall in FUTURE sessions.
+         This is NOT where your reply to the user goes — always produce
+         a normal text reply after any memphis_journal call.
 INPUT: { content: string, tags?: string[] }
 OUTPUT: { success: boolean, index: number, hash: string, indexed: boolean }
 

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -147,7 +147,8 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
   const tools: RuntimeToolDefinition[] = [
     buildTool({
       name: 'memphis_journal',
-      description: 'Save an entry to the Memphis journal chain',
+      description:
+        'Save important context or observations to the journal chain for later recall. This is NOT a channel for replying to the user — always produce a normal text reply after any tool calls.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -29,6 +29,33 @@ describe('gateway system prompt', () => {
     expect(prompt).toContain('memphis_search');
   });
 
+  // Regression guard for the 2026-04-20 "tool-call-as-reply" bug:
+  // qwen2.5:7b + memphis_journal was emitting `{"content": "Hey there!"}`
+  // as the REPLY instead of producing a text response. The root cause
+  // was a tool description + PURPOSE line that primed small models
+  // toward treating the journal as a chat output channel.
+  it('injects the Tool discipline preamble and journal-purpose guard when journal is available', () => {
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_journal', 'memphis_recall'],
+    });
+
+    expect(prompt).toContain('## Tool discipline');
+    expect(prompt).toContain(
+      'They are NEVER how you reply to the user.',
+    );
+    expect(prompt).toContain(
+      'After executing any tool call(s), you MUST produce a plain text response',
+    );
+    expect(prompt).toContain(
+      'Save context you want to recall in FUTURE sessions',
+    );
+    expect(prompt).toContain(
+      'This is NOT where your reply to the user goes',
+    );
+    // Negative: legacy misleading line must be gone
+    expect(prompt).not.toContain('PURPOSE: Write to the journal chain. This is your persistent memory.');
+  });
+
   it('adds instructions for preview tools when they are available', () => {
     const prompt = buildSystemPrompt({
       availableTools: ['memphis_chain_query', 'memphis_providers', 'memphis_system_info'],


### PR DESCRIPTION
## Summary

Fixes the 2026-04-20 live regression on WSL where qwen2.5:7b and similar small models emitted their **reply** as `memphis_journal({"content": "Hey there!"})` tool calls instead of producing plain text responses.

## Repro (from user's TUI session)

```
> yo
[Memphis] {"name": "memphis_journal", "arguments": {"content": "Hey there! How can I assist you today?"}}
reply complete via ollama / qwen2.5:7b · tok p:3371 c:27 t:3398
```

No text delivered to operator. Same pattern on `status`, `write me a code`, `what time is it?` — every turn swallowed into a tool call.

## Root cause — two priming locations

**`src/gateway/tool-executor.ts:149`** — tool description:
```typescript
description: 'Save an entry to the Memphis journal chain'
```
Neutral. Doesn't separate "save" from "reply."

**`src/gateway/system-prompt.ts:87`** — PURPOSE line:
```
PURPOSE: Write to the journal chain. This is your persistent memory.
```
"Your persistent memory" = "your output place" in a 7B model's mind. Verified by running the same input against Claude (`type=remote`) which does the right thing because its system-prompt-following discipline is stronger.

## Fix

1. **New `TOOL_DISCIPLINE_PREAMBLE`** prepended to every tool block in `buildToolInstructions`:
   > Tools save or retrieve state. They are NEVER how you reply to the user. After executing any tool call(s), you MUST produce a plain text response to the user. Do not package your reply as the argument to a tool. memphis_journal saves context for FUTURE sessions — it is not the channel for the response to the current message.

2. **Rewrote `memphis_journal` PURPOSE line** to state future-session intent + "not a reply" guard.

3. **Extended tool-executor description** so MCP clients without the system prompt get the same rule.

## Why this works

- **Additive for large models**: Claude 4.6 / GPT-4 already follow the implicit rule; adding an explicit one cannot regress them.
- **Corrective for small models**: qwen2.5:7b and similar will see the rule before any tool definition and pattern-match it.
- **No other tool schemas touched** — 32 other in-process tools remain unchanged.

## Test plan

- [x] `./node_modules/.bin/vitest run tests/unit/gateway.system-prompt.test.ts tests/unit/tool-registry-schema.test.ts tests/unit/tool-registry.test.ts` → **41/41 passed** locally
- [x] New regression assertion in `gateway.system-prompt.test.ts` — checks preamble appears and legacy "persistent memory" line is gone
- [x] Lint via pre-commit hook → clean
- [ ] CI `quality-gate` → green
- [ ] Manual after merge on WSL: `ollama/qwen2.5:7b`, "yo" → text reply, not journal tool-call

## Addresses

PR "J" in `.claude/plans/velvet-jingling-cookie.md` (P1 triage plan from 2026-04-20 live testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)