### PR TITLE
fix(heartbeat): gate memory warn on 128 MB heap floor (Bug 18)

### DIFF
--- a/src/infra/runtime/heartbeat-watchdog.ts
+++ b/src/infra/runtime/heartbeat-watchdog.ts
@@ -176,20 +176,46 @@ function runHealthChecks(): WatchdogCheck[] {
   // Process memory
   try {
     const mem = process.memoryUsage();
-    const heapUsedMb = Math.round(mem.heapUsed / (1024 * 1024));
-    const heapTotalMb = Math.round(mem.heapTotal / (1024 * 1024));
-    const ratio = mem.heapUsed / mem.heapTotal;
     const threshold = parseFloat(process.env.MEMPHIS_MEMORY_WARN_THRESHOLD ?? '0.9') || 0.9;
-    checks.push({
-      name: 'memory',
-      status: ratio > threshold ? 'warn' : 'ok',
-      message: `${heapUsedMb}/${heapTotalMb} MB (${Math.round(ratio * 100)}%)`,
-    });
+    checks.push(evaluateMemoryCheck(mem, { threshold }));
   } catch {
     checks.push({ name: 'memory', status: 'ok' });
   }
 
   return checks;
+}
+
+/**
+ * Pure memory-check evaluator. Exported so unit tests can drive it
+ * with synthetic `memoryUsage()` snapshots without touching the real
+ * process heap.
+ *
+ * The `minHeapBytes` gate was added because a young Node process
+ * routinely hits >90 % heapUsed/heapTotal in the first few seconds —
+ * that is normal GC pressure at a tiny heap size, not host-memory
+ * exhaustion. Operator on a 16 GB machine saw
+ * "warn:memory:40/43 MB (91%)" in PULSE. Requiring heapTotal to grow
+ * past 128 MB before we raise the warn filters out that false
+ * positive while still catching long-running processes that bloat.
+ */
+export const DEFAULT_MIN_HEAP_BYTES_FOR_WARN = 128 * 1024 * 1024;
+
+export function evaluateMemoryCheck(
+  mem: { heapUsed: number; heapTotal: number },
+  options: { threshold?: number; minHeapBytes?: number } = {},
+): WatchdogCheck {
+  const threshold = options.threshold ?? 0.9;
+  const minHeapBytes = options.minHeapBytes ?? DEFAULT_MIN_HEAP_BYTES_FOR_WARN;
+  const heapUsedMb = Math.round(mem.heapUsed / (1024 * 1024));
+  const heapTotalMb = Math.round(mem.heapTotal / (1024 * 1024));
+  const ratio = mem.heapTotal > 0 ? mem.heapUsed / mem.heapTotal : 0;
+  const overThreshold = ratio > threshold;
+  const heapMatureEnough = mem.heapTotal > minHeapBytes;
+  return {
+    name: 'memory',
+    status: overThreshold && heapMatureEnough ? 'warn' : 'ok',
+    message: `${heapUsedMb}/${heapTotalMb} MB (${Math.round(ratio * 100)}%)`,
+  };
 }
 
 function deriveHealth(checks: WatchdogCheck[]): WatchdogHealth {

--- a/tests/unit/heartbeat-memory-check.test.ts
+++ b/tests/unit/heartbeat-memory-check.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_MIN_HEAP_BYTES_FOR_WARN,
+  evaluateMemoryCheck,
+} from '../../src/infra/runtime/heartbeat-watchdog.js';
+
+const MB = 1024 * 1024;
+
+describe('evaluateMemoryCheck', () => {
+  it('returns ok when young heap exceeds 90% (filters GC-pressure false positive)', () => {
+    // Operator-reported shape: a freshly-booted Node process with
+    // heapTotal ≈ 43 MB and heapUsed ≈ 40 MB. That is 93 %, above the
+    // default 90 % threshold, but the heap is nowhere near a memory
+    // exhaustion signal — the process simply hasn't been asked to
+    // grow yet. The minHeapBytes gate must keep this at ok.
+    const result = evaluateMemoryCheck({ heapUsed: 40 * MB, heapTotal: 43 * MB });
+    expect(result.status).toBe('ok');
+    expect(result.message).toBe('40/43 MB (93%)');
+  });
+
+  it('emits warn once heap has matured past the 128 MB floor', () => {
+    // Same ~93 % ratio, but heapTotal is now well past the
+    // minHeapBytes threshold — this is a real long-running process
+    // under sustained heap pressure, so we must surface it.
+    const result = evaluateMemoryCheck({ heapUsed: 470 * MB, heapTotal: 500 * MB });
+    expect(result.status).toBe('warn');
+    expect(result.message).toBe('470/500 MB (94%)');
+  });
+
+  it('stays ok below the ratio threshold regardless of heap size', () => {
+    const result = evaluateMemoryCheck({ heapUsed: 100 * MB, heapTotal: 500 * MB });
+    expect(result.status).toBe('ok');
+  });
+
+  it('respects custom threshold + minHeapBytes overrides', () => {
+    // Allow the caller to tighten both knobs independently.
+    const result = evaluateMemoryCheck(
+      { heapUsed: 80 * MB, heapTotal: 100 * MB },
+      { threshold: 0.7, minHeapBytes: 50 * MB },
+    );
+    expect(result.status).toBe('warn');
+  });
+
+  it('reports 0% without crashing on zero heapTotal', () => {
+    // Defensive: never divide by zero even if the runtime somehow
+    // reports a nonsensical snapshot.
+    const result = evaluateMemoryCheck({ heapUsed: 0, heapTotal: 0 });
+    expect(result.status).toBe('ok');
+    expect(result.message).toBe('0/0 MB (0%)');
+  });
+
+  it('exposes the default floor as a testable constant', () => {
+    expect(DEFAULT_MIN_HEAP_BYTES_FOR_WARN).toBe(128 * MB);
+  });
+});


### PR DESCRIPTION
## Summary

- PULSE raised `warn:memory:40/43 MB (91%)` on fresh processes — normal young-heap GC pressure, not memory exhaustion. On a 16 GB host this degraded-state signal was pinned into PULSE detail from the first heartbeat.
- Add a `heapTotal > 128 MB` gate before the ratio warn fires. Long-running processes that actually bloat still trip the warn; freshly-booted ones stay ok until the heap has matured.
- Extract `evaluateMemoryCheck` as a pure function (mirrors how `buildHeartbeatDetail` is factored) so the behaviour is unit-testable without driving `process.memoryUsage()`.

**Behaviour change note**: operators who previously saw memory warns in the first ~60 s of a process will stop seeing them. The MEMPHIS_MEMORY_WARN_THRESHOLD env var still works; this just adds a size-floor gate on top of it.

## Test plan

- [x] `tests/unit/heartbeat-memory-check.test.ts` — young-heap false-positive stays ok
- [x] Mature-heap case at 94 % heap still emits warn
- [x] Custom threshold + minHeapBytes overrides work
- [x] Zero-heapTotal divide-by-zero guard
- [x] `tests/unit/heartbeat-watchdog-detail.test.ts` and pulse round-trip still green
- [x] Lint + typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)