### PR TITLE
docs: macOS service caveat + pepper-rotate --confirm (H5+H13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Then (or if you left `--with-init` off) walk the canonical first-run:
 ```bash
 memphis init                    # passphrase, vault, identity, first chain writes
 memphis provider add anthropic  # (optional) cloud provider — repeat for minimax/deepseek/glm
-memphis service install && memphis service restart
+memphis service install && memphis service restart  # Linux / WSL systemd-user only; see macOS note below
 memphis tui                     # open the native operator cockpit
 ```
+
+> **macOS operators**: `memphis service install` wires a systemd-user unit, so the step above is a no-op on macOS. Either run the runtime in a terminal with `npm run dev` while you need it, or provision a `launchd` plist at `~/Library/LaunchAgents/chains.memphis.runtime.plist` that `exec`s the same command. The remaining steps (`memphis init`, `memphis provider add …`, `memphis tui`) work identically across Linux, macOS, and WSL.
 
 That's it. Sovereign AI running on your machine, with encrypted vault, chain-backed memory, 200k-token Claude access (if you added anthropic), and local Ollama fallback when the network's down.
 

--- a/docs/operator/example-installation/04-vault-setup.md
+++ b/docs/operator/example-installation/04-vault-setup.md
@@ -109,8 +109,12 @@ To rotate just the per-entry pepper (lighter operation, master key
 unchanged):
 
 ```
-$ memphis vault pepper-rotate
+$ memphis vault pepper-rotate --confirm
 ```
+
+The `--confirm` flag is required — `pepper-rotate` rewraps the master
+key under a fresh pepper and rewrites `.env`, so the CLI refuses to
+run without the explicit acknowledgement.
 
 ## Recovery flow (forgot vault passphrase)
 


### PR DESCRIPTION
## Summary

Two operator-facing doc fixes Codex flagged:

- **H5** — README "Install in 8 minutes" panel told macOS operators to run `memphis service install && memphis service restart`, which wires a systemd *user* unit (Linux / WSL only). macOS operators who copy-pasted saw no-ops with no explanation. Add an inline note pointing to `npm run dev` / launchd plist.
- **H13** — `docs/operator/example-installation/04-vault-setup.md` showed `$ memphis vault pepper-rotate` without `--confirm`, but the CLI refuses without it (vault.handler.ts:360). Add `--confirm` to the example and explain the why-required.

## Test plan

- [x] README renders: macOS note inline under the 4-command block
- [x] 04-vault-setup.md: pepper-rotate example now matches the handler's gate
- [x] No code change, no test change

🤖 Generated with [Claude Code](https://claude.com/claude-code)