### PR TITLE
fix(tui): strip trailing newlines from stream chunks to kill blank-line tail

### DIFF
--- a/crates/memphis-tui/src/app.rs
+++ b/crates/memphis-tui/src/app.rs
@@ -3380,6 +3380,17 @@ impl AppState {
             return;
         }
 
+        // Strip trailing newline noise. LLM providers routinely close their
+        // final chunk with "…today?\n\n\n\n" — split('\n') turns those into
+        // empty slices and the peek-based push below emits them as blank
+        // transcript lines, producing 15–20 visible blanks after every
+        // reply (observed 2026-04-20 on operator WSL). Mid-chunk blank
+        // lines remain (paragraph separation preserved).
+        let chunk = chunk.trim_end_matches(|c: char| c == '\n' || c == '\r');
+        if chunk.is_empty() {
+            return;
+        }
+
         let mut parts = chunk.split('\n').peekable();
         while let Some(part) = parts.next() {
             if self.output_buffer.is_empty() {


### PR DESCRIPTION
## Summary

Every model reply in the operator TUI was followed by 15–20 blank lines before the next prompt. Visible in every operator WSL session today (2026-04-20).

## Repro (from operator log)

```
> who am i?
[Memphis] You are Marcin Kukla...

reply complete via ollama / qwen2.5-coder:3b · tok p:4092 c:49 t:4141




                         ← ~15-20 blank lines
> /tier
```

## Root cause

`append_stream_chunk` at `crates/memphis-tui/src/app.rs:3378` — LLM providers close their final streaming chunk with trailing newlines (`"…today?\n\n\n\n"`). `chunk.split('\n')` turned those into empty slices; the peek-based push-empty-line loop emitted a blank transcript line for each. The more newlines the model closed with, the more blanks in the transcript.

## Fix

Single `trim_end_matches` call before the split:

```rust
let chunk = chunk.trim_end_matches(|c: char| c == '\n' || c == '\r');
if chunk.is_empty() {
    return;
}
```

Mid-chunk blank lines (paragraph breaks, intentional `"\n\n"` separators between sentences) are preserved — only **trailing** noise is cut.

## Test plan

- [x] `cargo check -p memphis-tui` → clean build
- [x] No other rendering path touched (`append_line` / `append_lines` unaffected)
- [ ] Manual after merge + rebuild on WSL: `memphis tui` → any prompt → one blank line between `reply complete` footer and next `>` prompt, not 15-20
- [ ] CI `quality-gate` green

## Addresses

PR "TUI-blank" (P0) in `.claude/plans/velvet-jingling-cookie.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)