### PR TITLE
fix(bootstrap): friendly EADDRINUSE message on port conflict

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -322,7 +322,36 @@ export async function bootstrap(): Promise<void> {
     workPollingService: container.workPollingService,
   });
 
-  await app.listen({ host: config.HOST, port: config.PORT });
+  try {
+    await app.listen({ host: config.HOST, port: config.PORT });
+  } catch (err) {
+    // `npm run dev` against an already-running systemd service produced a
+    // raw EADDRINUSE stack trace with no operator guidance — observed
+    // repeatedly on WSL 2026-04-20. Catch the port-conflict case and
+    // surface a friendly, actionable message before rethrowing.
+    if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
+      const host = config.HOST;
+      const port = config.PORT;
+      console.error('');
+      console.error(
+        `Memphis cannot bind to ${host}:${port} — that port is already in use.`,
+      );
+      console.error(
+        'The most common cause is the systemd user service is already running.',
+      );
+      console.error('');
+      console.error('Next steps:');
+      console.error(`  memphis service status         # confirm the service is running`);
+      console.error(`  memphis service stop           # stop it, then retry this command`);
+      console.error(`  memphis service logs -n 100    # inspect what the service is doing`);
+      console.error('');
+      console.error(
+        'If you wanted to tail or manage the already-running runtime instead of starting a new one, use the commands above rather than `npm run dev`.',
+      );
+      console.error('');
+    }
+    throw err;
+  }
 
   // ── Optional channel gateway ────────────────────────────────────
   await startChannelGateway({


### PR DESCRIPTION
## Summary

- Wrap `app.listen()` in bootstrap with EADDRINUSE-aware error handler.
- Print actionable guidance (`memphis service status | stop | logs`) when the operator ran `npm run dev` while the systemd service already holds the port.
- Rethrow preserving exit semantics.

## Motivation

During hands-on WSL onboarding on 2026-04-20 the operator hit this error twice in one session:

```
Bootstrap failed Error: listen EADDRINUSE: address already in use 127.0.0.1:3000
    at Server.setupListenHandle ...
```

The raw Node stack trace left no hint that the cause was the running systemd user service — a universal foot-gun for anyone who has `memphis service start`ed and then tried `npm run dev`.

## Behaviour after this PR

```
Memphis cannot bind to 127.0.0.1:3000 — that port is already in use.
The most common cause is the systemd user service is already running.

Next steps:
  memphis service status         # confirm the service is running
  memphis service stop           # stop it, then retry this command
  memphis service logs -n 100    # inspect what the service is doing

If you wanted to tail or manage the already-running runtime instead of
starting a new one, use the commands above rather than \`npm run dev\`.
```

Non-EADDRINUSE bind errors still propagate unchanged.

## Test plan

- [x] `npx eslint src/app/bootstrap.ts` clean
- [x] `npx tsc --noEmit` clean
- [ ] CI quality-gate green
- [ ] Main CI green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)