### PR TITLE
fix(skills): validate tool names against TOOL_REGISTRY (Codex #242)

### DIFF
--- a/src/modules/skills/catalog.ts
+++ b/src/modules/skills/catalog.ts
@@ -452,7 +452,7 @@ export function renderSkillMarkdown(manifest: SkillManifest): string {
 export function validateSkillManifestFile(pathValue: string): SkillValidationResult {
   try {
     const ref = loadSkillManifestFromPath(pathValue);
-    const unknownTools = ref.manifest.tools.filter((name) => !(name in TOOL_REGISTRY));
+    const unknownTools = ref.manifest.tools.filter((name) => !Object.hasOwn(TOOL_REGISTRY, name));
     if (unknownTools.length > 0) {
       return {
         ok: false,

--- a/src/modules/skills/catalog.ts
+++ b/src/modules/skills/catalog.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 
 import { getSkillsPath } from '../../config/paths.js';
 import { AppError } from '../../core/errors.js';
+import { TOOL_REGISTRY } from '../../gateway/tool-registry.js';
 
 export type SkillManifest = {
   schemaVersion: 1;
@@ -450,7 +451,16 @@ export function renderSkillMarkdown(manifest: SkillManifest): string {
 
 export function validateSkillManifestFile(pathValue: string): SkillValidationResult {
   try {
-    return { ok: true, ref: loadSkillManifestFromPath(pathValue) };
+    const ref = loadSkillManifestFromPath(pathValue);
+    const unknownTools = ref.manifest.tools.filter((name) => !(name in TOOL_REGISTRY));
+    if (unknownTools.length > 0) {
+      return {
+        ok: false,
+        path: resolve(pathValue),
+        detail: `unknown tool(s): ${unknownTools.join(', ')} — must be in TOOL_REGISTRY`,
+      };
+    }
+    return { ok: true, ref };
   } catch (error) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary

`validateSkillManifestFile` now rejects manifests that declare tool names not in `TOOL_REGISTRY`, closing the gap flagged by Codex review on PR #242.

## Why

Codex finding on PR #242 commit 4b49aa9e1a:
> The new skills block says `memphis skills validate --file <manifest.json>` performs "schema + tool-name checks," but the CLI path in `src/infra/cli/commands/skills.ts` only calls `validateSkillManifestFile`, and that function validates schema shape only (no tools[] lookup against TOOL_REGISTRY). This gives operators and the model a false safety signal: manifests with unknown tool names can pass validation, then be imported/installed and later fail when the skill tries to use non-existent tools.

The system prompt text (line 619) is correct; implementation was the gap. I picked the "implement the check" path over "weaken the docs" — it's the stronger guarantee.

## Test plan

- [x] Typecheck clean
- [x] `tests/unit/skills.catalog.test.ts` still passes
- [ ] CI green
- [ ] Codex review

Note: waiting for Codex before merge.