### PR TITLE
fix(runtime): preserve PULSE.md detail across heartbeat rewrites

### DIFF
--- a/src/infra/runtime/heartbeat-watchdog.ts
+++ b/src/infra/runtime/heartbeat-watchdog.ts
@@ -257,22 +257,43 @@ export function loadPulseEntries(): PulseEntry[] {
     const lines = raw.split('\n');
 
     for (const line of lines) {
-      const match = line.match(
-        /^- (\S+) (BOOT|HEARTBEAT|IDENTITY-ASSERT|ADAPTATION|MODE-CHANGE) health=(\S+) uptime=(\d+)s/,
+      const base = line.match(
+        /^- (\S+) (BOOT|HEARTBEAT|IDENTITY-ASSERT|ADAPTATION|MODE-CHANGE) health=(\S+) uptime=(\d+)s(.*)$/,
       );
-      if (match) {
-        const entry: PulseEntry = {
-          timestamp: match[1]!,
-          event: match[2]!.toLowerCase().replace(/-/g, '-') as PulseEventType,
-          health: match[3] as PulseEntry['health'],
-          uptimeSeconds: parseInt(match[4]!, 10),
-        };
-        const surfaces = line.match(/surfaces=(\S+)/);
-        if (surfaces) {
-          entry.activeSurfaces = surfaces[1]!.split(',').filter(Boolean);
-        }
-        entries.push(entry);
+      if (!base) continue;
+
+      const entry: PulseEntry = {
+        timestamp: base[1]!,
+        event: base[2]!.toLowerCase().replace(/-/g, '-') as PulseEventType,
+        health: base[3] as PulseEntry['health'],
+        uptimeSeconds: parseInt(base[4]!, 10),
+      };
+
+      // Extract structured tail fields (mode=…, surfaces=…) and treat
+      // whatever is left as free-form `detail`. Previously the parser
+      // ignored both mode and detail, so the next `writePulseEvent`
+      // rebuilt the file WITHOUT the detail text — `tail PULSE.md` only
+      // ever showed the reason on the newest heartbeat. (Codex B4.)
+      let tail = base[5] ?? '';
+
+      const modeMatch = tail.match(/(?:^|\s)mode=(\S+)/);
+      if (modeMatch) {
+        entry.cognitiveMode = modeMatch[1]!;
+        tail = tail.replace(modeMatch[0], ' ');
       }
+
+      const surfacesMatch = tail.match(/(?:^|\s)surfaces=(\S+)/);
+      if (surfacesMatch) {
+        entry.activeSurfaces = surfacesMatch[1]!.split(',').filter(Boolean);
+        tail = tail.replace(surfacesMatch[0], ' ');
+      }
+
+      const detail = tail.replace(/\s+/g, ' ').trim();
+      if (detail.length > 0) {
+        entry.detail = detail;
+      }
+
+      entries.push(entry);
     }
     return entries;
   } catch {

--- a/tests/unit/pulse-entry-round-trip.test.ts
+++ b/tests/unit/pulse-entry-round-trip.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  loadPulseEntries,
+  writePulseEvent,
+} from '../../src/infra/runtime/heartbeat-watchdog.js';
+
+let previousMemphisDir: string | undefined;
+let scratch = '';
+
+beforeEach(() => {
+  previousMemphisDir = process.env.MEMPHIS_DATA_DIR;
+  scratch = mkdtempSync(join(tmpdir(), 'memphis-pulse-roundtrip-'));
+  process.env.MEMPHIS_DATA_DIR = scratch;
+});
+
+afterEach(() => {
+  if (previousMemphisDir === undefined) {
+    delete process.env.MEMPHIS_DATA_DIR;
+  } else {
+    process.env.MEMPHIS_DATA_DIR = previousMemphisDir;
+  }
+});
+
+describe('PULSE.md detail round-trip', () => {
+  it('preserves the detail field across write → load → rewrite', () => {
+    writePulseEvent({
+      timestamp: '2026-04-21T10:00:00.000Z',
+      event: 'heartbeat',
+      health: 'degraded',
+      uptimeSeconds: 60,
+      detail: 'warn:embed_bridge:bridge unavailable warn:memory:475/524 MB (91%)',
+    });
+
+    const loaded = loadPulseEntries();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].detail).toBe(
+      'warn:embed_bridge:bridge unavailable warn:memory:475/524 MB (91%)',
+    );
+  });
+
+  it('preserves cognitiveMode + activeSurfaces + detail together', () => {
+    writePulseEvent({
+      timestamp: '2026-04-21T10:05:00.000Z',
+      event: 'heartbeat',
+      health: 'degraded',
+      uptimeSeconds: 300,
+      cognitiveMode: 'A',
+      activeSurfaces: ['telegram', 'tui'],
+      detail: 'warn:memory:92%',
+    });
+
+    const [entry] = loadPulseEntries();
+    expect(entry.cognitiveMode).toBe('A');
+    expect(entry.activeSurfaces).toEqual(['telegram', 'tui']);
+    expect(entry.detail).toBe('warn:memory:92%');
+  });
+
+  it('healthy heartbeats without detail stay undetailed after reload', () => {
+    writePulseEvent({
+      timestamp: '2026-04-21T10:10:00.000Z',
+      event: 'heartbeat',
+      health: 'healthy',
+      uptimeSeconds: 120,
+    });
+
+    const [entry] = loadPulseEntries();
+    expect(entry.detail).toBeUndefined();
+    expect(entry.health).toBe('healthy');
+  });
+
+  it('writes a second entry without losing detail from the first', () => {
+    writePulseEvent({
+      timestamp: '2026-04-21T10:15:00.000Z',
+      event: 'heartbeat',
+      health: 'degraded',
+      uptimeSeconds: 60,
+      detail: 'warn:memory:91%',
+    });
+    // Simulate the next heartbeat rewriting PULSE.md via loadPulseEntries
+    // (which runs inside writePulseEvent). Before this fix, the first
+    // entry's detail was dropped here.
+    writePulseEvent({
+      timestamp: '2026-04-21T10:16:00.000Z',
+      event: 'heartbeat',
+      health: 'healthy',
+      uptimeSeconds: 120,
+    });
+
+    const entries = loadPulseEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].detail).toBe('warn:memory:91%');
+    expect(entries[1].detail).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Context

Codex caught that PR #211 (PULSE heartbeat detail) was **half-landed**: \`writePulseEvent\` emits the \`detail\` field on new lines, but \`loadPulseEntries\` never parses it. Every heartbeat tick rewrites PULSE.md through load → push → trim → write, so the moment the next heartbeat fires, all prior detail strings are dropped. Operators see the failing-check reason only on the single newest entry — the historical context the field was added to preserve never actually persists.

Same applies to \`cognitiveMode\`: the writer emits \`mode=…\` but the old parser never captured it. Two half-landed fields.

## Fix

\`loadPulseEntries\` now extracts the full post-base tail of the line, strips structured \`mode=…\` and \`surfaces=…\` tokens (with anchored \`(?:^|\\s)\` so they don't match arbitrary substrings in detail text), and treats whatever's left as the free-form \`detail\` field.

Regex change: base pattern ends at \`(.*)$\` instead of stopping at uptime, capturing the remainder. Two non-destructive matches pull out \`mode\` and \`surfaces\`; the residue after stripping is the detail. Empty tail → \`detail\` stays undefined (healthy heartbeats stay clean in the output).

No changes to \`writePulseEvent\`. No behaviour change for operators with no prior heartbeats.

## Test plan

4 new unit tests (\`tests/unit/pulse-entry-round-trip.test.ts\`):
- \`detail\` round-trips through write → load → rewrite
- \`cognitiveMode + activeSurfaces + detail\` all survive together
- Healthy heartbeat without detail stays \`detail: undefined\` after reload
- **Two-entry write**: first entry's detail survives the second write's load-rewrite cycle — the exact regression Codex flagged

Existing \`tests/unit/heartbeat-watchdog-detail.test.ts\` still passes (4 tests, unchanged).

\`npx tsc --noEmit\` + \`npx eslint\` clean.

## User-visible effect after merge

Marcin's next \`tail ~/.memphis/config/PULSE.md\` will show:

\`\`\`
- 2026-04-21T10:15:07.105Z HEARTBEAT health=degraded uptime=60s warn:embed_bridge:bridge unavailable warn:memory:475/524 MB (91%)
\`\`\`

— and that detail string will **stay in the file** across subsequent heartbeats, so we can finally trace why PULSE goes degraded 60 s after every boot (likely embed_bridge warm-up, but we'll see).

## Codex items addressed

- **B4** (PR #211, \`src/infra/runtime/heartbeat-watchdog.ts:260\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)