### PR TITLE
feat(system-prompt): full 5-mode cognitive block (Sprint 0.5 G6)

### DIFF
--- a/src/gateway/agent-runtime.ts
+++ b/src/gateway/agent-runtime.ts
@@ -6,7 +6,6 @@ import {
   buildRecalledMemoryFragment,
 } from './system-prompt.js';
 import { executeToolCalls } from './tool-orchestration.js';
-import { getCognitiveModeConfig } from '../cognitive/modes.js';
 import { getDataDir } from '../config/paths.js';
 import type { TokenUsage } from '../core/types.js';
 import { resolveAgentProfile } from '../infra/agent-profile.js';
@@ -158,8 +157,6 @@ export function buildRuntimeSystemPrompt(options: AgentPromptOptions = {}): stri
   }
 
   const cognitiveMode = getCognitiveMode(rawEnv);
-  const cognitiveModeConfig = getCognitiveModeConfig(cognitiveMode);
-  const cognitiveModeAddendum = `Mode ${cognitiveMode} — ${cognitiveModeConfig.name}: ${cognitiveModeConfig.description} (style: ${cognitiveModeConfig.style}, pattern: ${cognitiveModeConfig.pattern})`;
 
   // Resolve install root + data dir per turn so the system prompt
   // renders operator-accurate paths. Legacy prompt hardcoded
@@ -184,7 +181,7 @@ export function buildRuntimeSystemPrompt(options: AgentPromptOptions = {}): stri
     strictMode: (rawEnv.RUST_CHAIN_REQUIRE_SIGNATURES ?? '').toLowerCase() === 'true',
     agentName: resolvedProfile.profile.agentName,
     ownerName: resolvedProfile.profile.ownerName,
-    cognitiveModeAddendum,
+    activeCognitiveMode: cognitiveMode,
     installRoot,
     dataDir,
   });

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import { LOOP_LIMITS, formatLoopLimitsLine } from './loop-limits.js';
 import { TOOL_REGISTRY, type ToolMeta, type ToolTier } from './tool-registry.js';
