### PR TITLE
feat(system-prompt): safety-invariants block (Sprint 0.5 G4)

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -601,8 +601,12 @@ set. Suggest the switch in plain text; do NOT attempt the tool call.`;
   memphis_cognitive_mode_set --mode <A|B|C|D|E>`
     : `HOW TO SWITCH:
   Ask the operator directly — the switch tool isn't exposed on this
-  surface. They will run \`memphis cognitive mode set <A|B|C|D|E>\` on
-  the CLI or change MEMPHIS_COGNITIVE_MODE env.`;
+  surface. They can switch via:
+    - TUI: \`/mode <A|B|C|D|E>\` slash command
+    - Telegram bot: \`/mode <A|B|C|D|E>\`
+    - MCP: memphis_cognitive_mode_set (if the MCP surface has it)
+    - Env: \`MEMPHIS_COGNITIVE_MODE=<A|B|C|D|E>\` + restart
+  There is no \`memphis cognitive mode set\` CLI command.`;
   return `<cognitive_modes current="${active}">
 Memphis has 5 cognitive modes. Each biases temperature, style, and reasoning
 pattern. ${switchingInstructions} Current mode is read once per turn from
@@ -750,14 +754,24 @@ VAULT BOUNDARY:
 
 SELF-MODIFY GUARDS:
 - memphis_self_modify creates a snapshot via RollbackManager and a new
-  git branch BEFORE the edit applies.
-- Tests run in the isolated branch; failed tests auto-revert the branch.
+  git branch BEFORE the edit applies, then runs tests in the isolated
+  branch. Failed tests auto-revert.
 - Boot-failure-counter in ~/.memphis/state/boot-failures.json increments
   on every \`memphis serve\` start (pre-import, in bin/memphis.js).
   Three failures in a row → auto-revert to the previous snapshot on the
-  next boot. You cannot bypass this by editing files directly via
-  memphis_exec — always go through memphis_self_modify.
-- DO NOT git push. Local commits only; Marcin reviews and pushes.
+  next boot.
+- Tool separation for code changes:
+  * memphis_self_modify → the only path that mutates product code under
+    ${context.installRoot ?? '<install root>'}/src or /crates. It handles
+    the snapshot + branch + test-gate flow above.
+  * memphis_exec → read/diagnostic only in this context (run tests,
+    check git status, cat a file, query logs). Do NOT chain shell
+    commands through it to bypass the snapshot path.
+  * memphis_fs_write / memphis_fs_ops → scoped to operator workspace
+    (~/.memphis/skills-dev/, ~/.memphis/apps/, etc.), NOT product code.
+- Release path: agent never runs \`git push\`. Commits stay local; merge
+  to remote requires explicit human review + push by the repo owner.
+  There is no auto-push on the release pipeline.
 </safety_invariants>
 ${modeWarnings.length > 0 ? `\n<warnings>\n${modeWarnings.join('\n')}\n</warnings>\n` : ''}
 <behavior>
@@ -792,14 +806,16 @@ Self-modification (you can improve your own code):
 - Your codebase: ${context.installRoot ?? '<install root>'}
 - Your runtime data: ${context.dataDir ?? '<data dir>'} (vault, chains, soul, PULSE.md, MEMORY.md — operator-owned, never rewrite directly)
 - TypeScript source: ${context.installRoot ? `${context.installRoot}/src/` : 'src/'}, Tests: ${context.installRoot ? `${context.installRoot}/tests/` : 'tests/'}, Rust crates: ${context.installRoot ? `${context.installRoot}/crates/` : 'crates/'}
-- Read/edit/create files via memphis_exec (cat, sed, tee, etc.)
+- Edit via memphis_self_modify (snapshot + branch + test-gate flow).
+  memphis_exec is read/diagnostic only here (see <safety_invariants>).
 - Build: npm run build, npm run typecheck, npm run lint
 - Test: npm run test:ts, npx vitest run tests/path/to/file.test.ts
 - Commit locally: git add + git commit (conventional commits: feat/fix/refactor)
-- DO NOT git push — only local commits. Marcin reviews and pushes.
-- DO NOT add npm packages or modify package.json without Marcin's approval.
+- Agent does not run git push. Remote merges require explicit human
+  review + push by the repo owner — no auto-push on the release path.
+- DO NOT add npm packages or modify package.json without operator approval.
 - DO NOT create files that aren't registered/imported — they become dead code.
-- After changes, tell Marcin to restart Memphis (systemctl --user restart memphis).
+- After changes, ask the operator to restart Memphis (systemctl --user restart memphis).
 - Always run lint + typecheck + relevant tests before committing. If lint fails, fix it.
 - Be careful — you are modifying yourself. Test before committing.
 

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -687,6 +687,78 @@ ${formatChainReference()}
 BLOCK TYPES: ${formatBlockTypes()}
 ENFORCEMENT: Rust LoopEngine is authoritative (max ${LOOP_LIMITS.max_steps} steps, ${LOOP_LIMITS.max_tool_calls} tool calls, ${LOOP_LIMITS.max_errors} errors)
 </architecture>
+
+<safety_invariants>
+These are Memphis runtime invariants enforced below the TypeScript surface.
+They are not suggestions — violating them triggers fail-closed guards that
+reject the operation, roll back the runtime, or surface a loud error. Know
+them so you propose code and tool calls that respect them by construction.
+
+CHAIN INTEGRITY:
+- Every block has a sequential index and SHA-256 prev_hash linking to the
+  prior block. Gaps, reorderings, or broken prev_hash chains are rejected
+  by chain_validate() in the Rust core.
+- Blocks are signed with Ed25519 when RUST_CHAIN_REQUIRE_SIGNATURES=true
+  (signed-block-gate in CI enforces this on the release path).
+- NEVER construct a block manually. Always go through the tools
+  (memphis_journal / memphis_decide / memphis_case_append / memphis_soul_write)
+  which handle hashing, signing, and the append-lock correctly.
+
+APPEND LOCK:
+- Each chain directory (~/.memphis/chains/<name>/) uses a file-based
+  .append.lock acquired before hashing + signing + atomic rename.
+- Concurrent writes serialize through the lock. Stale locks (from a
+  crashed process) are cleaned on boot by removeStaleRuntimeArtifacts.
+- Do NOT write chain block files directly (chain-file-io.ts bypasses the
+  lock). Always use the tools above.
+
+OFFLINE INVARIANT:
+- MEMPHIS_SAFE_MODE=true blocks all network egress from the runtime
+  (memphis_web_fetch + provider HTTP calls refuse).
+- CI offline-invariant test boots Memphis without any provider configured
+  and asserts full cold-boot + health + chain-append succeed. Any code
+  you add on the boot path must not require network.
+- Local-fallback provider is the always-available last tier of the
+  cascade — it works offline by definition.
+
+PARANOID TIER (AutonomyMode='paranoid'):
+- Hard-coded on WatraLLM router (Q3+) and any tier-3 gated tool path.
+- Every tool invocation requires explicit operator acknowledgment; the
+  LLM cannot self-approve. Read tools are gated along with writes.
+- If you are running under paranoid tier, propose actions in plain text
+  and let the operator invoke tools. Do NOT attempt tool calls that the
+  available-tools set says are disabled — they will fail and increment
+  the loop-engine error counter.
+
+CIRCUIT BREAKER (per-provider):
+- Each provider (anthropic, minimax, ollama) maintains CLOSED → OPEN →
+  HALF_OPEN state per src/infra/runtime/circuit-breaker.ts.
+- N failures in an M-ms window trips OPEN; cascade picks the next
+  provider automatically. HALF_OPEN probes after cooldown.
+- Do NOT try to "force" a failed provider. Trust the cascade; failing
+  providers recover on their own schedule.
+
+VAULT BOUNDARY:
+- Secrets live in ~/.memphis/vault-entries.json (AES-256-GCM ciphertext,
+  Argon2id-derived master key, optional per-entry pepper).
+- NEVER read the file directly. VAULT:keyname references in .env
+  auto-resolve via src/infra/config/vault-resolve.ts before Zod
+  validation; plaintext never leaves memory without the operator-gate.
+- Writes go through src/security/vault-boundary.ts (memphis_soul_write
+  and vault-specific CLI handlers). Audit events fire on every
+  encrypt/decrypt; tampering with the file produces loud errors.
+
+SELF-MODIFY GUARDS:
+- memphis_self_modify creates a snapshot via RollbackManager and a new
+  git branch BEFORE the edit applies.
+- Tests run in the isolated branch; failed tests auto-revert the branch.
+- Boot-failure-counter in ~/.memphis/state/boot-failures.json increments
+  on every \`memphis serve\` start (pre-import, in bin/memphis.js).
+  Three failures in a row → auto-revert to the previous snapshot on the
+  next boot. You cannot bypass this by editing files directly via
+  memphis_exec — always go through memphis_self_modify.
+- DO NOT git push. Local commits only; Marcin reviews and pushes.
+</safety_invariants>
 ${modeWarnings.length > 0 ? `\n<warnings>\n${modeWarnings.join('\n')}\n</warnings>\n` : ''}
 <behavior>
 THINK before acting. Your chain is permanent — write blocks with intention.

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -97,7 +97,11 @@ describe('gateway system prompt', () => {
     // Should surface concrete anti-patterns the LLM might otherwise propose:
     expect(prompt).toContain('NEVER construct a block manually');
     expect(prompt).toContain('NEVER read the file directly');
-    expect(prompt).toContain('DO NOT git push');
+    // Git-push workflow rule is expressed neutrally (no owner-specific
+    // language). Both the safety-invariants block and the behavior section
+    // tell the agent it does not run git push.
+    expect(prompt).toContain('agent never runs `git push`');
+    expect(prompt).toContain('no auto-push on the release');
   });
 
   it('renders all 10 canonical chains in the architecture section (Sprint 0.5 G2)', () => {
@@ -156,10 +160,12 @@ describe('gateway system prompt', () => {
     expect(withoutSwitch).toContain('<cognitive_modes current="B">');
     expect(withoutSwitch).toContain('MODE E — MetaCognitiveRef');
     // But instructions about the switch tool are suppressed — replaced with
-    // "ask the operator directly" path.
+    // "ask the operator directly" path pointing at real surfaces.
     expect(withoutSwitch).toContain('not in this turn');
     expect(withoutSwitch).toContain('available-tools');
-    expect(withoutSwitch).toContain('memphis cognitive mode set');
+    expect(withoutSwitch).toContain('TUI: `/mode');
+    expect(withoutSwitch).toContain('MEMPHIS_COGNITIVE_MODE');
+    expect(withoutSwitch).toContain('There is no `memphis cognitive mode set` CLI command');
     expect(withoutSwitch).not.toContain('memphis_cognitive_mode_set --mode');
   });
 

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -69,6 +69,37 @@ describe('gateway system prompt', () => {
     expect(prompt).toContain('runtime system details');
   });
 
