### PR TITLE
fix(operator): strip <think>…</think> reasoning blocks from model output

### DIFF
--- a/crates/memphis-operator/src/chat.rs
+++ b/crates/memphis-operator/src/chat.rs
@@ -24,6 +24,7 @@ use crate::{
         ChatStreamEvent, ChatToolCall, ChatToolDefinition, ProviderStatus, TokenUsageSummary,
     },
     runtime::{MemoryQueryResult, OperatorRuntime, SearchMode},
+    think_stripper::{strip_think_blocks, ThinkStripper},
     OperatorError,
 };
 
@@ -291,12 +292,22 @@ impl OperatorRuntime {
         loop {
             ensure_chat_not_cancelled(cancel_flag)?;
             let mut stream_guard = StreamingOutputGuard::new();
+            let mut think_stripper = ThinkStripper::new();
             let mut stream_sink = |event: ChatStreamEvent| match event {
                 ChatStreamEvent::Text(chunk) => {
+                    // Reasoning-model <think>…</think> blocks are the model's
+                    // internal deliberation and must not reach the TUI. Strip
+                    // them out of the live stream before StreamingOutputGuard
+                    // sees them so the operator only watches the final answer
+                    // render.
+                    let visible = think_stripper.push(chunk.as_str());
+                    if visible.is_empty() {
+                        return;
+                    }
                     let mut emit_text = |text: &str| {
                         on_chunk(ChatStreamEvent::Text(text.to_string()));
                     };
-                    stream_guard.push(chunk.as_str(), &mut emit_text);
+                    stream_guard.push(visible.as_str(), &mut emit_text);
                 }
                 ChatStreamEvent::Usage(usage) => on_chunk(ChatStreamEvent::Usage(usage)),
             };
@@ -310,7 +321,16 @@ impl OperatorRuntime {
             let mut emit_text = |text: &str| {
                 on_chunk(ChatStreamEvent::Text(text.to_string()));
             };
+            let think_tail = think_stripper.finalize();
+            if !think_tail.is_empty() {
+                stream_guard.push(think_tail.as_str(), &mut emit_text);
+            }
             completion.content = stream_guard.finish(self, "rust-tui", &mut emit_text)?;
+            // Belt and suspenders: if the non-streaming path was taken OR a
+            // provider delivered the full think block in its final content
+            // field, scrub the accumulated content too before it gets
+            // persisted to the chat history.
+            completion.content = strip_think_blocks(completion.content.as_str());
             let assistant_tool_calls = completion.tool_calls.clone();
             pending.push(MessageToPersist {
                 role: "assistant",

--- a/crates/memphis-operator/src/lib.rs
+++ b/crates/memphis-operator/src/lib.rs
@@ -2,6 +2,7 @@ mod chat;
 mod config;
 mod provider;
 mod runtime;
+mod think_stripper;
 
 pub use chat::{ChatExchange, ChatSessionView, ChatTranscriptEntry, JournalWriteResult};
 pub use config::OperatorConfig;

--- a/crates/memphis-operator/src/think_stripper.rs
+++ b/crates/memphis-operator/src/think_stripper.rs
@@ -1,0 +1,235 @@
+//! Strip `<think>…</think>` reasoning blocks from model output.
+//!
+//! Reasoning-style models (MiniMax-M2.7, Qwen QwQ, DeepSeek-R1 and many
+//! distilled derivatives) embed their chain-of-thought in literal
+//! `<think>` XML-ish tags and expect the front-end to hide them before
+//! rendering to the end user. Memphis didn't strip them, so Marcin saw
+//! the model's internal deliberation scrolling across the TUI as plain
+//! text — distracting at best, confusing at worst.
+//!
+//! This module provides two surfaces:
+//!
+//! - [`strip_think_blocks`] — one-shot for the non-streaming path,
+//!   takes a full response string, returns the cleaned string.
+//! - [`ThinkStripper`] — streaming state machine that handles chunk
+//!   boundaries that fall mid-tag (e.g. `"<thi"` + `"nk>…"`), dropping
+//!   everything between `<think>` and `</think>` while still passing
+//!   surrounding text through in-order.
+//!
+//! An unclosed `<think>` at stream end is discarded — safer than leaking
+//! half of the model's private reasoning.
+
+const OPEN_TAG: &str = "<think>";
+const CLOSE_TAG: &str = "</think>";
+
+/// Remove every `<think>…</think>` pair from `content`. Unclosed `<think>`
+/// tags swallow everything from the open tag to the end of the string.
+pub fn strip_think_blocks(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    let mut rest = content;
+    while let Some(open_at) = rest.find(OPEN_TAG) {
+        out.push_str(&rest[..open_at]);
+        let after_open = &rest[open_at + OPEN_TAG.len()..];
+        match after_open.find(CLOSE_TAG) {
+            Some(close_at) => {
+                rest = &after_open[close_at + CLOSE_TAG.len()..];
+            }
+            None => return out, // unclosed — drop tail
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Streaming stripper that preserves chunk boundaries across split tags.
+///
+/// Typical use:
+///
+/// ```
+/// let mut stripper = ThinkStripper::new();
+/// for chunk in chunks {
+///     let emit = stripper.push(chunk);
+///     if !emit.is_empty() { send(&emit); }
+/// }
+/// let tail = stripper.finalize();
+/// if !tail.is_empty() { send(&tail); }
+/// ```
+pub struct ThinkStripper {
+    carry: String,
+    inside: bool,
+}
+
+impl Default for ThinkStripper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ThinkStripper {
+    pub fn new() -> Self {
+        Self {
+            carry: String::new(),
+            inside: false,
+        }
+    }
+
+    /// Feed a chunk, return the portion safe to emit (outside any open
+    /// `<think>` block). Content that may be part of a split tag is
+    /// retained internally and released on the next `push` or `finalize`.
+    pub fn push(&mut self, chunk: &str) -> String {
+        self.carry.push_str(chunk);
+        let mut output = String::new();
+        loop {
+            if self.inside {
+                match self.carry.find(CLOSE_TAG) {
+                    Some(idx) => {
+                        self.carry.drain(..idx + CLOSE_TAG.len());
+                        self.inside = false;
+                        // Loop: another block or plain text may follow.
+                    }
+                    None => {
+                        // Keep only the tail that might still match CLOSE_TAG
+                        // across the next chunk.
+                        retain_tail(&mut self.carry, CLOSE_TAG.len() - 1);
+                        return output;
+                    }
+                }
+            } else {
+                match self.carry.find(OPEN_TAG) {
+                    Some(idx) => {
+                        output.push_str(&self.carry[..idx]);
+                        self.carry.drain(..idx + OPEN_TAG.len());
+                        self.inside = true;
+                    }
+                    None => {
+                        // Flush everything except a tail that might still
+                        // complete OPEN_TAG across the next chunk.
+                        let tail_keep = OPEN_TAG.len() - 1;
+                        if self.carry.len() > tail_keep {
+                            let split = safe_boundary(&self.carry, self.carry.len() - tail_keep);
+                            output.push_str(&self.carry[..split]);
+                            self.carry.drain(..split);
+                        }
+                        return output;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Flush remaining text. Returns anything carried that is outside a
+    /// think block. Unclosed block content is discarded.
+    pub fn finalize(self) -> String {
+        if self.inside {
+            String::new()
+        } else {
+            self.carry
+        }
+    }
+}
+
+fn retain_tail(s: &mut String, tail_bytes: usize) {
+    if s.len() <= tail_bytes {
+        return;
+    }
+    let split = safe_boundary(s, s.len() - tail_bytes);
+    s.drain(..split);
+}
+
+fn safe_boundary(s: &str, desired: usize) -> usize {
+    let mut idx = desired.min(s.len());
+    while idx < s.len() && !s.is_char_boundary(idx) {
+        idx += 1;
+    }
+    idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_think_blocks_removes_single_block() {
+        let input = "before <think>inner</think> after";
+        assert_eq!(strip_think_blocks(input), "before  after");
+    }
+
+    #[test]
+    fn strip_think_blocks_handles_multiple_blocks() {
+        let input = "a<think>1</think>b<think>2</think>c";
+        assert_eq!(strip_think_blocks(input), "abc");
+    }
+
+    #[test]
+    fn strip_think_blocks_drops_unclosed_tail() {
+        let input = "visible <think>hidden";
+        assert_eq!(strip_think_blocks(input), "visible ");
+    }
+
+    #[test]
+    fn strip_think_blocks_preserves_content_without_tags() {
+        let input = "plain text answer with <other> tags";
+        assert_eq!(strip_think_blocks(input), input);
+    }
+
+    #[test]
+    fn think_stripper_preserves_whole_chunks_of_plain_text() {
+        let mut s = ThinkStripper::new();
+        let out = s.push("hello world");
+        let tail = s.finalize();
+        assert_eq!(format!("{out}{tail}"), "hello world");
+    }
+
+    #[test]
+    fn think_stripper_removes_block_fully_inside_one_chunk() {
+        let mut s = ThinkStripper::new();
+        let out = s.push("a<think>b</think>c");
+        let tail = s.finalize();
+        assert_eq!(format!("{out}{tail}"), "ac");
+    }
+
+    #[test]
+    fn think_stripper_handles_open_tag_split_across_chunks() {
+        let mut s = ThinkStripper::new();
+        let a = s.push("visible <thi");
+        let b = s.push("nk>hidden</think> more");
+        let tail = s.finalize();
+        assert_eq!(format!("{a}{b}{tail}"), "visible  more");
+    }
+
+    #[test]
+    fn think_stripper_handles_close_tag_split_across_chunks() {
+        let mut s = ThinkStripper::new();
+        let a = s.push("pre <think>reasoning</th");
+        let b = s.push("ink>post");
+        let tail = s.finalize();
+        assert_eq!(format!("{a}{b}{tail}"), "pre post");
+    }
+
+    #[test]
+    fn think_stripper_drops_unclosed_block_on_finalize() {
+        let mut s = ThinkStripper::new();
+        let a = s.push("visible <think>lost");
+        let tail = s.finalize();
+        assert_eq!(format!("{a}{tail}"), "visible ");
+    }
+
+    #[test]
+    fn think_stripper_handles_multiple_blocks_across_chunks() {
+        let mut s = ThinkStripper::new();
+        let a = s.push("a<think>1</think>b<thi");
+        let b = s.push("nk>2</think>c");
+        let tail = s.finalize();
+        assert_eq!(format!("{a}{b}{tail}"), "abc");
+    }
+
+    #[test]
+    fn think_stripper_preserves_utf8_across_chunk_boundary() {
+        // Polish text surrounded by blocks; make sure nothing corrupts
+        // multi-byte chars through the tail-keep logic.
+        let mut s = ThinkStripper::new();
+        let a = s.push("Języki: <think>hidden</think> żółć");
+        let tail = s.finalize();
+        assert_eq!(format!("{a}{tail}"), "Języki:  żółć");
+    }
+}

--- a/crates/memphis-operator/src/think_stripper.rs
+++ b/crates/memphis-operator/src/think_stripper.rs
@@ -45,7 +45,7 @@ pub fn strip_think_blocks(content: &str) -> String {
 ///
 /// Typical use:
 ///
-/// ```
+/// ```ignore
 /// let mut stripper = ThinkStripper::new();
 /// for chunk in chunks {
 ///     let emit = stripper.push(chunk);


### PR DESCRIPTION
## Context

Marcin's TUI session against MiniMax-M2.7 showed the model's internal reasoning leaking into the rendered response:

```
[Memphis] <think>For the Memphis agent: the cognitive mode might affect
verbosity. I should ask for clarification or give a quick practical
answer about what I know from the codebase...</think>

Zależy od kontekstu — kilka opcji: ...
```

Reasoning-style models (MiniMax-M2.7, Qwen QwQ, DeepSeek-R1, and the distilled derivatives running on local Ollama) emit their chain-of-thought in literal `<think>` XML-ish tags and expect the UI layer to hide them before rendering. Memphis didn't, so the operator saw every deliberation step.

## Change

New `crates/memphis-operator/src/think_stripper.rs` module with two surfaces:

- **`strip_think_blocks(content: &str) -> String`** — one-shot scrub for the non-streaming path and for the final accumulated assistant content. An unclosed `<think>` swallows the tail (safer than leaking half a reasoning trace).
- **`ThinkStripper`** — streaming state machine. Holds a trailing buffer large enough to detect open/close tags split across chunk boundaries, e.g. `"pre <thi"` + `"nk>hidden</think> post"` → `"pre post"`.

Wiring in `chat.rs` streaming sink:

1. Every chunk runs through `ThinkStripper.push()` **before** `StreamingOutputGuard`, so operators only ever see the public response render live.
2. `ThinkStripper.finalize()` flushes any safe tail; unclosed tail is discarded.
3. After `stream_guard.finish()`, `completion.content` runs through `strip_think_blocks` — belt-and-suspenders for providers that deliver the full reasoning block in their final content field rather than streaming it.

This covers both MiniMax (streaming) and Ollama (also streaming) and anything else in between.

## Test plan

11 unit tests:

- `strip_think_blocks_*`: single block, multiple blocks, unclosed tail drop, plain content passthrough.
- `think_stripper_*`: plain chunks, block fully inside one chunk, open tag split across chunks, close tag split across chunks, unclosed block drop on finalize, multiple blocks across chunks, **UTF-8 Polish text surviving the tail-keep logic** (regression guard against the mojibake class of bug from PR #210).

```
cargo test -p memphis-operator --lib
test result: ok. 54 passed; 0 failed; 0 ignored
```

## Manual verification (post-merge)

```bash
cd ~/memphis && git pull && npm run build && memphis service restart
memphis tui
/model MiniMax-M2.7
cześć, jak się masz?
# Expected: the visible reply only — no <think>…</think> scroll.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)