### PR TITLE
feat(setup): memphis setup telegram wizard

### DIFF
--- a/src/infra/cli/commands/setup-telegram.ts
+++ b/src/infra/cli/commands/setup-telegram.ts
@@ -1,0 +1,201 @@
+/**
+ * Memphis Telegram Channel Setup Wizard
+ *
+ * Usage:
+ *   memphis setup telegram --bot-token <token> [--allowed-user-ids <csv>] [--json]
+ *
+ * Stores the bot token in vault, writes vault-backed env references,
+ * and (by default) probes api.telegram.org/getMe to verify the token.
+ * Mirrors the envelope pattern of `memphis setup matrix` but targets
+ * the much smaller Telegram surface: no Docker, no registration step.
+ */
+
+import { probeVaultCipherCycle, storeVaultSecret } from '../../../security/vault-boundary.js';
+import { upsertEnvVars } from '../../config/env-file.js';
+import type { CliContext } from '../context.js';
+import { print } from '../utils/render.js';
+
+export type TelegramSetupOptions = {
+  botToken?: string;
+  allowedUserIds?: string;
+  skipProbe?: boolean;
+  json?: boolean;
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type TelegramSetupResult = {
+  ok: boolean;
+  vaultKey: string;
+  envPath: string;
+  envRefs: string[];
+  botInfo?: { id: number; username: string };
+  probeAttempted: boolean;
+  allowedUserIds: string[];
+  warnings: string[];
+  manualSteps: string[];
+};
+
+const VAULT_KEY = 'telegram_bot_token';
+const BOT_TOKEN_SHAPE = /^\d{5,}:[A-Za-z0-9_-]{20,}$/;
+
+function parseUserIds(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+async function probeGetMe(
+  token: string,
+  fetchImpl: typeof fetch,
+): Promise<{ id: number; username: string } | undefined> {
+  try {
+    const resp = await fetchImpl(`https://api.telegram.org/bot${token}/getMe`);
+    if (!resp.ok) return undefined;
+    const data = (await resp.json()) as {
+      ok: boolean;
+      result?: { id: number; username: string };
+    };
+    return data.ok && data.result ? { id: data.result.id, username: data.result.username } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function runTelegramSetup(
+  options: TelegramSetupOptions,
+): Promise<TelegramSetupResult> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const botToken = options.botToken?.trim();
+  if (!botToken) {
+    throw new Error(
+      'memphis setup telegram requires --bot-token <token> (get one from @BotFather on Telegram).',
+    );
+  }
+
+  const warnings: string[] = [];
+  const manualSteps: string[] = [];
+
+  if (!BOT_TOKEN_SHAPE.test(botToken)) {
+    warnings.push(
+      'Bot token does not match the expected `<id>:<secret>` shape from @BotFather. Continuing anyway — verify with `memphis telegram status`.',
+    );
+  }
+
+  const rawIds = options.allowedUserIds?.trim() ?? '';
+  const allowedUserIds = rawIds ? parseUserIds(rawIds) : [];
+  for (const id of allowedUserIds) {
+    if (!/^\d+$/.test(id)) {
+      throw new Error(`Invalid allowed user id: "${id}". Telegram user IDs are numeric.`);
+    }
+  }
+  if (allowedUserIds.length === 0) {
+    warnings.push(
+      'No --allowed-user-ids set. The bot will reject every inbound message until MEMPHIS_TELEGRAM_ALLOWED_USER_IDS is populated.',
+    );
+  }
+
+  const probe = probeVaultCipherCycle({ surface: 'cli', command: 'setup telegram' }, env);
+  if (!probe.ok) {
+    throw new Error(
+      `Vault is not ready for secret storage: ${probe.error}. Run \`memphis init\` first to provision the vault.`,
+    );
+  }
+
+  let botInfo: TelegramSetupResult['botInfo'];
+  const probeAttempted = !options.skipProbe;
+  if (probeAttempted) {
+    botInfo = await probeGetMe(botToken, fetchImpl);
+    if (!botInfo) {
+      warnings.push(
+        'Could not verify the bot via https://api.telegram.org/bot<token>/getMe. The token is stored anyway; rerun `memphis telegram smoke-test` once the network is reachable.',
+      );
+    }
+  }
+
+  storeVaultSecret(VAULT_KEY, botToken, { surface: 'cli', command: 'setup telegram' }, env);
+
+  const envUpdates = [{ key: 'MEMPHIS_TELEGRAM_BOT_TOKEN', value: `VAULT:${VAULT_KEY}` }];
+  if (allowedUserIds.length > 0) {
+    envUpdates.push({
+      key: 'MEMPHIS_TELEGRAM_ALLOWED_USER_IDS',
+      value: allowedUserIds.join(','),
+    });
+  }
+  const envUpdate = upsertEnvVars(envUpdates);
+
+  manualSteps.push(
+    'Enable the channel gateway if not already: set MEMPHIS_CHANNEL_GATEWAY_ENABLED=true in .env',
+    'Restart Memphis so the gateway picks up the new token:',
+    '  memphis service restart        # systemd user service path',
+    '  # or Ctrl-C + `npm run dev`    # dev session path',
+    'Verify delivery end-to-end: memphis telegram smoke-test',
+  );
+  if (allowedUserIds.length === 0) {
+    manualSteps.push(
+      'When you know your Telegram user id (send /start to your bot, watch the logs), rerun:',
+      '  memphis setup telegram --bot-token <same-token> --allowed-user-ids <id1,id2>',
+    );
+  }
+
+  return {
+    ok: true,
+    vaultKey: VAULT_KEY,
+    envPath: envUpdate.path,
+    envRefs: envUpdates.map((u) => `${u.key}=${u.value}`),
+    botInfo,
+    probeAttempted,
+    allowedUserIds,
+    warnings,
+    manualSteps,
+  };
+}
+
+export async function handleTelegramSetupCommand(context: CliContext): Promise<boolean> {
+  const { command, subcommand, json, botToken, allowedUserIds } = context.args;
+  if (command !== 'setup' || subcommand !== 'telegram') return false;
+
+  try {
+    const result = await runTelegramSetup({
+      botToken,
+      allowedUserIds,
+      json: Boolean(json),
+    });
+
+    if (json) {
+      print(result, true);
+    } else {
+      console.log('\n✓ Telegram channel configured');
+      console.log(`  Vault key:  ${result.vaultKey}`);
+      console.log(`  Env file:   ${result.envPath}`);
+      for (const ref of result.envRefs) console.log(`  ${ref}`);
+      if (result.botInfo) {
+        console.log(`  Bot reached: @${result.botInfo.username} (${result.botInfo.id})`);
+      }
+      if (result.warnings.length > 0) {
+        console.log('\n  Warnings:');
+        for (const w of result.warnings) console.log(`    • ${w}`);
+      }
+      if (result.manualSteps.length > 0) {
+        console.log('\n  Next steps:');
+        for (const step of result.manualSteps) console.log(`    ${step}`);
+      }
+      console.log('');
+    }
+
+    process.exitCode = result.ok ? 0 : 1;
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (json) {
+      print({ ok: false, error: message }, true);
+    } else {
+      console.error(`\n❌ Telegram setup failed: ${message}\n`);
+    }
+    process.exitCode = 1;
+    return true;
+  }
+}

--- a/src/infra/cli/commands/setup.ts
+++ b/src/infra/cli/commands/setup.ts
@@ -37,6 +37,7 @@ import {
   SUPPORTED_PROVIDERS,
   type ProviderName,
 } from './provider.js';
+import { handleTelegramSetupCommand } from './setup-telegram.js';
 import {
   generateSecureToken as generateApiToken,
   generateVaultPepper,
@@ -1286,9 +1287,12 @@ export async function handleSetupCommand(
     process.exitCode = status.state === 'initialized-clean' ? 0 : 1;
     return true;
   }
+  if (command === 'setup' && subcommand === 'telegram') {
+    return handleTelegramSetupCommand(context);
+  }
   if (subcommand) {
     throw new Error(
-      `${command} supports only: ${command} [--state <mode>] [--non-interactive] [--operator-passphrase <secret>] [--passphrase <secret>] [--recovery-question <q>] [--recovery-answer <a>] [--json] | ${command} status [--json]`,
+      `${command} supports only: ${command} [--state <mode>] [--non-interactive] [--operator-passphrase <secret>] [--passphrase <secret>] [--recovery-question <q>] [--recovery-answer <a>] [--json] | ${command} status [--json] | setup telegram --bot-token <token> [--allowed-user-ids <csv>] [--json]`,
     );
   }
   if (out || force) {

--- a/tests/unit/setup-telegram.test.ts
+++ b/tests/unit/setup-telegram.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/security/vault-boundary.js', () => ({
+  storeVaultSecret: vi.fn(),
+  probeVaultCipherCycle: vi.fn(() => ({ ok: true })),
+}));
+
+vi.mock('../../src/infra/config/env-file.js', () => ({
+  upsertEnvVars: vi.fn(() => ({ path: '/tmp/.env', updated: [], added: [] })),
+}));
+
+import { runTelegramSetup } from '../../src/infra/cli/commands/setup-telegram.js';
+import { upsertEnvVars } from '../../src/infra/config/env-file.js';
+import {
+  probeVaultCipherCycle,
+  storeVaultSecret,
+} from '../../src/security/vault-boundary.js';
+
+const mockedStore = vi.mocked(storeVaultSecret);
+const mockedProbe = vi.mocked(probeVaultCipherCycle);
+const mockedUpsert = vi.mocked(upsertEnvVars);
+
+function makeFetchOk(botInfo: { id: number; username: string }): typeof fetch {
+  return (async () => ({
+    ok: true,
+    async json() {
+      return { ok: true, result: botInfo };
+    },
+  })) as unknown as typeof fetch;
+}
+
+function makeFetchFail(): typeof fetch {
+  return (async () => ({
+    ok: false,
+    async json() {
+      return { ok: false };
+    },
+  })) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedProbe.mockReturnValue({ ok: true });
+  mockedUpsert.mockReturnValue({
+    path: '/tmp/.env',
+    updated: [],
+    added: [],
+  } as unknown as ReturnType<typeof upsertEnvVars>);
+});
+
+describe('runTelegramSetup', () => {
+  it('stores token in vault, writes env refs, and reports bot info on happy path', async () => {
+    const result = await runTelegramSetup({
+      botToken: '1234567:AAAaaa-bbb-ccc-ddd-eee-fff-ggg-hhh',
+      allowedUserIds: '111111, 222222',
+      fetchImpl: makeFetchOk({ id: 42, username: 'memphis_bot' }),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.vaultKey).toBe('telegram_bot_token');
+    expect(result.botInfo).toEqual({ id: 42, username: 'memphis_bot' });
+    expect(result.allowedUserIds).toEqual(['111111', '222222']);
+    expect(result.envRefs).toContain('MEMPHIS_TELEGRAM_BOT_TOKEN=VAULT:telegram_bot_token');
+    expect(result.envRefs).toContain('MEMPHIS_TELEGRAM_ALLOWED_USER_IDS=111111,222222');
+    expect(mockedStore).toHaveBeenCalledWith(
+      'telegram_bot_token',
+      '1234567:AAAaaa-bbb-ccc-ddd-eee-fff-ggg-hhh',
+      expect.objectContaining({ surface: 'cli', command: 'setup telegram' }),
+      expect.anything(),
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('warns when bot token shape is off', async () => {
+    const result = await runTelegramSetup({
+      botToken: 'not-a-telegram-token',
+      allowedUserIds: '1',
+      skipProbe: true,
+    });
+    expect(result.warnings.some((w) => w.includes('<id>:<secret>'))).toBe(true);
+  });
+
+  it('warns when no allowed user ids are provided', async () => {
+    const result = await runTelegramSetup({
+      botToken: '1234567:AAAaaa-bbb-ccc-ddd-eee-fff-ggg-hhh',
+      skipProbe: true,
+    });
+    expect(result.allowedUserIds).toEqual([]);
+    expect(result.warnings.some((w) => w.includes('MEMPHIS_TELEGRAM_ALLOWED_USER_IDS'))).toBe(true);
+    expect(result.manualSteps.some((s) => s.includes('memphis setup telegram'))).toBe(true);
+  });
+
+  it('rejects non-numeric allowed user ids', async () => {
+    await expect(
+      runTelegramSetup({
+        botToken: '1234567:AAAaaa-bbb-ccc-ddd-eee-fff-ggg-hhh',
+        allowedUserIds: '111,abc',
+        skipProbe: true,
+      }),
+    ).rejects.toThrow(/numeric/);
+  });
+
+  it('requires --bot-token', async () => {
+    await expect(runTelegramSetup({})).rejects.toThrow(/--bot-token/);
+  });
+
+  it('fails fast when vault is not ready', async () => {
+    mockedProbe.mockReturnValue({ ok: false, error: 'vault not initialized' });
+    await expect(
+      runTelegramSetup({
+        botToken: '1234567:AAAaaa-bbb-ccc-ddd-eee-fff-ggg-hhh',
+        allowedUserIds: '111',
+        skipProbe: true,
+      }),
+    ).rejects.toThrow(/memphis init/);
+  });
+
+  it('warns when the getMe probe cannot verify the token', async () => {
+    const result = await runTelegramSetup({
+      botToken: '1234567:AAAaaa-bbb-ccc-ddd-eee-fff-ggg-hhh',
+      allowedUserIds: '111',
+      fetchImpl: makeFetchFail(),
+    });
+    expect(result.botInfo).toBeUndefined();
+    expect(result.warnings.some((w) => w.includes('getMe'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

New `memphis setup telegram` command — a guided wizard that complements the existing `memphis telegram configure` with stricter validation and a live getMe probe against api.telegram.org.

- `src/infra/cli/commands/setup-telegram.ts` with `runTelegramSetup` (programmatic) and `handleTelegramSetupCommand` (CLI dispatch), mirroring the shape of `memphis setup matrix`.
- Validates token shape (`<id>:<secret>` from @BotFather), allowed user IDs (numeric), vault readiness before any write, and probes https://api.telegram.org/bot<token>/getMe to verify the token before closing the session.
- Gracefully degrades if the probe fails — warns but still stores the token so an offline setup is usable.
- Writes vault-backed env refs via `upsertEnvVars` (no duplicate-line bugs on re-runs).
- Wired into `handleSetupCommand` on `setup telegram`; updated the usage error message to advertise the new path.

## Motivation

`memphis telegram configure` exists but is low-visibility and requires both flags simultaneously with no help about what a valid token or user id looks like. Operators hitting the Telegram onboarding step for the first time tend to paste a malformed token and get a silent failure when a message arrives hours later.

This wizard fails fast with an explicit warning on a bad token shape, verifies the bot actually exists via getMe, and hands back a copy-pasteable list of next-steps (enable channel gateway, restart service, run smoke test).

## Test plan

- [x] 7 new unit tests (`setup-telegram.test.ts`): happy path, bad-token-shape warning, missing-allow-list warning, non-numeric id rejection, missing token, vault-not-ready, getMe probe failure.
- [x] Existing `setup.command.test.ts` still passes.
- [x] `npx eslint` + `tsc --noEmit` clean.
- [ ] CI quality-gate green.
- [ ] Main CI green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)