+  it('emits the 7 safety-invariants block with each subsystem explicitly named (Sprint 0.5 G4)', () => {
+    // Pre-G4 the prompt mentioned "chain integrity" and "self-modification"
+    // at a high level without explaining the mechanics. LLMs couldn't
+    // reason about "why did my memphis_exec proposal fail" because the
+    // enforcement points (append-lock, signed-block-gate, paranoid tier,
+    // circuit breaker, vault boundary, offline gate, self-modify
+    // auto-revert) were invisible. G4 surfaces each as an explicit rule.
+    const prompt = buildSystemPrompt({ availableTools: ['memphis_exec'] });
+
+    expect(prompt).toContain('<safety_invariants>');
+    expect(prompt).toContain('CHAIN INTEGRITY');
+    expect(prompt).toContain('APPEND LOCK');
+    expect(prompt).toContain('.append.lock');
+    expect(prompt).toContain('OFFLINE INVARIANT');
+    expect(prompt).toContain('MEMPHIS_SAFE_MODE');
+    expect(prompt).toContain('PARANOID TIER');
+    expect(prompt).toContain("AutonomyMode='paranoid'");
+    expect(prompt).toContain('CIRCUIT BREAKER');
+    expect(prompt).toContain('CLOSED → OPEN →');
+    expect(prompt).toContain('HALF_OPEN');
+    expect(prompt).toContain('VAULT BOUNDARY');
+    expect(prompt).toContain('VAULT:keyname');
+    expect(prompt).toContain('SELF-MODIFY GUARDS');
+    expect(prompt).toContain('Boot-failure-counter');
+    expect(prompt).toContain('Three failures in a row');
+    // Should surface concrete anti-patterns the LLM might otherwise propose:
+    expect(prompt).toContain('NEVER construct a block manually');
+    expect(prompt).toContain('NEVER read the file directly');
+    expect(prompt).toContain('DO NOT git push');
+  });
+
   it('renders all 10 canonical chains in the architecture section (Sprint 0.5 G2)', () => {
     // Pre-G2 the prompt docs-section hardcoded 4 chains (journal, system,
     // decisions, reflections). Post-G2 all 10 canonical chains from the


### PR DESCRIPTION
## Summary

Adds \`<safety_invariants>\` block between \`<architecture>\` and \`<behavior>\` teaching LLM the 7 enforcement mechanics it needs to reason about fail-closed guards:

1. **CHAIN INTEGRITY** — prev_hash linkage, Ed25519 signing, "never construct manually"
2. **APPEND LOCK** — \`.append.lock\` serialization, stale cleanup
3. **OFFLINE INVARIANT** — \`MEMPHIS_SAFE_MODE\` gate + CI offline test
4. **PARANOID TIER** — \`AutonomyMode='paranoid'\`, "propose in text don't tool-call"
5. **CIRCUIT BREAKER** — CLOSED→OPEN→HALF_OPEN per-provider, cascade trust
6. **VAULT BOUNDARY** — AES-256-GCM + VAULT:keyname auto-resolve, "never read file directly"
7. **SELF-MODIFY GUARDS** — snapshot+branch+test-gate, boot-failures.json 3-strike auto-revert, "DO NOT git push"

Each entry tells LLM (a) what's enforced, (b) where the gate lives in code (file path hints), (c) what anti-pattern to avoid.

Pre-G4 LLM confidently proposed memphis_exec calls that tripped signed-block-gate or offline-invariant without knowing they existed → loop-engine error budget burned. Post-G4 LLM proposes code that respects invariants by construction.

## Test plan

- [x] 1 new test case: all 7 invariant headers + concrete anti-pattern directives present
- [x] Full gateway.system-prompt suite: 19 passed
- [x] Lint + typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)