### PR TITLE
fix(cli): do not print resolved vault plaintext in readiness ok detail

### DIFF
--- a/src/infra/cli/commands/readiness.ts
+++ b/src/infra/cli/commands/readiness.ts
@@ -176,9 +176,11 @@ async function checkDefaultProvider(env: NodeJS.ProcessEnv): Promise<ReadinessRo
     // + provider setup — it is NOT a resolution failure on its own. The
     // readiness CLI runs before `resolveVaultSecrets`, so we do the vault
     // lookup ourselves and fail only when the referenced vault entry is
-    // missing or unreadable.
-    const baseResolved = resolveVaultSecret(base, env);
-    if (baseResolved === undefined) {
+    // missing or unreadable. Do NOT print the resolved values in the ok
+    // detail — Codex caught that `${baseResolved}` would leak decrypted
+    // URLs (potentially with embedded creds) and plaintext key material
+    // into terminal history / logs / monitoring.
+    if (resolveVaultSecret(base, env) === undefined) {
       return row(
         'default_provider',
         'Default provider',
@@ -186,8 +188,7 @@ async function checkDefaultProvider(env: NodeJS.ProcessEnv): Promise<ReadinessRo
         `${baseVar} references a vault entry that does not exist or could not be read. Run memphis vault list + memphis doctor --deep.`,
       );
     }
-    const keyResolved = resolveVaultSecret(key, env);
-    if (keyResolved === undefined) {
+    if (resolveVaultSecret(key, env) === undefined) {
       return row(
         'default_provider',
         'Default provider',
@@ -195,7 +196,14 @@ async function checkDefaultProvider(env: NodeJS.ProcessEnv): Promise<ReadinessRo
         `${keyVar} references a vault entry that does not exist or could not be read. Run memphis vault list + memphis doctor --deep.`,
       );
     }
-    return row('default_provider', 'Default provider', 'ok', `${provider} → ${baseResolved}`);
+    const baseSource = /^VAULT:/i.test(base) ? `${baseVar} (vault-resolved)` : baseVar;
+    const keySource = /^VAULT:/i.test(key) ? `${keyVar} (vault-resolved)` : keyVar;
+    return row(
+      'default_provider',
+      'Default provider',
+      'ok',
+      `${provider} → ${baseSource} + ${keySource}`,
+    );
   }
 
   // Vault-keyed providers: anthropic, minimax, deepseek, glm. Actually call

--- a/tests/unit/readiness.test.ts
+++ b/tests/unit/readiness.test.ts
@@ -80,7 +80,7 @@ function allHealthy(): void {
   // Default: pass through untouched (plaintext) or resolve VAULT: to a fixed value.
   mockedResolveVaultSecret.mockImplementation((value: string | undefined) => {
     if (!value) return undefined;
-    if (value.startsWith('VAULT:')) return 'vault-resolved';
+    if (value.startsWith('VAULT:')) return 'SUPER-SECRET-PLAINTEXT';
     return value;
   });
 }
@@ -231,13 +231,18 @@ describe('checkDefaultProvider covers every DEFAULT_PROVIDER value', () => {
     });
     const prov = report.rows.find((r) => r.id === 'default_provider');
     expect(prov?.level).toBe('ok');
+    // Leakage guard (Codex P2): detail must NOT contain the resolved
+    // plaintext. `SHARED_LLM_API_KEY` is typically sensitive; the URL
+    // could carry embedded credentials too. Surface only env var names.
+    expect(prov?.detail).not.toContain('SUPER-SECRET-PLAINTEXT');
+    expect(prov?.detail).toContain('SHARED_LLM_API_KEY (vault-resolved)');
   });
 
   it('shared-llm fails when API_KEY vault entry cannot be resolved', async () => {
     mockedResolveVaultSecret.mockImplementation((value: string | undefined) => {
       if (!value) return undefined;
       if (value === 'VAULT:missing_key') return undefined; // vault miss
-      if (value.startsWith('VAULT:')) return 'vault-resolved';
+      if (value.startsWith('VAULT:')) return 'SUPER-SECRET-PLAINTEXT';
       return value;
     });
     const report = await buildReadinessReport({
@@ -257,7 +262,7 @@ describe('checkDefaultProvider covers every DEFAULT_PROVIDER value', () => {
     mockedResolveVaultSecret.mockImplementation((value: string | undefined) => {
       if (!value) return undefined;
       if (value === 'VAULT:dec_llm_base') return undefined;
-      if (value.startsWith('VAULT:')) return 'vault-resolved';
+      if (value.startsWith('VAULT:')) return 'SUPER-SECRET-PLAINTEXT';
       return value;
     });
     const report = await buildReadinessReport({


### PR DESCRIPTION
## Context

Codex P2 follow-up on PR #219. When \`shared-llm\` / \`decentralized-llm\` uses a vault-resolved \`API_BASE\` or \`API_KEY\`, the success row used \`\${baseResolved}\` in its detail string — leaking the decrypted plaintext into \`memphis readiness\` output, including terminal history, log pipelines, monitoring scrapers, and the JSON output consumed by CI.

\`SHARED_LLM_API_KEY\` IS the secret. \`SHARED_LLM_API_BASE\` could carry embedded credentials (\`https://user:pass@host/...\`). Either way, printing the resolved value is a confidentiality leak readiness should never cause.

## Fix

Drop the resolved value from the detail entirely. Render env var names plus a \`(vault-resolved)\` marker when resolution happened:

Before:
\`\`\`
✓ Default provider  shared-llm → https://llm.internal/v1  (when API_BASE is plaintext URL)
✓ Default provider  shared-llm → SUPER-SECRET-PLAINTEXT   (when API_BASE was VAULT:ref and resolved — the bug)
\`\`\`

After:
\`\`\`
✓ Default provider  shared-llm → SHARED_LLM_API_BASE + SHARED_LLM_API_KEY (vault-resolved)
\`\`\`

Operators still see *which source* is in play (envvar names + whether it went through vault) without ever seeing the decrypted payload.

## Test plan

Updated existing \"shared-llm passes when API_KEY is a valid VAULT ref\" test:
- default mock return value changed to a distinctive \`SUPER-SECRET-PLAINTEXT\` so a leak test has a clear signal
- asserts \`detail\` does NOT contain the plaintext
- asserts \`detail\` DOES contain \`SHARED_LLM_API_KEY (vault-resolved)\` — still-useful-to-operator visibility

16/16 readiness tests pass.

## Codex items addressed

- P2 follow-up on PR #219 (\`readiness.ts:198\`, vault plaintext leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)