### PR TITLE
fix(skills): emit grounded "None installed" fragment when catalog is empty

### DIFF
--- a/src/modules/skills/runtime.ts
+++ b/src/modules/skills/runtime.ts
@@ -60,8 +60,22 @@ export function buildInstalledSkillsPromptFragment(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): string {
   const installed = listInstalledSkillSummaries(rawEnv);
+
+  // Previously returned an empty string when no skills were installed,
+  // which left the model to hallucinate about its "skills" from training
+  // priors (e.g. "I can program in Rust, TypeScript, Python" or inventing
+  // fictional `exacct`-style commands as capabilities). Observed on
+  // operator WSL 2026-04-20 with qwen2.5-coder:3b.
+  //
+  // Emit a grounded "None installed" statement so the model has a fact
+  // to cite when the operator asks about skills. The note below
+  // explicitly forbids inventing capabilities beyond the tool list.
   if (installed.length === 0) {
-    return '';
+    return `<installed_skills>
+No operator skill packs are installed in this runtime. \`memphis skills list\` would return an empty catalog.
+
+When the operator asks about your SKILLS or CAPABILITIES, say plainly that no skills are installed and point them to the <tools> block below for what you can actually do. Do NOT invent programming languages, CLI flags, or framework names as "skills" — the only grounded capabilities are the tools listed in <tools>.
+</installed_skills>`;
   }
 
   const lines = installed
@@ -75,7 +89,7 @@ export function buildInstalledSkillsPromptFragment(
     ]);
 
   return `<installed_skills>
-Installed operator skill packs provide extra workflow guidance. When a skill clearly matches the task, follow it unless the operator asks for a different path.
+Installed operator skill packs provide extra workflow guidance. When a skill clearly matches the task, follow it unless the operator asks for a different path. Do NOT invent additional skills beyond those listed here.
 ${lines.join('\n')}
 </installed_skills>`;
 }


### PR DESCRIPTION
## Summary

`buildInstalledSkillsPromptFragment` returned an empty string when no skill packs were installed. Small open-weight models (qwen2.5-coder:3b in particular) saw no `<installed_skills>` block in the system prompt and fell back to hallucinating skills from training priors — claiming to offer "Rust, TypeScript, Python programming", inventing fictional `exacct` CLI flags, or citing frameworks with no runtime presence.

## Repro (operator WSL 2026-04-20)

```
> skils? do you have any?
[Memphis] Yes, I have several skills and abilities...
  1. Programming languages: I can write and execute code in a variety
     of programming languages, including Rust, TypeScript, and Python.
  2. Data processing...
  3. Natural language processing...
  4. Machine learning...
  5. Artificial intelligence...
```

`memphis skills list` on the same runtime would have returned an empty catalog.

## Root cause

`src/modules/skills/runtime.ts:59-81` — early return:

```typescript
if (installed.length === 0) {
  return '';         // ← no grounded statement
}
```

With nothing injected, the model had no fact to cite and invented capabilities.

## Fix

Emit an explicit "None installed" `<installed_skills>` block with a discipline rule forbidding invention:

```
<installed_skills>
No operator skill packs are installed in this runtime. `memphis skills list` would return an empty catalog.

When the operator asks about your SKILLS or CAPABILITIES, say plainly that no skills are installed and point them to the <tools> block below for what you can actually do. Do NOT invent programming languages, CLI flags, or framework names as "skills" — the only grounded capabilities are the tools listed in <tools>.
</installed_skills>
```

Populated-catalog branch gets a matching `Do NOT invent additional skills` line so the rule holds regardless.

## Why not system-prompt.ts change

Explored that path first. The wiring was already in place — `buildRuntimeSystemPrompt` at `src/gateway/agent-runtime.ts:177` already calls `buildInstalledSkillsPromptFragment`. The gap was inside that function. Fixing the empty-case return is a one-file, single-function change.

## Test plan

- [x] `eslint` clean
- [x] `tests/unit/skills.catalog.test.ts` (2 tests) still passes
- [ ] CI `quality-gate` → green
- [ ] Manual on WSL after merge + restart:
  ```
  memphis tui
  /provider ollama
  /model qwen2.5-coder:3b
  > do you have any skills?
  ```
  Expected: model says "No skills are installed, my grounded capabilities are the tools listed..." instead of inventing "Rust/TypeScript/Python programming" etc.

## Out of scope

- MCP tool wrapper for `memphis skills list` (the data is now in the prompt; a tool call remains possible as follow-up if operators want introspection at runtime).
- Larger "groundedness" rework of the system prompt — that's a cognitive-architecture concern, not a single-bug fix.

## Addresses

PR "skill-catalog-prompt" (P1) in `.claude/plans/velvet-jingling-cookie.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)