### PR TITLE
fix: correctness batch (B10 rmdir re-throw, B11 audit tag, B12 getMe timeout)

### DIFF
--- a/src/infra/cli/commands/provider.ts
+++ b/src/infra/cli/commands/provider.ts
@@ -114,6 +114,7 @@ export async function enrollProviderKey(
   provider: ProviderName,
   apiKey: string,
   env: NodeJS.ProcessEnv = process.env,
+  options: { command?: string } = {},
 ): Promise<ProviderAddResult> {
   if (!SUPPORTED_PROVIDERS.includes(provider)) {
     throw new Error(
@@ -133,7 +134,13 @@ export async function enrollProviderKey(
     storeVaultSecret(
       config.vaultKey,
       apiKey,
-      { surface: 'cli', command: 'provider add' },
+      // The audit entry's `command` field is the only place where the
+      // init flow vs. the manual `provider add` call are
+      // distinguishable post-hoc. Default stays `provider add` for
+      // the direct CLI path; `setup.ts` / init flow passes
+      // `'memphis init'` so the audit log attributes enrolment to the
+      // actual operator action.
+      { surface: 'cli', command: options.command ?? 'provider add' },
       env,
     );
   } catch (err) {

--- a/src/infra/cli/commands/setup-telegram.ts
+++ b/src/infra/cli/commands/setup-telegram.ts
@@ -47,12 +47,22 @@ function parseUserIds(raw: string): string[] {
     .filter((s) => s.length > 0);
 }
 
+const GETME_TIMEOUT_MS = 5_000;
+
 async function probeGetMe(
   token: string,
   fetchImpl: typeof fetch,
 ): Promise<{ id: number; username: string } | undefined> {
+  // AbortController caps the probe at 5 s. Without it, `fetch` hung
+  // indefinitely on offline / captive-portal environments during
+  // `memphis setup telegram` — the whole init flow waited on
+  // api.telegram.org with no feedback. Codex flagged on #202.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GETME_TIMEOUT_MS);
   try {
-    const resp = await fetchImpl(`https://api.telegram.org/bot${token}/getMe`);
+    const resp = await fetchImpl(`https://api.telegram.org/bot${token}/getMe`, {
+      signal: controller.signal,
+    });
     if (!resp.ok) return undefined;
     const data = (await resp.json()) as {
       ok: boolean;
@@ -61,6 +71,8 @@ async function probeGetMe(
     return data.ok && data.result ? { id: data.result.id, username: data.result.username } : undefined;
   } catch {
     return undefined;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/src/infra/cli/commands/setup.ts
+++ b/src/infra/cli/commands/setup.ts
@@ -969,7 +969,9 @@ async function maybeEnrollProvidersForInit(
 
     try {
       const apiKey = await promptHiddenSecret(`${provider} API key`);
-      const result = await enrollProviderKey(provider as ProviderName, apiKey, process.env);
+      const result = await enrollProviderKey(provider as ProviderName, apiKey, process.env, {
+        command: 'memphis init',
+      });
       console.log(`  ✓ ${result.message}`);
       enrolled.push(provider as ProviderName);
       for (const step of result.nextSteps ?? []) {

--- a/tests/cognitive/empty-blocks-handling.test.ts
+++ b/tests/cognitive/empty-blocks-handling.test.ts
@@ -24,6 +24,7 @@ beforeEach(() => {
 });
 
 function rmWithRetry(dir: string): void {
+  let lastErr: unknown;
   for (let attempt = 0; attempt < 4; attempt += 1) {
     try {
       fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
@@ -31,8 +32,13 @@ function rmWithRetry(dir: string): void {
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== 'ENOTEMPTY' && code !== 'EBUSY') throw err;
+      lastErr = err;
     }
   }
+  // Retries exhausted — surface the last ENOTEMPTY/EBUSY so afterEach
+  // doesn't silently leak a tmpdir. Previously this returned without
+  // signalling the failure, which made flaky rmdir's invisible.
+  throw lastErr;
 }
 
 afterEach(() => {

--- a/tests/unit/cli.provider-enroll.test.ts
+++ b/tests/unit/cli.provider-enroll.test.ts
@@ -69,4 +69,33 @@ describe('enrollProviderKey', () => {
       /memphis vault init/,
     );
   });
+
+  it('defaults the audit command tag to "provider add"', async () => {
+    // The prior "vault-not-initialized" test leaves a throwing
+    // implementation on `mockedStore`; vi.clearAllMocks only clears
+    // call history, not implementations. Reset the impl before the
+    // happy-path audit-tag cases.
+    mockedStore.mockReset();
+    await enrollProviderKey('minimax', 'valid-key-12345', {});
+    expect(mockedStore).toHaveBeenCalledWith(
+      'minimax_api_key',
+      'valid-key-12345',
+      expect.objectContaining({ command: 'provider add' }),
+      expect.anything(),
+    );
+  });
+
+  it('honors an explicit command override so init-flow enrolments are attributable', async () => {
+    // Codex on #201: the audit trail must distinguish `memphis init`
+    // enrolments from `memphis provider add` enrolments so later
+    // vault-audit reads can explain where each key came from.
+    mockedStore.mockReset();
+    await enrollProviderKey('minimax', 'valid-key-12345', {}, { command: 'memphis init' });
+    expect(mockedStore).toHaveBeenCalledWith(
+      'minimax_api_key',
+      'valid-key-12345',
+      expect.objectContaining({ command: 'memphis init' }),
+      expect.anything(),
+    );
+  });
 });

--- a/tests/unit/setup-telegram.test.ts
+++ b/tests/unit/setup-telegram.test.ts
@@ -134,4 +134,50 @@ describe('runTelegramSetup', () => {
     expect(result.botInfo).toBeUndefined();
     expect(result.warnings.some((w) => w.includes('getMe'))).toBe(true);
   });
+
+  it('passes an AbortSignal to fetch so the getMe probe cannot hang forever', async () => {
+    // Codex on #202: offline / captive-portal environments made the
+    // getMe probe hang indefinitely. probeGetMe now wires an
+    // AbortController at 5 s; verify the signal is actually threaded
+    // into the fetch call.
+    let observedInit: { signal?: AbortSignal } | undefined;
+    const fetchSpy = (async (_url: string, init?: { signal?: AbortSignal }) => {
+      observedInit = init;
+      return {
+        ok: true,
+        async json() {
+          return { ok: true, result: { id: 42, username: 'memphis_bot' } };
+        },
+      };
+    }) as unknown as typeof fetch;
+
+    await runTelegramSetup({
+      botToken: '1234567:AAAaaa-bbb-ccc-ddd-eee-fff-ggg-hhh',
+      allowedUserIds: '111',
+      fetchImpl: fetchSpy,
+    });
+
+    expect(observedInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('swallows an AbortError from getMe into the "could not verify" warning', async () => {
+    const fetchImpl = (async () => {
+      // Simulate an upstream timeout: the passed signal aborts and
+      // fetch rejects with an AbortError. probeGetMe must treat this
+      // as "probe failed" rather than escaping to the caller.
+      const err = new Error('The operation was aborted.');
+      err.name = 'AbortError';
+      return await Promise.reject(err);
+    }) as unknown as typeof fetch;
+
+    const result = await runTelegramSetup({
+      botToken: '1234567:AAAaaa-bbb-ccc-ddd-eee-fff-ggg-hhh',
+      allowedUserIds: '111',
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.botInfo).toBeUndefined();
+    expect(result.warnings.some((w) => w.includes('getMe'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Three small correctness fixes Codex flagged on 2026-04-20 review:

- **B10 (#206)** — `rmWithRetry` in `tests/cognitive/empty-blocks-handling.test.ts` swallowed ENOTEMPTY/EBUSY after exhausting retries. Now re-throws the last error so flaky afterEach rmdir's become visible.
- **B11 (#201)** — `enrollProviderKey` hard-coded `command: 'provider add'` in the audit entry. Add optional `{ command }` param; init flow (`setup.ts`) passes `'memphis init'`. Default unchanged for direct CLI callers.
- **B12 (#202)** — `probeGetMe` had no timeout; offline / captive-portal environments hung `memphis setup telegram` on api.telegram.org indefinitely. Wrap in `AbortController` with 5 s deadline; AbortError is still swallowed into the existing "could not verify" warning.

## Test plan

- [x] `tests/cognitive/empty-blocks-handling.test.ts` — 4 passed (happy-path regression check)
- [x] `tests/unit/cli.provider-enroll.test.ts` — 2 new tests: default tag + explicit override
- [x] `tests/unit/setup-telegram.test.ts` — 2 new tests: AbortSignal threaded to fetch + AbortError → warning
- [x] Lint + typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)