### PR TITLE
fix(self-update): lockfile add/remove detection + upstream-ref fallback (B5+B6)

### DIFF
--- a/src/infra/self-update/source-checkout.ts
+++ b/src/infra/self-update/source-checkout.ts
@@ -56,6 +56,12 @@ export type SourceCheckResult = {
   remote: string;
   branch: string;
   error?: string;
+  /**
+   * Non-fatal advisories surfaced to the caller. Populated, for
+   * example, when `resolveBranchRef` had to fall back from
+   * `origin/<branch>` to the configured `@{upstream}`.
+   */
+  warnings?: string[];
 };
 
 export type SourceInstallOptions = {
@@ -122,6 +128,24 @@ export function detectSourceCheckout(
   };
 }
 
+/**
+ * Treat any transition as a lockfile change: add (undefined →
+ * defined), remove (defined → undefined), or content change (hash
+ * mismatch). Exported for unit tests. The previous
+ * `preHash && postHash && preHash !== postHash` heuristic silently
+ * dropped install on the add-a-lockfile case, leaving `node_modules`
+ * out of sync with the committed lock. (Codex on #212.)
+ */
+export function computePackageLockChanged(
+  preHash: string | undefined,
+  postHash: string | undefined,
+): boolean {
+  return (
+    (preHash === undefined) !== (postHash === undefined) ||
+    (preHash !== undefined && postHash !== undefined && preHash !== postHash)
+  );
+}
+
 function hashFile(path: string): string | undefined {
   if (!existsSync(path)) return undefined;
   try {
@@ -132,14 +156,45 @@ function hashFile(path: string): string | undefined {
   }
 }
 
+export type ResolvedBranchRef = {
+  refName: string;
+  source: 'origin' | 'upstream';
+  warning?: string;
+};
+
 function resolveBranchRef(
   runner: SourceRunner,
   runtimeRoot: string,
   branch: string,
-): string {
-  // `origin/<branch>` tracks the remote if `git fetch` ran. Fall back to
-  // HEAD when the user is already on a disconnected branch.
-  return `origin/${branch}`;
+): ResolvedBranchRef | { error: string } {
+  // Prefer `origin/<branch>` when the remote actually has that ref.
+  // `git rev-parse --verify <ref>` returns 0 only when the ref
+  // resolves, so we can probe cheaply before committing to it.
+  const originRef = `origin/${branch}`;
+  const originProbe = runGit(['rev-parse', '--verify', originRef], runner, runtimeRoot);
+  if (originProbe.status === 0) {
+    return { refName: originRef, source: 'origin' };
+  }
+
+  // Fall back to the branch's configured upstream (may be
+  // `origin/<other>` for workflows that push through a different
+  // name, or `upstream/<branch>` for fork setups). The `@{upstream}`
+  // revision syntax resolves to whatever tracking ref is configured.
+  const upstreamProbe = runGit(['rev-parse', '--abbrev-ref', `${branch}@{upstream}`], runner, runtimeRoot);
+  if (upstreamProbe.status === 0) {
+    const upstream = upstreamProbe.stdout.trim();
+    if (upstream) {
+      return {
+        refName: upstream,
+        source: 'upstream',
+        warning: `origin/${branch} does not exist; using configured upstream ${upstream}`,
+      };
+    }
+  }
+
+  return {
+    error: `branch ${branch} has no upstream (neither origin/${branch} nor @{upstream} resolved). Set one with \`git branch --set-upstream-to=<remote>/<branch>\` or push the branch to origin.`,
+  };
 }
 
 export function checkSourceUpdate(
@@ -179,7 +234,23 @@ export function checkSourceUpdate(
     };
   }
 
-  const refName = resolveBranchRef(runner, runtimeRoot, branch);
+  const refResult = resolveBranchRef(runner, runtimeRoot, branch);
+  if ('error' in refResult) {
+    return {
+      ok: false,
+      mode: 'source-checkout',
+      updateAvailable: false,
+      currentCommit: detection.head ?? '',
+      latestCommit: '',
+      commitsBehind: 0,
+      subjects: [],
+      remote: detection.remote ?? '',
+      branch,
+      error: refResult.error,
+    };
+  }
+  const refName = refResult.refName;
+  const refWarnings = refResult.warning ? [refResult.warning] : undefined;
   const latest = runGit(['rev-parse', refName], runner, runtimeRoot);
   if (latest.status !== 0) {
     return {
@@ -193,6 +264,7 @@ export function checkSourceUpdate(
       remote: detection.remote ?? '',
       branch,
       error: `could not resolve ${refName}: ${latest.stderr.trim()}`,
+      warnings: refWarnings,
     };
   }
 
@@ -210,6 +282,7 @@ export function checkSourceUpdate(
       subjects: [],
       remote: detection.remote ?? '',
       branch,
+      warnings: refWarnings,
     };
   }
 
@@ -236,6 +309,7 @@ export function checkSourceUpdate(
     subjects,
     remote: detection.remote ?? '',
     branch,
+    warnings: refWarnings,
   };
 }
 
@@ -320,7 +394,7 @@ export function installSourceUpdate(
   }
 
   const postHash = hashFile(lockPath);
