### PR TITLE
fix(pulse): positional mode/surfaces parse (follow-up #217)

### DIFF
--- a/src/infra/runtime/heartbeat-watchdog.ts
+++ b/src/infra/runtime/heartbeat-watchdog.ts
@@ -296,22 +296,29 @@ export function loadPulseEntries(): PulseEntry[] {
       };
 
       // Extract structured tail fields (mode=…, surfaces=…) and treat
-      // whatever is left as free-form `detail`. Previously the parser
-      // ignored both mode and detail, so the next `writePulseEvent`
-      // rebuilt the file WITHOUT the detail text — `tail PULSE.md` only
-      // ever showed the reason on the newest heartbeat. (Codex B4.)
-      let tail = base[5] ?? '';
+      // whatever is left as free-form `detail`. Writer order is fixed
+      // (mode first, then surfaces, then detail), so parse
+      // positionally rather than regex-matching the whole tail — a
+      // detail string containing literal "mode=…" or "surfaces=…"
+      // (e.g., an error message like "mode=readonly refused") would
+      // otherwise get pulled into cognitiveMode / activeSurfaces and
+      // vanish from detail. (Codex follow-up on #217.)
+      let tail = (base[5] ?? '').replace(/^\s+/, '');
 
-      const modeMatch = tail.match(/(?:^|\s)mode=(\S+)/);
-      if (modeMatch) {
-        entry.cognitiveMode = modeMatch[1]!;
-        tail = tail.replace(modeMatch[0], ' ');
+      if (tail.startsWith('mode=')) {
+        const match = tail.match(/^mode=(\S+)\s*/);
+        if (match) {
+          entry.cognitiveMode = match[1]!;
+          tail = tail.slice(match[0].length);
+        }
       }
 
-      const surfacesMatch = tail.match(/(?:^|\s)surfaces=(\S+)/);
-      if (surfacesMatch) {
-        entry.activeSurfaces = surfacesMatch[1]!.split(',').filter(Boolean);
-        tail = tail.replace(surfacesMatch[0], ' ');
+      if (tail.startsWith('surfaces=')) {
+        const match = tail.match(/^surfaces=(\S+)\s*/);
+        if (match) {
+          entry.activeSurfaces = match[1]!.split(',').filter(Boolean);
+          tail = tail.slice(match[0].length);
+        }
       }
 
       const detail = tail.replace(/\s+/g, ' ').trim();

--- a/tests/unit/pulse-entry-round-trip.test.ts
+++ b/tests/unit/pulse-entry-round-trip.test.ts
@@ -73,6 +73,45 @@ describe('PULSE.md detail round-trip', () => {
     expect(entry.health).toBe('healthy');
   });
 
+  it('preserves a detail string that legitimately contains "mode=…" and "surfaces=…"', () => {
+    // Codex follow-up on #217: the parser previously ran
+    // `/(?:^|\s)mode=(\S+)/` against the full tail, which would pull
+    // the literal "mode=readonly" out of a detail like
+    // "fail:chain_adapter:mode=readonly blocked" and misassign it to
+    // cognitiveMode — and drop it from detail on rewrite. The
+    // positional parser must leave these substrings inside detail
+    // when they are not in the mode / surfaces prefix slot.
+    writePulseEvent({
+      timestamp: '2026-04-21T10:17:00.000Z',
+      event: 'heartbeat',
+      health: 'degraded',
+      uptimeSeconds: 60,
+      detail: 'fail:chain_adapter:mode=readonly surfaces=mcp blocked',
+    });
+
+    const [entry] = loadPulseEntries();
+    expect(entry.cognitiveMode).toBeUndefined();
+    expect(entry.activeSurfaces).toBeUndefined();
+    expect(entry.detail).toBe('fail:chain_adapter:mode=readonly surfaces=mcp blocked');
+  });
+
+  it('still extracts mode / surfaces when they appear in the prefix slot even with a literal "mode=" in detail', () => {
+    writePulseEvent({
+      timestamp: '2026-04-21T10:18:00.000Z',
+      event: 'heartbeat',
+      health: 'degraded',
+      uptimeSeconds: 60,
+      cognitiveMode: 'B',
+      activeSurfaces: ['tui'],
+      detail: 'fail:vault:mode=locked requires pepper',
+    });
+
+    const [entry] = loadPulseEntries();
+    expect(entry.cognitiveMode).toBe('B');
+    expect(entry.activeSurfaces).toEqual(['tui']);
+    expect(entry.detail).toBe('fail:vault:mode=locked requires pepper');
+  });
+
   it('writes a second entry without losing detail from the first', () => {
     writePulseEvent({
       timestamp: '2026-04-21T10:15:00.000Z',


### PR DESCRIPTION
## Summary

`loadPulseEntries` ran anchored regex `(?:^|\s)mode=(\S+)` / `surfaces=(\S+)` against the full line tail, so a free-form detail string containing literal \"mode=…\" (for example `fail:chain_adapter:mode=readonly`) got its substring pulled out and misassigned to `cognitiveMode` — and then dropped from detail on the next rewrite.

Writer emits fields in fixed order (mode → surfaces → detail), so parse positionally: only consume `mode=` / `surfaces=` when they are the next token, leave the rest in detail.

## Test plan

- [x] `tests/unit/pulse-entry-round-trip.test.ts` — 2 new tests:
  - Detail with literal `mode=readonly surfaces=mcp blocked` stays intact in `detail`, `cognitiveMode` / `activeSurfaces` remain undefined.
  - Prefix-slot `mode=B` + detail containing literal `mode=locked` both round-trip cleanly.
- [x] Existing 4 round-trip + 4 buildHeartbeatDetail + 6 memory-check tests still pass.
- [x] Lint + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)