+import { COGNITIVE_MODES, type CognitiveMode } from '../cognitive/modes.js';
 
 export interface SystemPromptContext {
   /** Current chain block counts by name */
@@ -27,8 +28,21 @@ export interface SystemPromptContext {
   ownerName?: string;
   /** ISKRA soul identity content (if loaded) */
   iskraContent?: string;
-  /** Active cognitive mode addendum */
+  /**
+   * Legacy: freeform cognitive-mode addendum. Kept for backward compatibility
+   * with external callers that build their own one-liner. When both this and
+   * `activeCognitiveMode` are set, the full `<cognitive_modes>` block wins and
+   * this is ignored.
+   */
   cognitiveModeAddendum?: string;
+  /**
+   * Active cognitive mode (A-E). When set, the prompt emits the full
+   * `<cognitive_modes>` block with all 5 mode definitions and the current
+   * mode highlighted — replacing the old one-liner addendum that told the
+   * LLM which mode it was in without any context about what the other
+   * modes meant or how to switch. (Sprint 0.5 G6.)
+   */
+  activeCognitiveMode?: CognitiveMode;
   /**
    * Memphis install root (where TypeScript source + Rust crates live).
    * When present, self-modification instructions reference this path
@@ -528,6 +542,47 @@ WHEN NOT TO USE:
   return sections.join('\n\n');
 }
 
+// ── Cognitive modes block (Sprint 0.5 G6) ────────────────────────────────────
+// Single source of truth: COGNITIVE_MODES in src/cognitive/modes.ts. Rendering
+// here so the LLM sees the full 5-mode map with the active mode highlighted.
+// Pre-G6 the addendum was a one-liner like "Mode B — Inferred Decisions:
+// temp=0.5, style=deliberate, pattern=evidence" which told the model which
+// mode it was in without any context about what the other modes existed for
+// or how to request a switch. Ops saw Mode B chats that should have gone to
+// Mode E reflection but the model had no vocabulary to suggest it.
+
+function renderCognitiveModeLine(mode: CognitiveMode, isActive: boolean): string {
+  const cfg = COGNITIVE_MODES[mode];
+  const marker = isActive ? ' ← CURRENTLY ACTIVE' : '';
+  return `MODE ${mode} — ${cfg.name} (temp=${cfg.temperature}, style=${cfg.style}, pattern=${cfg.pattern})${marker}
+  ${cfg.description}`;
+}
+
+function renderCognitiveModesBlock(active: CognitiveMode): string {
+  const modeLines = (Object.keys(COGNITIVE_MODES) as CognitiveMode[])
+    .map((mode) => renderCognitiveModeLine(mode, mode === active))
+    .join('\n\n');
+  return `<cognitive_modes current="${active}">
+Memphis has 5 cognitive modes. Each biases temperature, style, and reasoning
+pattern. The operator (or the memphis_cognitive_mode_set tool, tier-2,
+requires vault passphrase) can switch modes mid-session. Current mode is read
+once per turn from the soul manifest; no mid-turn switching.
+
+${modeLines}
+
+WHEN TO PROPOSE A MODE SWITCH:
+- Long analytical sessions with Mode A (fast) → suggest B (deliberate)
+- Repeating architectural decisions without evidence → suggest B
+- Forecasting / what-if analysis → suggest C
+- Multi-agent coordination, consensus-building → suggest D
+- Daily / weekly reflection cycles → suggest E (and the reflection loop
+  will likely auto-switch to E on schedule anyway)
+
+HOW TO SWITCH (when operator approves):
+  memphis_cognitive_mode_set --mode <A|B|C|D|E>
+</cognitive_modes>`;
+}
+
 // ── Core System Prompt ───────────────────────────────────────────────────────
 
 export function buildSystemPrompt(context: SystemPromptContext = {}): string {
@@ -560,9 +615,18 @@ export function buildSystemPrompt(context: SystemPromptContext = {}): string {
     ? `<soul_identity>\n${escapePromptFragmentText(context.iskraContent)}\n</soul_identity>\n\n`
     : '';
 
-  const cognitiveModeSection = context.cognitiveModeAddendum
-    ? `\n<cognitive_mode>\n${escapePromptFragmentText(context.cognitiveModeAddendum)}\n</cognitive_mode>\n`
-    : '';
+  // Sprint 0.5 G6: render the full 5-mode map with the active mode
+  // highlighted when `activeCognitiveMode` is set. Falls back to the legacy
+  // one-liner addendum when only `cognitiveModeAddendum` is provided, and to
+  // empty string when neither is set. Prior behaviour was always the legacy
+  // one-liner which told the LLM which mode it was in but not what the other
+  // modes meant or how to switch — so Mode B conversations never knew Mode
+  // E's reflection role existed.
+  const cognitiveModeSection = context.activeCognitiveMode
+    ? `\n${renderCognitiveModesBlock(context.activeCognitiveMode)}\n`
+    : context.cognitiveModeAddendum
+      ? `\n<cognitive_mode>\n${escapePromptFragmentText(context.cognitiveModeAddendum)}\n</cognitive_mode>\n`
+      : '';
 
   return `<memphis_system>
 ${iskraSection}<identity>

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -69,6 +69,53 @@ describe('gateway system prompt', () => {
     expect(prompt).toContain('runtime system details');
   });
 
+  it('renders full 5-mode cognitive block when activeCognitiveMode is set (Sprint 0.5 G6)', () => {
+    // Pre-G6 the prompt had a one-liner addendum — "Mode B: temp=0.5..." —
+    // which told the LLM which mode was active but nothing about the other
+    // 4 modes, when to propose switching, or how. The full <cognitive_modes>
+    // block fixes that with explicit mode-switch guidance.
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_recall'],
+      activeCognitiveMode: 'B',
+    });
+
+    expect(prompt).toContain('<cognitive_modes current="B">');
+    expect(prompt).toContain('MODE A — ConsciousCapture');
+    expect(prompt).toContain('MODE B — InferredDecisions');
+    expect(prompt).toContain('← CURRENTLY ACTIVE');
+    expect(prompt).toContain('MODE C — PredictivePatterns');
+    expect(prompt).toContain('MODE D — CollectiveCoord');
+    expect(prompt).toContain('MODE E — MetaCognitiveRef');
+    expect(prompt).toContain('WHEN TO PROPOSE A MODE SWITCH');
+    expect(prompt).toContain('memphis_cognitive_mode_set');
+    // Every mode has its distinct (temperature, style, pattern) footprint
+    expect(prompt).toContain('temp=0.3');
+    expect(prompt).toContain('temp=0.7');
+  });
+
+  it('falls back to legacy one-liner cognitiveModeAddendum for backward compat (G6)', () => {
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_recall'],
+      cognitiveModeAddendum: 'Mode B — Inferred Decisions: temp=0.5',
+    });
+
+    expect(prompt).toContain('<cognitive_mode>');
+    expect(prompt).toContain('Mode B — Inferred Decisions: temp=0.5');
+    // Shouldn't render the full block when only the legacy field is set.
+    expect(prompt).not.toContain('<cognitive_modes current=');
+  });
+
+  it('prefers full block over legacy addendum when both are set (G6 precedence)', () => {
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_recall'],
+      activeCognitiveMode: 'C',
+      cognitiveModeAddendum: 'legacy one-liner',
+    });
+
+    expect(prompt).toContain('<cognitive_modes current="C">');
+    expect(prompt).not.toContain('legacy one-liner');
+  });
+
   it('auto-generates tool docs from the registry for tools without hand-authored blocks (Sprint 0.5 G1)', () => {
     // Pre-G1 behaviour: these 3 tools were registered but the prompt had no
     // <tool> block for them, so small LLMs had no tier/capability/input-shape


### PR DESCRIPTION
## Summary

Replaces one-liner cognitive-mode addendum with full \`<cognitive_modes>\` block. Pre-G6 LLM knew "Mode B is active" but nothing about other 4 modes. Post-G6 it sees all 5 modes + when to suggest switches + how to execute the switch.

\`\`\`
<cognitive_modes current="B">
...
MODE A — ConsciousCapture (temp=0.3, style=fast, pattern=concise)
  Quick, minimal context captures — fast pattern matching

MODE B — InferredDecisions (temp=0.5, style=deliberate, pattern=detailed) ← CURRENTLY ACTIVE
  Deep analysis with evidence chains — detailed reasoning

MODE C — PredictivePatterns ...
MODE D — CollectiveCoord ...
MODE E — MetaCognitiveRef ...

WHEN TO PROPOSE A MODE SWITCH: ...
HOW TO SWITCH: memphis_cognitive_mode_set --mode <A|B|C|D|E>
</cognitive_modes>
\`\`\`

Single source of truth: \`COGNITIVE_MODES\` in \`src/cognitive/modes.ts\`.

## Schema changes

- \`SystemPromptContext.activeCognitiveMode?: CognitiveMode\` — new, preferred
- \`SystemPromptContext.cognitiveModeAddendum?: string\` — retained for backward compat
- Full block wins when both are set

## Test plan

- [x] 3 new cases: full-block rendering, legacy fallback, precedence
- [x] Full file: 15 passed (was 12)
- [x] Existing \`cli.agent-runtime.test.ts\`: 2 passed
- [x] Lint + typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)