-  const packageLockChanged = Boolean(preHash && postHash && preHash !== postHash);
+  const packageLockChanged = computePackageLockChanged(preHash, postHash);
 
   let installed = false;
   if (packageLockChanged) {

--- a/tests/unit/self-update.source-checkout.test.ts
+++ b/tests/unit/self-update.source-checkout.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   checkSourceUpdate,
+  computePackageLockChanged,
   detectSourceCheckout,
   installSourceUpdate,
   type SourceRunner,
@@ -112,6 +113,77 @@ describe('checkSourceUpdate', () => {
     const result = checkSourceUpdate(root, runner);
     expect(result.ok).toBe(false);
     expect(result.error).toContain('could not resolve host');
+  });
+
+  it('falls back to @{upstream} with a warning when origin/<branch> does not exist', () => {
+    // Codex on #212: some operator setups push through a fork, so
+    // `origin/<branch>` may not resolve but a configured upstream
+    // does. Verify the fallback picks the upstream ref and attaches
+    // a warning — we don't want to silently resolve to a ref the
+    // operator didn't set.
+    const root = makeFakeCheckout();
+    const { runner } = makeRunner({
+      'git rev-parse --abbrev-ref HEAD': { stdout: 'dev-branch\n' },
+      'git rev-parse HEAD': { stdout: 'aaaa111\n' },
+      'git config --get remote.origin.url': { stdout: 'origin\n' },
+      'git fetch --quiet origin': { stdout: '' },
+      'git rev-parse --verify origin/dev-branch': { status: 1, stderr: 'unknown revision' },
+      'git rev-parse --abbrev-ref dev-branch@{upstream}': {
+        stdout: 'upstream/dev-branch\n',
+      },
+      'git rev-parse upstream/dev-branch': { stdout: 'bbbb222\n' },
+      'git log --pretty=%s aaaa111..bbbb222': { stdout: 'feat: x\n' },
+    });
+    const result = checkSourceUpdate(root, runner);
+    expect(result.ok).toBe(true);
+    expect(result.updateAvailable).toBe(true);
+    expect(result.warnings?.some((w) => w.includes('upstream/dev-branch'))).toBe(true);
+  });
+
+  it('reports a no-upstream error when neither origin nor @{upstream} resolve', () => {
+    const root = makeFakeCheckout();
+    const { runner } = makeRunner({
+      'git rev-parse --abbrev-ref HEAD': { stdout: 'local-only\n' },
+      'git rev-parse HEAD': { stdout: 'aaaa111\n' },
+      'git config --get remote.origin.url': { stdout: 'origin\n' },
+      'git fetch --quiet origin': { stdout: '' },
+      'git rev-parse --verify origin/local-only': { status: 1, stderr: 'unknown revision' },
+      'git rev-parse --abbrev-ref local-only@{upstream}': {
+        status: 128,
+        stderr: 'fatal: no upstream configured for branch local-only',
+      },
+    });
+    const result = checkSourceUpdate(root, runner);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/no upstream/);
+  });
+});
+
+describe('computePackageLockChanged', () => {
+  it('returns false when both hashes match', () => {
+    expect(computePackageLockChanged('aaa', 'aaa')).toBe(false);
+  });
+
+  it('returns true when hashes differ', () => {
+    expect(computePackageLockChanged('aaa', 'bbb')).toBe(true);
+  });
+
+  it('returns true when a lockfile is added (undefined → defined)', () => {
+    // Previously `preHash && postHash && preHash !== postHash` was
+    // false in this case, so `npm install` was skipped when a pull
+    // introduced package-lock.json. Now it correctly surfaces the
+    // change.
+    expect(computePackageLockChanged(undefined, 'aaa')).toBe(true);
+  });
+
+  it('returns true when a lockfile is removed (defined → undefined)', () => {
+    expect(computePackageLockChanged('aaa', undefined)).toBe(true);
+  });
+
+  it('returns false when neither pre nor post hash exists', () => {
+    // Repo genuinely has no lockfile before and after — nothing to
+    // install from, nothing to do.
+    expect(computePackageLockChanged(undefined, undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Two correctness fixes on `src/infra/self-update/source-checkout.ts` Codex flagged on #212:

- **B5** `packageLockChanged` returned false when the lockfile transitioned between undefined and defined, so a pull that *added* `package-lock.json` silently skipped `npm install` and left `node_modules` stale. Extracted to `computePackageLockChanged(preHash, postHash)` — treats add/remove as changed.
- **B6** `resolveBranchRef` hard-coded `origin/<branch>`. Fork-based workflows where `origin/<branch>` doesn't exist but a configured upstream does got a silent fail-through. Now probes origin → falls back to `<branch>@{upstream}` → returns a structured no-upstream error when neither resolves. Fallback attaches a warning to the check result so the operator knows which ref was chosen.

Adds `warnings?: string[]` to `SourceCheckResult`.

## Test plan

- [x] 4 pure tests for `computePackageLockChanged` (same/differ/add/remove + no-lockfile baseline)
- [x] 2 end-to-end tests for branch-ref resolution (upstream fallback warning, no-upstream error)
- [x] Existing 10 source-checkout tests still pass (mocked runner defaults keep origin/<branch> resolving as before)
- [x] Lint + typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)