### PR TITLE
chore(gitignore): stop tracking crates/memphis-napi/index.node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,14 @@ compose/synapse/homeserver.generated.yaml
 # ── Rust build ───────────────────────────────────────────────────────────────
 /target/
 
+# NAPI bridge binary. Rebuilt on demand by:
+#   - package.json `predev` hook
+#   - ops/memphis.service `ExecStartPre`
+#   - scripts/install.sh + scripts/bootstrap.sh
+# Historically committed 4× (~156 MB of blob bloat in git history before
+# this PR). Nothing reads the tracked copy — every install path rebuilds.
+crates/memphis-napi/index.node
+
 # ── Benchmarks & reports (generated) ─────────────────────────────────────────
 data/phase08/
 data/retrieval-benchmark-reports/


### PR DESCRIPTION
## Summary

Closes **follow-up #1 from PR #179 body** — the NAPI binary has been committed 4 times in history (~156 MB of blob bloat) despite being a pure build artifact. No consumer reads the tracked copy; every install path rebuilds.

## Change

- `git rm --cached crates/memphis-napi/index.node` — removes from index; binary **stays on filesystem** so local runtime keeps working.
- `.gitignore` entry in the "Rust build" section with explanatory comment pointing to the 4 rebuild paths: `predev` hook, systemd `ExecStartPre`, `install.sh`, `bootstrap.sh`.

## What this PR does NOT do

- **No history rewrite.** The 4 historical 23–54 MB blobs stay in the pack. Full scrub via `git-filter-repo` or BFG is a separate operator-led migration — not hot, would require coordinating clones across contributors.
- Does not change any build script; every rebuild path already exists and works.

## Test plan

- [x] `git ls-files crates/memphis-napi/index.node` → empty after commit
- [x] `test -f crates/memphis-napi/index.node` → still present on disk
- [x] `.gitignore` now lists the path
- [ ] After merge: fresh `git clone` + `npm run build:rust` produces the binary as usual; `git status` stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)