### PR TITLE
fix(cli): readiness probes vault + covers every DEFAULT_PROVIDER value

### DIFF
--- a/src/infra/cli/commands/readiness.ts
+++ b/src/infra/cli/commands/readiness.ts
@@ -22,6 +22,7 @@ import { resolve } from 'node:path';
 import { getTelegramReadinessStatus } from '../../../gateway/channels/telegram-readiness.js';
 import { LOOP_LIMITS } from '../../../gateway/loop-limits.js';
 import { inspectFirstRunStatus } from '../../../onboarding/first-run.js';
+import { resolveProviderKeyResult } from '../../../providers/index.js';
 import { probeVaultCipherCycle } from '../../../security/vault-boundary.js';
 import { getChainAdapterStatus } from '../../storage/chain-adapter.js';
 import { getRustEmbedAdapterStatus } from '../../storage/rust-embed-adapter.js';
@@ -132,32 +133,104 @@ async function checkEmbedPipeline(env: NodeJS.ProcessEnv): Promise<ReadinessRow>
 
 async function checkDefaultProvider(env: NodeJS.ProcessEnv): Promise<ReadinessRow> {
   const provider = env.DEFAULT_PROVIDER ?? 'anthropic';
-  const vaultKeyByProvider: Record<string, string | undefined> = {
-    anthropic: env.ANTHROPIC_VAULT_KEY,
-    minimax: env.MINIMAX_VAULT_KEY,
-    deepseek: env.DEEPSEEK_VAULT_KEY,
-    glm: env.GLM_VAULT_KEY,
-    'local-fallback': 'n/a',
-  };
-  const resolved = vaultKeyByProvider[provider];
+
+  // No-key providers: local-fallback is built in, ollama runs over HTTP
+  // without a key and has its own reachability check below.
   if (provider === 'local-fallback') {
     return row('default_provider', 'Default provider', 'info', 'local-fallback (no key required)');
   }
-  if (!resolved) {
-    return row(
-      'default_provider',
-      'Default provider',
-      'warn',
-      `${provider} is the default but no *_VAULT_KEY env var points at a vault entry`,
-      false,
-    );
+  if (provider === 'ollama') {
+    const url = env.OLLAMA_URL ?? 'http://127.0.0.1:11434';
+    return row('default_provider', 'Default provider', 'info', `ollama → ${url} (no key required)`);
   }
-  return row(
-    'default_provider',
-    'Default provider',
-    'ok',
-    `${provider} → vault(${resolved})`,
-  );
+
+  // OpenAI-compatible remote endpoints configured via *_API_BASE + *_API_KEY
+  // (vault-resolved at runtime). Here we just check whether both halves are
+  // set; the Rust runtime will reject a bad key when it tries to speak HTTP.
+  if (provider === 'shared-llm' || provider === 'decentralized-llm') {
+    const baseVar = provider === 'shared-llm' ? 'SHARED_LLM_API_BASE' : 'DECENTRALIZED_LLM_API_BASE';
+    const keyVar = provider === 'shared-llm' ? 'SHARED_LLM_API_KEY' : 'DECENTRALIZED_LLM_API_KEY';
+    const base = env[baseVar]?.trim();
+    const key = env[keyVar]?.trim();
+    if (!base) {
+      return row(
+        'default_provider',
+        'Default provider',
+        'fail',
+        `${provider} is the default but ${baseVar} is not set`,
+      );
+    }
+    if (!key) {
+      return row(
+        'default_provider',
+        'Default provider',
+        'fail',
+        `${provider} is the default but ${keyVar} is not set`,
+      );
+    }
+    return row('default_provider', 'Default provider', 'ok', `${provider} → ${base}`);
+  }
+
+  // Vault-keyed providers: anthropic, minimax, deepseek, glm. Actually call
+  // the resolver to verify the vault entry is readable — previously we only
+  // checked that *_VAULT_KEY was non-empty, which returned "ok" even when
+  // the vault entry itself was missing or broken. (Codex B2 + B3.)
+  const resolution = resolveProviderKeyResult(provider, env);
+  switch (resolution.source) {
+    case 'vault':
+      return row(
+        'default_provider',
+        'Default provider',
+        'ok',
+        `${provider} → vault entry resolved`,
+      );
+    case 'plaintext':
+      return row(
+        'default_provider',
+        'Default provider',
+        'warn',
+        `${provider} → plaintext key in env (consider moving to vault: memphis vault add --key ${provider}_api_key)`,
+        false,
+      );
+    case 'conflict':
+      return row(
+        'default_provider',
+        'Default provider',
+        'fail',
+        `${provider} has both a vault reference and a plaintext key, and the vault lookup failed: ${resolution.vaultError}. Resolve the conflict before restart.`,
+      );
+    case 'none':
+      switch (resolution.reason) {
+        case 'vault_not_configured':
+          return row(
+            'default_provider',
+            'Default provider',
+            'fail',
+            `${provider} is the default but its vault mapping is not registered (provider unknown to runtime-registry)`,
+          );
+        case 'vault_not_found':
+          return row(
+            'default_provider',
+            'Default provider',
+            'fail',
+            `${provider} has *_VAULT_KEY set but the vault entry is missing — run memphis vault add --key ${provider}_api_key`,
+          );
+        case 'vault_error':
+          return row(
+            'default_provider',
+            'Default provider',
+            'fail',
+            `${provider} vault lookup errored (bridge down? corrupted entry?). Try memphis doctor --deep`,
+          );
+        case 'plaintext_not_configured':
+          return row(
+            'default_provider',
+            'Default provider',
+            'fail',
+            `${provider} is the default but no *_VAULT_KEY or plaintext *_API_KEY is set`,
+          );
+      }
+  }
 }
 
 async function checkTelegram(

--- a/tests/unit/readiness.test.ts
+++ b/tests/unit/readiness.test.ts
@@ -19,12 +19,16 @@ vi.mock('../../src/infra/storage/chain-adapter.js', () => ({
 vi.mock('../../src/infra/storage/rust-embed-adapter.js', () => ({
   getRustEmbedAdapterStatus: vi.fn(),
 }));
+vi.mock('../../src/providers/index.js', () => ({
+  resolveProviderKeyResult: vi.fn(),
+}));
 
 import { getTelegramReadinessStatus } from '../../src/gateway/channels/telegram-readiness.js';
 import { buildReadinessReport } from '../../src/infra/cli/commands/readiness.js';
 import { getChainAdapterStatus } from '../../src/infra/storage/chain-adapter.js';
 import { getRustEmbedAdapterStatus } from '../../src/infra/storage/rust-embed-adapter.js';
 import { inspectFirstRunStatus } from '../../src/onboarding/first-run.js';
+import { resolveProviderKeyResult } from '../../src/providers/index.js';
 import { probeVaultCipherCycle } from '../../src/security/vault-boundary.js';
 
 const mockedTelegram = vi.mocked(getTelegramReadinessStatus);
@@ -32,6 +36,7 @@ const mockedFirstRun = vi.mocked(inspectFirstRunStatus);
 const mockedVault = vi.mocked(probeVaultCipherCycle);
 const mockedChain = vi.mocked(getChainAdapterStatus);
 const mockedEmbed = vi.mocked(getRustEmbedAdapterStatus);
+const mockedProvider = vi.mocked(resolveProviderKeyResult);
 
 function allHealthy(): void {
   mockedFirstRun.mockReturnValue({
@@ -66,6 +71,7 @@ function allHealthy(): void {
     allowlistEnabled: false,
     allowlistCount: 0,
   } as unknown as Awaited<ReturnType<typeof getTelegramReadinessStatus>>);
+  mockedProvider.mockReturnValue({ source: 'vault', key: 'secret-redacted' });
 }
 
 let scratch = '';
@@ -152,5 +158,115 @@ describe('buildReadinessReport', () => {
   // sanity: the tmpdir shim actually exists for the happy-path test
   it('scratch fixture is present for the suite', () => {
     expect(existsSync(join(scratch, '.env'))).toBe(true);
+  });
+});
+
+describe('checkDefaultProvider covers every DEFAULT_PROVIDER value', () => {
+  beforeEach(() => allHealthy());
+
+  it('ollama reports info (no key required) instead of warn', async () => {
+    const report = await buildReadinessReport({
+      env: {
+        MEMPHIS_ENV_FILE: join(scratch, '.env'),
+        DEFAULT_PROVIDER: 'ollama',
+        OLLAMA_URL: 'http://127.0.0.1:11434',
+      },
+    });
+    const prov = report.rows.find((r) => r.id === 'default_provider');
+    expect(prov?.level).toBe('info');
+    expect(prov?.detail).toContain('ollama');
+    // Regression guard: previously this fell into the generic "no
+    // *_VAULT_KEY" warn branch and pushed exit code to 2.
+    expect(report.exitCode).not.toBe(1);
+  });
+
+  it('shared-llm fails loud when API_BASE is missing', async () => {
+    const report = await buildReadinessReport({
+      env: {
+        MEMPHIS_ENV_FILE: join(scratch, '.env'),
+        DEFAULT_PROVIDER: 'shared-llm',
+        SHARED_LLM_API_KEY: 'sk-x',
+      },
+    });
+    const prov = report.rows.find((r) => r.id === 'default_provider');
+    expect(prov?.level).toBe('fail');
+    expect(prov?.detail).toContain('SHARED_LLM_API_BASE');
+  });
+
+  it('shared-llm passes with both base + key set', async () => {
+    const report = await buildReadinessReport({
+      env: {
+        MEMPHIS_ENV_FILE: join(scratch, '.env'),
+        DEFAULT_PROVIDER: 'shared-llm',
+        SHARED_LLM_API_BASE: 'https://llm.example.com',
+        SHARED_LLM_API_KEY: 'sk-x',
+      },
+    });
+    expect(report.rows.find((r) => r.id === 'default_provider')?.level).toBe('ok');
+  });
+
+  it('anthropic vault_not_found fails loud (instead of fake-ok from env-only check)', async () => {
+    mockedProvider.mockReturnValue({
+      source: 'none',
+      reason: 'vault_not_found',
+    });
+    const report = await buildReadinessReport({
+      env: {
+        MEMPHIS_ENV_FILE: join(scratch, '.env'),
+        DEFAULT_PROVIDER: 'anthropic',
+        ANTHROPIC_VAULT_KEY: 'anthropic_api_key',
+      },
+    });
+    const prov = report.rows.find((r) => r.id === 'default_provider');
+    expect(prov?.level).toBe('fail');
+    expect(prov?.detail).toContain('vault entry is missing');
+    expect(report.exitCode).toBe(1);
+  });
+
+  it('anthropic vault_error fails with a doctor hint', async () => {
+    mockedProvider.mockReturnValue({ source: 'none', reason: 'vault_error' });
+    const report = await buildReadinessReport({
+      env: {
+        MEMPHIS_ENV_FILE: join(scratch, '.env'),
+        DEFAULT_PROVIDER: 'anthropic',
+        ANTHROPIC_VAULT_KEY: 'anthropic_api_key',
+      },
+    });
+    const prov = report.rows.find((r) => r.id === 'default_provider');
+    expect(prov?.level).toBe('fail');
+    expect(prov?.detail).toMatch(/vault lookup errored/);
+  });
+
+  it('plaintext source warns and suggests moving to vault', async () => {
+    mockedProvider.mockReturnValue({ source: 'plaintext', key: 'sk-plaintext' });
+    const report = await buildReadinessReport({
+      env: {
+        MEMPHIS_ENV_FILE: join(scratch, '.env'),
+        DEFAULT_PROVIDER: 'minimax',
+        MINIMAX_API_KEY: 'sk-plaintext',
+      },
+    });
+    const prov = report.rows.find((r) => r.id === 'default_provider');
+    expect(prov?.level).toBe('warn');
+    expect(prov?.detail).toMatch(/consider moving to vault/);
+  });
+
+  it('conflict source fails with the vault error surfaced', async () => {
+    mockedProvider.mockReturnValue({
+      source: 'conflict',
+      vaultError: "entry 'anthropic_api_key' not found in vault",
+      plaintextKey: 'sk-x',
+    });
+    const report = await buildReadinessReport({
+      env: {
+        MEMPHIS_ENV_FILE: join(scratch, '.env'),
+        DEFAULT_PROVIDER: 'anthropic',
+        ANTHROPIC_VAULT_KEY: 'anthropic_api_key',
+        ANTHROPIC_API_KEY: 'sk-x',
+      },
+    });
+    const prov = report.rows.find((r) => r.id === 'default_provider');
+    expect(prov?.level).toBe('fail');
+    expect(prov?.detail).toContain('not found in vault');
   });
 });


### PR DESCRIPTION
## Context

Codex flagged two coupled P1s in PR #204 (\`memphis readiness\`):

- **B2** — \`vaultKeyByProvider\` covered 4 of 8 \`PROVIDER_NAMES\` values. \`ollama\`, \`shared-llm\`, \`decentralized-llm\` fell into the generic "no *_VAULT_KEY env var" warn branch and pushed exit code to 2 for perfectly valid configs, breaking CI/shell guards that rely on non-zero as a real failure signal.
- **B3** — The resolved-key check only verified that \`*_VAULT_KEY\` was non-empty. A set ref with a missing or broken vault entry returned \`ok\`, letting operators pass a readiness gate with an unusable runtime.

## Fix

- \`ollama\` / \`local-fallback\` get an \`info\` row (no key required); they never trip the warn/fail path again.
- \`shared-llm\` / \`decentralized-llm\` (OpenAI-compatible via \`*_API_BASE\` + \`*_API_KEY\`) get explicit checks for both halves; missing base or key is a clear \`fail\` naming the exact env var.
- Vault-keyed providers (anthropic, minimax, deepseek, glm) now call \`resolveProviderKeyResult\` from \`src/providers/index.ts\` and render a specific level + actionable detail per return shape:

| source/reason | level | detail |
|---|---|---|
| \`vault\` | ok | "vault entry resolved" |
| \`plaintext\` | warn | "consider moving to vault: memphis vault add …" |
| \`conflict\` | fail | surfaces the vault error + guidance |
| \`none / vault_not_found\` | fail | "run memphis vault add --key <name>" |
| \`none / vault_error\` | fail | "memphis doctor --deep" hint |
| \`none / plaintext_not_configured\` | fail | names missing env var |
| \`none / vault_not_configured\` | fail | "provider unknown to runtime-registry" |

## Test plan

7 new unit tests in \`tests/unit/readiness.test.ts\` — each covers one branch of the new logic (ollama info, shared-llm missing base, shared-llm ok, vault_not_found fail, vault_error fail, plaintext warn, conflict fail). Existing 6 tests still pass (13 total).

\`resolveProviderKeyResult\` is mocked so the suite stays deterministic without a real vault.

\`npx tsc --noEmit\` + \`npx eslint\` clean.

## Codex items addressed

- **B2** + **B3** (PR #204, \`src/infra/cli/commands/readiness.ts\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)