### PR TITLE
fix(test): retry rmSync on ENOTEMPTY/EBUSY in empty-blocks-handling

### DIFF
--- a/tests/cognitive/empty-blocks-handling.test.ts
+++ b/tests/cognitive/empty-blocks-handling.test.ts
@@ -23,6 +23,18 @@ beforeEach(() => {
   process.env.HOME = tmpHome;
 });
 
+function rmWithRetry(dir: string): void {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOTEMPTY' && code !== 'EBUSY') throw err;
+    }
+  }
+}
+
 afterEach(() => {
   process.env.MEMPHIS_DIR = oldMemphisDir;
   if (oldHome === undefined) {
@@ -31,10 +43,10 @@ afterEach(() => {
     process.env.HOME = oldHome;
   }
   if (tmpMemphisDir && fs.existsSync(tmpMemphisDir)) {
-    fs.rmSync(tmpMemphisDir, { recursive: true, force: true });
+    rmWithRetry(tmpMemphisDir);
   }
   if (tmpHome && fs.existsSync(tmpHome)) {
-    fs.rmSync(tmpHome, { recursive: true, force: true });
+    rmWithRetry(tmpHome);
   }
 });
 


### PR DESCRIPTION
## Context

Main CI has gone red twice in the last two pushes with the same non-deterministic teardown failure:

```
FAIL tests/cognitive/empty-blocks-handling.test.ts > Empty blocks handling > Model E handles empty history safely
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/empty-cognitive-*'
```

`fs.rmSync(dir, { recursive: true, force: true })` is documented to swallow non-empty dir errors, but under concurrent vitest workers another cleanup routine can still write into the directory between `readdir` and `rmdir`, producing ENOTEMPTY from a successor syscall that the outer call no longer retries.

This is the block for PR #205 (and the reason PR #203 needed a rerun).

## Change

- New helper `rmWithRetry(dir)` in the same test file — calls `rmSync` with `maxRetries: 3, retryDelay: 50`, then wraps that in one more explicit retry loop catching `ENOTEMPTY` and `EBUSY`.
- afterEach now calls `rmWithRetry` on both tmp dirs.

No production code change. Scope is strictly the teardown.

## Test plan

- [x] `npx vitest run tests/cognitive/empty-blocks-handling.test.ts` passes locally.
- [x] `npx eslint tests/cognitive/empty-blocks-handling.test.ts` clean.
- [ ] CI quality-gate green.
- [ ] Main CI green after merge — this PR is the reason main is red, so landing it unblocks the rest of the sprint queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)