### PR TITLE
fix(config): load .env from install root, not process.cwd()

### DIFF
--- a/scripts/guard-drill-json-gate.sh
+++ b/scripts/guard-drill-json-gate.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Raw output can be contaminated with node deprecation warnings like
-# `(node:1234) [DEP0040] DeprecationWarning: ...` that land on stdout
-# in non-TTY CI environments. Extract the JSON blob by sed-stripping
-# everything before the first line that starts with `{`.
+# Node can emit deprecation warnings like `(node:1234) [DEP0040]
+# DeprecationWarning: …` to stdout in non-TTY CI environments, which
+# would otherwise contaminate the JSON output expected by both the
+# `jq` gates below and downstream consumers (tests/CI pipelines that
+# parse the whole stdout). Strip everything before the first `{` line
+# so both the script's output and internal parsing see clean JSON.
 RAW="$(npm run -s ops:drill-guards -- --json)"
-printf '%s\n' "$RAW"
-
 OUT="$(printf '%s\n' "$RAW" | sed -n '/^{/,$p')"
+
+printf '%s\n' "$OUT"
 
 jq -e '.schemaVersion == 1' <<<"$OUT" >/dev/null
 jq -e '.ok == true' <<<"$OUT" >/dev/null

--- a/scripts/guard-drill-json-gate.sh
+++ b/scripts/guard-drill-json-gate.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OUT="$(npm run -s ops:drill-guards -- --json)"
-printf '%s\n' "$OUT"
+# Raw output can be contaminated with node deprecation warnings like
+# `(node:1234) [DEP0040] DeprecationWarning: ...` that land on stdout
+# in non-TTY CI environments. Extract the JSON blob by sed-stripping
+# everything before the first line that starts with `{`.
+RAW="$(npm run -s ops:drill-guards -- --json)"
+printf '%s\n' "$RAW"
+
+OUT="$(printf '%s\n' "$RAW" | sed -n '/^{/,$p')"
 
 jq -e '.schemaVersion == 1' <<<"$OUT" >/dev/null
 jq -e '.ok == true' <<<"$OUT" >/dev/null

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -21,6 +21,7 @@ import { createOperatorChatSessionStore } from '../gateway/operator-chat-session
 import { providerToLlmClient } from '../gateway/provider-adapter.js';
 import { createInProcessToolExecutor } from '../gateway/tool-executor.js';
 import { checkOllama, checkRustToolchain } from '../infra/cli/utils/dependencies.js';
+import { resolveDotEnvPath } from '../infra/config/dotenv-file.js';
 import { loadConfig } from '../infra/config/env.js';
 import type { AppConfig } from '../infra/config/schema.js';
 import { createHttpServer } from '../infra/http/server.js';
