### PR TITLE
fix(cli): `memphis models` now defaults to `list`

### DIFF
--- a/src/infra/cli/handlers/system.handler.ts
+++ b/src/infra/cli/handlers/system.handler.ts
@@ -160,7 +160,14 @@ async function handleProviders(context: CliContext): Promise<boolean> {
 }
 
 async function handleModels(context: CliContext): Promise<boolean> {
-  if (context.args.subcommand !== 'list') {
+  // Default `memphis models` to `memphis models list` — the only supported
+  // subcommand today. Previously the handler returned false when no
+  // subcommand was supplied, which fell through to the dispatcher's
+  // "Unknown command: models" error (observed 2026-04-20 on operator WSL),
+  // even though `models` is in the command registry and `/help` advertises
+  // it. Explicit `memphis models list` still works identically.
+  const subcommand = context.args.subcommand ?? 'list';
+  if (subcommand !== 'list') {
     return false;
   }
 


### PR DESCRIPTION
## Summary

`memphis models` returned `[ERROR] Unknown command: models` despite appearing in the command registry and being advertised in `/help`. User-visible discoverability bug.

## Repro

```
memphis@memphis:~/memphis$ memphis models
[ERROR] Failed to load Memphis CLI: Unknown command: models
[ERROR] Stack: Error: Unknown command: models
    at executeCommand (file:///.../dispatcher.js:14:15)
```

## Root cause

`handleModels` in `src/infra/cli/handlers/system.handler.ts:162`:

```typescript
async function handleModels(context: CliContext): Promise<boolean> {
  if (context.args.subcommand !== 'list') {
    return false;   // ← fallthrough to "Unknown command"
  }
  ...
}
```

When user ran bare `memphis models`, subcommand was undefined, handler returned false, dispatcher threw "Unknown command". Explicit `memphis models list` worked.

## Fix

Default subcommand to `'list'` — the only supported one today:

```typescript
const subcommand = context.args.subcommand ?? 'list';
```

## Test plan

- [x] `eslint` clean
- [x] No test regression (handler signature unchanged)
- [ ] CI `quality-gate` → green
- [ ] Manual after merge:
  ```
  memphis models          # now shows models table, equivalent to `memphis models list`
  memphis models list     # unchanged
  memphis models --json   # JSON output
  ```

## Addresses

PR "cli-models-command" (P1) in `.claude/plans/velvet-jingling-cookie.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)