### PR TITLE
fix(system-prompt): dynamic install root + data dir (Sprint 0.5 G3)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -88,7 +88,7 @@ For each issue, include:
 
 # Persistent Agent Memory
 
-You have a persistent, file-based memory system at `/home/memphis_ai_brain_on_chain/memphis/.claude/agent-memory/code-reviewer/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+You have a persistent, file-based memory system at `<memphis-install-root>/.claude/agent-memory/code-reviewer/` (resolved at runtime — check `$MEMPHIS_INSTALL_ROOT` env or walk up from the repository root containing `package.json` with `"name": "@memphis-chains/memphis"`). The directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
 
 You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
 

--- a/docs/operator/OPERATOR-5MIN-RUNBOOK.md
+++ b/docs/operator/OPERATOR-5MIN-RUNBOOK.md
@@ -13,7 +13,7 @@ curl -sf http://127.0.0.1:11435/health
 ## 1) Runtime smoke (60s)
 
 ```bash
-cd /home/memphis_ai_brain_on_chain/memphis
+cd "$(memphis self-update --print-install-root 2>/dev/null || echo ~/memphis)"
 npm run smoke:ollama-runtime
 ```
 

--- a/src/gateway/agent-runtime.ts
+++ b/src/gateway/agent-runtime.ts
@@ -7,9 +7,11 @@ import {
 } from './system-prompt.js';
 import { executeToolCalls } from './tool-orchestration.js';
 import { getCognitiveModeConfig } from '../cognitive/modes.js';
+import { getDataDir } from '../config/paths.js';
 import type { TokenUsage } from '../core/types.js';
 import { resolveAgentProfile } from '../infra/agent-profile.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
+import { resolveInstallRoot } from '../infra/runtime/install-root.js';
 import { appendBlock, getChainAdapterStatus } from '../infra/storage/chain-adapter.js';
 import {
   NapiChainAdapter,
@@ -159,6 +161,22 @@ export function buildRuntimeSystemPrompt(options: AgentPromptOptions = {}): stri
   const cognitiveModeConfig = getCognitiveModeConfig(cognitiveMode);
   const cognitiveModeAddendum = `Mode ${cognitiveMode} — ${cognitiveModeConfig.name}: ${cognitiveModeConfig.description} (style: ${cognitiveModeConfig.style}, pattern: ${cognitiveModeConfig.pattern})`;
 
+  // Resolve install root + data dir per turn so the system prompt
+  // renders operator-accurate paths. Legacy prompt hardcoded
+  // `/home/memphis_ai_brain_on_chain/memphis/` which was tied to a
+  // specific host; current operators on different machines (or the
+  // npm-installed CLI) never had that path.
+  const installRoot = (() => {
+    try {
+      return resolveInstallRoot({ rawEnv });
+    } catch {
+      // No install root discoverable — leave undefined so the prompt
+      // renders a neutral placeholder rather than a stale path.
+      return undefined;
+    }
+  })();
+  const dataDir = getDataDir(rawEnv);
+
   const base = buildMemphisSystemPrompt({
     rustBridgeActive,
     availableTools: options.availableTools ?? [],
@@ -167,6 +185,8 @@ export function buildRuntimeSystemPrompt(options: AgentPromptOptions = {}): stri
     agentName: resolvedProfile.profile.agentName,
     ownerName: resolvedProfile.profile.ownerName,
     cognitiveModeAddendum,
+    installRoot,
+    dataDir,
   });
 
   const soulBlock = soulParts.length > 0 ? soulParts.join('\n\n') : '';

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -26,6 +26,25 @@ export interface SystemPromptContext {
   iskraContent?: string;
   /** Active cognitive mode addendum */
   cognitiveModeAddendum?: string;
+  /**
+   * Memphis install root (where TypeScript source + Rust crates live).
+   * When present, self-modification instructions reference this path
+   * instead of the legacy hardcoded `/home/memphis_ai_brain_on_chain/memphis/`
+   * which was tied to a specific host. Callers (`buildRuntimeSystemPrompt`)
+   * resolve via `resolveInstallRoot()`; omit to render a neutral
+   * `<install root>` placeholder so the prompt never ships a stale
+   * host-specific path in fresh deployments.
+   */
+  installRoot?: string;
+  /**
+   * Memphis runtime data directory (where ~/.memphis/ lives — vault,
+   * chains, soul, PULSE). Kept distinct from `installRoot` because
+   * operators running the packaged CLI have these at different
+   * paths. Both are rendered in the self-modification block so the
+   * LLM can reason about "is this file operator state or
+   * product code?".
+   */
+  dataDir?: string;
 }
 
 // ── Chain Architecture Reference ─────────────────────────────────────────────
@@ -483,8 +502,9 @@ Prompt-security rules:
 
 Self-modification (you can improve your own code):
 - BEFORE modifying code: run memphis_recall with query "przewodnik samomodyfikacji" to load your guide.
-- Your codebase: /home/memphis_ai_brain_on_chain/memphis/
-- TypeScript source: src/, Tests: tests/, Rust crates: crates/
+- Your codebase: ${context.installRoot ?? '<install root>'}
+- Your runtime data: ${context.dataDir ?? '<data dir>'} (vault, chains, soul, PULSE.md, MEMORY.md — operator-owned, never rewrite directly)
+- TypeScript source: ${context.installRoot ? `${context.installRoot}/src/` : 'src/'}, Tests: ${context.installRoot ? `${context.installRoot}/tests/` : 'tests/'}, Rust crates: ${context.installRoot ? `${context.installRoot}/crates/` : 'crates/'}
 - Read/edit/create files via memphis_exec (cat, sed, tee, etc.)
 - Build: npm run build, npm run typecheck, npm run lint
 - Test: npm run test:ts, npx vitest run tests/path/to/file.test.ts

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -69,6 +69,33 @@ describe('gateway system prompt', () => {
     expect(prompt).toContain('runtime system details');
   });
 
+  it('renders installRoot/dataDir placeholders when paths are not provided (Sprint 0.5 G3)', () => {
+    const prompt = buildSystemPrompt({ availableTools: ['memphis_recall'] });
+
+    // Legacy hardcoded host path must never ship in the prompt again.
+    expect(prompt).not.toContain('/home/memphis_ai_brain_on_chain/memphis/');
+    // Neutral placeholders stand in when the caller did not resolve
+    // an install root — avoids a stale path being baked into fresh
+    // installs that boot without `resolveInstallRoot` wiring.
+    expect(prompt).toContain('Your codebase: <install root>');
+    expect(prompt).toContain('Your runtime data: <data dir>');
+  });
+
+  it('threads concrete installRoot + dataDir into the self-modification block (G3)', () => {
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_recall'],
+      installRoot: '/opt/memphis',
+      dataDir: '/var/lib/memphis',
+    });
+
+    expect(prompt).toContain('Your codebase: /opt/memphis');
+    expect(prompt).toContain('Your runtime data: /var/lib/memphis');
+    expect(prompt).toContain('TypeScript source: /opt/memphis/src/');
+    expect(prompt).toContain('Tests: /opt/memphis/tests/');
+    expect(prompt).toContain('Rust crates: /opt/memphis/crates/');
+    expect(prompt).not.toContain('/home/memphis_ai_brain_on_chain/memphis/');
+  });
+
   it('escapes fetched-content closing tags', () => {
     const fragment = buildFetchedContentFragment(
       'https://example.test',


### PR DESCRIPTION
## Summary

Sprint 0.5 warm-up PR. Drops hardcoded \`/home/memphis_ai_brain_on_chain/memphis/\` from the self-modification block of \`buildSystemPrompt\`. Every primary LLM call was teaching operators a path that didn't exist on most hosts.

**SystemPromptContext** gains optional \`installRoot\` + \`dataDir\`; the self-modification block renders concrete paths when provided, neutral \`<install root>\` / \`<data dir>\` placeholders when absent. \`buildRuntimeSystemPrompt\` resolves per turn via \`resolveInstallRoot({ rawEnv })\` + \`getDataDir(rawEnv)\`.

Adjacent fixes (per "nie bierzemy jeńców"):
- \`docs/operator/OPERATOR-5MIN-RUNBOOK.md\`: hardcoded \`cd\` → dynamic probe
- \`.claude/agents/code-reviewer.md\`: same hardcoded memory path — replaced with runtime resolution instruction

Archived docs and memory snapshots keep the old path as historical provenance.

## Test plan

- [x] 2 new regression tests in \`tests/unit/gateway.system-prompt.test.ts\`: placeholder fallback + concrete substitution
- [x] Legacy host path guarded against in both (\`not.toContain('/home/memphis_ai_brain_on_chain/')\`)
- [x] Full file suite: 8 passed (was 6)
- [x] Lint + typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)