### PR TITLE
fix(runtime): resolve install root from binary path, not cwd

### DIFF
--- a/src/infra/cli/commands/readiness.ts
+++ b/src/infra/cli/commands/readiness.ts
@@ -25,13 +25,19 @@ import { inspectFirstRunStatus } from '../../../onboarding/first-run.js';
 import { resolveProviderKeyResult } from '../../../providers/index.js';
 import { probeVaultCipherCycle } from '../../../security/vault-boundary.js';
 import { resolveVaultSecret } from '../../config/vault-resolve.js';
+import { resolveInstallRoot } from '../../runtime/install-root.js';
 import { getChainAdapterStatus } from '../../storage/chain-adapter.js';
 import { getRustEmbedAdapterStatus } from '../../storage/rust-embed-adapter.js';
 import type { CliContext } from '../context.js';
 import { print } from '../utils/render.js';
 
 function resolveEnvPath(env: NodeJS.ProcessEnv): string {
-  return resolve(env.MEMPHIS_ENV_FILE ?? '.env');
+  if (env.MEMPHIS_ENV_FILE) return resolve(env.MEMPHIS_ENV_FILE);
+  try {
+    return resolve(resolveInstallRoot({ rawEnv: env }), '.env');
+  } catch {
+    return resolve('.env');
+  }
 }
 
 export type ReadinessLevel = 'ok' | 'warn' | 'fail' | 'info' | 'skip';

