### PR TITLE
fix(cli): match vault-resolved marker to resolveVaultSecret's exact prefix

### DIFF
--- a/src/infra/cli/commands/readiness.ts
+++ b/src/infra/cli/commands/readiness.ts
@@ -196,8 +196,13 @@ async function checkDefaultProvider(env: NodeJS.ProcessEnv): Promise<ReadinessRo
         `${keyVar} references a vault entry that does not exist or could not be read. Run memphis vault list + memphis doctor --deep.`,
       );
     }
-    const baseSource = /^VAULT:/i.test(base) ? `${baseVar} (vault-resolved)` : baseVar;
-    const keySource = /^VAULT:/i.test(key) ? `${keyVar} (vault-resolved)` : keyVar;
+    // Match the exact prefix `resolveVaultSecret` recognizes in
+    // `src/infra/config/vault-resolve.ts` — case-sensitive `VAULT:`.
+    // A mis-cased `vault:my_key` is a literal plaintext value that
+    // happens to look vault-ish; labelling it `(vault-resolved)` would
+    // lie to operators. (Codex P2 follow-up on #220.)
+    const baseSource = base.startsWith('VAULT:') ? `${baseVar} (vault-resolved)` : baseVar;
+    const keySource = key.startsWith('VAULT:') ? `${keyVar} (vault-resolved)` : keyVar;
     return row(
       'default_provider',
       'Default provider',

--- a/tests/unit/readiness.test.ts
+++ b/tests/unit/readiness.test.ts
@@ -238,6 +238,24 @@ describe('checkDefaultProvider covers every DEFAULT_PROVIDER value', () => {
     expect(prov?.detail).toContain('SHARED_LLM_API_KEY (vault-resolved)');
   });
 
+  it('does not label mis-cased `vault:` values as vault-resolved', async () => {
+    // resolveVaultSecret is case-sensitive on the prefix; a lowercase
+    // `vault:` is a literal plaintext and must NOT carry the
+    // (vault-resolved) marker.
+    mockedResolveVaultSecret.mockImplementation((value: string | undefined) => value);
+    const report = await buildReadinessReport({
+      env: {
+        MEMPHIS_ENV_FILE: join(scratch, '.env'),
+        DEFAULT_PROVIDER: 'shared-llm',
+        SHARED_LLM_API_BASE: 'https://llm.example.com',
+        SHARED_LLM_API_KEY: 'vault:mis_cased',
+      },
+    });
+    const prov = report.rows.find((r) => r.id === 'default_provider');
+    expect(prov?.level).toBe('ok');
+    expect(prov?.detail).not.toContain('vault-resolved');
+  });
+
   it('shared-llm fails when API_KEY vault entry cannot be resolved', async () => {
     mockedResolveVaultSecret.mockImplementation((value: string | undefined) => {
       if (!value) return undefined;


### PR DESCRIPTION
## Context

Codex P2 on PR #220. The \`(vault-resolved)\` marker was driven by \`/^VAULT:/i\` — case-insensitive — but \`resolveVaultSecret\` in \`src/infra/config/vault-resolve.ts:19\` is case-sensitive and only recognizes the exact uppercase \`VAULT:\` prefix. With a mis-cased value like \`vault:my_key\`, readiness claimed "ok (vault-resolved)" even though no resolution occurred; operator sees green, runtime fails on an invalid literal key.

## Fix

One-line swap: \`/^VAULT:/i.test(x)\` → \`x.startsWith('VAULT:')\`. Marker now tracks actual resolver behaviour.

## Test

New unit test feeds \`vault:mis_cased\` and asserts the ok detail does NOT carry \`(vault-resolved)\` — so operator isn't lied to. 17/17 readiness tests pass.

## Codex items addressed

- P2 follow-up on PR #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)