### PR TITLE
fix(runtime): name failing checks in PULSE.md heartbeat detail

### DIFF
--- a/src/infra/runtime/heartbeat-watchdog.ts
+++ b/src/infra/runtime/heartbeat-watchdog.ts
@@ -290,15 +290,36 @@ export function writeBootPulse(): void {
   });
 }
 
+/**
+ * Turn the `WatchdogCheck[]` array into a single-line detail string that
+ * names the failing checks. Example output:
+ *
+ *     warn:embed_bridge:bridge unavailable warn:memory:475/524 MB (91%)
+ *
+ * Returns `undefined` when every check is ok, so the PULSE line stays
+ * clean on healthy heartbeats.
+ */
+export function buildHeartbeatDetail(checks: WatchdogCheck[]): string | undefined {
+  const problems = checks
+    .filter((check) => check.status !== 'ok')
+    .map((check) => {
+      const hint = check.message ? `:${check.message}` : '';
+      return `${check.status}:${check.name}${hint}`;
+    });
+  return problems.length > 0 ? problems.join(' ') : undefined;
+}
+
 function writeHeartbeatPulse(heartbeat: WatchdogHeartbeat): void {
   const surfaces = getActiveSurfacesSnapshot()
     .filter((snapshot) => !snapshot.stale)
     .map((snapshot) => snapshot.surface);
+
   writePulseEvent({
     timestamp: heartbeat.timestamp,
     event: 'heartbeat',
     health: heartbeat.health,
     uptimeSeconds: heartbeat.uptimeSeconds,
     activeSurfaces: surfaces.length > 0 ? surfaces : undefined,
+    detail: buildHeartbeatDetail(heartbeat.checks),
   });
 }

--- a/tests/unit/heartbeat-watchdog-detail.test.ts
+++ b/tests/unit/heartbeat-watchdog-detail.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildHeartbeatDetail } from '../../src/infra/runtime/heartbeat-watchdog.js';
+
+describe('buildHeartbeatDetail', () => {
+  it('returns undefined when every check is ok', () => {
+    expect(
+      buildHeartbeatDetail([
+        { name: 'chain_adapter', status: 'ok' },
+        { name: 'vault_bridge', status: 'ok', message: 'rust disabled' },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it('names each failing check with its status and message', () => {
+    const detail = buildHeartbeatDetail([
+      { name: 'chain_adapter', status: 'ok' },
+      { name: 'embed_bridge', status: 'warn', message: 'bridge unavailable' },
+      { name: 'memory', status: 'warn', message: '475/524 MB (91%)' },
+    ]);
+    expect(detail).toBe('warn:embed_bridge:bridge unavailable warn:memory:475/524 MB (91%)');
+  });
+
+  it('drops the message suffix when the check has no message', () => {
+    const detail = buildHeartbeatDetail([
+      { name: 'chain_adapter', status: 'fail' },
+    ]);
+    expect(detail).toBe('fail:chain_adapter');
+  });
+
+  it('surfaces both warn and fail together', () => {
+    const detail = buildHeartbeatDetail([
+      { name: 'vault_bridge', status: 'fail', message: 'bridge unavailable' },
+      { name: 'memory', status: 'warn', message: '92%' },
+    ]);
+    expect(detail).toBe('fail:vault_bridge:bridge unavailable warn:memory:92%');
+  });
+});


### PR DESCRIPTION
## Context

Marcin keeps seeing `PULSE:degraded` in the TUI status bar but PULSE.md itself gives no clue why:

```
- 2026-04-20T23:15:07.105Z HEARTBEAT health=degraded uptime=60s
- 2026-04-20T23:24:07.296Z HEARTBEAT health=degraded uptime=601s
- 2026-04-20T23:34:07.466Z HEARTBEAT
```

The watchdog actually knows which check(s) triggered the `degraded` aggregation — it just drops that information before handing the heartbeat to `writeHeartbeatPulse`. This PR threads it into the `detail` field that `PulseEntry` already supports.

## After

```
- 2026-04-20T23:15:07.105Z HEARTBEAT health=degraded uptime=60s \
  warn:embed_bridge:bridge unavailable warn:memory:475/524 MB (91%)
```

One `tail ~/.memphis/config/PULSE.md` now answers "what's degraded?" without digging into code.

## Change

- Extract `buildHeartbeatDetail(checks)` as an exported pure function in `crates/memphis-operator-…` — wait, TS, `src/infra/runtime/heartbeat-watchdog.ts`. It maps `WatchdogCheck[]` → a compact `"<status>:<name>[:<message>] "-joined` string, or `undefined` when every check is ok.
- `writeHeartbeatPulse` passes the result as `detail`. Healthy heartbeats stay silent (detail absent), so the format doesn't bloat when nothing is wrong.
- Shape is stable and machine-readable: status words come from the enum `ok | warn | fail`, names come from the fixed check list, and the optional message is whatever the check author put in.

## Test plan

4 unit tests in `tests/unit/heartbeat-watchdog-detail.test.ts`:
- all-ok returns `undefined`
- multi-warn formats with messages
- missing-message check falls back to `status:name`
- mixed warn+fail preserves order and status words

`npx eslint` + `tsc --noEmit` clean.

## Follow-up

Once Marcin's next degraded heartbeat fires with the detail in place, he'll see exactly which check warns. Expected suspects given his setup (PR #210 landed, rust bridge loaded): `embed_bridge` warming up OR `memory` > 90% heap ratio. Targeted fix follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)