### PR TITLE
docs(roadmap): consolidate Phase 0 deltas, add N31 app.rs split, fix vendoring drift

### DIFF
--- a/docs/roadmap/Y1-2026-05-to-2027-05.md
+++ b/docs/roadmap/Y1-2026-05-to-2027-05.md
@@ -10,10 +10,10 @@
 
 ## Context
 
-**Why this exists.** Memphis at v1.0.1 post-Phase-4 stabilization has a credible base but a gap between pitch and code. The 2026-04-21 audit catalogued 11 "nadpiski" (code/docs pretending to do more than shipped). Separately, the long-term product bet is **WatraLLM** — a small (≤1.5B), censure-free, non-instruct base fine-tuned nightly on the operator's own Memphis chains. The container for that training data is a vendored `.mv2`-shaped format (memvid-core reference only — we own the stack).
+**Why this exists.** Memphis at v1.0.1 post-Phase-4 stabilization has a credible base but a gap between pitch and code. The 2026-04-21 audit catalogued 11 "nadpiski" (code/docs pretending to do more than shipped). Separately, the long-term product bet is **WatraLLM** — a small (≤1.5B), censure-free, non-instruct base fine-tuned nightly on the operator's own Memphis chains. Training substrate is the `.mv2` format from the actively-maintained `memvid-core` crate (Apache-2.0, pinned as `stable-platform`).
 
 **Two decisions framed this plan:**
-1. **Own the stack.** Zero live external dependencies on volatile upstream. Every dependency is stdlib / stable-platform / vendored-frozen / scheduled-for-rewrite / blocked. memvid-core and OpenMythos go into `vendor/` as frozen snapshots; if they drift we patch, never auto-update. OpenMythos Rust rewrite lives on the Q4/Y2 stretch list.
+1. **Own the stack, but match reality of each dependency.** Deps are classified `stdlib` / `stable-platform` (pinned crates.io with bump-on-review) / `vendored-frozen` (copied into `vendor/` for dormant or hostile upstream) / `scheduled-for-rewrite` / `blocked`. Phase 0 reclassified memvid-core to stable-platform after confirming upstream health; OpenMythos stays as Y2 research arm, not a Y1 dep.
 2. **Commercial-ready main from day one.** Apache-2.0 license, dep audit clean (zero GPL/AGPL), commercial fork launches **Y2 Q2 (2027-08 after the main year)** not sooner. Main stabilization priority through 2027-Q1.
 
 **Product pipeline at steady state:**
@@ -30,11 +30,27 @@ Memphis chains ──► .mv2 export (own format) ──► nightly Watrowanie �
 
 **Goal:** every README claim backed by code; every stub closed or explicitly re-labelled; nightly Watrowanie working on the operator's own box by Q3 producing a running WatraLLM-v1 checkpoint; Y2 Q2 commercial fork framework ready.
 
+## Phase 0 deltas applied
+
+Five deltas from the 2026-04-21 research + scan pass (raw findings in `docs/roadmap/phase-0-findings-2026-04-21.md`) are folded into every section below. Consolidated here so the binding-state is scannable without hunting through workstreams:
+
+- **D1 — memvid-core: `stable-platform`, not `vendored-frozen`.** Upstream at v2.0.139 (2026-03-13), Apache-2.0, actively maintained. `Cargo.toml` pins `memvid-core = "2.0"` with deliberate bump-on-review; no `vendor/memvid-core/` directory, no git-subtree.
+- **D2 — `memvid/claude-brain` added as reference architecture study.** MIT, v1.0.7 Jan 2026, 458 stars. Same TS+Rust stack as Memphis. Q1 Phase 0 deliverable studies their `.mv2` writer patterns before our own adapter lands.
+- **D3 — OpenMythos demoted to Y2 research arm.** Not used in Y1 training pipeline. Q3 trains with `HF transformers + peft + bitsandbytes` (all `stable-platform` from PyPI). OpenMythos Rust rewrite is N29 stretch in Q4/Y2.
+- **D4 — Base model primary: Qwen3-0.6B-base** (Apache-2.0). Pointer/router task is narrow enough for the smallest Qwen3 dense base. Qwen3-1.7B-base as upgrade path if eval accuracy falls below 70% on held-out set. TinyLlama-1.1B-base remains as escape floor only.
+- **D5 — WatraLLM role locked: pointer/router service**, not a chat-provider-cascade entry. Lives in `src/watra/router.ts`; exposed to primary LLM via new tier-0 read tool `memphis_watra_pointer`. Paranoid-tier output by construction. Tool-use expansion is explicit Y2 decision gate.
+
 ## Principles (non-negotiable)
 
 1. **Rust core authoritative.** `crates/memphis-core|memphis-operator|memphis-embed` own data plane; TS orchestrates via NAPI. When Rust and TS both implement a surface, Rust is canonical; TS fallback only when Rust bridge status reports unavailable.
