### PR TITLE
fix(operator): send Ollama tool_call arguments as object, not string

### DIFF
--- a/crates/memphis-operator/src/provider.rs
+++ b/crates/memphis-operator/src/provider.rs
@@ -460,7 +460,7 @@ impl ProviderRuntime {
             .unwrap_or_else(|| "http://127.0.0.1:11434".to_string());
         let ollama_messages = messages
             .iter()
-            .map(message_to_provider_json)
+            .map(ollama_message_to_json)
             .collect::<Vec<_>>();
         let all_messages = if let Some(system_prompt) = opts.system_prompt.as_deref() {
             let mut combined = vec![json!({ "role": "system", "content": system_prompt })];
@@ -528,7 +528,7 @@ impl ProviderRuntime {
             .unwrap_or_else(|| "http://127.0.0.1:11434".to_string());
         let ollama_messages = messages
             .iter()
-            .map(message_to_provider_json)
+            .map(ollama_message_to_json)
             .collect::<Vec<_>>();
         let all_messages = if let Some(system_prompt) = opts.system_prompt.as_deref() {
             let mut combined = vec![json!({ "role": "system", "content": system_prompt })];
@@ -1600,6 +1600,29 @@ fn build_tools_json(tools: &[ChatToolDefinition]) -> Vec<Value> {
 }
 
 fn message_to_provider_json(message: &ChatMessage) -> Value {
+    build_message_json(message, ProviderMessageStyle::OpenAiCompatible)
+}
+
+/// Ollama's /api/chat accepts a superset of the OpenAI shape, but with one
+/// critical difference: tool-call `arguments` must be a JSON **object**, not
+/// a stringified JSON. Sending the OpenAI-style string produces:
+///
+///   400 {"error":"Value looks like object, but can't find closing '}' symbol"}
+///
+/// because Ollama's Go parser then tries to parse the string as an object
+/// and fails on quote-escape boundaries. Observed on operator WSL 2026-04-21
+/// after the previous session left assistant tool_call rows in history.
+fn ollama_message_to_json(message: &ChatMessage) -> Value {
+    build_message_json(message, ProviderMessageStyle::Ollama)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ProviderMessageStyle {
+    OpenAiCompatible,
+    Ollama,
+}
+
+fn build_message_json(message: &ChatMessage, style: ProviderMessageStyle) -> Value {
     match message {
         ChatMessage::System { content } => {
             json!({ "role": "system", "content": sanitize_for_json(content) })
@@ -1619,14 +1642,23 @@ fn message_to_provider_json(message: &ChatMessage) -> Value {
                     "content": if content.is_empty() { Value::Null } else { Value::String(content.clone()) },
                     "tool_calls": tool_calls
                         .iter()
-                        .map(|call| json!({
-                            "id": call.id,
-                            "type": "function",
-                            "function": {
-                                "name": call.name,
-                                "arguments": serde_json::to_string(&call.arguments).unwrap_or_else(|_| "{}".to_string()),
-                            }
-                        }))
+                        .map(|call| {
+                            let arguments: Value = match style {
+                                ProviderMessageStyle::OpenAiCompatible => Value::String(
+                                    serde_json::to_string(&call.arguments)
+                                        .unwrap_or_else(|_| "{}".to_string()),
+                                ),
+                                ProviderMessageStyle::Ollama => call.arguments.clone(),
+                            };
+                            json!({
+                                "id": call.id,
+                                "type": "function",
+                                "function": {
+                                    "name": call.name,
+                                    "arguments": arguments,
+                                }
+                            })
+                        })
                         .collect::<Vec<_>>(),
                 })
             }
@@ -2678,5 +2710,57 @@ mod tests {
     fn extract_provider_error_hint_handles_empty_body() {
         assert_eq!(extract_provider_error_hint(""), "<empty body>");
         assert_eq!(extract_provider_error_hint("   "), "<empty body>");
+    }
+
+    #[test]
+    fn openai_compatible_serializes_tool_call_arguments_as_string() {
+        let msg = ChatMessage::Assistant {
+            content: String::new(),
+            tool_calls: vec![ChatToolCall {
+                id: "call_1".to_string(),
+                name: "memphis_recall".to_string(),
+                arguments: json!({"query": "hello"}),
+            }],
+        };
+        let out = message_to_provider_json(&msg);
+        let args = out
+            .pointer("/tool_calls/0/function/arguments")
+            .expect("arguments present");
+        assert!(args.is_string(), "OpenAI style expects stringified args; got {args:?}");
+        assert_eq!(args.as_str().unwrap(), r#"{"query":"hello"}"#);
+    }
+
+    #[test]
+    fn ollama_serializes_tool_call_arguments_as_object() {
+        let msg = ChatMessage::Assistant {
+            content: String::new(),
+            tool_calls: vec![ChatToolCall {
+                id: "call_1".to_string(),
+                name: "memphis_recall".to_string(),
+                arguments: json!({"query": "hello"}),
+            }],
+        };
+        let out = ollama_message_to_json(&msg);
+        let args = out
+            .pointer("/tool_calls/0/function/arguments")
+            .expect("arguments present");
+        assert!(args.is_object(), "Ollama expects object args; got {args:?}");
+        assert_eq!(args.get("query").and_then(Value::as_str), Some("hello"));
+    }
+
+    #[test]
+    fn ollama_and_openai_agree_on_non_tool_messages() {
+        for msg in [
+            ChatMessage::System { content: "hi".to_string() },
+            ChatMessage::User { content: "yo".to_string() },
+            ChatMessage::Tool {
+                tool_call_id: "call_x".to_string(),
+                content: "ok".to_string(),
+            },
+        ] {
+            let oai = message_to_provider_json(&msg);
+            let oll = ollama_message_to_json(&msg);
+            assert_eq!(oai, oll, "non-tool-call messages must be identical across styles");
+        }
     }
 }


### PR DESCRIPTION
## Context

Marcin swapped the TUI to Ollama after Anthropic billing ran out and MiniMax tripped on Bug #208. Ollama rejects the very first turn with:

```
provider request failed: http://127.0.0.1:11434/api/chat: status code 400:
{"error":"Value looks like object, but can't find closing '}' symbol"}
```

## Root cause

`message_to_provider_json` in `crates/memphis-operator/src/provider.rs:1602` (pre-PR) serialized assistant `tool_calls[].function.arguments` as a JSON **string** — the OpenAI spec requirement:

```rust
"arguments": serde_json::to_string(&call.arguments).unwrap_or_else(|_| "{}".to_string())
```

MiniMax, DeepSeek, and GLM all follow OpenAI and accept that. **Ollama does not.** Ollama's `/api/chat` wants `arguments` to be a JSON object directly. When it receives the stringified form, its Go-side parser tries to re-parse the string as an object and blows up on the escape boundaries — hence the very specific "looks like object, but can't find closing `}`" diagnostic.

Every Ollama chat whose session history contained an assistant row with `tool_calls` — i.e. any session that had previously talked to Anthropic or MiniMax — failed with this 400 on the next turn.

## Change

- Introduce a style-aware internal helper `build_message_json(msg, style)` with `ProviderMessageStyle::{OpenAiCompatible, Ollama}`.
- Thin aliases:
  - `message_to_provider_json(msg)` → OpenAI-compatible (unchanged semantics, still returns stringified arguments).
  - `ollama_message_to_json(msg)` → Ollama (returns arguments as the original `Value` object).
- `chat_ollama` + `chat_ollama_stream` switch to `ollama_message_to_json`. OpenAI-compat paths (MiniMax/DeepSeek/GLM) keep the original.
- Non-tool-call messages (system/user/tool-role) are byte-identical across styles; test pins that invariant so a future refactor doesn't accidentally drift them apart.

## Test plan

3 new unit tests in `tests mod`:

- `openai_compatible_serializes_tool_call_arguments_as_string`
- `ollama_serializes_tool_call_arguments_as_object`
- `ollama_and_openai_agree_on_non_tool_messages`

Full crate run:

```
cargo test -p memphis-operator --lib
test result: ok. 33 passed; 0 failed; 0 ignored
```

## Manual verification (post-merge)

```bash
cd ~/memphis && git pull && npm run build && memphis service restart
memphis tui
/model qwen2.5:7b
# Any message — no more "Value looks like object" 400.
```

## Relation to PR #208

PR #208 fixes a different bug (pair-aware history truncation — MiniMax `tool_use_id not found`). That PR is about **which rows load**; this PR is about **how they serialize**. Orthogonal; landing order doesn't matter. Both bugs only manifested together because Marcin exercised multiple providers against the same session history today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)