### PR TITLE
feat(memory): propagate turnId + consent to durable memory writes (N8)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -472,6 +472,7 @@ async function startChannelGateway(container?: {
   });
   const memory = createInProcessMemoryClient({ surface: 'telegram' });
   const toolExecutor = createInProcessToolExecutor({
+    surface: 'telegram',
     evolveSessionRepository: container?.evolveSessionRepository,
     permissionRepo: container?.toolPermissionRepository,
     caseAdapter: new CaseChainAdapter(process.env),
@@ -919,10 +920,12 @@ function buildLocalWorkerRuntimeDeps(
   container: ReturnType<typeof createAppContainer>,
 ): HttpChatRuntimeDeps {
   return {
-    // Local worker processes queued HTTP chat turns; same service-surface
-    // policy as the HTTP server itself so consent defaults stay consistent.
-    memory: createInProcessMemoryClient({ surface: 'http.chat' }),
+    // Local worker processes queued HTTP chat turns; same canonical
+    // surface key (`http.chat.generate`) as HTTP server and chat-work so
+    // policy/audit/consent all resolve to one row.
+    memory: createInProcessMemoryClient({ surface: 'http.chat.generate' }),
     toolExecutor: createInProcessToolExecutor({
+      surface: 'http.chat.generate',
       evolveSessionRepository: container.evolveSessionRepository,
       permissionRepo: container.toolPermissionRepository,
       caseAdapter: new CaseChainAdapter(process.env),

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -470,7 +470,7 @@ async function startChannelGateway(container?: {
   const llm = providerToLlmClient(provider, {
     temperature: getCognitiveModeConfig(cognitiveMode).temperature,
   });
-  const memory = createInProcessMemoryClient();
+  const memory = createInProcessMemoryClient({ surface: 'telegram' });
   const toolExecutor = createInProcessToolExecutor({
     evolveSessionRepository: container?.evolveSessionRepository,
     permissionRepo: container?.toolPermissionRepository,
@@ -919,7 +919,9 @@ function buildLocalWorkerRuntimeDeps(
   container: ReturnType<typeof createAppContainer>,
 ): HttpChatRuntimeDeps {
   return {
-    memory: createInProcessMemoryClient(),
+    // Local worker processes queued HTTP chat turns; same service-surface
+    // policy as the HTTP server itself so consent defaults stay consistent.
+    memory: createInProcessMemoryClient({ surface: 'http.chat' }),
     toolExecutor: createInProcessToolExecutor({
       evolveSessionRepository: container.evolveSessionRepository,
       permissionRepo: container.toolPermissionRepository,

--- a/src/gateway/memory-client.ts
+++ b/src/gateway/memory-client.ts
@@ -42,7 +42,14 @@ export function createInProcessMemoryClient(rawEnv: NodeJS.ProcessEnv = process.
       }
 
       const content = `[${userId}] User: ${userText}\nAssistant: ${assistantReply.slice(0, 500)}`;
-      const result = await runMemphisJournal({ content, tags: ['conversation', userId] });
+      // In-process chat surface — consent default is 'local-only' per
+      // gateway/surface-policy chat class. Explicit surface hint lets
+      // MEMPHIS_SURFACE_CLI_CHAT_DEFAULT_CONSENT operators retune.
+      const result = await runMemphisJournal({
+        content,
+        tags: ['conversation', userId],
+        surface: 'cli.chat',
+      });
       if (!result.success) {
         throw new Error(result.error ?? 'memory_store_blocked');
       }

--- a/src/gateway/memory-client.ts
+++ b/src/gateway/memory-client.ts
@@ -12,7 +12,30 @@ function shouldUseIsolatedTestMemory(rawEnv: NodeJS.ProcessEnv): boolean {
   );
 }
 
-export function createInProcessMemoryClient(rawEnv: NodeJS.ProcessEnv = process.env): MemoryClient {
+export type InProcessMemoryClientOptions = {
+  rawEnv?: NodeJS.ProcessEnv;
+  /**
+   * Caller surface used for per-surface consent resolution on journal
+   * writes. Maps to `resolveSurfacePolicy(surface).defaultConsent` via
+   * `runMemphisJournal` → `resolveConsent`. Defaults to 'cli.chat' since
+   * the original caller was the CLI interactive chat path, but every
+   * non-CLI call site (HTTP server, telegram bootstrap, worker handler)
+   * MUST pass its own surface so env overrides like
+   * `MEMPHIS_SURFACE_TELEGRAM_DEFAULT_CONSENT` actually take effect.
+   */
+  surface?: string;
+};
+
+export function createInProcessMemoryClient(
+  options: NodeJS.ProcessEnv | InProcessMemoryClientOptions = process.env,
+): MemoryClient {
+  // Back-compat: the legacy single-arg form passed `rawEnv` positionally.
+  const resolved: InProcessMemoryClientOptions =
+    options && typeof options === 'object' && 'surface' in options
+      ? options
+      : { rawEnv: options as NodeJS.ProcessEnv };
+  const rawEnv = resolved.rawEnv ?? process.env;
+  const surface = resolved.surface ?? 'cli.chat';
   const isolatedTestMemory = shouldUseIsolatedTestMemory(rawEnv);
 
   return {
@@ -42,13 +65,10 @@ export function createInProcessMemoryClient(rawEnv: NodeJS.ProcessEnv = process.
       }
 
       const content = `[${userId}] User: ${userText}\nAssistant: ${assistantReply.slice(0, 500)}`;
-      // In-process chat surface — consent default is 'local-only' per
-      // gateway/surface-policy chat class. Explicit surface hint lets
-      // MEMPHIS_SURFACE_CLI_CHAT_DEFAULT_CONSENT operators retune.
       const result = await runMemphisJournal({
         content,
         tags: ['conversation', userId],
-        surface: 'cli.chat',
+        surface,
       });
       if (!result.success) {
         throw new Error(result.error ?? 'memory_store_blocked');

--- a/src/gateway/surface-policy.ts
+++ b/src/gateway/surface-policy.ts
@@ -39,12 +39,13 @@ export type SurfacePolicySettingName =
   | 'allowCognitivePrelude'
   | 'allowMemoryRecall'
   | 'allowMemoryWrite'
-  | 'allowOperatorOverride';
+  | 'allowOperatorOverride'
+  | 'defaultConsent';
 
 type SurfacePolicySettingDefinition = {
   name: SurfacePolicySettingName;
   envSuffix: string;
-  kind: 'tier' | 'boolean';
+  kind: 'tier' | 'boolean' | 'consent';
 };
 
 export type SurfacePolicyOverride = {
@@ -73,6 +74,7 @@ const SURFACE_POLICY_SETTING_DEFINITIONS: readonly SurfacePolicySettingDefinitio
   { name: 'allowMemoryRecall', envSuffix: 'ALLOW_MEMORY_RECALL', kind: 'boolean' },
   { name: 'allowMemoryWrite', envSuffix: 'ALLOW_MEMORY_WRITE', kind: 'boolean' },
   { name: 'allowOperatorOverride', envSuffix: 'ALLOW_OPERATOR_OVERRIDE', kind: 'boolean' },
+  { name: 'defaultConsent', envSuffix: 'DEFAULT_CONSENT', kind: 'consent' },
 ] as const;
 
 type SurfaceDefaults = Omit<SurfacePolicy, 'surface' | 'surfaceClass'>;
@@ -271,6 +273,8 @@ export function normalizeSurfacePolicySettingName(
     allowmemoryrecall: 'allowMemoryRecall',
     allowmemorywrite: 'allowMemoryWrite',
     allowoperatoroverride: 'allowOperatorOverride',
+    defaultconsent: 'defaultConsent',
+    consent: 'defaultConsent',
   };
   return aliases[normalized];
 }
@@ -290,6 +294,15 @@ export function parseSurfacePolicySettingValue(
       return normalized;
     }
     throw new Error(`Invalid value for ${setting}: ${value}. Expected 0, 1, 2, or 3.`);
+  }
+
+  if (definition.kind === 'consent') {
+    if (normalized === 'exportable' || normalized === 'local-only' || normalized === 'anonymized') {
+      return normalized;
+    }
+    throw new Error(
+      `Invalid value for ${setting}: ${value}. Expected exportable, local-only, or anonymized.`,
+    );
   }
 
   if (['1', 'true', 'yes', 'on'].includes(normalized)) return 'true';

--- a/src/gateway/surface-policy.ts
+++ b/src/gateway/surface-policy.ts
@@ -2,6 +2,13 @@ import { getToolMeta, type ToolTier } from './tool-registry.js';
 
 export type SurfaceClass = 'operator' | 'chat' | 'service';
 
+/**
+ * Per-block consent level stamped on memory writes. Mirrors
+ * `ConsentLevel` from `src/trajectory/schema.ts` — kept locally as a
+ * string literal to avoid a runtime cycle between gateway and trajectory.
+ */
+export type SurfaceConsent = 'exportable' | 'local-only' | 'anonymized';
+
 export type SurfacePolicy = {
   surface: string;
   surfaceClass: SurfaceClass;
@@ -12,6 +19,17 @@ export type SurfacePolicy = {
   allowMemoryRecall: boolean;
   allowMemoryWrite: boolean;
   allowOperatorOverride: boolean;
+  /**
+   * Default consent level for durable memory writes originating from this
+   * surface. Read by `storeDurableMemory` when caller does not pass an
+   * explicit consent value. Operator-facing + service surfaces default to
+   * `exportable` (decisions/reflections/patterns are shareable); chat
+   * surfaces default to `local-only` (journal/cases stay on-host).
+   *
+   * Per Y1 roadmap consent defaults rule; see
+   * docs/dev/TRAJECTORY-EXPORT-V1.md consent handling section.
+   */
+  defaultConsent: SurfaceConsent;
 };
 
 export type SurfacePolicySettingName =
@@ -68,6 +86,7 @@ const SURFACE_DEFAULTS: Record<SurfaceClass, SurfaceDefaults> = {
     allowMemoryRecall: true,
     allowMemoryWrite: true,
     allowOperatorOverride: true,
+    defaultConsent: 'exportable',
   },
   chat: {
     maxToolTier: 0,
@@ -77,6 +96,7 @@ const SURFACE_DEFAULTS: Record<SurfaceClass, SurfaceDefaults> = {
     allowMemoryRecall: true,
     allowMemoryWrite: true,
     allowOperatorOverride: false,
+    defaultConsent: 'local-only',
   },
   service: {
     maxToolTier: 1,
@@ -86,6 +106,7 @@ const SURFACE_DEFAULTS: Record<SurfaceClass, SurfaceDefaults> = {
     allowMemoryRecall: true,
     allowMemoryWrite: true,
     allowOperatorOverride: false,
+    defaultConsent: 'exportable',
   },
 };
 
@@ -189,7 +210,19 @@ export function resolveSurfacePolicy(
       rawEnv[`${prefix}ALLOW_OPERATOR_OVERRIDE`],
       defaults.allowOperatorOverride,
     ),
+    defaultConsent: parseConsentEnv(
+      rawEnv[`${prefix}DEFAULT_CONSENT`],
+      defaults.defaultConsent,
+    ),
   };
+}
+
+function parseConsentEnv(value: string | undefined, fallback: SurfaceConsent): SurfaceConsent {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === 'exportable' || normalized === 'local-only' || normalized === 'anonymized') {
+    return normalized;
+  }
+  return fallback;
 }
 
 export function isToolAllowedForSurface(toolName: string, policy: SurfacePolicy): boolean {

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -166,7 +166,12 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         };
       },
       async execute(input) {
-        return runMemphisJournal(input);
+        // Thread caller surface into the journal write so consent
+        // resolution honors the active turn's surface policy
+        // (MEMPHIS_SURFACE_<SURFACE>_DEFAULT_CONSENT overrides apply).
+        // Falls through to 'mcp' default inside runMemphisJournal when
+        // no surface was configured on the executor (raw MCP server).
+        return runMemphisJournal({ ...input, surface: deps.surface });
       },
     }),
     buildTool({

--- a/src/infra/cli/commands/interaction.ts
+++ b/src/infra/cli/commands/interaction.ts
@@ -306,7 +306,7 @@ async function resolveAgentRuntime(options: {
   const container = options.context?.getContainer();
   const runtime = {
     chatProvider: cascade.provider,
-    memory: createInProcessMemoryClient(),
+    memory: createInProcessMemoryClient({ surface: 'cli.chat' }),
     userId: actorId,
     conversationId,
     conversationContext: container?.conversationContextService,

--- a/src/infra/cli/commands/interaction.ts
+++ b/src/infra/cli/commands/interaction.ts
@@ -23,6 +23,8 @@ type InteractionHandler = (context: CliContext) => Promise<boolean>;
 
 function buildToolExecutorDeps(context: CliContext): InProcessToolExecutorDeps {
   return {
+    // CLI interactive chat surface for consent resolution on tool writes.
+    surface: 'cli.chat',
     evolveSessionRepository: context.getContainer().evolveSessionRepository,
     permissionRepo: context.getContainer().toolPermissionRepository,
     caseAdapter: new CaseChainAdapter(process.env),

--- a/src/infra/cli/handlers/embed.handler.ts
+++ b/src/infra/cli/handlers/embed.handler.ts
@@ -23,6 +23,9 @@ export const embedCommandHandler: CommandHandler = {
       if (!id || value === undefined) {
         throw new Error('embed store requires --id and --value');
       }
+      // CLI is an operator-surface write: operator explicitly typed
+      // the command, so default consent is 'exportable'. No turnId —
+      // this is an out-of-turn direct memory seed, not a conversation turn.
       print(
         {
           ok: true,
@@ -31,6 +34,7 @@ export const embedCommandHandler: CommandHandler = {
             content: value,
             source: 'cli-embed',
             tags: ['operator-memory'],
+            consent: 'exportable',
           }),
         },
         json,

--- a/src/infra/cli/handlers/worker.handler.ts
+++ b/src/infra/cli/handlers/worker.handler.ts
@@ -11,9 +11,14 @@ import { print } from '../utils/render.js';
 function buildRuntime(context: CliContext) {
   const container = context.getContainer();
   return {
-    memory: createInProcessMemoryClient({ surface: 'cli.worker' }),
+    // CLI worker processes `chat.generate` queue items — these are
+    // HTTP-originated chat turns executed out-of-band (see
+    // `executeChatGenerateWork` in local-worker-runner.ts). Surface
+    // MUST match the HTTP chat canonical key so consent / policy /
+    // audit lookups agree with the original turn's attribution.
+    memory: createInProcessMemoryClient({ surface: 'http.chat.generate' }),
     toolExecutor: createInProcessToolExecutor({
-      surface: 'cli.worker',
+      surface: 'http.chat.generate',
       evolveSessionRepository: container.evolveSessionRepository,
       permissionRepo: container.toolPermissionRepository,
       caseAdapter: new CaseChainAdapter(process.env),

--- a/src/infra/cli/handlers/worker.handler.ts
+++ b/src/infra/cli/handlers/worker.handler.ts
@@ -11,7 +11,7 @@ import { print } from '../utils/render.js';
 function buildRuntime(context: CliContext) {
   const container = context.getContainer();
   return {
-    memory: createInProcessMemoryClient(),
+    memory: createInProcessMemoryClient({ surface: 'cli.worker' }),
     toolExecutor: createInProcessToolExecutor({
       evolveSessionRepository: container.evolveSessionRepository,
       permissionRepo: container.toolPermissionRepository,

--- a/src/infra/cli/handlers/worker.handler.ts
+++ b/src/infra/cli/handlers/worker.handler.ts
@@ -13,6 +13,7 @@ function buildRuntime(context: CliContext) {
   return {
     memory: createInProcessMemoryClient({ surface: 'cli.worker' }),
     toolExecutor: createInProcessToolExecutor({
+      surface: 'cli.worker',
       evolveSessionRepository: container.evolveSessionRepository,
       permissionRepo: container.toolPermissionRepository,
       caseAdapter: new CaseChainAdapter(process.env),

--- a/src/infra/http/routes/memory.ts
+++ b/src/infra/http/routes/memory.ts
@@ -1,4 +1,5 @@
 import { getChainPath } from '../../../config/paths.js';
+import { resolveSurfacePolicy } from '../../../gateway/surface-policy.js';
 import { runMemphisRecall, type RecallMode } from '../../../mcp/tools/recall.js';
 import { writeSecurityAudit, type SecurityAuditEvent } from '../../logging/security-audit.js';
 import { storeDurableMemory, type DurableMemoryStoreResult } from '../../memory/durable-memory.js';
@@ -70,18 +71,21 @@ export type MemoryRouteDeps = {
 };
 
 const defaultDeps: MemoryRouteDeps = {
-  store: (input) =>
-    storeDurableMemory({
+  store: (input, rawEnv = process.env) => {
+    // Honor MEMPHIS_SURFACE_<surface>_DEFAULT_CONSENT override:
+    // resolve the 'http' surface policy (service class) and fall back to
+    // its defaultConsent when the caller didn't pass an explicit value.
+    // Caller-provided consent always wins.
+    const surfacePolicy = resolveSurfacePolicy('http', rawEnv);
+    return storeDurableMemory({
       content: input.content,
       tags: input.tags,
       chain: input.chain,
       source: input.source,
       turnId: input.turnId,
-      // HTTP is a service surface; default consent for journal writes is
-      // 'exportable' (decisions/reflections shareable) — caller (http
-      // handler) overrides per-endpoint as needed.
-      consent: input.consent ?? 'exportable',
-    }),
+      consent: input.consent ?? surfacePolicy.defaultConsent,
+    });
+  },
   search: embedSearch,
   exactSearch: searchExactMemory,
   audit: writeSecurityAudit,

--- a/src/infra/http/routes/memory.ts
+++ b/src/infra/http/routes/memory.ts
@@ -43,7 +43,14 @@ type ExactSearchResult = ExactSearchOutput;
 
 export type MemoryRouteDeps = {
   store: (
-    input: { content: string; tags?: string[]; chain?: string; source?: string },
+    input: {
+      content: string;
+      tags?: string[];
+      chain?: string;
+      source?: string;
+      turnId?: string;
+      consent?: 'exportable' | 'local-only' | 'anonymized';
+    },
     rawEnv?: NodeJS.ProcessEnv,
   ) => Promise<DurableMemoryStoreResult>;
   search: (
@@ -69,6 +76,11 @@ const defaultDeps: MemoryRouteDeps = {
       tags: input.tags,
       chain: input.chain,
       source: input.source,
+      turnId: input.turnId,
+      // HTTP is a service surface; default consent for journal writes is
+      // 'exportable' (decisions/reflections shareable) — caller (http
+      // handler) overrides per-endpoint as needed.
+      consent: input.consent ?? 'exportable',
     }),
   search: embedSearch,
   exactSearch: searchExactMemory,
@@ -183,7 +195,14 @@ export function registerMemoryRoutes(
     }
 
     try {
-      const result = await deps.store({ content, tags, chain, source: 'http-api' }, process.env);
+      // HTTP /api/journal is an out-of-turn operator/agent write. No
+      // request-scoped turnId is propagated yet (turn binding on the
+      // HTTP chat path is the scope of N9/exporter, not N8). Consent
+      // defaults via deps.store to 'exportable' for service surface.
+      const result = await deps.store(
+        { content, tags, chain, source: 'http-api' },
+        process.env,
+      );
       deps.audit(
         {
           action: 'journal.append',

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -156,7 +156,7 @@ export function createHttpServer(
     requestIdHeader: 'x-request-id',
   });
   const chatRuntime = {
-    memory: createInProcessMemoryClient(),
+    memory: createInProcessMemoryClient({ surface: 'http.chat' }),
     toolExecutor: createInProcessToolExecutor({
       evolveSessionRepository: repos?.evolveSessionRepository,
       permissionRepo: repos?.toolPermissionRepository,

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -155,9 +155,15 @@ export function createHttpServer(
     },
     requestIdHeader: 'x-request-id',
   });
+  // Use the canonical HTTP chat surface key so both memory writes and
+  // policy/audit lookups resolve the same row (including any
+  // MEMPHIS_SURFACE_HTTP_CHAT_GENERATE_DEFAULT_CONSENT overrides). Other
+  // HTTP code paths (chat-work, routes/chat) already use
+  // 'http.chat.generate' as the canonical surface name.
   const chatRuntime = {
-    memory: createInProcessMemoryClient({ surface: 'http.chat' }),
+    memory: createInProcessMemoryClient({ surface: 'http.chat.generate' }),
     toolExecutor: createInProcessToolExecutor({
+      surface: 'http.chat.generate',
       evolveSessionRepository: repos?.evolveSessionRepository,
       permissionRepo: repos?.toolPermissionRepository,
       caseAdapter: new CaseChainAdapter(process.env),

--- a/src/infra/memory/durable-memory.ts
+++ b/src/infra/memory/durable-memory.ts
@@ -1,4 +1,5 @@
 import { indexExactSearchBlock } from './exact-search.js';
+import type { SurfaceConsent } from '../../gateway/surface-policy.js';
 import { scanContent } from '../../security/content-scan.js';
 import { emitRuntimeSecurityEvent } from '../../security/runtime-security-events.js';
 import { appendBlock } from '../storage/chain-adapter.js';
@@ -10,6 +11,22 @@ export type DurableMemoryStoreInput = {
   memoryId?: string;
   source?: string;
   chain?: string;
+  /**
+   * Turn identifier linking this memory block to a conversation turn.
+   * Passed from `src/gateway/turn-runtime.ts::generateTurnId()` when the
+   * write happens inside a user-initiated turn. `undefined` for
+   * scheduled / boot / system-event writes (unlinked events per
+   * trajectory v1 schema).
+   */
+  turnId?: string;
+  /**
+   * Consent level stamped on the persisted block. Defaults come from
+   * `SurfacePolicy.defaultConsent`; callers pass an explicit value when
+   * they know better (e.g. operator CLI writes → 'exportable'; telegram
+   * chat writes → 'local-only'). If omitted AND no default from caller,
+   * falls back to 'local-only' (privacy-first).
+   */
+  consent?: SurfaceConsent;
 };
 
 export type DurableMemoryStoreResult = {
@@ -67,12 +84,20 @@ export async function storeDurableMemory(
   }
 
   const chain = input.chain?.trim() || 'journal';
-  const block = await deps.append(chain, {
+  const consent: SurfaceConsent = input.consent ?? 'local-only';
+  const blockPayload: Record<string, unknown> = {
     content: input.content,
     tags: input.tags ?? [],
     source: input.source ?? 'memphis',
     memory_id: input.memoryId,
-  });
+    consent,
+  };
+  // Only stamp turnId when present — unlinked events (scheduled writes,
+  // boot-time system events) legitimately have no turn binding.
+  if (input.turnId) {
+    blockPayload.turn_id = input.turnId;
+  }
+  const block = await deps.append(chain, blockPayload);
 
   const memoryId = input.memoryId?.trim() || buildDefaultMemoryId(chain, block.index);
   const embedTags = buildEmbedTags(chain, input.tags);

--- a/src/infra/memory/durable-memory.ts
+++ b/src/infra/memory/durable-memory.ts
@@ -1,5 +1,5 @@
 import { indexExactSearchBlock } from './exact-search.js';
-import type { SurfaceConsent } from '../../gateway/surface-policy.js';
+import { resolveSurfacePolicy, type SurfaceConsent } from '../../gateway/surface-policy.js';
 import { scanContent } from '../../security/content-scan.js';
 import { emitRuntimeSecurityEvent } from '../../security/runtime-security-events.js';
 import { appendBlock } from '../storage/chain-adapter.js';
@@ -20,13 +20,24 @@ export type DurableMemoryStoreInput = {
    */
   turnId?: string;
   /**
-   * Consent level stamped on the persisted block. Defaults come from
-   * `SurfacePolicy.defaultConsent`; callers pass an explicit value when
-   * they know better (e.g. operator CLI writes → 'exportable'; telegram
-   * chat writes → 'local-only'). If omitted AND no default from caller,
-   * falls back to 'local-only' (privacy-first).
+   * Consent level stamped on the persisted block. Resolution order:
+   *   1. Explicit `consent` value (caller knows best).
+   *   2. `surface` hint → `resolveSurfacePolicy(surface).defaultConsent`
+   *      (honors MEMPHIS_SURFACE_<NAME>_DEFAULT_CONSENT env overrides).
+   *   3. Fallback 'exportable' — matches pre-N8 grandfathering where
+   *      consent-less legacy blocks are read as exportable per
+   *      docs/dev/TRAJECTORY-EXPORT-V1.md consent-handling section.
+   * Callers should always pass either `consent` or `surface` for
+   * explicit semantics; bare fallback exists only for backward compat.
    */
   consent?: SurfaceConsent;
+  /**
+   * Surface hint used when `consent` is absent. Resolved via
+   * `resolveSurfacePolicy(surface).defaultConsent`, so per-surface env
+   * overrides apply uniformly to MCP / CLI / HTTP / telegram writes
+   * without each caller re-implementing consent lookup.
+   */
+  surface?: string;
 };
 
 export type DurableMemoryStoreResult = {
@@ -52,6 +63,30 @@ const defaultDeps: DurableMemoryDeps = {
 
 function uniqueTags(tags: string[]): string[] {
   return Array.from(new Set(tags.filter((tag) => tag.trim().length > 0)));
+}
+
+/**
+ * Resolve the final consent value for a write per the 3-step order
+ * documented on `DurableMemoryStoreInput.consent`. Extracted so tests
+ * and advanced callers can inspect the exact fallback path.
+ */
+export function resolveConsent(input: {
+  consent?: SurfaceConsent;
+  surface?: string;
+}): SurfaceConsent {
+  if (input.consent) return input.consent;
+  if (input.surface) {
+    try {
+      return resolveSurfacePolicy(input.surface).defaultConsent;
+    } catch {
+      // Surface resolution is pure in practice; the catch is defensive
+      // so a future env-var parsing bug can't break memory writes.
+    }
+  }
+  // Pre-N8 grandfathering: legacy consent-less blocks are read as
+  // exportable per trajectory-v1 spec. Preserve that default for callers
+  // that pass neither an explicit consent nor a surface hint.
+  return 'exportable';
 }
 
 export function buildDefaultMemoryId(chain: string, index: number): string {
@@ -84,7 +119,7 @@ export async function storeDurableMemory(
   }
 
   const chain = input.chain?.trim() || 'journal';
-  const consent: SurfaceConsent = input.consent ?? 'local-only';
+  const consent: SurfaceConsent = resolveConsent(input);
   const blockPayload: Record<string, unknown> = {
     content: input.content,
     tags: input.tags ?? [],

--- a/src/mcp/tools/journal.ts
+++ b/src/mcp/tools/journal.ts
@@ -5,6 +5,15 @@ import { emitRuntimeSecurityEvent } from '../../security/runtime-security-events
 export type MemphisJournalInput = {
   content: string;
   tags?: string[];
+  /**
+   * Caller surface for consent resolution. Defaults to 'mcp' for legacy
+   * MCP-server callers; in-process chat memory clients pass 'cli.chat',
+   * HTTP chat paths pass 'http.chat', telegram passes 'telegram', etc.
+   * Routed through `resolveConsent` in durable-memory.ts so that
+   * MEMPHIS_SURFACE_<SURFACE>_DEFAULT_CONSENT overrides take effect per
+   * caller rather than being flattened to a single 'mcp' bucket.
+   */
+  surface?: string;
 };
 
 export type MemphisJournalOutput = {
@@ -54,10 +63,9 @@ export async function runMemphisJournal(
     content: input.content,
     tags: input.tags,
     source: 'mcp',
-    // MCP is an operator-adjacent surface; its consent default is
-    // 'exportable' per src/gateway/surface-policy.ts operator-class.
-    // Passing the surface hint routes through resolveConsent so any
-    // MEMPHIS_SURFACE_MCP_DEFAULT_CONSENT override applies.
-    surface: 'mcp',
+    // Route surface through resolveConsent so MEMPHIS_SURFACE_<SURFACE>_
+    // DEFAULT_CONSENT overrides apply per caller. Default 'mcp' kept for
+    // MCP-server writes; in-process chat/HTTP callers override explicitly.
+    surface: input.surface ?? 'mcp',
   });
 }

--- a/src/mcp/tools/journal.ts
+++ b/src/mcp/tools/journal.ts
@@ -54,5 +54,10 @@ export async function runMemphisJournal(
     content: input.content,
     tags: input.tags,
     source: 'mcp',
+    // MCP is an operator-adjacent surface; its consent default is
+    // 'exportable' per src/gateway/surface-policy.ts operator-class.
+    // Passing the surface hint routes through resolveConsent so any
+    // MEMPHIS_SURFACE_MCP_DEFAULT_CONSENT override applies.
+    surface: 'mcp',
   });
 }

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -23,6 +23,7 @@ describe('mcp tools', () => {
       content: 'hello',
       tags: ['x'],
       source: 'mcp',
+      surface: 'mcp',
     });
     expect(out).toMatchObject({
       success: true,

--- a/tests/unit/durable-memory.turnid.test.ts
+++ b/tests/unit/durable-memory.turnid.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { storeDurableMemory } from '../../src/infra/memory/durable-memory.js';
+
+/**
+ * N8 — turnId + consent propagation tests.
+ *
+ * Verifies that the Y1 trajectory-export v1 plumbing reaches the
+ * block.data payload end-to-end through `storeDurableMemory`:
+ *   - explicit `turnId` + `consent` propagate into the appendBlock call
+ *   - omitting `turnId` leaves the field unset (not emitted as `undefined`)
+ *   - omitting `consent` defaults to 'local-only' (privacy-first)
+ *   - existing callers (no turnId/consent) remain backward compatible
+ */
+
+type AppendResult = {
+  index: number;
+  hash: string;
+  chain: string;
+  timestamp: string;
+};
+
+function mockAppend(result: Partial<AppendResult> = {}): ReturnType<typeof vi.fn> {
+  return vi.fn(async () => ({
+    index: 1,
+    hash: 'h1',
+    chain: 'journal',
+    timestamp: '2026-04-23T00:00:00.000Z',
+    ...result,
+  }));
+}
+
+function mockIndex(): ReturnType<typeof vi.fn> {
+  return vi.fn(() => ({ id: 'x', count: 1, dim: 32, provider: 'local-deterministic' }));
+}
+
+describe('durable memory — turnId + consent propagation (N8)', () => {
+  it('stamps turnId + consent on the appended block', async () => {
+    const append = mockAppend();
+    const index = mockIndex();
+
+    await storeDurableMemory(
+      {
+        content: 'operator confirmed deploy plan',
+        tags: ['decisions'],
+        source: 'cli',
+        chain: 'decisions',
+        turnId: 'turn_abc123',
+        consent: 'exportable',
+      },
+      { append: append as never, index: index as never },
+    );
+
+    expect(append).toHaveBeenCalledTimes(1);
+    const [chainArg, dataArg] = append.mock.calls[0];
+    expect(chainArg).toBe('decisions');
+    expect(dataArg).toMatchObject({
+      content: 'operator confirmed deploy plan',
+      consent: 'exportable',
+      turn_id: 'turn_abc123',
+    });
+  });
+
+  it('omits turn_id when turnId not provided (unlinked events)', async () => {
+    const append = mockAppend();
+    const index = mockIndex();
+
+    await storeDurableMemory(
+      {
+        content: 'scheduler tick',
+        tags: ['scheduler'],
+        source: 'cron',
+        chain: 'system',
+        consent: 'exportable',
+        // no turnId — scheduled write
+      },
+      { append: append as never, index: index as never },
+    );
+
+    const [, dataArg] = append.mock.calls[0];
+    expect(dataArg).toHaveProperty('consent', 'exportable');
+    expect(dataArg).not.toHaveProperty('turn_id');
+  });
+
+  it("defaults consent to 'local-only' when caller omits it (privacy-first)", async () => {
+    const append = mockAppend();
+    const index = mockIndex();
+
+    await storeDurableMemory(
+      {
+        content: 'conversation frame',
+        source: 'chat',
+        // neither turnId nor consent passed
+      },
+      { append: append as never, index: index as never },
+    );
+
+    const [, dataArg] = append.mock.calls[0];
+    expect(dataArg).toHaveProperty('consent', 'local-only');
+    expect(dataArg).not.toHaveProperty('turn_id');
+  });
+
+  it('accepts anonymized consent level', async () => {
+    const append = mockAppend();
+    const index = mockIndex();
+
+    await storeDurableMemory(
+      {
+        content: 'sensitive observation',
+        chain: 'journal',
+        turnId: 'turn_xyz',
+        consent: 'anonymized',
+      },
+      { append: append as never, index: index as never },
+    );
+
+    const [, dataArg] = append.mock.calls[0];
+    expect(dataArg).toMatchObject({ consent: 'anonymized', turn_id: 'turn_xyz' });
+  });
+
+  it('preserves backward compat — existing callers without turnId/consent still work', async () => {
+    const append = mockAppend();
+    const index = mockIndex();
+
+    const result = await storeDurableMemory(
+      {
+        memoryId: 'legacy-1',
+        content: 'pre-N8 caller',
+        tags: ['legacy'],
+      },
+      { append: append as never, index: index as never },
+    );
+
+    expect(result.success).toBe(true);
+    const [, dataArg] = append.mock.calls[0];
+    // consent default lands on the block; turn_id does not leak
+    expect(dataArg).toMatchObject({ consent: 'local-only' });
+    expect(dataArg).not.toHaveProperty('turn_id');
+  });
+});

--- a/tests/unit/durable-memory.turnid.test.ts
+++ b/tests/unit/durable-memory.turnid.test.ts
@@ -82,22 +82,58 @@ describe('durable memory — turnId + consent propagation (N8)', () => {
     expect(dataArg).not.toHaveProperty('turn_id');
   });
 
-  it("defaults consent to 'local-only' when caller omits it (privacy-first)", async () => {
+  it("defaults consent to 'exportable' when caller omits consent AND surface (grandfathering)", async () => {
     const append = mockAppend();
     const index = mockIndex();
 
     await storeDurableMemory(
       {
-        content: 'conversation frame',
+        content: 'legacy caller frame',
         source: 'chat',
-        // neither turnId nor consent passed
+        // neither turnId, consent, nor surface passed
+      },
+      { append: append as never, index: index as never },
+    );
+
+    const [, dataArg] = append.mock.calls[0];
+    // Pre-N8 grandfathering per trajectory-v1 spec — consent-less
+    // legacy blocks read as exportable, so write-side fallback matches.
+    expect(dataArg).toHaveProperty('consent', 'exportable');
+    expect(dataArg).not.toHaveProperty('turn_id');
+  });
+
+  it('resolves consent from surface hint (chat class → local-only)', async () => {
+    const append = mockAppend();
+    const index = mockIndex();
+
+    await storeDurableMemory(
+      {
+        content: 'telegram journal entry',
+        source: 'telegram',
+        surface: 'telegram',
       },
       { append: append as never, index: index as never },
     );
 
     const [, dataArg] = append.mock.calls[0];
     expect(dataArg).toHaveProperty('consent', 'local-only');
-    expect(dataArg).not.toHaveProperty('turn_id');
+  });
+
+  it('explicit consent outranks surface hint', async () => {
+    const append = mockAppend();
+    const index = mockIndex();
+
+    await storeDurableMemory(
+      {
+        content: 'operator override',
+        surface: 'telegram',
+        consent: 'exportable',
+      },
+      { append: append as never, index: index as never },
+    );
+
+    const [, dataArg] = append.mock.calls[0];
+    expect(dataArg).toHaveProperty('consent', 'exportable');
   });
 
   it('accepts anonymized consent level', async () => {
@@ -133,8 +169,9 @@ describe('durable memory — turnId + consent propagation (N8)', () => {
 
     expect(result.success).toBe(true);
     const [, dataArg] = append.mock.calls[0];
-    // consent default lands on the block; turn_id does not leak
-    expect(dataArg).toMatchObject({ consent: 'local-only' });
+    // Grandfathered fallback: legacy callers get exportable (matches
+    // trajectory-v1 reader assumption for consent-less old blocks).
+    expect(dataArg).toMatchObject({ consent: 'exportable' });
     expect(dataArg).not.toHaveProperty('turn_id');
   });
 });

--- a/tests/unit/surface-policy.test.ts
+++ b/tests/unit/surface-policy.test.ts
@@ -61,6 +61,18 @@ describe('surface policy', () => {
     expect(parseSurfacePolicySettingValue('maxToolTier', '2')).toBe('2');
   });
 
+  it('surfaces DEFAULT_CONSENT in override list and accepts consent aliases', () => {
+    const rawEnv = {
+      MEMPHIS_SURFACE_TELEGRAM_DEFAULT_CONSENT: 'exportable',
+    } as NodeJS.ProcessEnv;
+    expect(listSurfacePolicyOverrides('telegram', rawEnv)).toEqual([
+      expect.objectContaining({ setting: 'defaultConsent', rawValue: 'exportable' }),
+    ]);
+    expect(normalizeSurfacePolicySettingName('default-consent')).toBe('defaultConsent');
+    expect(normalizeSurfacePolicySettingName('consent')).toBe('defaultConsent');
+    expect(parseSurfacePolicySettingValue('defaultConsent', 'local-only')).toBe('local-only');
+  });
+
   it('treats telegram default full-tier mode as canonical but still flags risky overrides', () => {
     const telegramDefault = resolveSurfacePolicy('telegram', {} as NodeJS.ProcessEnv);
     const telegramWarn = resolveSurfacePolicy('telegram', {


### PR DESCRIPTION
## Summary

Closes Y1 Q1 **N8** — trajectory PR B: turnId + consent propagation through \`storeDurableMemory\` end-to-end. Unblocks **N9** (PR C exporter).

## Scope

- \`src/gateway/surface-policy.ts\` — SurfacePolicy grows \`defaultConsent\` (\`SurfaceConsent\` union) + per-SurfaceClass defaults + env override + \`parseConsentEnv\` helper
- \`src/infra/memory/durable-memory.ts\` — Input grows \`turnId?\` + \`consent?\`, stamps \`data.consent\` always and \`data.turn_id\` when present
- \`src/infra/cli/handlers/embed.handler.ts\` — CLI embed store → explicit \`consent: 'exportable'\`
- \`src/infra/http/routes/memory.ts\` — MemoryRouteDeps grows turnId + consent passthrough
- \`tests/unit/durable-memory.turnid.test.ts\` (new) — 5 cases: explicit, unlinked, default, anonymized, backcompat

## Test plan

- [x] \`npx tsc -p tsconfig.json --noEmit\` clean
- [x] New 5 tests pass
- [x] Existing 12 durable-memory tests pass (backward compat)
- [x] \`npx eslint\` clean
- [ ] CI quality-gate green
- [ ] Codex review

## Security / scope

- [x] Threat surface unchanged
- [x] No secret path change
- [x] \`secret-scan.sh\` clean

## Dependency classification

No new deps. \`dep-freeze-check.yml\` no-op.

## Backwards compat

- [x] Callers without turnId/consent still work (tested)
- [x] Old blocks without consent → readers treat as \`exportable\` (v1 spec grandfathering)
- [x] Schema additive only

## Roadmap

- Closes **N8** (Q1)
- Unblocks **N9** (Q1 exporter, next PR)