### PR TITLE
feat(init): chain provider enrollment into memphis init

### DIFF
--- a/src/infra/cli/commands/provider.ts
+++ b/src/infra/cli/commands/provider.ts
@@ -7,7 +7,7 @@ import { upsertEnvVars } from '../../config/env-file.js';
 import type { CliContext } from '../context.js';
 import { print } from '../utils/render.js';
 
-async function promptHiddenSecret(label: string): Promise<string> {
+export async function promptHiddenSecret(label: string): Promise<string> {
   const stdin = process.stdin;
   const stdout = process.stdout;
   if (!stdin.isTTY) {
@@ -54,7 +54,7 @@ async function promptHiddenSecret(label: string): Promise<string> {
   });
 }
 
-type ProviderName =
+export type ProviderName =
   | 'anthropic'
   | 'minimax'
   | 'deepseek'
@@ -98,9 +98,9 @@ const PROVIDERS: Record<ProviderName, ProviderConfig> = {
   },
 };
 
-const SUPPORTED_PROVIDERS = Object.keys(PROVIDERS) as ProviderName[];
+export const SUPPORTED_PROVIDERS = Object.keys(PROVIDERS) as ProviderName[];
 
-type ProviderAddResult = {
+export type ProviderAddResult = {
   ok: boolean;
   provider: ProviderName;
   vaultKey: string;
@@ -109,6 +109,72 @@ type ProviderAddResult = {
   message: string;
   nextSteps?: string[];
 };
+
+export async function enrollProviderKey(
+  provider: ProviderName,
+  apiKey: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ProviderAddResult> {
+  if (!SUPPORTED_PROVIDERS.includes(provider)) {
+    throw new Error(
+      `Unsupported provider: ${provider}. Supported: ${SUPPORTED_PROVIDERS.join(', ')}`,
+    );
+  }
+  if (!apiKey) {
+    throw new Error('API key cannot be empty.');
+  }
+  if (apiKey.length < 8) {
+    throw new Error('API key appears to be invalid (too short)');
+  }
+
+  const config = PROVIDERS[provider];
+
+  try {
+    storeVaultSecret(
+      config.vaultKey,
+      apiKey,
+      { surface: 'cli', command: 'provider add' },
+      env,
+    );
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    if (error.includes('vault not initialized')) {
+      throw new Error(
+        'Vault is not initialized. Run "memphis vault init" first, then retry this command.',
+      );
+    }
+    throw err;
+  }
+
+  const envRefValue = renderEnvRefValue(provider);
+  const envUpdate = upsertEnvVars([{ key: config.envRef.envKey, value: envRefValue }]);
+
+  const nextSteps: string[] = [];
+  if (provider === 'anthropic') {
+    nextSteps.push(
+      '# Anthropic OAuth is preferred over API key — if you have not yet:',
+      'memphis auth anthropic',
+    );
+  }
+  if (provider === 'shared-llm' || provider === 'decentralized-llm') {
+    const baseEnv =
+      provider === 'shared-llm' ? 'SHARED_LLM_API_BASE' : 'DECENTRALIZED_LLM_API_BASE';
+    nextSteps.push(
+      `# ${provider} also needs ${baseEnv} set in .env to reach the remote endpoint.`,
+    );
+  }
+  nextSteps.push('memphis doctor        # verify the configuration');
+
+  return {
+    ok: true,
+    provider,
+    vaultKey: config.vaultKey,
+    envPath: envUpdate.path,
+    envRef: `${config.envRef.envKey}=${envRefValue}`,
+    message: `${provider} API key stored encrypted in vault; ${config.envRef.envKey} reference written to ${envUpdate.path}`,
+    nextSteps,
+  };
+}
 
 function renderEnvRefValue(provider: ProviderName): string {
   const cfg = PROVIDERS[provider];
@@ -160,72 +226,18 @@ export async function handleProviderCommand(context: CliContext): Promise<boolea
       apiKey = await promptHiddenSecret(`${provider} API key`);
     }
 
-    if (!apiKey) {
-      throw new Error('API key cannot be empty.');
-    }
-
-    if (apiKey.length < 8) {
-      throw new Error('API key appears to be invalid (too short)');
-    }
-
-    const config = PROVIDERS[provider];
-
-    try {
-      storeVaultSecret(
-        config.vaultKey,
-        apiKey,
-        { surface: 'cli', command: 'provider add' },
-        process.env,
-      );
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      if (error.includes('vault not initialized')) {
-        throw new Error(
-          'Vault is not initialized. Run "memphis vault init" first, then retry this command.',
-        );
-      }
-      throw err;
-    }
-
-    const envRefValue = renderEnvRefValue(provider);
-    const envUpdate = upsertEnvVars([{ key: config.envRef.envKey, value: envRefValue }]);
-
-    const nextSteps: string[] = [];
-    if (provider === 'anthropic') {
-      nextSteps.push(
-        '# Anthropic OAuth is preferred over API key — if you have not yet:',
-        'memphis auth anthropic',
-      );
-    }
-    if (provider === 'shared-llm' || provider === 'decentralized-llm') {
-      const baseEnv =
-        provider === 'shared-llm' ? 'SHARED_LLM_API_BASE' : 'DECENTRALIZED_LLM_API_BASE';
-      nextSteps.push(
-        `# ${provider} also needs ${baseEnv} set in .env to reach the remote endpoint.`,
-      );
-    }
-    nextSteps.push('memphis doctor        # verify the configuration');
-
-    const result: ProviderAddResult = {
-      ok: true,
-      provider,
-      vaultKey: config.vaultKey,
-      envPath: envUpdate.path,
-      envRef: `${config.envRef.envKey}=${envRefValue}`,
-      message: `${provider} API key stored encrypted in vault; ${config.envRef.envKey} reference written to ${envUpdate.path}`,
-      nextSteps,
-    };
+    const result = await enrollProviderKey(provider, apiKey, process.env);
 
     if (!json) {
       console.log(chalk.green.bold('\n✓ Provider configured successfully\n'));
       console.log(`  Provider: ${chalk.cyan(provider)}`);
-      console.log(`  Vault key: ${chalk.gray(config.vaultKey)}`);
+      console.log(`  Vault key: ${chalk.gray(result.vaultKey)}`);
       console.log(`  Env ref: ${chalk.gray(result.envRef)}`);
-      console.log(`  Env file: ${chalk.gray(envUpdate.path)}`);
+      console.log(`  Env file: ${chalk.gray(result.envPath)}`);
       console.log(chalk.gray('\n  API key stored encrypted in vault, not in .env.'));
-      if (nextSteps.length > 0) {
+      if (result.nextSteps && result.nextSteps.length > 0) {
         console.log('\n  Next steps:');
-        for (const step of nextSteps) console.log(`    ${step}`);
+        for (const step of result.nextSteps) console.log(`    ${step}`);
       }
       console.log();
     }

--- a/src/infra/cli/commands/setup.ts
+++ b/src/infra/cli/commands/setup.ts
@@ -32,6 +32,12 @@ import { repairRuntimeState, type RuntimeRepairResult } from '../../runtime/runt
 import { buildSecretAwareness, type SecretAwareness } from '../../secret-awareness.js';
 import type { CliContext } from '../context.js';
 import {
+  enrollProviderKey,
+  promptHiddenSecret,
+  SUPPORTED_PROVIDERS,
+  type ProviderName,
+} from './provider.js';
+import {
   generateSecureToken as generateApiToken,
   generateVaultPepper,
   normalizeDataDirectory,
@@ -700,6 +706,7 @@ type InitCommandResult = {
   summary: string;
   warnings: string[];
   nextSteps: string[];
+  enrolledProviders?: ProviderName[];
 };
 
 function createRl(): readline.Interface {
@@ -935,6 +942,51 @@ async function ensureVaultForInit(
   }
 }
 
+async function maybeEnrollProvidersForInit(
+  rl: readline.Interface | null,
+  context: CliContext,
+  nextSteps: string[],
+): Promise<ProviderName[]> {
+  if (!rl || isNonInteractiveInit(context)) return [];
+
+  const wantsEnrollment = await askYesNo(
+    rl,
+    'Enroll a provider API key now? (vault is ready; keys go in encrypted)',
+    false,
+  );
+  if (!wantsEnrollment) return [];
+
+  const enrolled: ProviderName[] = [];
+  while (true) {
+    const provider = await askChoice(
+      rl,
+      'Provider',
+      [...SUPPORTED_PROVIDERS, 'skip'] as const,
+      'skip',
+    );
+    if (provider === 'skip') break;
+
+    try {
+      const apiKey = await promptHiddenSecret(`${provider} API key`);
+      const result = await enrollProviderKey(provider as ProviderName, apiKey, process.env);
+      console.log(`  ✓ ${result.message}`);
+      enrolled.push(provider as ProviderName);
+      for (const step of result.nextSteps ?? []) {
+        if (step.startsWith('#')) continue;
+        if (!nextSteps.includes(step)) nextSteps.push(step);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.log(`  ✗ Provider enrollment failed: ${message}`);
+    }
+
+    const wantsAnother = await askYesNo(rl, 'Enroll another provider?', false);
+    if (!wantsAnother) break;
+  }
+
+  return enrolled;
+}
+
 async function promptFirstRunMode(
   rl: readline.Interface | null,
   context: CliContext,
@@ -1151,6 +1203,7 @@ async function runInitCommand(context: CliContext): Promise<InitCommandResult> {
   try {
     await ensureOperatorPassphraseForInit(rl, context, warnings);
     await ensureVaultForInit(rl, context);
+    const enrolledProviders = await maybeEnrollProvidersForInit(rl, context, nextSteps);
 
     const mode = await promptFirstRunMode(rl, context);
     const preview =
@@ -1210,6 +1263,7 @@ async function runInitCommand(context: CliContext): Promise<InitCommandResult> {
       summary: applied.summary,
       warnings,
       nextSteps,
+      enrolledProviders,
     };
   } finally {
     rl?.close();

--- a/tests/unit/cli.provider-enroll.test.ts
+++ b/tests/unit/cli.provider-enroll.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/security/vault-boundary.js', () => ({
+  storeVaultSecret: vi.fn(),
+}));
+
+vi.mock('../../src/infra/config/env-file.js', () => ({
+  upsertEnvVars: vi.fn(() => ({ path: '/tmp/.env', updated: [], added: [] })),
+}));
+
+import { enrollProviderKey } from '../../src/infra/cli/commands/provider.js';
+import { upsertEnvVars } from '../../src/infra/config/env-file.js';
+import { storeVaultSecret } from '../../src/security/vault-boundary.js';
+
+const mockedStore = vi.mocked(storeVaultSecret);
+const mockedUpsert = vi.mocked(upsertEnvVars);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUpsert.mockReturnValue({
+    path: '/tmp/.env',
+    updated: [],
+    added: [],
+  } as unknown as ReturnType<typeof upsertEnvVars>);
+});
+
+describe('enrollProviderKey', () => {
+  it('stores vault secret and upserts env ref for a vault-key provider', async () => {
+    const result = await enrollProviderKey('anthropic', 'sk-ant-very-long-key', {});
+    expect(result.ok).toBe(true);
+    expect(result.vaultKey).toBe('anthropic_api_key');
+    expect(result.envRef).toBe('ANTHROPIC_VAULT_KEY=anthropic_api_key');
+    expect(mockedStore).toHaveBeenCalledWith(
+      'anthropic_api_key',
+      'sk-ant-very-long-key',
+      expect.objectContaining({ surface: 'cli', command: 'provider add' }),
+      expect.anything(),
+    );
+    expect(mockedUpsert).toHaveBeenCalledWith([
+      { key: 'ANTHROPIC_VAULT_KEY', value: 'anthropic_api_key' },
+    ]);
+    expect(result.nextSteps?.some((s) => s.includes('memphis auth anthropic'))).toBe(true);
+  });
+
+  it('uses VAULT: prefix style for shared-llm', async () => {
+    const result = await enrollProviderKey('shared-llm', 'shared-key-1234567', {});
+    expect(result.envRef).toBe('SHARED_LLM_API_KEY=VAULT:shared_llm_api_key');
+    expect(result.nextSteps?.some((s) => s.includes('SHARED_LLM_API_BASE'))).toBe(true);
+  });
+
+  it('rejects an unsupported provider', async () => {
+    await expect(
+      enrollProviderKey('openai' as Parameters<typeof enrollProviderKey>[0], 'key12345', {}),
+    ).rejects.toThrow(/Unsupported provider: openai/);
+    expect(mockedStore).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty or short api key', async () => {
+    await expect(enrollProviderKey('minimax', '', {})).rejects.toThrow(/cannot be empty/);
+    await expect(enrollProviderKey('minimax', 'short', {})).rejects.toThrow(/too short/);
+    expect(mockedStore).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a vault-not-initialized error with a friendly hint', async () => {
+    mockedStore.mockImplementation(() => {
+      throw new Error('vault not initialized');
+    });
+    await expect(enrollProviderKey('minimax', 'valid-key-1234', {})).rejects.toThrow(
+      /memphis vault init/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `enrollProviderKey(provider, apiKey, env)` from `provider add` so the same logic powers both that command and the init flow.
- After `ensureVaultForInit`, `memphis init` now asks **"Enroll a provider API key now?"** — default **No**, opt-in only.
- Interactive loop: pick provider (from `SUPPORTED_PROVIDERS` plus `skip`), hidden-prompt key, store in vault, offer another.
- Enrollment failures are reported and swallowed; init completes regardless.
- Provider-specific next-steps (e.g. `memphis auth anthropic`) flow into `InitCommandResult.nextSteps`.
- New `enrolledProviders` field on `InitCommandResult`.
- Non-interactive `memphis init` is unchanged (short-circuits before any prompt).

## Motivation

Until now, after a successful `memphis init` the operator had to hunt through docs for `memphis provider add <name>` to reach a working first conversation. That's one of the most common "what next?" moments during onboarding. Chaining the enrollment step keeps the installation → running-model path a single command flow, while keeping each provider opt-in (no surprise prompts).

## Test plan

- [x] `npx vitest run tests/unit/cli.provider-enroll.test.ts` — 5 new tests pass (happy path, `shared-llm` VAULT: style, unsupported provider, short/empty key, vault-not-initialized friendly error).
- [x] `npx vitest run tests/unit/setup.command.test.ts tests/unit/cli.provider.test.ts` — existing tests still pass.
- [x] `npx eslint` + `tsc --noEmit` clean.
- [ ] CI quality-gate green.
- [ ] Main CI green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)