### PR TITLE
feat(trajectory): v1 schema module (direction #1 PR "A")

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memphis-chains/memphis",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memphis-chains/memphis",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/trajectory/index.ts
+++ b/src/trajectory/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Trajectory export — module entry point.
+ *
+ * This module ships the v1 schema contract only. Exporter logic, CLI
+ * commands, and runtime turnId propagation are separate follow-up PRs
+ * per docs/dev/TRAJECTORY-EXPORT-V1.md implementation sequence.
+ */
+
+export {
+  SCHEMA_VERSION,
+  TrajectoryEventKind,
+  ConsentLevel,
+  TrajectorySurface,
+  Provenance,
+  TrajectoryEvent,
+  AgentIdentity,
+  TrajectoryIntegrity,
+  Trajectory,
+  toJsonSchema,
+} from './schema.js';
+
+export type {
+  TrajectoryEventKindT,
+  ConsentLevelT,
+  TrajectorySurfaceT,
+  ProvenanceT,
+  TrajectoryEventT,
+  AgentIdentityT,
+  TrajectoryIntegrityT,
+  TrajectoryT,
+} from './schema.js';

--- a/src/trajectory/schema.ts
+++ b/src/trajectory/schema.ts
@@ -1,0 +1,181 @@
+/**
+ * Trajectory export — schema v1 (direction #1 PR "A").
+ *
+ * Pure contract module. No runtime side effects, no chain I/O, no CLI
+ * surface. Exporter, CLI command, turnId propagation, HF-dataset format,
+ * and consent backfill are separate follow-up PRs (B–E).
+ *
+ * Design grounded in docs/dev/TRAJECTORY-EXPORT-V1.md and the concrete
+ * `NapiBlock` shape from src/infra/storage/chain-file-io.ts:24.
+ *
+ * Five open questions from the design proposal are resolved with
+ * defaults documented inline below. Reviewer can flag any to change
+ * before merge — changes are small, localized.
+ */
+
+import { z } from 'zod';
+
+export const SCHEMA_VERSION = 1 as const;
+
+// ── Enums ────────────────────────────────────────────────────────────
+
+/**
+ * Nine event kinds cover every currently-observable turn artifact:
+ * user input, prompt fragments the runtime assembled, tool calls and
+ * their results, the assistant response, the cognitive prelude and
+ * post-pass from `src/gateway/cognitive-runtime.ts`, durable chain
+ * writes, and system events from boot / health / scheduler loops.
+ */
+export const TrajectoryEventKind = z.enum([
+  'user_input',
+  'prompt_fragment',
+  'tool_call',
+  'tool_result',
+  'model_response',
+  'cognitive_prelude',
+  'cognitive_post',
+  'chain_write',
+  'system_event',
+]);
+
+/**
+ * DEFAULT: three-level consent (see TRAJECTORY-EXPORT-V1.md Q#4). The
+ * anonymized level is honored by the exporter by hashing the content
+ * field; smart PII scrubbing is explicitly v2.
+ */
+export const ConsentLevel = z.enum(['exportable', 'local-only', 'anonymized']);
+
+/**
+ * Surface classification. `scheduler` covers cron-driven writes that
+ * have no user-facing session; `system` covers boot / health / runtime
+ * events that live on the `system` chain. DEFAULT Q#3: system events
+ * are included in trajectory output marked with surface='system' so
+ * consumers can filter, instead of split into a separate stream.
+ */
+export const TrajectorySurface = z.enum([
+  'cli',
+  'http',
+  'mcp',
+  'telegram',
+  'scheduler',
+  'system',
+]);
+
+// ── Provenance ───────────────────────────────────────────────────────
+
+/**
+ * Provenance is direct 1:1 mapping from `NapiBlock` fields in
+ * src/infra/storage/chain-file-io.ts. No recomputation — the exporter
+ * copies these straight off the read block. For in-memory events with
+ * no backing chain block (frame-buffer snapshots, prompt-building
+ * fragments), provenance is null.
+ *
+ * DEFAULT Q#4: blockHash uses SHA-256 of raw content, consistent with
+ * `crates/memphis-core/src/block.rs` canonical hashing. No alternate
+ * digest algorithms in v1.
+ */
+export const Provenance = z.object({
+  chain: z.string().min(1),
+  blockIndex: z.number().int().nonnegative(),
+  blockHash: z.string().min(1), // hex-encoded SHA-256
+  prevHash: z.string().min(1),
+  signer: z.string().optional(), // hex-encoded Ed25519 pubkey
+  signature: z.string().optional(), // hex-encoded Ed25519 signature
+});
+
+// ── Event ────────────────────────────────────────────────────────────
+
+/**
+ * A single event in a trajectory. Every event carries its kind, a
+ * timestamp, the session binding (null for unbound events), the
+ * surface it originated from, the consent level that gates its
+ * export, optional provenance (null for in-memory), and a kind-
+ * specific payload. Payload shapes per kind are documented in
+ * TRAJECTORY-EXPORT-V1.md §Schema v1; runtime validation keeps the
+ * payload as a record and defers per-kind typing to v1.1+.
+ */
+export const TrajectoryEvent = z.object({
+  kind: TrajectoryEventKind,
+  ts: z.string().datetime({ offset: true }),
+  turnId: z.string().nullable(),
+  surface: TrajectorySurface,
+  consent: ConsentLevel,
+  provenance: Provenance.nullable(),
+  payload: z.record(z.string(), z.unknown()),
+});
+
+// ── Agent identity ───────────────────────────────────────────────────
+
+/**
+ * Agent identity snapshot at trajectory start. DEFAULT Q#2:
+ * `instanceId` is the hex-encoded Ed25519 pubkey from the soul
+ * manifest — more stable than a manifest-hash that rotates with
+ * unrelated manifest edits.
+ */
+export const AgentIdentity = z.object({
+  agentName: z.string().min(1),
+  ownerName: z.string().min(1),
+  instanceId: z.string().min(1),
+});
+
+// ── Integrity snapshot ───────────────────────────────────────────────
+
+/**
+ * Tail hashes per chain at export time. Consumers can verify their
+ * copy of the trajectory against the producing runtime's chain state
+ * without re-reading the whole chain. `eventCount` and
+ * `signedEventCount` are convenience counters for dataset filters.
+ */
+export const TrajectoryIntegrity = z.object({
+  chainHashes: z.record(z.string(), z.string()),
+  eventCount: z.number().int().nonnegative(),
+  signedEventCount: z.number().int().nonnegative(),
+});
+
+// ── Trajectory ───────────────────────────────────────────────────────
+
+/**
+ * A complete trajectory = one session's ordered story. DEFAULT Q#1:
+ * `trajectoryId` is a per-session UUID stable across reboots —
+ * replay (direction #2) needs stable identity for replayable ground
+ * truth. `sessionId` is null when the events are scheduler-driven or
+ * otherwise unbound to an operator session.
+ */
+export const Trajectory = z.object({
+  schemaVersion: z.literal(SCHEMA_VERSION),
+  trajectoryId: z.string().uuid(),
+  sessionId: z.string().nullable(),
+  agentIdentity: AgentIdentity,
+  startedAt: z.string().datetime({ offset: true }),
+  completedAt: z.string().datetime({ offset: true }).nullable(),
+  turns: z.number().int().nonnegative(),
+  events: z.array(TrajectoryEvent),
+  integrity: TrajectoryIntegrity,
+});
+
+// ── Inferred TypeScript types ────────────────────────────────────────
+
+export type TrajectoryEventKindT = z.infer<typeof TrajectoryEventKind>;
+export type ConsentLevelT = z.infer<typeof ConsentLevel>;
+export type TrajectorySurfaceT = z.infer<typeof TrajectorySurface>;
+export type ProvenanceT = z.infer<typeof Provenance>;
+export type TrajectoryEventT = z.infer<typeof TrajectoryEvent>;
+export type AgentIdentityT = z.infer<typeof AgentIdentity>;
+export type TrajectoryIntegrityT = z.infer<typeof TrajectoryIntegrity>;
+export type TrajectoryT = z.infer<typeof Trajectory>;
+
+// ── JSON Schema export (DEFAULT Q#5) ─────────────────────────────────
+
+/**
+ * Emits the Trajectory schema as a JSON Schema document so external
+ * consumers (HuggingFace datasets, future RL tooling, third-party
+ * validators) can validate trajectories without pulling the `zod`
+ * runtime. Shipped in `dist/` via the existing `tsc` build — adds
+ * no extra build-step.
+ */
+export function toJsonSchema(): Record<string, unknown> {
+  // Zod 4 ships a native JSON-Schema emitter — no external dependency
+  // required. External validators and dataset loaders (HuggingFace
+  // datasets, RL tooling) consume this directly.
+  return z.toJSONSchema(Trajectory) as Record<string, unknown>;
+}

--- a/tests/unit/trajectory-schema.test.ts
+++ b/tests/unit/trajectory-schema.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for the trajectory schema v1 contract
+ * (docs/dev/TRAJECTORY-EXPORT-V1.md, PR "A" in the implementation
+ * sequence). Pure contract tests — no chain I/O, no runtime.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  SCHEMA_VERSION,
+  Trajectory,
+  TrajectoryEvent,
+  TrajectoryEventKind,
+  ConsentLevel,
+  TrajectorySurface,
+  Provenance,
+  toJsonSchema,
+} from '../../src/trajectory/schema.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const VALID_PROVENANCE = {
+  chain: 'journal',
+  blockIndex: 7,
+  blockHash: 'a'.repeat(64),
+  prevHash: 'b'.repeat(64),
+  signer: 'c'.repeat(64),
+  signature: 'd'.repeat(128),
+};
+
+const MINIMAL_EVENT = {
+  kind: 'user_input' as const,
+  ts: '2026-04-20T12:34:56.000Z',
+  turnId: 'turn-abc',
+  surface: 'cli' as const,
+  consent: 'exportable' as const,
+  provenance: null,
+  payload: { text: 'hi' },
+};
+
+const MINIMAL_TRAJECTORY = {
+  schemaVersion: 1 as const,
+  trajectoryId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+  sessionId: 's-abc',
+  agentIdentity: {
+    agentName: 'Memphis',
+    ownerName: 'Wodzu',
+    instanceId: 'e'.repeat(64),
+  },
+  startedAt: '2026-04-20T12:30:00.000Z',
+  completedAt: '2026-04-20T12:40:00.000Z',
+  turns: 1,
+  events: [MINIMAL_EVENT],
+  integrity: {
+    chainHashes: { journal: 'f'.repeat(64) },
+    eventCount: 1,
+    signedEventCount: 0,
+  },
+};
+
+// ── Core shape acceptance ───────────────────────────────────────────
+
+describe('trajectory schema v1 — Trajectory shape', () => {
+  it('accepts a minimal valid trajectory', () => {
+    expect(() => Trajectory.parse(MINIMAL_TRAJECTORY)).not.toThrow();
+  });
+
+  it('accepts a trajectory with provenance-backed event', () => {
+    const trajectoryWithProvenance = {
+      ...MINIMAL_TRAJECTORY,
+      events: [
+        {
+          ...MINIMAL_EVENT,
+          provenance: VALID_PROVENANCE,
+        },
+      ],
+    };
+    expect(() => Trajectory.parse(trajectoryWithProvenance)).not.toThrow();
+  });
+
+  it('accepts null sessionId (scheduler-driven / unbound trajectory)', () => {
+    const unbound = { ...MINIMAL_TRAJECTORY, sessionId: null };
+    expect(() => Trajectory.parse(unbound)).not.toThrow();
+  });
+
+  it('accepts null completedAt (in-progress trajectory)', () => {
+    const inProgress = { ...MINIMAL_TRAJECTORY, completedAt: null };
+    expect(() => Trajectory.parse(inProgress)).not.toThrow();
+  });
+
+  it('exposes SCHEMA_VERSION = 1', () => {
+    expect(SCHEMA_VERSION).toBe(1);
+  });
+
+  it('rejects trajectory with wrong schemaVersion', () => {
+    const wrong = { ...MINIMAL_TRAJECTORY, schemaVersion: 2 };
+    expect(() => Trajectory.parse(wrong)).toThrow();
+  });
+
+  it('rejects trajectory with non-UUID trajectoryId', () => {
+    const wrong = { ...MINIMAL_TRAJECTORY, trajectoryId: 'not-a-uuid' };
+    expect(() => Trajectory.parse(wrong)).toThrow();
+  });
+
+  it('rejects trajectory with negative turn count', () => {
+    const wrong = { ...MINIMAL_TRAJECTORY, turns: -1 };
+    expect(() => Trajectory.parse(wrong)).toThrow();
+  });
+
+  it('rejects trajectory with missing agentIdentity', () => {
+    const incomplete: Record<string, unknown> = { ...MINIMAL_TRAJECTORY };
+    delete incomplete.agentIdentity;
+    expect(() => Trajectory.parse(incomplete)).toThrow();
+  });
+});
+
+// ── Event kind coverage ─────────────────────────────────────────────
+
+describe('trajectory schema v1 — TrajectoryEventKind coverage', () => {
+  const kinds = [
+    'user_input',
+    'prompt_fragment',
+    'tool_call',
+    'tool_result',
+    'model_response',
+    'cognitive_prelude',
+    'cognitive_post',
+    'chain_write',
+    'system_event',
+  ] as const;
+
+  for (const kind of kinds) {
+    it(`accepts kind '${kind}'`, () => {
+      const event = { ...MINIMAL_EVENT, kind };
+      expect(() => TrajectoryEvent.parse(event)).not.toThrow();
+    });
+  }
+
+  it('enum options cover the documented 9 kinds', () => {
+    expect(TrajectoryEventKind.options).toHaveLength(9);
+    expect([...TrajectoryEventKind.options].sort()).toEqual([...kinds].sort());
+  });
+
+  it('rejects unknown event kind', () => {
+    const event = { ...MINIMAL_EVENT, kind: 'make_coffee' };
+    expect(() => TrajectoryEvent.parse(event)).toThrow();
+  });
+});
+
+// ── Consent levels ──────────────────────────────────────────────────
+
+describe('trajectory schema v1 — ConsentLevel', () => {
+  it('accepts the three documented levels', () => {
+    for (const level of ['exportable', 'local-only', 'anonymized'] as const) {
+      expect(() => ConsentLevel.parse(level)).not.toThrow();
+    }
+  });
+
+  it('rejects unknown consent level', () => {
+    expect(() => ConsentLevel.parse('public')).toThrow();
+  });
+});
+
+// ── Surface classification ──────────────────────────────────────────
+
+describe('trajectory schema v1 — TrajectorySurface', () => {
+  it('accepts cli/http/mcp/telegram/scheduler/system', () => {
+    for (const s of ['cli', 'http', 'mcp', 'telegram', 'scheduler', 'system'] as const) {
+      expect(() => TrajectorySurface.parse(s)).not.toThrow();
+    }
+  });
+
+  it('rejects unknown surface', () => {
+    expect(() => TrajectorySurface.parse('ircd')).toThrow();
+  });
+});
+
+// ── Provenance ──────────────────────────────────────────────────────
+
+describe('trajectory schema v1 — Provenance', () => {
+  it('accepts a valid provenance record', () => {
+    expect(() => Provenance.parse(VALID_PROVENANCE)).not.toThrow();
+  });
+
+  it('accepts provenance with signer+signature omitted (unsigned legacy blocks)', () => {
+    const unsigned = {
+      chain: 'journal',
+      blockIndex: 0,
+      blockHash: 'a'.repeat(64),
+      prevHash: 'b'.repeat(64),
+    };
+    expect(() => Provenance.parse(unsigned)).not.toThrow();
+  });
+
+  it('rejects provenance with missing blockHash', () => {
+    const bad: Record<string, unknown> = { ...VALID_PROVENANCE };
+    delete bad.blockHash;
+    expect(() => Provenance.parse(bad)).toThrow();
+  });
+
+  it('rejects provenance with negative blockIndex', () => {
+    const bad = { ...VALID_PROVENANCE, blockIndex: -1 };
+    expect(() => Provenance.parse(bad)).toThrow();
+  });
+});
+
+// ── JSON Schema export ──────────────────────────────────────────────
+
+describe('trajectory schema v1 — toJsonSchema()', () => {
+  it('produces a JSON Schema document with $schema marker', () => {
+    const schema = toJsonSchema();
+    expect(schema).toBeTypeOf('object');
+    expect(schema.$schema).toContain('json-schema.org');
+  });
+
+  it('emits serializable JSON (no circular refs, no functions)', () => {
+    const schema = toJsonSchema();
+    // If this throws, the schema can't be shipped via `dist/` or consumed
+    // by external validators (HuggingFace datasets, RL tooling).
+    expect(() => JSON.stringify(schema)).not.toThrow();
+  });
+
+  it('mentions every top-level Trajectory field somewhere in the document', () => {
+    // `zod-to-json-schema` may wrap in `definitions` / use `$ref` hops —
+    // we only assert that every field name the schema promises is
+    // present in the serialized output, not its exact location.
+    const serialized = JSON.stringify(toJsonSchema());
+    for (const key of Object.keys(MINIMAL_TRAJECTORY)) {
+      expect(serialized).toContain(`"${key}"`);
+    }
+  });
+
+  it('mentions every TrajectoryEventKind enum value in the document', () => {
+    const serialized = JSON.stringify(toJsonSchema());
+    for (const kind of TrajectoryEventKind.options) {
+      expect(serialized).toContain(`"${kind}"`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**Implements PR "A"** from the 5-part trajectory-export sequence locked in `docs/dev/TRAJECTORY-EXPORT-V1.md` (design proposal from PR #182). Pure contract module — no runtime side effects, no chain I/O, no CLI surface. Enables PRs B–E to build on a stable schema.

This is the first code-level step toward the lab-pivot roadmap's direction #1 (trajectory-grade dataset export), which is the blocker for directions #2 (replay/A-B), #3 (RLAIF reward), #4 (consent/federation), and #5 (tool-use dataset).

## Files

- `src/trajectory/schema.ts` — Zod schemas + inferred TS types + `toJsonSchema()` exporter
- `src/trajectory/index.ts` — barrel re-exports + `SCHEMA_VERSION = 1`
- `tests/unit/trajectory-schema.test.ts` — **32 contract tests**

## Five open questions from PR #182 — defaults chosen

| Q | Default | Rationale |
|---|---|---|
| `trajectoryId` identity | per-session UUID (v4), stable across reboots | Replay (direction #2) needs stable identity for replayable ground truth |
| `instanceId` source | hex Ed25519 pubkey | More stable than `soul-manifest` hash that rotates on unrelated manifest edits |
| System events placement | included, `surface='system'` | Consumers filter; avoids split-stream reassembly overhead |
| Content digest | SHA-256 of raw content | Consistent with `NapiBlock.hash` in `crates/memphis-core/src/block.rs` |
| Schema distribution | native `z.toJSONSchema()` shipped in `dist/` | Zero extra build step, zero extra dep |

## No new external dependency

Originally tried pulling in `zod-to-json-schema` (~30 KB). Turned out silently incompatible with Zod 4 schemas (produced empty `{"$schema":...}` output with no fields). **Zod 4 ships a native `z.toJSONSchema()`** — used that instead. No dep diff; cleaner.

## Test coverage (32 tests, 0 failures)

- Full trajectory acceptance: minimal, with provenance, null sessionId, null completedAt
- Rejection paths: wrong schemaVersion, non-UUID trajectoryId, negative turns, missing agentIdentity
- `TrajectoryEventKind` enum — all 9 values accepted, unknowns rejected
- `ConsentLevel` enum — all 3 values accepted, unknowns rejected
- `TrajectorySurface` enum — all 6 values accepted, unknowns rejected
- `Provenance` — valid, unsigned-legacy (missing signer+signature OK), missing blockHash rejected, negative blockIndex rejected
- `toJsonSchema()` — produces `$schema`-marked document, serializable via JSON.stringify, mentions every root field + every `TrajectoryEventKind` enum value

## Out of scope (deliberate — follow-up PRs)

| PR | Concern |
|---|---|
| **B** | `storeDurableMemory` gains `turnId` + `consent` params; all callers updated |
| **C** | `memphis export trajectories` CLI + exporter core (chain → TrajectoryEvent mapping) |
| **D** | HF-dataset directory output format |
| **E** | Consent backfill helper (`memphis consent mark`) |

Direction #1 is considered shipped when PR "C" merges. This PR lays the stone.

## Test plan

- [x] `./node_modules/.bin/vitest run tests/unit/trajectory-schema.test.ts` → **32/32 passed**
- [x] `npx eslint src/trajectory/ tests/unit/trajectory-schema.test.ts` → clean
- [x] No new runtime surface touched; no existing test affected
- [ ] CI `quality-gate` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)