### PR TITLE
fix(vault): honor MEMPHIS_OPERATOR_PASSPHRASE env + bump to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memphis-chains/memphis",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memphis-chains/memphis",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memphis-chains/memphis",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Memphis sovereign AI runtime with chain-backed memory, encrypted vault, and a native operator console",
   "main": "dist/index.js",
   "type": "module",

--- a/src/infra/auth/operator-gate.ts
+++ b/src/infra/auth/operator-gate.ts
@@ -219,6 +219,18 @@ export async function requireOperatorAuth(
     return valid;
   }
 
+  // Non-interactive: passphrase from env (CI / scripted runs)
+  const envPassphrase = rawEnv.MEMPHIS_OPERATOR_PASSPHRASE?.trim();
+  if (envPassphrase) {
+    const valid = validateOperatorPassphrase(envPassphrase, rawEnv);
+    if (valid) {
+      authorizeSession();
+      return true;
+    }
+    // Env var present but wrong — fail closed (same semantics as file)
+    return false;
+  }
+
   // Auto-read from .tier2-passphrase file (enables self-auth without TTY)
   const autoPassphrase = readTier2PassphraseFromFile(rawEnv);
   if (autoPassphrase) {


### PR DESCRIPTION
## Summary

- `requireOperatorAuth` now honors `MEMPHIS_OPERATOR_PASSPHRASE` env var (between inline-passphrase arg and `.tier2-passphrase` file fallback). Fails closed on wrong value — same semantics as the file path.
- Bumps `package.json` 1.4.0 → 1.5.0 to match the already-pushed `v1.5.0` tag on main.

## Why

`release.yml` on `v1.5.0` tag has failed twice (runs 24787494939, 24790672532) with `SyntaxError: Unexpected end of JSON input` in the final `rc-drill.sh` parser. I traced the empty JSON to `vault add` (inline script line 47, not init as I initially thought):

```
vaultadd_exit=0 size=0
--- vault-add.err ---
🔐 Operator passphrase:   ← waiting for stdin, no TTY, hangs
```

`rc-drill.sh:151` already exports `MEMPHIS_OPERATOR_PASSPHRASE`, but `operator-gate.ts` never read it — only honored `--operator-passphrase` CLI flag and `.tier2-passphrase` file. `vault add` doesn't accept `--operator-passphrase`, so in env -i it fell to the interactive prompt.

## Test plan

- [x] Local repro: full fresh-env drill (env -i) through `vault add --json` — returns valid JSON (was empty)
- [x] Typecheck clean
- [ ] CI (release gates) green
- [ ] Release workflow on next `v1.5.0` tag re-push goes green

Note to self: waiting for Codex review before merge (lesson from #243 which merged in 2 min with zero review).