### PR TITLE
docs(readme): canonical "Install in 8 minutes" landing panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,41 @@ Every decision Memphis makes is recorded. Every secret is encrypted at rest. Eve
 
 ---
 
+## Install in 8 minutes
+
+Linux, macOS, or WSL2. Installs Node 22, Rust stable, Ollama, clones the repo, builds everything, and links the `memphis` CLI globally:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Memphis-Chains/memphis/main/scripts/install.sh | bash
+```
+
+Then walk the canonical first-run:
+
+```bash
+memphis init                    # passphrase, vault, identity, first chain writes
+memphis provider add anthropic  # (optional) cloud provider — repeat for minimax/deepseek/glm
+memphis service install && memphis service restart
+memphis tui                     # open the native operator cockpit
+```
+
+That's it. Sovereign AI running on your machine, with encrypted vault, chain-backed memory, 200k-token Claude access (if you added anthropic), and local Ollama fallback when the network's down.
+
+**What you get in 5 minutes** (past the Rust build, which dominates the 8-minute clock):
+
+- **Encrypted vault** — Argon2id + AES-256-GCM, separate operator and vault passphrases, 2FA Q&A recovery
+- **3-tier provider cascade** — `anthropic → ollama → local-fallback`. One drops, next takes over automatically
+- **Chain-backed memory** — journal / decisions / reflections / 8 semantic case roles, every block SHA-256 linked and Ed25519 signed
+- **Native TUI cockpit** (Rust) — chat, memory browser, session history, vault, cases, system health, all in one terminal
+- **Telegram-ready** — `memphis setup telegram` (coming soon) or `.env` config for remote bot access
+- **MCP-ready** — stdio + HTTP transport for Claude Code / ChatGPT / Cursor integration
+- **HTTP API** — Fastify on `:3000`, bearer-token protected, `/v1/chat/*`, `/v1/ops/status`, `/v1/vault/*`, SSE session events
+
+**New to Memphis?** The Polish step-by-step walkthrough [`docs/operator/install-fresh-user.pl.md`](./docs/operator/install-fresh-user.pl.md) (20 KB, 11 steps with verification after each) assumes zero prior knowledge and explains what each command does and why.
+
+**Experienced operator?** Jump straight to [`docs/operator/install.en.md`](./docs/operator/install.en.md) or [`docs/operator/install.pl.md`](./docs/operator/install.pl.md) for the compact reference.
+
+---
+
 ## Why Memphis Exists
 
 Technology can be chains or keys. The centralized AI model — where your conversations, your data, your business logic live on someone else's servers, governed by someone else's policies — is a sovereignty problem. Memphis solves it:


### PR DESCRIPTION
## Summary

Surfaces the canonical one-liner install flow at the top of README.md. Previously the `curl | bash` one-liner existed at `README.md:37` but was buried below paragraphs of sovereignty messaging — an operator glancing at the repo for the first time had to scroll past "Why Memphis Exists" to find it.

## Change

New **"Install in 8 minutes"** panel inserted above "Why Memphis Exists". Contains:

1. **One-liner** (unchanged):
   ```
   curl -fsSL https://raw.githubusercontent.com/Memphis-Chains/memphis/main/scripts/install.sh | bash
   ```

2. **Four canonical post-install commands** in the right order:
   ```
   memphis init                    # passphrase, vault, identity
   memphis provider add anthropic  # (optional) cloud provider
   memphis service install && memphis service restart
   memphis tui                     # open operator cockpit
   ```

3. **"What you get in 5 minutes"** bullet list — vault, 3-tier provider cascade, chain-backed memory, TUI cockpit, Telegram-ready, MCP-ready, HTTP API with SSE.

4. **Dual paths to further docs**:
   - Novice: `docs/operator/install-fresh-user.pl.md` (PR #189, 20 KB PL step-by-step)
   - Experienced: `docs/operator/install.{en,pl}.md` (compact reference)

## Why not collapse the existing Quick Start section?

Kept as-is — it holds the CLI cheat-sheet table which is valuable reference material. This PR adds a hero panel above it; the two are complementary, not redundant.

## Test plan

- [x] `vitest run tests/ops/{public-status,rc-release-truth,release-candidate-path}-docs-contract.test.ts` → **8/8 passed** — all required strings still present (`v1.4.0`, `production-ready for first install`, `docs/PROJECT-STATUS.md`, `docs/ROADMAP-CURRENT.md`, `docs/CLEAN-INSTALL.md`, `Worker / Async Runtime`, Apache-2.0)
- [ ] CI `quality-gate` → green (docs-only)
- [ ] Visual check on GitHub after merge: the install panel is above the fold on a 1080p monitor

## Addresses

PR "A" in `.claude/plans/velvet-jingling-cookie.md` (onboarding v2 plan — canonical landing). Follow-ups B–F land the wizard integrations, LOOP_LIMITS convergence, readiness command, and installer `--with-init` flag respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)