--- a/src/infra/config/dotenv-file.ts
+++ b/src/infra/config/dotenv-file.ts
@@ -1,9 +1,22 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
+
+import { resolveInstallRoot } from '../runtime/install-root.js';
 
 export function resolveDotEnvPath(rawEnv: NodeJS.ProcessEnv = process.env): string {
   const explicit = rawEnv.MEMPHIS_ENV_FILE?.trim();
-  return resolve(explicit && explicit.length > 0 ? explicit : '.env');
+  if (explicit && explicit.length > 0) {
+    return resolve(explicit);
+  }
+  // Default to `<installRoot>/.env` so `memphis` run from anywhere on the
+  // machine reads the same config — previously this anchored on
+  // `process.cwd()`, so `memphis tui` from `~` got empty defaults while
+  // the same command from `~/memphis` got the full operator setup.
+  try {
+    return join(resolveInstallRoot({ rawEnv }), '.env');
+  } catch {
+    return resolve('.env');
+  }
 }
 
 export function setDotEnvValues(

--- a/src/infra/runtime/install-root.ts
+++ b/src/infra/runtime/install-root.ts
@@ -1,0 +1,137 @@
+/**
+ * Discover the Memphis install root regardless of the operator's current
+ * working directory.
+ *
+ * Previously the CLI resolved runtime root via `resolveRuntimeRoot(cwd)`,
+ * which anchored on `process.cwd()`. Running `memphis self-update` or
+ * `memphis tui` from `$HOME` (not the checkout) silently fell back to
+ * "no package.json here" → release mode or missing `.env` → defaults.
+ * The user observed both: "up to date (1.4.0)" from the home dir while
+ * the source checkout had 13 commits ahead, and a TUI that loaded
+ * different config based on the invoking shell's cwd.
+ *
+ * This module resolves install root from three sources, in order:
+ *
+ * 1. `MEMPHIS_RUNTIME_ROOT` env var (explicit override, highest priority)
+ * 2. Walk up from `import.meta.url` / the CLI's own file location until
+ *    a `package.json` with `name === '@memphis-chains/memphis'` is found
+ * 3. Fall back to `process.cwd()` so unit tests that patch cwd still work
+ *
+ * Exposes `resolveInstallRoot()` as the single source of truth; other
+ * helpers in this package should use it rather than reimplementing cwd
+ * walks.
+ */
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MEMPHIS_PACKAGE_NAME = '@memphis-chains/memphis';
+
+function parsePackageName(root: string): string | null {
+  const packageJsonPath = join(root, 'package.json');
+  if (!existsSync(packageJsonPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { name?: string };
+    return typeof parsed.name === 'string' ? parsed.name : null;
+  } catch {
+    return null;
+  }
+}
+
+function walkUpToPackage(startDir: string): string | null {
+  let current = resolve(startDir);
+  let lastParent: string | null = null;
+  while (current !== lastParent) {
+    if (parsePackageName(current) === MEMPHIS_PACKAGE_NAME) {
+      return current;
+    }
+    lastParent = current;
+    current = dirname(current);
+  }
+  return null;
+}
+
+function resolveFromImportUrl(importUrl: string): string | null {
+  try {
+    const filePath = fileURLToPath(importUrl);
+    // When the CLI is npm-linked (`/usr/local/bin/memphis` → symlink),
+    // fileURLToPath gives the symlink target inside the source tree.
+    // Walk up from that directory to the package.json.
+    const realFile = existsSync(filePath) ? realpathSync(filePath) : filePath;
+    return walkUpToPackage(dirname(realFile));
+  } catch {
+    return null;
+  }
+}
+
+export type InstallRootSource = 'env-override' | 'binary-path' | 'cwd-fallback';
+
+export type InstallRootResolution = {
+  root: string;
+  source: InstallRootSource;
+};
+
+/**
+ * Resolve the Memphis install root.
+ *
+ * `options.importUrl` should be the caller's `import.meta.url` when the
+ * caller is itself a module inside the install tree — this lets the
+ * function walk up from the calling file's location regardless of cwd.
+ * When absent, we try the default CLI entry location via
+ * `process.argv[1]`, then fall back to cwd. When the env override is
+ * set, it always wins.
+ */
+export function resolveInstallRootWithSource(
+  options: {
+    rawEnv?: NodeJS.ProcessEnv;
+    cwd?: string;
+    importUrl?: string;
+  } = {},
+): InstallRootResolution {
+  const env = options.rawEnv ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+
+  const override = env.MEMPHIS_RUNTIME_ROOT?.trim();
+  if (override && parsePackageName(resolve(override)) === MEMPHIS_PACKAGE_NAME) {
+    return { root: resolve(override), source: 'env-override' };
+  }
+
+  if (options.importUrl) {
+    const fromUrl = resolveFromImportUrl(options.importUrl);
+    if (fromUrl) return { root: fromUrl, source: 'binary-path' };
+  }
+
+  // Prefer cwd walk-up over `process.argv[1]` because the operator's
+  // explicit shell context (where they ran `memphis`) is usually what
+  // they want. argv[1] is used only as a last-resort "the CLI itself
+  // lives inside a memphis checkout even if cwd has wandered off".
+  const fromCwd = walkUpToPackage(cwd);
+  if (fromCwd) return { root: fromCwd, source: 'cwd-fallback' };
+
+  // Fallback for when neither cwd nor import.meta.url helped: resolve
+  // the process entry point. `process.argv[1]` is the CLI script path —
+  // realpathSync follows `npm link` symlinks back to the real source
+  // tree. This is what makes `memphis self-update` from `$HOME` find
+  // the checkout.
+  const argvEntry = process.argv[1];
+  if (argvEntry) {
+    try {
+      const real = realpathSync(argvEntry);
+      const found = walkUpToPackage(dirname(real));
+      if (found) return { root: found, source: 'binary-path' };
+    } catch {
+      /* ignore */
+    }
+  }
+
+  throw new Error(
+    'Could not locate Memphis install root. Set MEMPHIS_RUNTIME_ROOT=<path> or run from the source checkout.',
+  );
+}
+
+export function resolveInstallRoot(
+  options?: Parameters<typeof resolveInstallRootWithSource>[0],
+): string {
+  return resolveInstallRootWithSource(options).root;
+}

--- a/src/infra/runtime/user-service.ts
+++ b/src/infra/runtime/user-service.ts
@@ -2,6 +2,8 @@ import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
+import { resolveInstallRoot } from './install-root.js';
+
 export type UserServiceStatus = {
   name: string;
   available: boolean;
@@ -55,11 +57,23 @@ function parsePackageName(root: string): string | null {
 }
 
 export function resolveRuntimeRoot(cwd = process.cwd()): string {
+  // Keep the explicit-cwd-matches path first so unit tests + callers that
+  // know where they are still short-circuit without touching disk.
   const root = resolve(cwd);
   if (parsePackageName(root) === MEMPHIS_PACKAGE_NAME) {
     return root;
   }
-  throw new Error('run this command from the Memphis runtime root (directory with package.json)');
+  // Fall through to install-root discovery: env override → walk-up from
+  // the CLI binary path (realpath-resolves `npm link` symlinks) → walk-up
+  // from cwd. This is what makes `memphis tui` / `memphis self-update`
+  // work from anywhere, not just `~/memphis/`.
+  try {
+    return resolveInstallRoot({ cwd });
+  } catch {
+    throw new Error(
+      'run this command from the Memphis runtime root (directory with package.json), or set MEMPHIS_RUNTIME_ROOT=<path>',
+    );
+  }
 }
 
 function nodeBinPath(): string {

--- a/tests/unit/install-root.test.ts
+++ b/tests/unit/install-root.test.ts
@@ -1,0 +1,95 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  resolveInstallRoot,
+  resolveInstallRootWithSource,
+} from '../../src/infra/runtime/install-root.js';
+
+function makePackage(root: string, name: string): void {
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name }, null, 2));
+}
+
+let scratch = '';
+let checkout = '';
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'memphis-install-root-'));
+  checkout = join(scratch, 'memphis');
+  mkdirSync(checkout, { recursive: true });
+  makePackage(checkout, '@memphis-chains/memphis');
+});
+
+describe('resolveInstallRoot — env override wins', () => {
+  it('MEMPHIS_RUNTIME_ROOT pointing at a valid checkout is returned verbatim', () => {
+    const result = resolveInstallRootWithSource({
+      rawEnv: { MEMPHIS_RUNTIME_ROOT: checkout },
+      cwd: '/tmp', // deliberately wrong — override must win
+    });
+    expect(result.root).toBe(checkout);
+    expect(result.source).toBe('env-override');
+  });
+
+  it('MEMPHIS_RUNTIME_ROOT pointing at a non-checkout is ignored', () => {
+    const unrelated = mkdtempSync(join(tmpdir(), 'unrelated-'));
+    const result = resolveInstallRootWithSource({
+      rawEnv: { MEMPHIS_RUNTIME_ROOT: unrelated },
+      cwd: checkout, // correct cwd as fallback
+    });
+    expect(result.root).toBe(checkout);
+    expect(result.source).toBe('cwd-fallback');
+  });
+});
+
+describe('resolveInstallRoot — walk-up from import URL', () => {
+  it('finds the package root from a nested module path', () => {
+    const nestedDir = join(checkout, 'dist/infra/cli');
+    mkdirSync(nestedDir, { recursive: true });
+    const nestedFile = join(nestedDir, 'index.js');
+    writeFileSync(nestedFile, '// cli entry');
+
+    const result = resolveInstallRootWithSource({
+      rawEnv: {},
+      cwd: '/tmp',
+      importUrl: `file://${nestedFile}`,
+    });
+    expect(result.root).toBe(checkout);
+    expect(result.source).toBe('binary-path');
+  });
+});
+
+describe('resolveInstallRoot — cwd fallback', () => {
+  it('walks up from cwd when no env override or import URL is given', () => {
+    const inside = join(checkout, 'src/infra/cli');
+    mkdirSync(inside, { recursive: true });
+    const result = resolveInstallRootWithSource({
+      rawEnv: {},
+      cwd: inside,
+    });
+    expect(result.root).toBe(checkout);
+    expect(result.source).toBe('cwd-fallback');
+  });
+
+  it('throws with actionable guidance when all discovery paths miss', () => {
+    // Simulate the pathological case: no env override, no matching cwd,
+    // no importUrl, and `process.argv[1]` sits outside any memphis
+    // checkout. We stub argv[1] for the duration of the call.
+    const nothing = mkdtempSync(join(tmpdir(), 'no-package-'));
+    const saved = process.argv[1];
+    process.argv[1] = join(nothing, 'fake-bin');
+    try {
+      expect(() =>
+        resolveInstallRoot({
+          rawEnv: {},
+          cwd: nothing,
+          importUrl: `file://${join(nothing, 'virtual')}`,
+        }),
+      ).toThrow(/MEMPHIS_RUNTIME_ROOT/);
+    } finally {
+      process.argv[1] = saved;
+    }
+  });
+});