@@ -414,8 +415,12 @@ export async function bootstrap(): Promise<void> {
 const bootstrapLog = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
 
 export function resolveBootstrapEnvPath(rawEnv: NodeJS.ProcessEnv = process.env): string {
-  const explicitPath = rawEnv.MEMPHIS_ENV_FILE?.trim();
-  return explicitPath && explicitPath.length > 0 ? explicitPath : '.env';
+  // Route through the shared `resolveDotEnvPath` so bootstrap reads
+  // the same file that `setDotEnvValues` writes. Previously this
+  // defaulted to `.env` in cwd while config mutations honoured the
+  // install root, producing a split where `memphis config set` wrote
+  // to one file and bootstrap read another. Codex P1 follow-up on #222.
+  return resolveDotEnvPath(rawEnv);
 }
 
 export function resolveChannelGatewayToken(rawEnv: NodeJS.ProcessEnv = process.env): string | null {

--- a/src/infra/cli/commands/readiness.ts
+++ b/src/infra/cli/commands/readiness.ts
@@ -151,12 +151,13 @@ async function checkDefaultProvider(env: NodeJS.ProcessEnv): Promise<ReadinessRo
     return row('default_provider', 'Default provider', 'info', `ollama → ${url} (no key required)`);
   }
 
-  // OpenAI-compatible remote endpoints configured via *_API_BASE + *_API_KEY.
-  // resolveVaultSecrets would have already expanded `VAULT:<key>` into the
-  // real value at runtime — if the literal `VAULT:...` is still in env when
-  // readiness runs, the vault lookup failed and the runtime will fall back
-  // or refuse to speak. Treat that as a fail, not ok. (Codex P1 follow-up
-  // on #218.)
+  // OpenAI-compatible remote endpoints configured via *_API_BASE +
+  // *_API_KEY. `VAULT:<entry>` is the on-disk form the CLI writes —
+  // the readiness command runs BEFORE `resolveVaultSecrets`, so we do
+  // the vault lookup ourselves via `resolveVaultSecret` and fail only
+  // when the referenced entry is missing or unreadable. Plaintext
+  // values are trusted as-is (the runtime's HTTP call is the real
+  // validator). See Codex trail on PRs #218 → #219 → #220 → #221.
   if (provider === 'shared-llm' || provider === 'decentralized-llm') {
     const baseVar = provider === 'shared-llm' ? 'SHARED_LLM_API_BASE' : 'DECENTRALIZED_LLM_API_BASE';
     const keyVar = provider === 'shared-llm' ? 'SHARED_LLM_API_KEY' : 'DECENTRALIZED_LLM_API_KEY';

--- a/src/infra/config/env.ts
+++ b/src/infra/config/env.ts
@@ -1,12 +1,13 @@
 import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 import dotenv from 'dotenv';
 
-import { resolveDotEnvPath } from './dotenv-file.js';
 import { applyConfigProfile, validateProductionSafety } from './profiles.js';
 import { AppConfig, envSchema } from './schema.js';
 import { resolveVaultSecrets } from './vault-resolve.js';
 import { errorTemplates } from '../../core/errors.js';
+import { resolveInstallRoot } from '../runtime/install-root.js';
 
 /**
  * Load `.env` at module import time. Replaces the old
@@ -36,14 +37,32 @@ import { errorTemplates } from '../../core/errors.js';
 export function loadDotEnvFromInstallRoot(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): string | null {
+  // DELIBERATELY NOT routing through `resolveDotEnvPath` here:
+  // that helper catches install-root discovery errors and returns
+  // `resolve('.env')` so config writes have SOMEWHERE to go, but
+  // for module-load-time read we need the opposite policy — if
+  // install-root can't be found, we must NOT silently read
+  // `./env` from cwd (that's the exact cwd-dependence bug the
+  // whole refactor is trying to close). Resolve the two branches
+  // explicitly.
+  const explicit = rawEnv.MEMPHIS_ENV_FILE?.trim();
+  if (explicit && explicit.length > 0) {
+    return loadIfValid(resolve(explicit));
+  }
   let envPath: string;
   try {
-    envPath = resolveDotEnvPath(rawEnv);
+    envPath = join(resolveInstallRoot({ rawEnv }), '.env');
   } catch {
-    // Install-root not findable and no explicit override: behave as
-    // "no .env found" rather than falling through to cwd.
+    // No install-root discoverable + no explicit override → no .env.
+    // Operators using env-vars-only deployments still work (env is
+    // already populated by the time this runs); they just miss the
+    // file load, which is correct.
     return null;
   }
+  return loadIfValid(envPath);
+}
+
+function loadIfValid(envPath: string): string | null {
   if (!existsSync(envPath)) {
     return null;
   }

--- a/src/infra/config/env.ts
+++ b/src/infra/config/env.ts
@@ -24,7 +24,7 @@ import { resolveInstallRoot } from '../runtime/install-root.js';
  *   2. `<installRoot>/.env` via `resolveInstallRoot`
  *   3. `./env` relative to cwd (inside `resolveDotEnvPath`'s own fallback)
  *
- * If the resolved path exists and `dotenv.config({ path })` succeeds,
+ * If the resolved path exists and `dotenv.config({ path, quiet })` succeeds,
  * the path is returned. If the path doesn't exist, or dotenv reports
  * a parse/read error, the loader returns `null` — deliberately does
  * NOT silently re-fall-back to `dotenv.config()` (no path), because
@@ -66,7 +66,12 @@ function loadIfValid(envPath: string): string | null {
   if (!existsSync(envPath)) {
     return null;
   }
-  const result = dotenv.config({ path: envPath });
+  // `quiet: true` suppresses dotenv v17+'s stdout banner
+  // (`◇ injected env (N) from .env …`). That banner would otherwise
+  // glue onto the JSON emitted by scripts like
+  // `scripts/drill-guard-failures.mts --json`, breaking
+  // `JSON.parse(result.stdout)` in the ops gate tests.
+  const result = dotenv.config({ path: envPath, quiet: true });
   if (result.error) {
     // Parse or permission failure on the resolved file — surface it
     // on stderr so the operator notices, and return null so callers

--- a/src/infra/config/env.ts
+++ b/src/infra/config/env.ts
@@ -1,9 +1,48 @@
-import 'dotenv/config';
+import { existsSync } from 'node:fs';
 
+import dotenv from 'dotenv';
+
+import { resolveDotEnvPath } from './dotenv-file.js';
 import { applyConfigProfile, validateProductionSafety } from './profiles.js';
 import { AppConfig, envSchema } from './schema.js';
 import { resolveVaultSecrets } from './vault-resolve.js';
 import { errorTemplates } from '../../core/errors.js';
+
+/**
+ * Load `.env` at module import time. Replaces the old
+ * `import 'dotenv/config'` side-effect that loaded from
+ * `process.cwd()` — running `memphis` from anywhere outside the
+ * source checkout picked up an empty env, including a missing
+ * `MEMPHIS_VAULT_PEPPER`, which made the Rust operator fail vault
+ * decryption on every chat turn (operator reported as "vault: failed
+ * to decrypt vault state" after swapping into the TUI from
+ * `$HOME`).
+ *
+ * Resolution order via `resolveDotEnvPath`:
+ *   1. `MEMPHIS_ENV_FILE` explicit override wins
+ *   2. `<installRoot>/.env` via `resolveInstallRoot`
+ *   3. `./env` relative to cwd (original behaviour)
+ *
+ * Returns the path that was actually loaded, or null if nothing was
+ * loaded. Exported so tests can invoke deterministically.
+ */
+export function loadDotEnvFromInstallRoot(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): string | null {
+  try {
+    const envPath = resolveDotEnvPath(rawEnv);
+    if (existsSync(envPath)) {
+      dotenv.config({ path: envPath });
+      return envPath;
+    }
+  } catch {
+    /* fall through to cwd behaviour */
+  }
+  const fallback = dotenv.config();
+  return fallback.parsed ? '.env' : null;
+}
+
+loadDotEnvFromInstallRoot();
 
 function hasValue(value: string | undefined): boolean {
   return Boolean(value && value.trim().length > 0);

--- a/src/infra/config/env.ts
+++ b/src/infra/config/env.ts
@@ -18,28 +18,46 @@ import { errorTemplates } from '../../core/errors.js';
  * to decrypt vault state" after swapping into the TUI from
  * `$HOME`).
  *
- * Resolution order via `resolveDotEnvPath`:
- *   1. `MEMPHIS_ENV_FILE` explicit override wins
+ * Resolution is entirely via `resolveDotEnvPath`:
+ *   1. `MEMPHIS_ENV_FILE` explicit override
  *   2. `<installRoot>/.env` via `resolveInstallRoot`
- *   3. `./env` relative to cwd (original behaviour)
+ *   3. `./env` relative to cwd (inside `resolveDotEnvPath`'s own fallback)
  *
- * Returns the path that was actually loaded, or null if nothing was
- * loaded. Exported so tests can invoke deterministically.
+ * If the resolved path exists and `dotenv.config({ path })` succeeds,
+ * the path is returned. If the path doesn't exist, or dotenv reports
+ * a parse/read error, the loader returns `null` — deliberately does
+ * NOT silently re-fall-back to `dotenv.config()` (no path), because
+ * that reintroduces cwd-dependence and can silently pull an unrelated
+ * `.env` from the operator's shell working directory (Codex P1).
+ *
+ * Operators can still force a specific file via `MEMPHIS_ENV_FILE`;
+ * absence of a `.env` anywhere is valid (everything via env vars).
  */
 export function loadDotEnvFromInstallRoot(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): string | null {
+  let envPath: string;
   try {
-    const envPath = resolveDotEnvPath(rawEnv);
-    if (existsSync(envPath)) {
-      dotenv.config({ path: envPath });
-      return envPath;
-    }
+    envPath = resolveDotEnvPath(rawEnv);
   } catch {
-    /* fall through to cwd behaviour */
+    // Install-root not findable and no explicit override: behave as
+    // "no .env found" rather than falling through to cwd.
+    return null;
   }
-  const fallback = dotenv.config();
-  return fallback.parsed ? '.env' : null;
+  if (!existsSync(envPath)) {
+    return null;
+  }
+  const result = dotenv.config({ path: envPath });
+  if (result.error) {
+    // Parse or permission failure on the resolved file — surface it
+    // on stderr so the operator notices, and return null so callers
+    // don't think env was loaded. (Codex P2 on #225.)
+    console.warn(
+      `[memphis-config] Failed to load ${envPath}: ${result.error.message}`,
+    );
+    return null;
+  }
+  return envPath;
 }
 
 loadDotEnvFromInstallRoot();

--- a/src/infra/runtime/install-root.ts
+++ b/src/infra/runtime/install-root.ts
@@ -10,12 +10,18 @@
  * the source checkout had 13 commits ahead, and a TUI that loaded
  * different config based on the invoking shell's cwd.
  *
- * This module resolves install root from three sources, in order:
+ * This module resolves install root from four sources, in order:
  *
  * 1. `MEMPHIS_RUNTIME_ROOT` env var (explicit override, highest priority)
- * 2. Walk up from `import.meta.url` / the CLI's own file location until
- *    a `package.json` with `name === '@memphis-chains/memphis'` is found
- * 3. Fall back to `process.cwd()` so unit tests that patch cwd still work
+ * 2. Walk up from `options.importUrl` when the caller passes its own
+ *    `import.meta.url` (most specific intent)
+ * 3. Walk up from `process.cwd()` — preserves the old behaviour for
+ *    operators who were already running inside the checkout and keeps
+ *    unit tests that patch cwd deterministic
+ * 4. Walk up from `realpath(process.argv[1])` — resolves the npm-linked
+ *    `memphis` binary back to the real source tree, which is what lets
+ *    `memphis self-update` / `memphis tui` find the checkout when run
+ *    from `$HOME`
  *
  * Exposes `resolveInstallRoot()` as the single source of truth; other
  * helpers in this package should use it rather than reimplementing cwd
@@ -82,6 +88,17 @@ export type InstallRootResolution = {
  * `process.argv[1]`, then fall back to cwd. When the env override is
  * set, it always wins.
  */
+// Process-local memoisation. Install root cannot change during a process
+// lifetime — every resolver input (env override, importUrl, cwd at time
+// of first call, argv[1]) is pinned at process start. The walk-up is
+// cheap but `resolveDotEnvPath` runs on every config read, so caching
+// the successful resolution keeps the hot paths off the disk.
+let memoizedResolution: InstallRootResolution | null = null;
+
+export function resetInstallRootMemoForTests(): void {
+  memoizedResolution = null;
+}
+
 export function resolveInstallRootWithSource(
   options: {
     rawEnv?: NodeJS.ProcessEnv;
@@ -89,6 +106,14 @@ export function resolveInstallRootWithSource(
     importUrl?: string;
   } = {},
 ): InstallRootResolution {
+  // Only hit the cache for the default / no-override call — tests that
+  // pass explicit options get fresh resolution every time so fixtures
+  // don't leak across cases.
+  const useCache =
+    options.rawEnv === undefined &&
+    options.cwd === undefined &&
+    options.importUrl === undefined;
+  if (useCache && memoizedResolution) return memoizedResolution;
   const env = options.rawEnv ?? process.env;
   const cwd = options.cwd ?? process.cwd();
 

--- a/src/onboarding/first-run.ts
+++ b/src/onboarding/first-run.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from 'node:path';
 import { getChainPath, getDataDir, normalizeChainName } from '../config/paths.js';
 import { loadAgentProfile, writeAgentProfile } from '../infra/agent-profile.js';
 import { isOperatorConfigured } from '../infra/auth/operator-gate.js';
+import { resolveDotEnvPath } from '../infra/config/dotenv-file.js';
 import { appendBlock } from '../infra/storage/chain-adapter.js';
 import { updateSoulMemory } from '../soul/memory.js';
 import type { SoulMemoryUpdate } from '../soul/types.js';
@@ -132,8 +133,13 @@ function getVaultStatePath(rawEnv: NodeJS.ProcessEnv = process.env): string {
 }
 
 function getEnvFilePath(rawEnv: NodeJS.ProcessEnv = process.env): string {
-  const explicitPath = rawEnv.MEMPHIS_ENV_FILE?.trim();
-  return explicitPath && explicitPath.length > 0 ? explicitPath : '.env';
+  // Route through the shared `resolveDotEnvPath` so onboarding status
+  // checks look at the same file the rest of the CLI writes to.
+  // Previously this defaulted to `.env` in cwd while config mutations
+  // honoured the install root — `inspectFirstRunStatus` then reported
+  // `envPresent=false` even right after a successful `memphis init`
+  // that wrote to installRoot/.env. Codex P1 follow-up on #222.
+  return resolveDotEnvPath(rawEnv);
 }
 
 export function loadFirstRunRecord(rawEnv: NodeJS.ProcessEnv = process.env): FirstRunRecord | null {

--- a/tests/unit/bootstrap.env-file.test.ts
+++ b/tests/unit/bootstrap.env-file.test.ts
@@ -3,8 +3,15 @@ import { describe, expect, it } from 'vitest';
 import { resolveBootstrapEnvPath } from '../../src/app/bootstrap.js';
 
 describe('bootstrap env-file resolution', () => {
-  it('defaults to repo .env when no explicit env file is configured', () => {
-    expect(resolveBootstrapEnvPath({})).toBe('.env');
+  it('defaults to `<installRoot>/.env` when no explicit env file is configured', () => {
+    // `resolveBootstrapEnvPath` now routes through the shared
+    // `resolveDotEnvPath` so bootstrap reads the same file that
+    // config writes target. Previously returned the cwd-relative
+    // `.env` literal; now returns an absolute path anchored on the
+    // install root.
+    const result = resolveBootstrapEnvPath({});
+    expect(result).toMatch(/\.env$/);
+    expect(result.startsWith('/')).toBe(true);
   });
 
   it('honors MEMPHIS_ENV_FILE for isolated runtime boot paths', () => {

--- a/tests/unit/env-dotenv-loading.test.ts
+++ b/tests/unit/env-dotenv-loading.test.ts
@@ -22,8 +22,13 @@ describe('loadDotEnvFromInstallRoot', () => {
   });
 
   afterEach(() => {
-    process.env[SENTINEL] = savedSentinel;
-    process.env.MEMPHIS_ENV_FILE = savedEnvFile;
+    // `process.env[key] = undefined` stores the literal string
+    // 'undefined' in Node, not unset — delete explicitly when the
+    // saved value was undefined. (Codex P2 on #225.)
+    if (savedSentinel === undefined) delete process.env[SENTINEL];
+    else process.env[SENTINEL] = savedSentinel;
+    if (savedEnvFile === undefined) delete process.env.MEMPHIS_ENV_FILE;
+    else process.env.MEMPHIS_ENV_FILE = savedEnvFile;
   });
 
   it('loads the file pointed at by MEMPHIS_ENV_FILE', () => {
@@ -36,17 +41,13 @@ describe('loadDotEnvFromInstallRoot', () => {
     expect(process.env[SENTINEL]).toBe('loaded-from-explicit-path');
   });
 
-  it('returns null when neither MEMPHIS_ENV_FILE nor any fallback resolves', () => {
-    // Point MEMPHIS_ENV_FILE at a file that does not exist; fall-through
-    // to the install-root path (also missing here) and finally to
-    // dotenv.config() which sees nothing useful in cwd.
+  it('returns null when MEMPHIS_ENV_FILE points at a non-existent path', () => {
+    // Fail-closed: do NOT silently re-fall-back to cwd dotenv.config(),
+    // which would reintroduce cwd-dependence and potentially read an
+    // unrelated .env. (Codex P1 on #225.)
     const missing = join(scratch, 'does-not-exist.env');
     const result = loadDotEnvFromInstallRoot({ MEMPHIS_ENV_FILE: missing });
-
-    // Either null (no env found anywhere) or the real repo .env if
-    // running inside the checkout. Either way the explicit missing
-    // path must NOT be reported as loaded.
-    expect(result).not.toBe(missing);
+    expect(result).toBeNull();
   });
 
   it('does not throw when all resolution paths fail', () => {
@@ -56,5 +57,13 @@ describe('loadDotEnvFromInstallRoot', () => {
         MEMPHIS_RUNTIME_ROOT: join(scratch, 'no-package'),
       }),
     ).not.toThrow();
+  });
+
+  it('returns null when the resolved file is unreadable (dotenv parse error)', () => {
+    // Use a path that exists but is actually a directory — dotenv's
+    // readFileSync raises EISDIR and result.error is set.
+    const notAFile = scratch; // `scratch` is a directory
+    const result = loadDotEnvFromInstallRoot({ MEMPHIS_ENV_FILE: notAFile });
+    expect(result).toBeNull();
   });
 });

--- a/tests/unit/env-dotenv-loading.test.ts
+++ b/tests/unit/env-dotenv-loading.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadDotEnvFromInstallRoot } from '../../src/infra/config/env.js';
+
+const SENTINEL = 'MEMPHIS_DOTENV_LOAD_SENTINEL';
+
+describe('loadDotEnvFromInstallRoot', () => {
+  let savedSentinel: string | undefined;
+  let savedEnvFile: string | undefined;
+  let scratch = '';
+
+  beforeEach(() => {
+    savedSentinel = process.env[SENTINEL];
+    savedEnvFile = process.env.MEMPHIS_ENV_FILE;
+    delete process.env[SENTINEL];
+    delete process.env.MEMPHIS_ENV_FILE;
+    scratch = mkdtempSync(join(tmpdir(), 'memphis-env-loader-'));
+  });
+
+  afterEach(() => {
+    process.env[SENTINEL] = savedSentinel;
+    process.env.MEMPHIS_ENV_FILE = savedEnvFile;
+  });
+
+  it('loads the file pointed at by MEMPHIS_ENV_FILE', () => {
+    const envPath = join(scratch, 'custom.env');
+    writeFileSync(envPath, `${SENTINEL}=loaded-from-explicit-path\n`);
+
+    const loaded = loadDotEnvFromInstallRoot({ MEMPHIS_ENV_FILE: envPath });
+
+    expect(loaded).toBe(envPath);
+    expect(process.env[SENTINEL]).toBe('loaded-from-explicit-path');
+  });
+
+  it('returns null when neither MEMPHIS_ENV_FILE nor any fallback resolves', () => {
+    // Point MEMPHIS_ENV_FILE at a file that does not exist; fall-through
+    // to the install-root path (also missing here) and finally to
+    // dotenv.config() which sees nothing useful in cwd.
+    const missing = join(scratch, 'does-not-exist.env');
+    const result = loadDotEnvFromInstallRoot({ MEMPHIS_ENV_FILE: missing });
+
+    // Either null (no env found anywhere) or the real repo .env if
+    // running inside the checkout. Either way the explicit missing
+    // path must NOT be reported as loaded.
+    expect(result).not.toBe(missing);
+  });
+
+  it('does not throw when all resolution paths fail', () => {
+    expect(() =>
+      loadDotEnvFromInstallRoot({
+        MEMPHIS_ENV_FILE: join(scratch, 'gone.env'),
+        MEMPHIS_RUNTIME_ROOT: join(scratch, 'no-package'),
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Context

Root cause of the \"vault: failed to decrypt vault state\" error operators hit in the TUI when invoking \`memphis tui\` from \`\$HOME\`:

\`\`\`
> /model MiniMax-M2.7
> yo
[Memphis]
vault: failed to decrypt vault state
\`\`\`

\`src/infra/config/env.ts\` loaded \`.env\` via the side-effect \`import 'dotenv/config'\`, which defaults to \`<cwd>/.env\`. Running \`memphis\` from anywhere other than the checkout picked up an empty env. The Rust operator's vault decrypt then saw either no \`MEMPHIS_VAULT_PEPPER\` or one inherited from the shell that didn't match what the vault state file was encrypted with, and blew up.

PR #222 (install-root from binary path) fixed the cwd anchoring for \`resolveRuntimeRoot\` and \`resolveDotEnvPath\`, but the dotenv **module-level auto-load** was not routed through the same helper. This PR closes that gap.

## Fix

- Replace \`import 'dotenv/config'\` with an explicit \`loadDotEnvFromInstallRoot()\` invocation that routes through \`resolveDotEnvPath\`:
  1. \`MEMPHIS_ENV_FILE\` explicit override wins
  2. \`<installRoot>/.env\` via \`resolveInstallRoot\`
  3. \`./env\` relative to cwd (original behaviour)
- Guarded by \`existsSync\` so a fresh install pre-\`memphis init\` doesn't log a noisy "file not found".
- Exported so tests can call deterministically. Module-level invocation preserves the old side-effect semantics for existing import chains.
- Returns the path loaded (or null), useful for future diagnostics.

## Test plan

3 unit tests in \`tests/unit/env-dotenv-loading.test.ts\`:
- explicit \`MEMPHIS_ENV_FILE\` path loads and sets a sentinel var (happy path)
- missing explicit path does not falsely report as loaded
- no crash when every resolution path fails

\`npx tsc --noEmit\` + \`npx eslint\` clean.

## Operator-visible effect

After this merges and Marcin rebuilds:

\`\`\`bash
cd ~   # or anywhere
memphis tui
/model MiniMax-M2.7
yo
# Normal response — vault decrypt succeeds.
\`\`\`

\`MEMPHIS_VAULT_PEPPER\` is resolved from the same \`.env\` regardless of invoking directory, so the Rust operator's vault state key matches what the state file was sealed with.

## Codex items addressed

- **N1** (vault decrypt failure observed today during Phase 1 execution, identified as cwd-dependent dotenv loading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)