-2. **Own the stack.** No live dependency on volatile upstream. Every non-stdlib/non-stable-platform dep is classified vendored-frozen, scheduled-for-rewrite, or blocked. `vendor/<name>/` holds frozen copies; upstream updates are a deliberate patch decision.
-3. **No new formats if one exists (and is ownable).** `.mv2` layout per memvid's `MV2_SPEC.md` is our substrate; we vendor the reference implementation, port what we need into `crates/memphis-export`, and rewrite in Rust where the vendored code is brittle.
+2. **Own the stack — with dep class discipline.** Every dep is classified:
+   - `stdlib` (Node/Rust stdlib),
+   - `stable-platform` (pinned crates.io/npm/PyPI version, bump-on-review; includes memvid-core, fastify, tokio, serde, peft, bitsandbytes),
+   - `vendored-frozen` (copied into `vendor/<name>/` with original LICENSE preserved — reserved for dormant/hostile upstream, none at Y1 start),
+   - `scheduled-for-rewrite` (Rust rewrite queued; populated by Q3 audit),
+   - `blocked` (GPL/AGPL, unmaintained, CVE-flagged).
+   No Dependabot auto-merge. Vendored-or-stable-platform is the "own-the-stack" way; both honor the principle, neither is default — class is chosen per upstream health.
+3. **No new formats if one exists (and is ownable).** `.mv2` layout per memvid's `MV2_SPEC.md` is our substrate. `memvid-core` is a `stable-platform` crates.io dependency; we write the Memphis adapter (`crates/memphis-export/`) against its public API and monitor upstream for breaking changes.
 4. **Every README promise shippable today.** Zero "coming soon" in README without a flagged enable path.
 5. **Every stub explicit.** A function whose only job is `throw new Error('not yet')` is either deleted or surfaced via `memphis doctor` + `/v1/ops/status.selfCheck`.
 6. **Commercial-ready license hygiene.** Apache-2.0 on main. Zero GPL/AGPL in dependency tree (incl. vendored). CLA framework ready Q4 2026; commercial fork (private repo) launches Y2 Q2 2027.
@@ -72,7 +88,7 @@ Memphis chains ──► .mv2 export (own format) ──► nightly Watrowanie �
    - Verify `crates/memphis-export/` does NOT exist (plan assumes green-field).
    - Verify `crates/memphis-core/src/block.rs` exports the Ed25519 signer keypair API we need for `.mv2` TOC signing.
    - Verify Cargo workspace `crates/Cargo.toml` can accept a new member cleanly.
