### PR TITLE
fix(vault): auto-enable provider env var on vault add for known slots

### DIFF
--- a/src/infra/cli/handlers/vault.handler.ts
+++ b/src/infra/cli/handlers/vault.handler.ts
@@ -201,9 +201,55 @@ async function handleVaultAdd(context: CliContext): Promise<boolean> {
     { surface: 'cli', command: 'vault add' },
     process.env,
   );
-  print({ ok: true, entry: toVaultEntryMetadata(stored) }, json);
+
+  // Auto-enable provider env var for recognized slots. The provider
+  // registry at src/providers/runtime-registry.ts gates vault lookup
+  // on `<PROVIDER>_VAULT_KEY` env vars. Without this step, an operator
+  // who ran `memphis vault add --key anthropic_api_key …` would still
+  // see `[down] ANTHROPIC_API_KEY not set` in the TUI status pill —
+  // the vault entry existed but the registry had no instruction to
+  // look it up. Observed on operator WSL 2026-04-20.
+  const envVar = PROVIDER_VAULT_ENV_MAP[key];
+  let autoEnabledEnv: string | undefined;
+  if (envVar) {
+    upsertEnvVars([{ key: envVar, value: key }]);
+    autoEnabledEnv = envVar;
+  }
+
+  print(
+    {
+      ok: true,
+      entry: toVaultEntryMetadata(stored),
+      ...(autoEnabledEnv
+        ? { autoEnabled: { envVar: autoEnabledEnv, hint: 'Restart the service to pick up the new provider configuration.' } }
+        : {}),
+    },
+    json,
+  );
+
+  if (autoEnabledEnv && !json) {
+    process.stdout.write(
+      `\nnote: auto-enabled ${autoEnabledEnv}=${key} in .env — restart the service to pick up the provider.\n`,
+    );
+  }
   return true;
 }
+
+/**
+ * Vault-key → provider-registry env var. Keys here mirror the
+ * VAULT_KEY_MAP table in src/providers/runtime-registry.ts. When an
+ * operator stores a secret under one of these names, auto-enable the
+ * corresponding env var so the provider becomes usable on next
+ * restart without manual .env edits.
+ */
+const PROVIDER_VAULT_ENV_MAP: Record<string, string> = {
+  anthropic_api_key: 'ANTHROPIC_VAULT_KEY',
+  anthropic_oauth_refresh_token: 'ANTHROPIC_VAULT_KEY',
+  anthropic_oauth_client_secret: 'ANTHROPIC_OAUTH_SECRET_VAULT_KEY',
+  minimax_api_key: 'MINIMAX_VAULT_KEY',
+  deepseek_api_key: 'DEEPSEEK_VAULT_KEY',
+  glm_api_key: 'GLM_VAULT_KEY',
+};
 
 async function handleVaultGet(context: CliContext): Promise<boolean> {
   if (!(await requireOperatorAuth())) throw new Error('Operator authentication failed.');


### PR DESCRIPTION
## Summary

Closes the silent two-sources-of-truth trap observed on operator WSL 2026-04-20: `memphis vault add --key anthropic_api_key ...` succeeds, the vault has the secret, but `src/providers/runtime-registry.ts` only looks it up when the corresponding `ANTHROPIC_VAULT_KEY` env var is set — and that line is commented out by default in `.env.example`. The Anthropic provider stayed `[down][!] ANTHROPIC_API_KEY not set` despite a healthy vault entry.

## Repro

```
memphis vault add --key anthropic_api_key     # ok, integrityOk: true
memphis service restart
memphis providers list                         # only 2 providers, anthropic missing
grep ANTHROPIC ~/memphis/.env                  # # ANTHROPIC_VAULT_KEY=... (still commented)
```

## Fix

After `storeVaultSecret` succeeds in `handleVaultAdd`, look up the key in a slot table:

```typescript
const PROVIDER_VAULT_ENV_MAP = {
  anthropic_api_key:              'ANTHROPIC_VAULT_KEY',
  anthropic_oauth_refresh_token:  'ANTHROPIC_VAULT_KEY',
  anthropic_oauth_client_secret:  'ANTHROPIC_OAUTH_SECRET_VAULT_KEY',
  minimax_api_key:                'MINIMAX_VAULT_KEY',
  deepseek_api_key:               'DEEPSEEK_VAULT_KEY',
  glm_api_key:                    'GLM_VAULT_KEY',
};
```

If the key matches, call the existing `upsertEnvVars` helper from `src/infra/config/env-file.ts` to write `<ENV_VAR>=<key>` into `.env`. That helper already handles "replace existing uncommented line" and "append at end" cases.

## Output paths

- Human: `print({ ok: true, entry: ... })` plus a `note:` footer telling the operator to restart the service.
- JSON: adds `autoEnabled: { envVar, hint }` so scripted flows can detect and act on the change.

## Keys NOT in the map

`matrix_access_token`, `synjar_api_key`, custom operator secrets — no `.env` mutation unless the key matches a documented provider slot. No silent env writes for arbitrary names.

## Test plan

- [x] `tsc --noEmit` → clean
- [x] Lint via pre-commit hook → clean
- [ ] CI `quality-gate` → green
- [ ] Manual on WSL after merge:
  ```
  # Pre-check
  grep ANTHROPIC_VAULT_KEY ~/memphis/.env    # => "# ANTHROPIC_VAULT_KEY=..." (commented)

  # Add key
  memphis vault add --key anthropic_api_key   # enters wizard, stores secret

  # Post-check
  grep ANTHROPIC_VAULT_KEY ~/memphis/.env    # now shows "ANTHROPIC_VAULT_KEY=anthropic_api_key" (uncommented)
  memphis service restart
  memphis providers list                      # anthropic now up
  ```

## Out of scope

- Removing the `# ANTHROPIC_VAULT_KEY=` commented line — left alone for backwards compatibility; the uncommented line below it wins at load time.
- Auto-restart after mutation — surprising UX; explicit `note: ... — restart the service` is clearer.
- `.env.example` cleanup — separate installer/template concern.

## Addresses

PR "vault-autoenable" (P2) in `.claude/plans/velvet-jingling-cookie.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)