### PR TITLE
fix(cli): align doctor header + configure retired with exit-code contract

### DIFF
--- a/src/infra/cli/commands/configure.ts
+++ b/src/infra/cli/commands/configure.ts
@@ -381,5 +381,12 @@ export async function handleConfigureCommand(context: CliContext): Promise<boole
     console.warn('     config.yaml + DID that did not reconcile with the canonical state.)\n');
   }
   print(deprecated, json);
+  // Mark the process failure so scripts wrapping `memphis configure`
+  // see a non-zero exit and stop. Returning true only tells the
+  // dispatcher "I handled this command" — it does NOT set exit code.
+  // Without this, operators with stale automation (legacy install
+  // scripts, CI wrappers) were getting exit 0 + "ok: false" and
+  // blindly continuing with an uninitialized runtime. (Codex H4.)
+  process.exitCode = 1;
   return true;
 }

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1609,11 +1609,14 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
 export function printDoctorHumanV2(report: DoctorReport): void {
   const icon = (l: DoctorCheckLevel): string => (l === 'pass' ? '✓' : l === 'warn' ? '⚠' : '✗');
   const border = '═'.repeat(76);
-  // Header aligns with the visible summary counters below. `report.ok`
-  // tracks an internal `requiredFailures` metric that can diverge from
-  // the public `summary.fail` count — operators read the two visible
-  // numbers and expect them to match the header verdict.
-  const passed = report.summary.fail === 0;
+  // Header must agree with the command's exit code. `report.ok` tracks
+  // the internal `requiredFailures` metric — a required check can be
+  // `warn` (e.g. `levelFrom(…, { required: true })`) which contributes
+  // to `report.ok=false` AND process.exitCode=1 without appearing in
+  // `summary.fail`. Using `summary.fail === 0` for the header produced
+  // a banner that said PASS while the command was actually failing,
+  // which Codex caught on PR #186. Bind the verdict to `report.ok`.
+  const passed = report.ok;
   console.log(`╔${border}╗`);
   console.log(`║ ${`MEMPHIS DOCTOR v2.0 ${passed ? 'PASS' : 'FAIL'}`.padEnd(75)}║`);
   console.log(`╚${border}╝`);

--- a/tests/doctor-v2.test.ts
+++ b/tests/doctor-v2.test.ts
@@ -51,6 +51,39 @@ describe('doctor v2', () => {
     expect(output).toContain('Summary: total=');
   });
 
+  it('header PASS/FAIL tracks report.ok, not summary.fail', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    // Build a fixture with a required-warn that flips report.ok=false
+    // while summary.fail stays 0 — the exact divergence Codex flagged.
+    const report = {
+      ok: false,
+      checks: [
+        {
+          id: 'required-warn',
+          tier: 1,
+          title: 'Required warn case',
+          level: 'warn',
+          detail: 'missing DID',
+          required: true,
+        },
+      ],
+      summary: { total: 1, pass: 0, warn: 1, fail: 0, required: 1, requiredFailures: 1 },
+      repair: { ok: true, status: 'healthy', recommendedAction: 'none', applied: [], warnings: [] },
+      repairStatus: 'healthy',
+      repairable: false,
+      recommendedAction: 'none',
+      repairs: [],
+      firstRunPlan: { summary: 'initialized', nextCommand: 'none' },
+    } as unknown as Parameters<typeof printDoctorHumanV2>[0];
+
+    printDoctorHumanV2(report);
+
+    const output = log.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toContain('MEMPHIS DOCTOR v2.0 FAIL');
+    expect(output).not.toContain('MEMPHIS DOCTOR v2.0 PASS');
+  });
+
   it('legacy exports remain compatible', async () => {
     const doctor = await import('../src/infra/cli/utils/doctor.js');
     const report = await doctor.runDoctorChecks();

--- a/tests/unit/configure-retired.test.ts
+++ b/tests/unit/configure-retired.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { handleConfigureCommand } from '../../src/infra/cli/commands/configure.js';
+import type { CliContext } from '../../src/infra/cli/context.js';
+
+const exitCodeSnapshot = () => process.exitCode;
+
+describe('memphis configure (retired)', () => {
+  let savedExitCode: number | string | undefined;
+
+  beforeEach(() => {
+    savedExitCode = process.exitCode;
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+  });
+
+  it('returns handled=true AND sets process.exitCode=1 for JSON mode', async () => {
+    const context = {
+      args: { command: 'configure', json: true },
+    } as unknown as CliContext;
+
+    const handled = await handleConfigureCommand(context);
+
+    expect(handled).toBe(true);
+    expect(exitCodeSnapshot()).toBe(1);
+  });
+
+  it('returns handled=true AND sets process.exitCode=1 in human mode', async () => {
+    const context = {
+      args: { command: 'configure', json: false },
+    } as unknown as CliContext;
+
+    const handled = await handleConfigureCommand(context);
+
+    expect(handled).toBe(true);
+    expect(exitCodeSnapshot()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Context

Two Codex items with the same shape: the visible signal disagreed with \`process.exitCode\`, so CI scripts and shell guards trusted the wrong thing.

**H1 — \`printDoctorHumanV2\` header (PR #186).** \`report.summary.fail === 0\` drove the PASS/FAIL banner, but \`report.ok\` (which \`handleDoctor\` passes to \`process.exitCode\`) is derived from \`summary.requiredFailures\`. A required-warn (e.g. \`t4-2fa\` marked \`required: true\`) flips \`report.ok=false\` + \`exit=1\` while \`summary.fail\` stays 0. Operators saw "MEMPHIS DOCTOR v2.0 PASS" with a non-zero exit code.

**H4 — \`handleConfigureCommand\` (PR #194).** Returned \`true\` (handled) and printed \`{ ok: false, deprecated: true, reason: 'memphis-configure-is-retired' }\`, but never set \`process.exitCode\`. Scripts wrapping \`memphis configure\` got exit 0 and continued with an uninitialized runtime — exactly the regression the hard-block was supposed to close.

## Fix

- **Doctor header**: bind verdict to \`report.ok\` instead of \`summary.fail === 0\`.
- **Configure retired**: set \`process.exitCode = 1\` before returning.

## Test plan

- \`tests/doctor-v2.test.ts\` — new fixture with required-warn case (\`report.ok=false\`, \`summary.fail=0\`) asserts header says FAIL, not PASS.
- \`tests/unit/configure-retired.test.ts\` (new) — both JSON and human modes set \`process.exitCode=1\` and return handled=true. Snapshots + restores exitCode around each run.

9/9 tests pass locally across the two files.

\`npx tsc --noEmit\` + \`npx eslint\` clean.

## Codex items addressed

- **H1** (PR #186, \`doctor-v2.ts:1613\`).
- **H4** (PR #194, \`configure.ts:383\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)