### PR TITLE
fix(operator): surface provider error body on non-2xx HTTP status

### DIFF
--- a/crates/memphis-operator/src/provider.rs
+++ b/crates/memphis-operator/src/provider.rs
@@ -1972,9 +1972,57 @@ fn post_response(
     for (key, value) in extra_headers {
         request = request.set(key, value);
     }
-    request
-        .send_json(payload)
-        .map_err(|error| OperatorError::Message(format!("provider request failed: {error}")))
+    request.send_json(payload).map_err(|error| match error {
+        // Without this branch the caller only sees "status code 400" — ureq
+        // drops the response body that contains the provider's actual
+        // reason (e.g. Anthropic `{"type":"error","error":{...}}`).
+        // Surfacing that body turns an opaque 400 into an actionable one.
+        ureq::Error::Status(code, response) => {
+            let body = response.into_string().unwrap_or_default();
+            let hint = extract_provider_error_hint(body.as_str());
+            OperatorError::Message(format!(
+                "provider request failed: {url}: status code {code}: {hint}"
+            ))
+        }
+        other => OperatorError::Message(format!("provider request failed: {url}: {other}")),
+    })
+}
+
+/// Best-effort extraction of a human-readable reason from a provider error
+/// body. Supports the Anthropic shape (`{"type":"error","error":{"type","message"}}`)
+/// and the OpenAI-compatible shape (`{"error":{"message"}}`). Falls back to
+/// the first 200 characters of the raw body when the JSON is unexpected —
+/// an imperfect hint still beats a bare status code.
+fn extract_provider_error_hint(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "<empty body>".to_string();
+    }
+    if let Ok(parsed) = serde_json::from_str::<Value>(trimmed) {
+        if let Some(err) = parsed.get("error") {
+            let message = err
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let kind = err.get("type").and_then(Value::as_str).unwrap_or_default();
+            if !message.is_empty() || !kind.is_empty() {
+                return match (kind, message) {
+                    ("", m) => m.to_string(),
+                    (k, "") => k.to_string(),
+                    (k, m) => format!("{k}: {m}"),
+                };
+            }
+        }
+        if let Some(msg) = parsed.get("message").and_then(Value::as_str) {
+            return msg.to_string();
+        }
+    }
+    let snippet: String = trimmed.chars().take(200).collect();
+    if snippet.len() < trimmed.len() {
+        format!("{snippet}…")
+    } else {
+        snippet
+    }
 }
 
 fn post_json(
@@ -2593,5 +2641,42 @@ mod tests {
         );
 
         server.join().expect("server thread");
+    }
+
+    #[test]
+    fn extract_provider_error_hint_parses_anthropic_shape() {
+        let body = r#"{"type":"error","error":{"type":"invalid_request_error","message":"messages: at least one message is required"}}"#;
+        let hint = extract_provider_error_hint(body);
+        assert!(hint.contains("invalid_request_error"), "hint was {hint:?}");
+        assert!(hint.contains("at least one message is required"), "hint was {hint:?}");
+    }
+
+    #[test]
+    fn extract_provider_error_hint_parses_openai_shape() {
+        let body = r#"{"error":{"message":"model not found","type":"invalid_request_error","code":"model_not_found"}}"#;
+        let hint = extract_provider_error_hint(body);
+        assert!(hint.contains("model not found"), "hint was {hint:?}");
+    }
+
+    #[test]
+    fn extract_provider_error_hint_falls_back_to_snippet_on_non_json() {
+        let body = "<html><body>503 gateway timeout</body></html>";
+        let hint = extract_provider_error_hint(body);
+        assert!(hint.starts_with("<html>"), "hint was {hint:?}");
+        assert!(hint.contains("503 gateway timeout"), "hint was {hint:?}");
+    }
+
+    #[test]
+    fn extract_provider_error_hint_truncates_long_bodies() {
+        let body = "x".repeat(500);
+        let hint = extract_provider_error_hint(&body);
+        assert!(hint.ends_with('…'), "hint was {hint:?}");
+        assert!(hint.chars().count() <= 201, "hint length was {}", hint.chars().count());
+    }
+
+    #[test]
+    fn extract_provider_error_hint_handles_empty_body() {
+        assert_eq!(extract_provider_error_hint(""), "<empty body>");
+        assert_eq!(extract_provider_error_hint("   "), "<empty body>");
     }
 }


### PR DESCRIPTION
## Context

Marcin hit this in the TUI today after pulling main:

```
[Memphis] provider request failed: https://api.anthropic.com/v1/messages: status code 400
```

The error is opaque — the actual reason lives in Anthropic's JSON response body (e.g. `{"type":"error","error":{"type":"invalid_request_error","message":"..."}}`), and `format!("{error}")` on `ureq::Error::Status(code, response)` drops that body on the floor. Blind debugging from a bare "400" is a guessing game; this PR is the diagnostic step before any attempted fix.

Git history of `crates/memphis-operator/` across the last 10 main commits shows only **one** operator change (`da6c642`, PR #197, env-configurable loop limits) which is verified not to touch request shape. The regression cause is unknown and the error surface itself is blocking investigation.

## Change

- **`post_response`** (`crates/memphis-operator/src/provider.rs:1959`) now pattern-matches `ureq::Error::Status(code, response)` to read the body and fold it into the error message. Transport errors (timeout, DNS) keep the existing code path.
- **New helper `extract_provider_error_hint`** parses the two common provider error shapes:
  - Anthropic: `{"type":"error","error":{"type","message"}}` → `"<type>: <message>"`
  - OpenAI-compatible: `{"error":{"message"}}` → `"<message>"`
  - Fallback: first 200 chars of the raw body (with `…` ellipsis when truncated)
  - Empty body → `"<empty body>"`
- Both streaming (`chat_anthropic_stream`) and non-streaming (`chat_anthropic`) paths share `post_response`, so the fix covers both automatically. MiniMax/Ollama/OpenAI-compatible paths inherit it too.

## Before → After

Before:
```
provider request failed: https://api.anthropic.com/v1/messages: status code 400
```

After (example):
```
provider request failed: https://api.anthropic.com/v1/messages: status code 400: invalid_request_error: tools.12.input_schema: Field 'properties' is required
```

## Test plan

- [x] `cargo check -p memphis-operator` clean.
- [x] `cargo test -p memphis-operator --lib` — 30/30 pass, including 5 new unit tests:
  - `extract_provider_error_hint_parses_anthropic_shape`
  - `extract_provider_error_hint_parses_openai_shape`
  - `extract_provider_error_hint_falls_back_to_snippet_on_non_json`
  - `extract_provider_error_hint_truncates_long_bodies`
  - `extract_provider_error_hint_handles_empty_body`
- [ ] CI quality-gate green.
- [ ] Main CI green after merge.

## Follow-up

Once this lands and Marcin reproduces the 400 with the new verbose message, we'll open PR 2 against whatever root cause the hint points at. Likely candidates (no code changes in this PR): nested-empty-object tool schemas, system-prompt payload bloat, message-array edge case. PR 2 is scoped only after the hint is in hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)