-   - Verify `vendor/` directory does NOT exist at Memphis repo root (we'll create it).
+   - Verify `vendor/` directory state (created only for deps we deliberately classify `vendored-frozen`; not needed at Y1 start since memvid-core is `stable-platform`).
    - Verify `src/federation/matrix/client.ts:19-23` deferred comment still present and enum `FederationTrustMode` still has `'public-deferred'` literal.
    - Full list of every `throw new Error('not yet'|'not available'|'not populated'|'unavailable')` in `src/` (the stub map).
 
@@ -89,15 +105,15 @@ Memphis chains ──► .mv2 export (own format) ──► nightly Watrowanie �
 
 ## Quarter-by-quarter
 
-### Q1 (2026-05 → 2026-07) — Honesty sprint + Trajectory B/C + memvid adapter scaffold + dep-freeze framework
+### Q1 (2026-05 → 2026-07) — Honesty sprint + Trajectory B/C + memvid adapter scaffold + dep-class framework
 
-**Theme:** close the 11 nadpiski; land trajectory B+C; vendor memvid-core; new-dep classification policy + CI gate.
+**Theme:** close the 11 nadpiski; land trajectory B+C; wire memvid-core as stable-platform dep and build the `.mv2` adapter crate; new dep-classification policy + CI gate.
 
 **Ship criteria (target v1.2.0, end-of-Q1 release):**
 
 - `memphis doctor --json | jq '.ok'` = true on fresh host, no deferred-feature warnings.
 - `memphis export trajectories --out <dir>` produces HF-dataset-shape per `docs/dev/TRAJECTORY-EXPORT-V1.md`.
-- `memphis export --format=mv2 --output <path>.mv2 --include journal` produces a valid `.mv2` (validated via vendored `memvid inspect` binary).
+- `memphis export --format=mv2 --output <path>.mv2 --include journal` produces a valid `.mv2` (validated via `memvid inspect` CLI or `memvid-core` round-trip test).
 - `docs/dev/DEPENDENCY-POLICY.md` committed; `.github/workflows/dep-freeze-check.yml` blocks unclassified new deps.
 - `docs/security/posture-2026-Q1.md` filed.
 - Zero `grep -r 'coming soon' README.md` matches.
@@ -121,18 +137,18 @@ Memphis chains ──► .mv2 export (own format) ──► nightly Watrowanie �
 | N8 | PR B — `turnId` propagation through `storeDurableMemory` + surface-policy `consent` default + all chain-append call sites |
 | N9 | PR C — Exporter core + `memphis export trajectories` CLI + integration fixtures |
 
-**Workstream C — `.mv2` adapter scaffold, vendored (N12)**
+**Workstream C — `.mv2` adapter scaffold, stable-platform dep (N12)**
 
-- Add `vendor/memvid-core/` as git-subtree (not submodule; subtree means no external-repo-binding at build time) snapshot of `/home/memphis/github-repos/memvid-memvid/` at a pinned SHA.
-- Original Apache-2.0 license preserved in `vendor/memvid-core/LICENSE`.
+- `memvid-core` pinned as `memvid-core = "2.0"` in workspace `Cargo.toml` (crates.io, Apache-2.0). Classified `stable-platform` per D1. Bumps are manual PR decisions, not Dependabot auto-merge.
 - New crate `crates/memphis-export/`:
-  - Path-depends on `../vendor/memvid-core` (NOT `memvid-core` from crates.io).
+  - `Cargo.toml` declares `memvid-core = { workspace = true }` + path-deps on `memphis-core`.
   - NAPI bindings in `src/lib.rs` exposing `exportMv2(opts) → ExportResult`.
-  - Module `src/mv2/writer.rs` — chain blocks → `.mv2` frames using vendored writer.
+  - Module `src/mv2/writer.rs` — chain blocks → `.mv2` frames via memvid-core's public API (`MemFile::new`, `put_bytes_with_options`, `commit`).
   - Module `src/mv2/tracks.rs` — per-chain frame grouping + metadata tags.
 - TS surface: `src/infra/cli/commands/export-mv2.ts` → `memphis export --format=mv2 --output <path>.mv2 --include journal`.
-- Minimum viable Q1: one track (`journal`), no privacy redaction, no signing. Round-trip validated.
-- Doc: `docs/dev/MV2-INTEGRATION.md` — maps Memphis block schema → `.mv2` frame schema. Explicitly notes "vendored from memvid at SHA <…>, not a live crates.io dependency."
+- Minimum viable Q1: one track (`journal`), no privacy redaction, no signing. Round-trip validated via either external `memvid inspect` CLI (dev tool, not runtime dep) or in-process `memvid-core` reader.
+- Reference study: read `memvid/claude-brain` source (D2) before shipping the writer — their TS-wrapper-over-Rust-core architecture mirrors ours and has solved the same NAPI bridge shape.
+- Doc: `docs/dev/MV2-INTEGRATION.md` — maps Memphis block schema → `.mv2` frame schema; pins the exact `memvid-core` version the adapter was built against; documents breaking-change watch policy.
 
 **Workstream D — Dependency ownership policy (N25)**
 
@@ -381,7 +397,7 @@ Status: `todo` / `in-progress` / `shipped` / `descoped`. Carry quarter-over-quar
 | N9 | Trajectory PR C (exporter + CLI) | `src/trajectory/exporter.ts` (new) | Q1 | todo |
 | N10 | Trajectory PR D (HF format) | `src/trajectory/exporter.ts` | Q2 | todo |
 | N11 | Trajectory PR E (consent backfill) | `src/infra/cli/commands/consent.ts` (new) | Q2 | todo |
-| N12 | `.mv2` adapter scaffold (journal-only, vendored memvid) | `crates/memphis-export/`, `vendor/memvid-core/` | Q1 | todo |
+| N12 | `.mv2` adapter scaffold (journal-only, stable-platform `memvid-core`) | `crates/memphis-export/` | Q1 | todo |
 | N13 | `.mv2` full round-trip (all tracks + signing + privacy) | `crates/memphis-export/`, `src/infra/cli/commands/export-mv2.ts` | Q2 | todo |
 | N14 | Matrix HMAC key exchange | `src/federation/keys/federation-mac.ts` (new) | Q3 | todo |
 | N15 | External security review Q2 | `docs/security/AUDIT-2026-Q2.md` (new) | Q2 | todo |
@@ -400,23 +416,25 @@ Status: `todo` / `in-progress` / `shipped` / `descoped`. Carry quarter-over-quar
 | N28 | Commercial fork framework (CLA, LICENSE-STRATEGY, private repo placeholder) — **prep only, no launch** | `.github/CLA.md`, `docs/legal/LICENSE-STRATEGY.md` | Q4 | todo |
 | N29 | OpenMythos Rust rewrite (stretch) | `crates/memphis-trainer/` (new) | Q4/Y2 | stretch |
 | N30 | Quarterly exit-test CI gate | `.github/workflows/quarterly-gate.yml` | Q1 | todo |
+| N31 | Split `app.rs` into per-screen modules (pre-req for Q3 Watra screen + pointer-card widget) | `crates/memphis-tui/src/app/*` (new modules: `chat.rs`, `memory.rs`, `watra.rs`, `replay.rs`, `widgets/pointer_card.rs`) | Q2-end / Q3-prep | todo |
 
 ---
 
 ## `.mv2` integration — binding spec (Q1 doc, Q2 impl)
 
-### Vendor strategy
+### Dependency strategy (per D1)
 
-- `vendor/memvid-core/` — git-subtree of `/home/memphis/github-repos/memvid-memvid/` at pinned SHA.
-- Apache-2.0 license preserved in `vendor/memvid-core/LICENSE`.
-- No crates.io dependency on `memvid-core`.
-- `.mv2` format per vendored `MV2_SPEC.md`: 4 KB header + embedded WAL (1-64 MB) + data segments + Tantivy lex index + HNSW vec index + time index + TOC footer.
-- Upstream updates: manual PR decision, not auto. If upstream breaks format we patch or freeze.
+- `memvid-core` pinned as `memvid-core = "2.0"` in workspace `Cargo.toml` (crates.io, Apache-2.0, v2.0.x active 2026-Q1).
+- Classified `stable-platform` per `docs/dev/DEPENDENCY-POLICY.md` — pinned version, bump-on-review, no Dependabot auto-merge.
+- Upstream is actively maintained (v2.0.139 released 2026-03-13); vendoring would cost us perf/bug fixes. If upstream breaks 2.0.x semver, we patch via fork + reclassify as `vendored-frozen`.
+- No `vendor/memvid-core/` directory. No git-subtree. Format spec remains authoritative at upstream `MV2_SPEC.md`; we link to the exact version hash in our integration doc.
+- `.mv2` format per `MV2_SPEC.md`: 4 KB header + embedded WAL (1-64 MB) + data segments + Tantivy lex index + HNSW vec index + time index + TOC footer.
+- Upstream updates: manual PR decision, not auto. If upstream breaks format we patch via local fork and reclassify to `vendored-frozen` with documented rationale.
 
 ### New crate: `crates/memphis-export`
 
 ```
-Cargo.toml — depends on memphis-core + ../vendor/memvid-core (path dep, not crates.io)
+Cargo.toml — depends on memphis-core + memvid-core (crates.io, workspace-pinned)
 src/
   lib.rs                 # NAPI bindings: exportMv2(opts) / importMv2(opts)
   mv2/
@@ -564,9 +582,9 @@ Validated by Zod schema in `src/watra/pointer.ts`. Anything not matching → rej
 | Class | Definition | Example |
 |-------|------------|---------|
 | `stdlib` | Node/Rust stdlib only | `fs`, `std::fs` |
-| `stable-platform` | Well-maintained platform SDK we trust | `fastify`, `tokio`, `serde` |
-| `vendored-frozen` | Copied to `vendor/<name>/`, pinned SHA, manual updates only | `memvid-core`, `OpenMythos`, `peft` (Q3) |
-| `scheduled-for-rewrite` | Live dep, Rust rewrite planned | (none Q1; populated by Q3 audit) |
+| `stable-platform` | Actively-maintained upstream, pinned version, bump-on-PR-review | `fastify`, `tokio`, `serde`, `memvid-core` (v2.0), `peft`, `bitsandbytes`, `transformers` |
+| `vendored-frozen` | Copied to `vendor/<name>/`, pinned SHA, manual updates — reserved for dormant/hostile upstream | (none at Y1 Q1 start; possible later if `memvid-core` 2.x breaks or OpenMythos turns unreliable) |
+| `scheduled-for-rewrite` | Live dep, Rust rewrite planned | (none Q1; populated by Q3 audit — candidates: OpenMythos Y2 Rust port) |
 | `blocked` | GPL/AGPL, unmaintained, CVE-flagged | — |
 
 ### PR flow
@@ -656,9 +674,10 @@ Last week of each quarter:
 ### Escape hatches
 
 - External Q2 audit surfaces P0 → Q2 theme pivots; `.mv2` full round-trip slips to Q3.
-- Q3 training corpus insufficient (<10k training examples from chains) → Q3 ship criteria relax to data-collection + 1 epoch on minimal data; WatraLLM-v1 definition narrows.
-- Hardware too constrained (4 GB VRAM cannot fit even TinyLlama-1.1B QLoRA) → fall back to Pythia-1B or 0.5B base; document limitation in `docs/operator/watra-hardware.md`.
-- Vendored dep (memvid/OpenMythos) breaks on patch → fork in `vendor/`, reclassify as scheduled-for-rewrite.
+- Q3 training corpus insufficient (<10k pointer pairs) → Q3 ship criteria relax to corpus-collection + synthesized dataset + 1 mini-epoch; WatraLLM-v1 definition narrows to structure-knowledge-only (no operator-specific pointers).
+- Hardware too constrained (4 GB VRAM cannot fit Qwen3-0.6B-base QLoRA) → fall back to TinyLlama-1.1B-base or Pythia-1B; document limitation in `docs/operator/watra-hardware.md`.
+- `memvid-core` upstream breaks 2.0.x semver (stable-platform → vendored-frozen transition) → fork into `vendor/memvid-core/` with documented rationale, reclassify, pin SHA, monitor upstream for upstream fix before re-adopting.
+- `app.rs` split (N31) runs over budget → ship Q3 Watra screen inline in monolithic app.rs temporarily, split as follow-up PR in Q4.
 
 ---
 
@@ -669,7 +688,7 @@ Last week of each quarter:
 - `src/soul/memory.ts` — N2
 - `src/gateway/tool-registry.ts` + handlers — N5
 - `src/trajectory/exporter.ts` (new) — N9
-- `crates/memphis-export/` (new) + `vendor/memvid-core/` (new vendored) — N12
+- `crates/memphis-export/` (new) + workspace `Cargo.toml` (memvid-core pin) — N12
 - `docs/dev/DEPENDENCY-POLICY.md`, `docs/dev/MV2-INTEGRATION.md`, `docs/security/posture-2026-Q1.md` (new)
 - `.github/pull_request_template.md`, `.github/workflows/dep-freeze-check.yml`, `.github/workflows/quarterly-gate.yml` (new)
 
@@ -677,13 +696,14 @@ Last week of each quarter:
 - `crates/memphis-export/` full round-trip — N13
 - `crates/memphis-embed/src/pipeline.rs` + `src/infra/storage/rust-embed-adapter.ts` — M6/N21
 - `src/infra/cli/commands/consent.ts` (new) — N11
+- `crates/memphis-tui/src/app/*` — N31 (split app.rs into per-screen modules, pre-req for Q3 Watra screen)
 - `docs/security/AUDIT-2026-Q2.md`, `docs/security/posture-2026-Q2.md`
 
 **Q3:**
-- `vendor/OpenMythos-python/` + `vendor/peft/` + `vendor/bitsandbytes/` (new vendored) — N16
-- `tools/training/mv2-to-hf.py`, `finetune.py`, `dataset-curate.py` (new) — N16
-- `src/providers/watra-local.ts` (new) — N17
+- `tools/training/mv2-to-hf.py`, `finetune.py`, `dataset-curate.py`, `structure-corpus.py`, `synthesize-pointer-pairs.py`, `eval-pointer.py` (new) — N16
+- `src/watra/router.ts`, `src/watra/pointer.ts` (new) — N17
 - `src/infra/cli/commands/watra.ts` (new) — N26
+- `crates/memphis-tui/src/app/watra.rs` + `widgets/pointer_card.rs` (new) — Q3 TUI integration of N17 on N31 foundations
 - `src/federation/keys/federation-mac.ts` (new) — N14
 - `docs/dev/DEPENDENCY-INVENTORY.md` (new) — N27
 - `~/.memphis/watra/` runtime layout
@@ -704,7 +724,9 @@ Last week of each quarter:
 memphis doctor --json | jq -e '.ok == true'
 memphis export trajectories --out /tmp/t --dry-run
 memphis export --format=mv2 --output /tmp/journal.mv2 --include journal
-vendor/memvid-core/bin/memvid inspect /tmp/journal.mv2 | grep -q 'valid'
+# Either external `memvid` dev CLI OR in-process round-trip test; both valid:
+memvid inspect /tmp/journal.mv2 | grep -q 'valid' \
+  || cargo test -p memphis-export -- mv2_roundtrip_minimal
 test -f docs/dev/DEPENDENCY-POLICY.md
 test -f docs/dev/MV2-INTEGRATION.md
 test -f docs/security/posture-2026-Q1.md
@@ -722,6 +744,9 @@ memphis import --from-mv2 /tmp/a.mv2 --into /tmp/memphis-test --dry-run
 python -c "from datasets import load_dataset; load_dataset('/tmp/trajectories-out')"
 test -f docs/security/AUDIT-2026-Q2.md
 memphis doctor --json | jq -e '.checks[] | select(.name=="embed_cascade") | .status == "ok"'
+# N31: app.rs split into per-screen modules, app.rs itself shrunk
+test -d crates/memphis-tui/src/app && \
+  [ "$(wc -l < crates/memphis-tui/src/app.rs)" -lt 3000 ]
 ```
 
 **Q3 (2027-01 last Monday):**


### PR DESCRIPTION
## Summary

Three cleanup passes on `docs/roadmap/Y1-2026-05-to-2027-05.md` after post-commit review spotted drift:

1. **Consolidated Phase 0 deltas.** Five deltas (D1 memvid stable-platform, D2 claude-brain study, D3 OpenMythos demoted, D4 Qwen3-0.6B-base primary, D5 WatraLLM pointer/router) were scattered across principles + workstreams + appendix. Now one scannable block after the product-pipeline diagram; raw audit log remains in `phase-0-findings-2026-04-21.md`.

2. **Added N31 — `app.rs` modularization split** (Q2-end / Q3-prep). The 5951-LOC `crates/memphis-tui/src/app.rs` post-PR #232 can't absorb Q3's Watra screen + pointer-card widget + chat pre-stage hook without crossing 6500 LOC. New per-screen module layout (`app/chat.rs`, `app/watra.rs`, `app/replay.rs`, `widgets/pointer_card.rs`) is the pre-req. Escape hatch added: if N31 runs long, Watra screen ships inline Q3 and splits Q4.

3. **Vendoring terminology drift fixed.** After Phase 0 D1 reclassified memvid-core as `stable-platform`, references to `vendor/memvid-core/` lingered in workstream C, `.mv2` integration spec, critical-path files, Q1 exit test, dep-classes table. All updated to reflect crates.io pin. `vendor/` directory creation is now reserved for deliberately-vendored deps (none at Y1 start).

Plus principle #2 and #3 tightened for consistency.

## Diff

- 59 insertions, 34 deletions across one file.

## Test plan

- [x] Doc-only change
- [x] Lint clean
- [x] Grep verified: zero remaining `vendor/memvid-core/` except the intentional D1 callout and the break-the-glass escape hatch
- [x] N31 exit-criterion baked into Q2 exit test (`app.rs < 3000 LOC` + `crates/memphis-tui/src/app/` dir exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)