--- a/tests/unit/service.command.test.ts
+++ b/tests/unit/service.command.test.ts
@@ -161,8 +161,19 @@ describe('user service helpers', () => {
     expect(unit).toContain('RestartPreventExitStatus=101 102 103');
   });
 
-  it('requires commands to run from the Memphis runtime root', () => {
+  it('errors with install-root guidance when every discovery path misses', () => {
+    // Previously resolveRuntimeRoot only checked cwd; since install-root
+    // resolution landed it also walks up from `process.argv[1]` (the
+    // npm-linked CLI binary), so a non-checkout cwd alone is no longer
+    // sufficient to trigger the error — the test has to stub argv[1]
+    // into a throwaway path too.
     const root = mkdtempSync(join(tmpdir(), 'memphis-non-root-'));
-    expect(() => resolveRuntimeRoot(root)).toThrow(/Memphis runtime root/);
+    const saved = process.argv[1];
+    process.argv[1] = join(root, 'fake-bin');
+    try {
+      expect(() => resolveRuntimeRoot(root)).toThrow(/MEMPHIS_RUNTIME_ROOT|runtime root/);
+    } finally {
+      process.argv[1] = saved;
+    }
   });
 });


### PR DESCRIPTION
## Context

Operator-reported regression today: \`memphis tui\` from \`\$HOME\` loaded an empty config (no anthropic, no telegram, defaults kicked in) while \`memphis tui\` from \`~/memphis\` loaded the full operator setup. Same command, different output, depending on which directory the shell was in.

\`memphis self-update install\` from \`\$HOME\` reported *"already up to date (1.4.0)"* even though the source checkout was 13 commits ahead of the tag — it silently fell through to the tarball release path because \`resolveRuntimeRoot(process.cwd())\` returned "no package.json here".

Root cause: every "where is Memphis installed?" helper anchored on \`process.cwd()\`. Run from anywhere that isn't the checkout root → wrong answer.

## Fix

New \`src/infra/runtime/install-root.ts\` centralizes discovery, in priority order:

1. **\`MEMPHIS_RUNTIME_ROOT\`** env var — explicit override.
2. **\`importUrl\`** passed by caller — walks up from the calling module.
3. **Walk up from cwd** — preserves old behaviour when the operator is already in the checkout; unit-test friendly.
4. **Walk up from \`realpath(process.argv[1])\`** — resolves \`npm link\` symlinks so \`/usr/local/bin/memphis\` → the real source tree. **This is what makes \`memphis\` from \`\$HOME\` find the install root.**

Throws with actionable guidance when every path misses.

## Wired into

- **\`src/infra/runtime/user-service.ts\` \`resolveRuntimeRoot\`** — falls through to \`resolveInstallRoot\` when cwd doesn't match. Keeps the cwd-short-circuit for tests + in-checkout runs.
- **\`src/infra/config/dotenv-file.ts\` \`resolveDotEnvPath\`** — default \`.env\` path becomes \`<installRoot>/.env\`, not \`./.env\`. Respects \`MEMPHIS_ENV_FILE\` override.
- **\`src/infra/cli/commands/readiness.ts\` \`resolveEnvPath\`** — same pattern.

Consumers inherit the fix transparently: self-update source mode now works from \`\$HOME\`, readiness picks up the right \`.env\`, service install/restart all share one source of truth.

## Test plan

5 new unit tests in \`tests/unit/install-root.test.ts\`:
- env override returns verbatim
- env override ignored when pointing at non-checkout (falls back)
- walk-up from \`importUrl\` hits nested module paths
- cwd fallback walks up from subdirectories
- throws with \`MEMPHIS_RUNTIME_ROOT\` guidance when all paths miss (stubs \`process.argv[1]\`)

22/22 tests pass across install-root + readiness.

\`npx tsc --noEmit\` + \`npx eslint\` clean.

## Operator-visible effect after merge

\`\`\`bash
# Before: only works from ~/memphis
cd ~/memphis && memphis tui
cd ~/memphis && memphis self-update install

# After: works from anywhere
memphis tui                     # reads ~/memphis/.env via npm-link realpath
memphis self-update install     # finds the checkout, runs source-mode flow
\`\`\`

Explicit override still works: \`MEMPHIS_RUNTIME_ROOT=/custom/path memphis tui\`.

## Codex items addressed

- Bug 17 / N4 (cwd-dependent runtime root resolution), raised by operator during today's sprint execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)