### PR TITLE
fix(installer): initialize WITH_INIT + gate first-run banner on actual exit code

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,8 @@ TARGET_DIR="${MEMPHIS_TARGET_DIR:-$HOME/memphis}"
 ASSUME_YES="${MEMPHIS_YES:-0}"
 CHECK_ONLY=0
 JSON_OUTPUT=0
+WITH_INIT=0
+INIT_OK=0
 SUPPORTED_NODE_MAJOR=22
 
 OS=""
@@ -454,7 +456,11 @@ print_next_steps() {
   local step_one="• memphis init              # passphrase, vault, identity, first-run
     • memphis auth anthropic    # (optional) browser OAuth login for Claude
     • memphis doctor            # verify everything is healthy"
-  if [[ "$WITH_INIT" == "1" ]]; then
+  # Gate the "first-run already completed" banner on an ACTUAL successful
+  # init run, not just on --with-init being asked for. The non-TTY path
+  # skips init entirely and the command itself can return non-zero; in
+  # both cases the operator still needs to run `memphis init` themselves.
+  if [[ "$INIT_OK" == "1" ]]; then
     init_note="First-run already completed via --with-init. Vault + identity are in place."
     step_one="• memphis auth anthropic    # (optional) browser OAuth login for Claude
     • memphis doctor            # verify everything is healthy"
@@ -545,11 +551,16 @@ main() {
       warn "--with-init requires a TTY for passphrase prompts; skipping and falling back to next-steps banner."
     else
       log "Running 'memphis init' (interactive)"
+      local init_rc=0
       if have memphis; then
-        memphis init || warn "memphis init returned non-zero; rerun manually once ready."
+        memphis init || init_rc=$?
       else
-        (cd "$TARGET_DIR" && npm run -s cli -- init) \
-          || warn "memphis init returned non-zero; rerun manually once ready."
+        (cd "$TARGET_DIR" && npm run -s cli -- init) || init_rc=$?
+      fi
+      if [[ "$init_rc" -eq 0 ]]; then
+        INIT_OK=1
+      else
+        warn "memphis init returned non-zero ($init_rc); rerun manually once ready."
       fi
     fi
   fi


### PR DESCRIPTION
## Context

Codex flagged two P1s against PR #205 (\`--with-init\`):

1. **Unbound variable under \`set -u\`.** \`scripts/install.sh\` runs with \`set -Eeuo pipefail\`, but \`WITH_INIT\` was never initialized at the top of the file. Plain \`curl … | bash\` (without \`--with-init\`) hit the first \`[[ "\$WITH_INIT" == "1" ]]\` check and aborted with an unbound-variable error — **after build/link had already run**. Every default install from the one-liner after PR #205 was a broken finish.

2. **Banner lied about first-run state.** The "First-run already completed via --with-init" text was gated on \`WITH_INIT=1\` being set, not on \`memphis init\` actually succeeding. Two ways to get the wrong banner:
   - Non-TTY path skipped init with a warning (the pipe form \`curl | bash -s -- --with-init\` has no TTY).
   - \`memphis init || warn\` absorbed any non-zero exit silently.
   
   Either way, the operator read "Vault + identity are in place" when nothing of the sort had happened.

## Fix

- Initialize \`WITH_INIT=0\` and \`INIT_OK=0\` at the top alongside \`CHECK_ONLY=0\`/\`JSON_OUTPUT=0\`.
- Wrap the init invocation so the exit code is captured. Set \`INIT_OK=1\` only on zero exit. Non-zero exit falls through with an explicit warn that includes the exit code.
- \`print_next_steps\` reads \`INIT_OK\`, not \`WITH_INIT\`. Non-TTY path and init-failed path both render the "run memphis init yourself" banner — matching reality.

## Test plan

- \`bash -n scripts/install.sh\` clean.
- \`bash scripts/install.sh --check-only --json\` emits the expected check-only summary without triggering the unbound-variable path (proving B1 fix).
- \`bash scripts/install.sh --help\` unchanged.
- Manual smoke (Marcin side): run the one-liner without \`--with-init\`; should complete, print the standard "Next steps" banner, not crash.

## Codex items addressed

- **B1** — \`WITH_INIT\` unbound under \`set -u\` (PR #205).
- **B7** — \`--with-init\` banner honesty (PR #205).

🤖 Generated with [Claude Code](https://claude.com/claude-code)