### PR TITLE
fix(vault): drop anthropic_oauth_refresh_token from PROVIDER_VAULT_ENV_MAP

### DIFF
--- a/src/infra/cli/handlers/vault.handler.ts
+++ b/src/infra/cli/handlers/vault.handler.ts
@@ -244,7 +244,14 @@ async function handleVaultAdd(context: CliContext): Promise<boolean> {
  */
 const PROVIDER_VAULT_ENV_MAP: Record<string, string> = {
   anthropic_api_key: 'ANTHROPIC_VAULT_KEY',
-  anthropic_oauth_refresh_token: 'ANTHROPIC_VAULT_KEY',
+  // NOTE: `anthropic_oauth_refresh_token` deliberately absent. The old
+  // entry pointed it at `ANTHROPIC_VAULT_KEY` — the same slot the API
+  // key uses — so `memphis vault add --key anthropic_oauth_refresh_token`
+  // would silently overwrite the operator's API key reference, breaking
+  // a working Anthropic setup on next service restart. The refresh
+  // token has no runtime resolver anyway (VAULT_KEY_MAP in
+  // `src/providers/index.ts` only maps `anthropic_api_key` +
+  // `anthropic_oauth_secret` to providers). Dropped per Codex H3.
   anthropic_oauth_client_secret: 'ANTHROPIC_OAUTH_SECRET_VAULT_KEY',
   minimax_api_key: 'MINIMAX_VAULT_KEY',
   deepseek_api_key: 'DEEPSEEK_VAULT_KEY',


### PR DESCRIPTION
## Context

Codex H3 flagged this on PR #193. \`PROVIDER_VAULT_ENV_MAP\` in \`src/infra/cli/handlers/vault.handler.ts\` contained:

\`\`\`ts
anthropic_oauth_refresh_token: 'ANTHROPIC_VAULT_KEY',
\`\`\`

Pointing the refresh token at the **same \`ANTHROPIC_VAULT_KEY\` slot** the API key uses. Consequences:

1. \`memphis vault add --key anthropic_oauth_refresh_token\` overwrites \`ANTHROPIC_VAULT_KEY=anthropic_api_key\` with \`ANTHROPIC_VAULT_KEY=anthropic_oauth_refresh_token\` in \`.env\`.
2. On service restart, \`createConfiguredRuntimeProviders\` resolves Anthropic via \`resolveProviderKeyResult('anthropic')\` → looks up the \`anthropic_api_key\` slot (fixed in \`VAULT_KEY_MAP\` in \`src/providers/index.ts\`) and either gets the refresh token (which is not a valid API key) or fails to resolve at all.
3. A working Anthropic setup breaks as a **side effect of a single unrelated vault add**.

The refresh token has no runtime resolver anyway — \`VAULT_KEY_MAP\` maps only \`anthropic_api_key\` and \`anthropic_oauth_secret\`. So the entry is purely harmful: it advertises an auto-enable path the runtime cannot consume.

## Fix

Dropped the entry. Added a comment explaining why it's absent so future contributors don't re-add it out of symmetry with the other entries.

## Test plan

No new test — dead code removal. Existing vault-handler tests still pass.

\`npx tsc --noEmit\` + \`npx eslint\` clean.

## Codex items addressed

- **H3** (PR #193, \`vault.handler.ts:247\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)