### PR TITLE
fix(embed): accept RUST_EMBED_PROVIDER_URL with or without /api/embeddings suffix

### DIFF
--- a/crates/memphis-embed/src/pipeline.rs
+++ b/crates/memphis-embed/src/pipeline.rs
@@ -124,7 +124,20 @@ impl EmbeddingProvider for OllamaProvider {
     }
 
     fn embed(&self, text: &str, dim: usize) -> Result<Vec<f32>, EmbedError> {
-        let url = format!("{}/api/embeddings", self.base_url);
+        // Operators sometimes configure `RUST_EMBED_PROVIDER_URL` with the
+        // full Ollama embeddings endpoint already appended (e.g.
+        // `http://127.0.0.1:11434/api/embeddings`). That produced a 404 on
+        // `http://.../api/embeddings/api/embeddings` because this function
+        // always appended the suffix. Observed 2026-04-20 on operator WSL
+        // during `memphis doctor --fix` embedding rebuild.
+        //
+        // Accept either form: strip a trailing `/api/embeddings` (with or
+        // without a trailing slash) from base_url before appending.
+        let trimmed = self.base_url.trim_end_matches('/');
+        let base = trimmed
+            .strip_suffix("/api/embeddings")
+            .unwrap_or(trimmed);
+        let url = format!("{}/api/embeddings", base);
         let payload = serde_json::json!({
             "model": &self.model,
             "prompt": text,


### PR DESCRIPTION
## Summary

Fixes 404 on Ollama embeddings rebuild when `RUST_EMBED_PROVIDER_URL` is set to the full endpoint (with `/api/embeddings` already appended) — a natural reading of the variable name.

## Repro

Operator WSL 2026-04-20 during `memphis doctor --fix`:

```
repair skipped: embedding rebuild skipped: embed_store_failed:
  provider request failed: ollama request failed:
  http://127.0.0.1:11434/api/embeddings/api/embeddings: status code 404
```

`.env` contained:
```
RUST_EMBED_PROVIDER_URL=http://127.0.0.1:11434/api/embeddings
```

Code at `crates/memphis-embed/src/pipeline.rs:127` did:
```rust
let url = format!("{}/api/embeddings", self.base_url);
```

→ `http://127.0.0.1:11434/api/embeddings` + `/api/embeddings` = **double path 404**.

## Fix

Strip trailing `/api/embeddings` (with or without trailing slash) from `base_url` before appending:

```rust
let trimmed = self.base_url.trim_end_matches('/');
let base = trimmed.strip_suffix("/api/embeddings").unwrap_or(trimmed);
let url = format!("{}/api/embeddings", base);
```

## Behavior matrix

| `RUST_EMBED_PROVIDER_URL` | Before | After |
|---|---|---|
| `http://127.0.0.1:11434` | ✓ `.../api/embeddings` | ✓ unchanged |
| `http://127.0.0.1:11434/` | ✓ `.../api/embeddings` | ✓ unchanged |
| `http://127.0.0.1:11434/api/embeddings` | ✗ `.../api/embeddings/api/embeddings` 404 | ✓ `.../api/embeddings` |
| `http://127.0.0.1:11434/api/embeddings/` | ✗ `.../api/embeddings/api/embeddings` 404 | ✓ `.../api/embeddings` |

## Test plan

- [x] `cargo check -p memphis-embed` → clean
- [ ] CI `quality-gate` → green
- [ ] Manual on WSL after merge + `npm run build`:
  ```bash
  memphis doctor --fix   # embedding rebuild now proceeds for both env-var forms
  memphis embed store --id probe --value 'hello world'
  memphis embed search --query 'hello'
  ```

## Out of scope

- Fixing `.env.example` / bootstrap template to use canonical form without `/api/embeddings` suffix — could still be done for clarity, but is no longer required now that both forms work.
- Same "append if not already present" logic for other provider URLs — they don't currently exhibit this pattern, but if they do, apply the same `strip_suffix` treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)