### PR TITLE
fix(configure): hard-block the retired wizard

### DIFF
--- a/src/infra/cli/commands/configure.ts
+++ b/src/infra/cli/commands/configure.ts
@@ -342,38 +342,44 @@ export async function runConfigureWizard(options: ConfigureOptions = {}): Promis
 }
 
 export async function handleConfigureCommand(context: CliContext): Promise<boolean> {
-  const {
-    command,
-    subcommand,
-    json,
-    dryRun,
-    nonInteractive,
-    passphrase,
-    recoveryQuestion,
-    recoveryAnswer,
-    noVault,
-  } = context.args;
+  const { command, subcommand, json } = context.args;
   if (command !== 'configure') return false;
   if (subcommand) throw new Error('configure does not take a subcommand');
 
-  // Deprecation warning — configure writes config.yaml which is no longer used
-  // Memphis now uses .env for all configuration via setup/onboarding
+  // `memphis configure` is retired. Previously this command warned loudly but
+  // still ran the legacy wizard, which would collect a vault passphrase,
+  // write `~/.memphis/config.yaml`, and generate a separate DID — producing
+  // a parallel source of truth next to the canonical `.env` + vault + soul
+  // manifest set up by `memphis init`. Observed 2026-04-20 on operator WSL:
+  // `memphis doctor` afterwards reported an orphan `config.yaml` and a
+  // "missing DID identity file" because the configure-DID and the init-path
+  // never reconciled.
+  //
+  // Hard-block: print the deprecation notice and exit without running the
+  // wizard. Operators who truly need to re-run onboarding use `memphis init`
+  // or `memphis repair runtime`.
+  const deprecated = {
+    ok: false,
+    deprecated: true,
+    reason: 'memphis-configure-is-retired',
+    message:
+      'memphis configure is retired. Use `memphis init` for operator onboarding; use `memphis setup matrix` only for the optional Matrix pilot. Previously this command would write a parallel config.yaml and DID that did not reconcile with the canonical state — it is now a no-op.',
+    replacement: {
+      onboarding: 'memphis init',
+      matrixPilot: 'memphis setup matrix',
+      repair: 'memphis repair runtime',
+    },
+  };
+
   if (!json) {
-    console.warn('\n  ⚠️  DEPRECATED: "memphis configure" is deprecated.');
-    console.warn('     Memphis now uses bootstrap + memphis init for the canonical first-run.');
+    console.warn('\n  ⚠️  DEPRECATED: "memphis configure" is retired.');
     console.warn('     Use "memphis init" for operator onboarding.');
     console.warn('     Use "memphis setup matrix" only for the optional Matrix pilot path.');
-    console.warn('     This command will be removed in a future version.\n');
+    console.warn('     Use "memphis repair runtime" to reconcile an existing setup.');
+    console.warn('');
+    console.warn('     (The legacy wizard has been removed — it produced a parallel');
+    console.warn('     config.yaml + DID that did not reconcile with the canonical state.)\n');
   }
-
-  const result = await runConfigureWizard({
-    nonInteractive,
-    dryRun,
-    passphrase,
-    recoveryQuestion,
-    recoveryAnswer,
-    noVault,
-  });
-  print(result, json);
+  print(deprecated, json);
   return true;
 }


### PR DESCRIPTION
## Summary

`memphis configure` printed a DEPRECATED warning and then **ran the wizard anyway** — collected a vault passphrase, wrote `~/.memphis/config.yaml`, and generated a separate DID. Parallel source of truth next to canonical `.env` + vault + soul-manifest path that `memphis init` owns.

## Repro (operator WSL 2026-04-20)

```
$ memphis configure
⚠️  DEPRECATED: "memphis configure" is deprecated.
△⬡◈ Memphis Setup Wizard (MVP)
? State directory location › /home/memphis/.memphis
✔ Vault passphrase … ...
...
Config: /home/memphis/.memphis/config.yaml
DID: did:memphis:dad3e28b2930eff911cd839ad41ff46b
```

Subsequent `memphis doctor`:
- Orphan files: `config.yaml`
- `⚠ DID generated: missing DID identity file`

## Fix

Remove wizard invocation. Return structured deprecation response; print human-readable banner with canonical replacements.

```typescript
const deprecated = {
  ok: false,
  deprecated: true,
  reason: 'memphis-configure-is-retired',
  message: 'memphis configure is retired. Use `memphis init` ...',
  replacement: {
    onboarding: 'memphis init',
    matrixPilot: 'memphis setup matrix',
    repair: 'memphis repair runtime',
  },
};
```

No state mutation. Exit via `ok: false`.

## Why hard-block (not repair the wizard)

The wizard creates formats memphis itself no longer consumes (`config.yaml`) and a DID that doesn't flow into canonical identity path. Rewriting it to match current contracts doubles state-initialization surface area. `memphis init` is the canonical path; configure is a ghost command. Stop it writing.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [ ] CI `quality-gate` → green
- [ ] Manual after merge on WSL:
  ```
  memphis configure
  # → deprecation banner + { ok: false, deprecated: true, … }, NO wizard prompts
  ls ~/.memphis/config.yaml
  # → does not exist (no new write)
  ```

## Out of scope

- Removing `runConfigureWizard` function entirely — dead-code cleanup PR.
- Cleaning up existing `config.yaml` / parallel DID — operators `rm` manually or `memphis doctor --fix`.

## Addresses

PR "configure-hardblock" (P1) in `.claude/plans/velvet-jingling-cookie.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)