### PR TITLE
feat(trajectory): exporter + memphis export trajectories CLI (N9 PR C)

### DIFF
--- a/src/infra/cli/commands/export-trajectories.ts
+++ b/src/infra/cli/commands/export-trajectories.ts
@@ -1,0 +1,134 @@
+/**
+ * `memphis export trajectories` CLI (Y1 Q1 N9 PR C).
+ *
+ * Writes one JSONL file per exported trajectory plus a manifest with
+ * summary counters. Output directory is flat by design: consumers can
+ * `for f in *.jsonl` without knowing session UUIDs in advance.
+ *
+ * Usage:
+ *   memphis export trajectories --out <dir> [--since ISO] [--consent X]
+ *                                [--dry-run] [--json]
+ *
+ * Flags:
+ *   --out <dir>       Required. Output directory (created if absent).
+ *   --since ISO       Optional. Only events with timestamp ≥ ISO export.
+ *   --consent LEVEL   'exportable' (default), 'anonymized', 'local-only',
+ *                     or 'all'. 'all' requires MEMPHIS_EXPORT_CONFIRM=1.
+ *   --dry-run         Summarize without writing files.
+ *   --json            Print structured summary.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+import {
+  exportTrajectories,
+  type ExportTrajectoriesInput,
+} from '../../../trajectory/exporter.js';
+import type { CliContext } from '../context.js';
+import { print } from '../utils/render.js';
+
+type ConsentFlag = NonNullable<ExportTrajectoriesInput['consent']>;
+
+function isValidConsent(raw: string): raw is ConsentFlag {
+  return raw === 'exportable' || raw === 'anonymized' || raw === 'local-only' || raw === 'all';
+}
+
+/**
+ * Returns `true` when the command was handled (command === 'export' +
+ * subcommand === 'trajectories'). Caller should match first-true-wins
+ * per the existing `src/infra/cli/commands/*` pattern.
+ */
+export async function handleExportTrajectoriesCommand(context: CliContext): Promise<boolean> {
+  if (context.args.command !== 'export' || context.args.subcommand !== 'trajectories') {
+    return false;
+  }
+
+  const { json, out, since, consent: consentRaw, dryRun } = context.args;
+  const consent = consentRaw ?? 'exportable';
+
+  if (!dryRun && (!out || out.trim().length === 0)) {
+    throw new Error(
+      'export trajectories requires --out <dir> (or --dry-run to summarize without writing)',
+    );
+  }
+
+  if (!isValidConsent(consent)) {
+    throw new Error(
+      `invalid --consent value '${consent}' (expected exportable|anonymized|local-only|all)`,
+    );
+  }
+
+  const opts: ExportTrajectoriesInput = {
+    consent,
+    sinceIso: since,
+    rawEnv: process.env,
+  };
+
+  const result = await exportTrajectories(opts);
+
+  if (dryRun) {
+    print(
+      {
+        ok: true,
+        data: {
+          dryRun: true,
+          ...result.summary,
+          skipped: result.skipped.length,
+        },
+      },
+      json,
+    );
+    return true;
+  }
+
+  const targetDir = resolve(out as string);
+  await mkdir(targetDir, { recursive: true });
+
+  const writtenFiles: string[] = [];
+  for (const trajectory of result.trajectories) {
+    const fname = `${trajectory.trajectoryId}.jsonl`;
+    const fpath = join(targetDir, fname);
+    // Self-describing JSONL: first line is `_meta` envelope, then one
+    // event per line in chronological order.
+    const meta = {
+      _meta: {
+        schemaVersion: trajectory.schemaVersion,
+        trajectoryId: trajectory.trajectoryId,
+        sessionId: trajectory.sessionId,
+        agentIdentity: trajectory.agentIdentity,
+        startedAt: trajectory.startedAt,
+        completedAt: trajectory.completedAt,
+        turns: trajectory.turns,
+        integrity: trajectory.integrity,
+      },
+    };
+    const lines = [JSON.stringify(meta), ...trajectory.events.map((e) => JSON.stringify(e))];
+    await writeFile(fpath, lines.join('\n') + '\n', 'utf8');
+    writtenFiles.push(fname);
+  }
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    schemaVersion: 1,
+    outDir: targetDir,
+    files: writtenFiles,
+    summary: result.summary,
+    skippedCount: result.skipped.length,
+  };
+  await writeFile(join(targetDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+
+  print(
+    {
+      ok: true,
+      data: {
+        outDir: targetDir,
+        files: writtenFiles.length,
+        ...result.summary,
+        skipped: result.skipped.length,
+      },
+    },
+    json,
+  );
+  return true;
+}

--- a/src/infra/cli/handlers/export.handler.ts
+++ b/src/infra/cli/handlers/export.handler.ts
@@ -1,0 +1,28 @@
+import { handleExportTrajectoriesCommand } from '../commands/export-trajectories.js';
+import type { CliContext } from '../context.js';
+import type { CommandHandler } from './command-handler.js';
+
+/**
+ * `memphis export [trajectories|...]` handler. Currently routes only
+ * `export trajectories` (Y1 Q1 N9 PR C). Future `export --format=mv2`
+ * (Y1 Q1 N12) will add another subcommand branch here.
+ */
+const EXPORT_COMMANDS = ['export'] as const;
+
+export const exportCommandHandler: CommandHandler = {
+  name: 'export',
+  commands: EXPORT_COMMANDS,
+  canHandle(context: CliContext): boolean {
+    if (!EXPORT_COMMANDS.includes(context.args.command as (typeof EXPORT_COMMANDS)[number])) {
+      return false;
+    }
+    // Only claim when we have a subcommand we know how to handle.
+    return context.args.subcommand === 'trajectories';
+  },
+  async handle(context: CliContext): Promise<boolean> {
+    if (context.args.subcommand === 'trajectories') {
+      return handleExportTrajectoriesCommand(context);
+    }
+    return false;
+  },
+};

--- a/src/infra/cli/parser.ts
+++ b/src/infra/cli/parser.ts
@@ -146,7 +146,6 @@ export function parseCommand(argv: string[]): CliArgs {
     botToken: readFlagValue(flags, '--bot-token'),
     allowedUserIds: readFlagValue(flags, '--allowed-user-ids'),
     pepperRestore: readFlagValue(flags, '--pepper-restore'),
-    consent: readFlagValue(flags, '--consent'),
     level: readFlagValue(flags, '--level'),
     fromIndex: readNumberFlag(flags, '--from-index'),
   };

--- a/src/infra/cli/parser.ts
+++ b/src/infra/cli/parser.ts
@@ -92,6 +92,7 @@ export function parseCommand(argv: string[]): CliArgs {
     cronPattern: readFlagValue(flags, '--cron-pattern'),
     apply: hasBooleanFlag(flags, '--apply'),
     dryRun: hasBooleanFlag(flags, '--dry-run'),
+    consent: readFlagValue(flags, '--consent'),
     skipRestart: hasBooleanFlag(flags, '--skip-restart'),
     skipBuild: hasBooleanFlag(flags, '--skip-build'),
     allowAllUsers: hasBooleanFlag(flags, '--allow-all-users'),

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -311,6 +311,7 @@ export const CLI_NON_COMPLETABLE_COMMANDS = new Set<string | undefined>([
   'auth', // namespace — always needs a subcommand
   'config', // namespace — always needs a subcommand
   'consent', // namespace — always needs a subcommand (e.g. `memphis consent mark`)
+  'export', // namespace — always needs a subcommand (e.g. `memphis export trajectories`)
 ]);
 
 type CommandKey = string | undefined;

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -40,6 +40,11 @@ export const CLI_COMMAND_REGISTRY = [
     createLazyHandlerLoader(() => import('./handlers/apps.handler.js'), 'appsCommandHandler'),
   ),
   createCommandRegistration(
+    'export',
+    ['export'],
+    createLazyHandlerLoader(() => import('./handlers/export.handler.js'), 'exportCommandHandler'),
+  ),
+  createCommandRegistration(
     'skills',
     ['skills', 'skill'],
     createLazyHandlerLoader(() => import('./handlers/skills.handler.js'), 'skillsCommandHandler'),

--- a/src/infra/cli/types.ts
+++ b/src/infra/cli/types.ts
@@ -115,6 +115,12 @@ export type CliArgs = {
   since?: string;
   until?: string;
   contains?: string;
+  /**
+   * Trajectory export consent filter
+   * ('exportable'|'local-only'|'anonymized'|'all'). Used by
+   * `memphis export trajectories`. See Y1 Q1 N9 + TRAJECTORY-EXPORT-V1.md.
+   */
+  consent?: string;
   status?: string;
   providerOnly: boolean;
   // Matrix setup

--- a/src/infra/cli/types.ts
+++ b/src/infra/cli/types.ts
@@ -136,8 +136,9 @@ export type CliArgs = {
   cronPattern?: string;
   // Backup restore
   pepperRestore?: string;
-  // Consent mark (N11)
-  consent?: string;
+  // Consent mark (N11) — `consent` is shared with the trajectory export
+  // flag above (both accept level strings), so only `level` + `fromIndex`
+  // are new here.
   level?: string;
   fromIndex?: number;
 };

--- a/src/infra/cli/utils/parser.ts
+++ b/src/infra/cli/utils/parser.ts
@@ -40,6 +40,7 @@ export type CliArgs = {
   deep?: boolean;
   apply: boolean;
   dryRun: boolean;
+  consent?: string;
   skipRestart: boolean;
   skipBuild: boolean;
   allowAllUsers: boolean;
@@ -151,6 +152,7 @@ export function parseCommand(argv: string[]): CliArgs {
     deep: hasBooleanFlag(flags, '--deep'),
     apply: hasBooleanFlag(flags, '--apply'),
     dryRun: hasBooleanFlag(flags, '--dry-run'),
+    consent: readFlagValue(flags, '--consent'),
     skipRestart: hasBooleanFlag(flags, '--skip-restart'),
     skipBuild: hasBooleanFlag(flags, '--skip-build'),
     allowAllUsers: hasBooleanFlag(flags, '--allow-all-users'),

--- a/src/memory/chain.ts
+++ b/src/memory/chain.ts
@@ -2,6 +2,11 @@ export interface Block {
   index?: number;
   timestamp?: string;
   hash?: string;
+  /** Hex-encoded hash of the previous block in the chain (block-level metadata,
+   * NOT a payload field). Consumers such as the trajectory exporter rely on
+   * this for provenance linkage; prior omission caused every exported event
+   * to fall back to `'0'.repeat(64)` which broke hash-chain verification. */
+  prev_hash?: string;
   chain?: string;
   data?: {
     content?: string;

--- a/src/trajectory/exporter.ts
+++ b/src/trajectory/exporter.ts
@@ -316,7 +316,13 @@ export async function exportTrajectories(
     for (const block of out.blocks) {
       totalBlocks += 1;
       if (since !== null) {
-        const ts = typeof block.timestamp === 'string' ? Date.parse(block.timestamp) : NaN;
+        // Normalize the same way mapBlockToEvent does — append 'Z'
+        // when missing a zone marker so legacy writes that omitted it
+        // still filter correctly against `--since` (JS Date.parse
+        // treats zone-less ISO strings as local time, not UTC).
+        let rawTs = typeof block.timestamp === 'string' ? block.timestamp : '';
+        if (rawTs && !/[zZ]|[+-]\d{2}:?\d{2}$/.test(rawTs)) rawTs = `${rawTs}Z`;
+        const ts = rawTs ? Date.parse(rawTs) : NaN;
         if (!Number.isNaN(ts) && ts < since) continue;
       }
       // Prefer block-level data.source for surface attribution —

--- a/src/trajectory/exporter.ts
+++ b/src/trajectory/exporter.ts
@@ -301,19 +301,30 @@ export async function exportTrajectories(
   let anonymizedEvents = 0;
 
   for (const chain of chains) {
-    const out = await query({ chain, limit: limitPerChain });
-    // Capture the live chain tip (last block's hash) BEFORE any
-    // consent/timestamp filtering. The integrity snapshot is a claim
-    // about the on-disk chain at export time — if the newest blocks are
-    // `local-only` under the default exporter filter, filtering-aware
-    // capture would silently leave `chainHashes[chain]` off the live
-    // tip (or omit the chain entirely). That breaks downstream consumers
-    // verifying exported trajectories against the live chain.
-    const tail = out.blocks[out.blocks.length - 1];
+    // Paginate via (limit, offset) until the query returns fewer rows
+    // than limitPerChain — that's the natural tail-of-chain signal. A
+    // single-window read would silently truncate history past the
+    // default 5000 blocks, invalidating "complete" exports.
+    let offset = 0;
+    let tail: Block | undefined;
+    const chainBlocks: Block[] = [];
+    // Safety cap so a runaway chain doesn't loop forever in pathological
+    // cases (e.g. if the backing store ignores limit). 10M blocks is
+    // well past every real memphis deployment.
+    const MAX_ITERATIONS = 10_000_000 / Math.max(1, limitPerChain);
+    for (let iteration = 0; iteration < MAX_ITERATIONS; iteration += 1) {
+      const page = await query({ chain, limit: limitPerChain, offset });
+      if (page.blocks.length === 0) break;
+      chainBlocks.push(...page.blocks);
+      tail = page.blocks[page.blocks.length - 1];
+      if (page.blocks.length < limitPerChain) break;
+      offset += page.blocks.length;
+    }
+    // Capture the live chain tip BEFORE any consent/timestamp filtering.
     if (tail && typeof tail.hash === 'string' && tail.hash.length > 0) {
       chainHashes[chain] = tail.hash;
     }
-    for (const block of out.blocks) {
+    for (const block of chainBlocks) {
       totalBlocks += 1;
       if (since !== null) {
         // Normalize the same way mapBlockToEvent does — append 'Z'
@@ -363,7 +374,12 @@ export async function exportTrajectories(
   const agentIdentity = resolveAgentIdentity(rawEnv);
   const trajectories: TrajectoryT[] = [];
   for (const [sessionKey, sessEvents] of bySession.entries()) {
-    const sorted = [...sessEvents].sort((a, b) => a.ts.localeCompare(b.ts));
+    // Sort by parsed epoch, not lexicographic `localeCompare`. ISO
+    // strings that carry different zone offsets (`2026-04-23T10:00:00Z`
+    // vs `2026-04-23T12:00:00+02:00`) are chronologically equal but
+    // compare unequal as strings, which would bury events out of
+    // order and miscompute startedAt/completedAt.
+    const sorted = [...sessEvents].sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
     const startedAt = sorted[0]?.ts ?? new Date().toISOString();
     const completedAt = sorted[sorted.length - 1]?.ts ?? null;
     const turns = new Set(sorted.map((e) => e.turnId).filter((t): t is string => !!t)).size;

--- a/src/trajectory/exporter.ts
+++ b/src/trajectory/exporter.ts
@@ -128,11 +128,20 @@ export function mapBlockToEvent(
 
   // Timestamp normalization: chain blocks use ISO-8601 UTC ('Z');
   // trajectory-v1 schema requires an offset-qualified datetime which
-  // includes 'Z'. Pass through verbatim if it parses.
+  // includes 'Z'. Pass through verbatim if it parses; otherwise tack
+  // on 'Z' then validate.
   let ts = block.timestamp;
   if (!/[zZ]|[+-]\d{2}:?\d{2}$/.test(ts)) {
     // Defensive normalization — some legacy writes may have omitted the Z.
     ts = `${ts}Z`;
+  }
+  // Validate by reparse — a malformed timestamp (e.g. `not-a-date`)
+  // would still propagate to `Trajectory.parse` later and invalidate
+  // the whole trajectory bucket, dropping other valid events with it.
+  // Reject at the source instead.
+  const parsed = Date.parse(ts);
+  if (Number.isNaN(parsed)) {
+    return { event: null, reason: `invalid timestamp: ${block.timestamp}` };
   }
 
   const data = block.data as Record<string, unknown>;
@@ -391,15 +400,23 @@ export async function exportTrajectories(
     }
   }
 
+  // Summary counters must reflect what actually ships — base on
+  // `validTrajectories` not `trajectories`, otherwise CLI/manifest
+  // outputs overstate event + session counts when schema validation
+  // drops any trajectory.
+  const includedEventsCount = validTrajectories.reduce(
+    (sum, traj) => sum + traj.events.length,
+    0,
+  );
   return {
     trajectories: validTrajectories,
     skipped,
     summary: {
       totalEvents: totalBlocks,
-      includedEvents: events.length,
+      includedEvents: includedEventsCount,
       filteredByConsent,
       anonymizedEvents,
-      sessionCount: trajectories.length,
+      sessionCount: validTrajectories.length,
       chainCount: chains.length,
     },
   };

--- a/src/trajectory/exporter.ts
+++ b/src/trajectory/exporter.ts
@@ -143,7 +143,15 @@ export function mapBlockToEvent(
   const kind = resolveEventKind(data);
   const payload = buildPayload(data, consent);
 
-  const prevHash = typeof data.prev_hash === 'string' ? data.prev_hash : '0'.repeat(64);
+  // prev_hash is BLOCK-level metadata on the chain record, not inside
+  // `data` (the payload). The prior `data.prev_hash` lookup always
+  // missed and fell back to all-zeros, breaking hash-chain verification
+  // downstream. Schema-level `data.prev_hash` remains a fallback purely
+  // in case a legacy seeder stored it there; production writers put it
+  // at the block level (see NapiBlock in chain-file-io.ts).
+  const blockPrev = typeof block.prev_hash === 'string' ? block.prev_hash : undefined;
+  const dataPrev = typeof data.prev_hash === 'string' ? data.prev_hash : undefined;
+  const prevHash = blockPrev ?? dataPrev ?? '0'.repeat(64);
 
   const event: TrajectoryEventT = {
     kind,
@@ -259,7 +267,17 @@ export async function exportTrajectories(
 
   for (const chain of chains) {
     const out = await query({ chain, limit: limitPerChain });
-    let lastHash = '';
+    // Capture the live chain tip (last block's hash) BEFORE any
+    // consent/timestamp filtering. The integrity snapshot is a claim
+    // about the on-disk chain at export time — if the newest blocks are
+    // `local-only` under the default exporter filter, filtering-aware
+    // capture would silently leave `chainHashes[chain]` off the live
+    // tip (or omit the chain entirely). That breaks downstream consumers
+    // verifying exported trajectories against the live chain.
+    const tail = out.blocks[out.blocks.length - 1];
+    if (tail && typeof tail.hash === 'string' && tail.hash.length > 0) {
+      chainHashes[chain] = tail.hash;
+    }
     for (const block of out.blocks) {
       totalBlocks += 1;
       if (since !== null) {
@@ -283,9 +301,7 @@ export async function exportTrajectories(
       }
       if (ev.consent === 'anonymized') anonymizedEvents += 1;
       events.push(ev);
-      if (ev.provenance?.blockHash) lastHash = ev.provenance.blockHash;
     }
-    if (lastHash) chainHashes[chain] = lastHash;
   }
 
   // Group into trajectories by turnId's session slice. Turn IDs look

--- a/src/trajectory/exporter.ts
+++ b/src/trajectory/exporter.ts
@@ -1,0 +1,395 @@
+/**
+ * Trajectory exporter — Y1 Q1 N9 (PR C).
+ *
+ * Reads chain blocks via the existing chain-query layer, maps each into
+ * a TrajectoryEvent per the v1 schema contract in `./schema.ts`, groups
+ * events by session (`turnId` binding from N8) into a Trajectory, and
+ * optionally writes to JSONL.
+ *
+ * Grandfathering rules (per docs/dev/TRAJECTORY-EXPORT-V1.md §Consent
+ * handling): blocks written before N8 have no `data.turn_id` /
+ * `data.consent`. Those are mapped as:
+ *   - turnId: null   (unlinked event — system/scheduler/legacy)
+ *   - consent: 'exportable' (legacy default; matches write-side grand-
+ *     fathering in `storeDurableMemory.resolveConsent()`)
+ *
+ * Anonymized consent honored by replacing `payload.content` with the
+ * SHA-256 hex of the original content; tags preserved. Smart PII
+ * scrubbing (name replacement etc.) is explicitly v2.
+ *
+ * Consent filtering (default): only 'exportable' events are returned.
+ * Callers that need more pass `consent: 'all'` AND set
+ * MEMPHIS_EXPORT_CONFIRM=1 (the exporter refuses 'all' without the
+ * confirm env so a mis-click can't leak local-only data).
+ */
+
+import { createHash } from 'node:crypto';
+
+import {
+  SCHEMA_VERSION,
+  Trajectory,
+  type ConsentLevelT,
+  type TrajectoryEventKindT,
+  type TrajectoryEventT,
+  type TrajectoryIntegrityT,
+  type TrajectorySurfaceT,
+  type TrajectoryT,
+} from './schema.js';
+import { runMemphisChainQuery } from '../mcp/tools/chain-query.js';
+import type { Block } from '../memory/chain.js';
+
+/**
+ * 8 live operator-content chains. Pulled as one set so the exporter
+ * can issue a chain_query per chain without re-hardcoding the list
+ * each time. Matches the canonical catalog in
+ * `src/memory/chain-catalog.ts`; `insights` + `soul` are included
+ * even though they're richer than durable memory to match the
+ * trajectory-v1 spec which groups all chain-write events uniformly.
+ */
+export const EXPORTABLE_CHAINS = [
+  'journal',
+  'decisions',
+  'reflections',
+  'cases',
+  'patterns',
+  'system',
+  'collective',
+  'proactive',
+  'insights',
+  'soul',
+] as const;
+
+export type ExportableChain = (typeof EXPORTABLE_CHAINS)[number];
+
+export interface ExportTrajectoriesInput {
+  /**
+   * Consent filter. 'exportable' = default; 'all' requires explicit
+   * confirmation env var `MEMPHIS_EXPORT_CONFIRM=1` and exports every
+   * non-anonymized block regardless of consent level. 'anonymized'
+   * exports only anonymized + exportable (never raw local-only).
+   */
+  consent?: ConsentLevelT | 'all';
+  /** ISO-8601 lower bound on block timestamp. */
+  sinceIso?: string;
+  /**
+   * Subset of chains to include. Defaults to all 10 live chains.
+   */
+  chains?: readonly string[];
+  /**
+   * Max blocks to fetch per chain. The limit is applied per-chain,
+   * after timestamp filtering, to keep memory usage predictable on
+   * operators with very long chains. Default 5000.
+   */
+  limitPerChain?: number;
+  /** Override the chain-query driver (test seam). */
+  query?: typeof runMemphisChainQuery;
+  /** Environment (for MEMPHIS_EXPORT_CONFIRM + agent identity). */
+  rawEnv?: NodeJS.ProcessEnv;
+}
+
+export interface ExportTrajectoriesOutput {
+  trajectories: TrajectoryT[];
+  /**
+   * Events that failed schema validation. Always empty in production —
+   * this is a safety net against malformed chain data. Populated when
+   * a block exists on-chain but couldn't be mapped to TrajectoryEvent.
+   */
+  skipped: Array<{ chain: string; blockIndex: number; reason: string }>;
+  /** Summary counters surfaced to operator + CLI JSON output. */
+  summary: {
+    totalEvents: number;
+    includedEvents: number;
+    filteredByConsent: number;
+    anonymizedEvents: number;
+    sessionCount: number;
+    chainCount: number;
+  };
+}
+
+const DEFAULT_LIMIT = 5000;
+
+/**
+ * Single-pass block → TrajectoryEvent mapping. Errors surface as
+ * `null` so the caller can accumulate `skipped` reasons.
+ */
+export function mapBlockToEvent(
+  block: Block,
+  chain: string,
+  surface: TrajectorySurfaceT,
+): { event: TrajectoryEventT | null; reason?: string } {
+  if (
+    typeof block.index !== 'number' ||
+    typeof block.timestamp !== 'string' ||
+    typeof block.hash !== 'string' ||
+    !block.data
+  ) {
+    return { event: null, reason: 'block missing index/timestamp/hash/data' };
+  }
+
+  // Timestamp normalization: chain blocks use ISO-8601 UTC ('Z');
+  // trajectory-v1 schema requires an offset-qualified datetime which
+  // includes 'Z'. Pass through verbatim if it parses.
+  let ts = block.timestamp;
+  if (!/[zZ]|[+-]\d{2}:?\d{2}$/.test(ts)) {
+    // Defensive normalization — some legacy writes may have omitted the Z.
+    ts = `${ts}Z`;
+  }
+
+  const data = block.data as Record<string, unknown>;
+  const turnIdRaw = data.turn_id;
+  const turnId = typeof turnIdRaw === 'string' && turnIdRaw.length > 0 ? turnIdRaw : null;
+
+  const consent: ConsentLevelT = resolveBlockConsent(data);
+  const kind = resolveEventKind(data);
+  const payload = buildPayload(data, consent);
+
+  const prevHash = typeof data.prev_hash === 'string' ? data.prev_hash : '0'.repeat(64);
+
+  const event: TrajectoryEventT = {
+    kind,
+    ts,
+    turnId,
+    surface,
+    consent,
+    provenance: {
+      chain,
+      blockIndex: block.index,
+      blockHash: block.hash,
+      prevHash,
+      ...(block.signer ? { signer: block.signer } : {}),
+      ...(block.signature ? { signature: block.signature } : {}),
+    },
+    payload,
+  };
+  return { event };
+}
+
+function resolveBlockConsent(data: Record<string, unknown>): ConsentLevelT {
+  const raw = data.consent;
+  if (raw === 'exportable' || raw === 'local-only' || raw === 'anonymized') return raw;
+  // Grandfathering: legacy consent-less blocks are treated as
+  // exportable per trajectory-v1 spec.
+  return 'exportable';
+}
+
+function resolveEventKind(data: Record<string, unknown>): TrajectoryEventKindT {
+  // Map Memphis block.data.type → trajectory event kind. Conservative
+  // fallback to 'chain_write' — the durable-memory spec never writes
+  // an unknown type, but unknown-type blocks from future versions
+  // should still export as writes rather than being dropped.
+  const type = data.type;
+  if (type === 'user_input') return 'user_input';
+  if (type === 'tool_call') return 'tool_call';
+  if (type === 'tool_result') return 'tool_result';
+  if (type === 'model_response') return 'model_response';
+  if (type === 'cognitive_prelude') return 'cognitive_prelude';
+  if (type === 'cognitive_post') return 'cognitive_post';
+  if (type === 'system' || type === 'system_event') return 'system_event';
+  if (type === 'prompt_fragment') return 'prompt_fragment';
+  return 'chain_write';
+}
+
+function buildPayload(data: Record<string, unknown>, consent: ConsentLevelT): Record<string, unknown> {
+  const contentRaw = typeof data.content === 'string' ? data.content : '';
+  const content = consent === 'anonymized' ? sha256Hex(contentRaw) : contentRaw;
+  const tags = Array.isArray(data.tags) ? (data.tags as unknown[]).filter((t) => typeof t === 'string') : [];
+  const source = typeof data.source === 'string' ? data.source : undefined;
+  const memoryId = typeof data.memory_id === 'string' ? data.memory_id : undefined;
+
+  const payload: Record<string, unknown> = {
+    content,
+    tags,
+    anonymized: consent === 'anonymized',
+  };
+  if (source !== undefined) payload.source = source;
+  if (memoryId !== undefined) payload.memory_id = memoryId;
+  if (data.type !== undefined) payload.block_type = data.type;
+  return payload;
+}
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+function surfaceForChain(chain: string): TrajectorySurfaceT {
+  // Heuristic mapping chain → trajectory surface. All durable-memory
+  // chains map to 'system' unless the block carries an explicit
+  // surface tag in `data.source`; the frame-level propagation of
+  // richer surface tracking is Y2 scope.
+  if (chain === 'system' || chain === 'collective' || chain === 'proactive') return 'system';
+  if (chain === 'insights' || chain === 'reflections' || chain === 'patterns') return 'scheduler';
+  return 'mcp';
+}
+
+/**
+ * Main exporter — returns one `Trajectory` per distinct session
+ * (grouped by `turnId` prefix when sessions aren't tagged, falling
+ * back to a single unbound trajectory for legacy unlinked events).
+ */
+export async function exportTrajectories(
+  input: ExportTrajectoriesInput = {},
+): Promise<ExportTrajectoriesOutput> {
+  const consentFilter = input.consent ?? 'exportable';
+  const rawEnv = input.rawEnv ?? process.env;
+
+  if (consentFilter === 'all') {
+    const confirm = rawEnv.MEMPHIS_EXPORT_CONFIRM?.trim();
+    if (confirm !== '1' && confirm !== 'true') {
+      throw new Error(
+        'exportTrajectories: --consent all requires MEMPHIS_EXPORT_CONFIRM=1 (prevents accidental leak of local-only events)',
+      );
+    }
+  }
+
+  const chains = (input.chains && input.chains.length > 0 ? input.chains : EXPORTABLE_CHAINS).slice();
+  const limitPerChain = input.limitPerChain ?? DEFAULT_LIMIT;
+  const query = input.query ?? runMemphisChainQuery;
+
+  const since = input.sinceIso ? Date.parse(input.sinceIso) : null;
+  if (input.sinceIso && (since === null || Number.isNaN(since))) {
+    throw new Error(`exportTrajectories: invalid --since value '${input.sinceIso}' (expected ISO-8601)`);
+  }
+
+  const events: TrajectoryEventT[] = [];
+  const skipped: ExportTrajectoriesOutput['skipped'] = [];
+  const chainHashes: Record<string, string> = {};
+  let totalBlocks = 0;
+  let filteredByConsent = 0;
+  let anonymizedEvents = 0;
+
+  for (const chain of chains) {
+    const out = await query({ chain, limit: limitPerChain });
+    let lastHash = '';
+    for (const block of out.blocks) {
+      totalBlocks += 1;
+      if (since !== null) {
+        const ts = typeof block.timestamp === 'string' ? Date.parse(block.timestamp) : NaN;
+        if (!Number.isNaN(ts) && ts < since) continue;
+      }
+      const surface = surfaceForChain(chain);
+      const mapped = mapBlockToEvent(block, chain, surface);
+      if (!mapped.event) {
+        skipped.push({
+          chain,
+          blockIndex: typeof block.index === 'number' ? block.index : -1,
+          reason: mapped.reason ?? 'unknown',
+        });
+        continue;
+      }
+      const ev = mapped.event;
+      if (!passesConsentFilter(ev.consent, consentFilter)) {
+        filteredByConsent += 1;
+        continue;
+      }
+      if (ev.consent === 'anonymized') anonymizedEvents += 1;
+      events.push(ev);
+      if (ev.provenance?.blockHash) lastHash = ev.provenance.blockHash;
+    }
+    if (lastHash) chainHashes[chain] = lastHash;
+  }
+
+  // Group into trajectories by turnId's session slice. Turn IDs look
+  // like 'turn_<sessionBase>_<counter>' in practice; we split on the
+  // last underscore to approximate session boundaries. Events with
+  // null turnId all land in the 'unbound' trajectory.
+  const bySession = new Map<string, TrajectoryEventT[]>();
+  for (const ev of events) {
+    const sessionKey = ev.turnId ? sessionFromTurnId(ev.turnId) : null;
+    const bucket = sessionKey ?? '__unbound__';
+    const arr = bySession.get(bucket) ?? [];
+    arr.push(ev);
+    bySession.set(bucket, arr);
+  }
+
+  const agentIdentity = resolveAgentIdentity(rawEnv);
+  const trajectories: TrajectoryT[] = [];
+  for (const [sessionKey, sessEvents] of bySession.entries()) {
+    const sorted = [...sessEvents].sort((a, b) => a.ts.localeCompare(b.ts));
+    const startedAt = sorted[0]?.ts ?? new Date().toISOString();
+    const completedAt = sorted[sorted.length - 1]?.ts ?? null;
+    const turns = new Set(sorted.map((e) => e.turnId).filter((t): t is string => !!t)).size;
+
+    const integrity: TrajectoryIntegrityT = {
+      chainHashes,
+      eventCount: sorted.length,
+      signedEventCount: sorted.filter((e) => e.provenance?.signature).length,
+    };
+
+    trajectories.push({
+      schemaVersion: SCHEMA_VERSION,
+      trajectoryId: stableUuidFromSessionKey(sessionKey),
+      sessionId: sessionKey === '__unbound__' ? null : sessionKey,
+      agentIdentity,
+      startedAt,
+      completedAt,
+      turns,
+      events: sorted,
+      integrity,
+    });
+  }
+
+  // Validate each via the schema before returning — defense-in-depth
+  // so a schema drift in this file is caught at export time, not by
+  // downstream consumers.
+  for (const traj of trajectories) {
+    Trajectory.parse(traj);
+  }
+
+  return {
+    trajectories,
+    skipped,
+    summary: {
+      totalEvents: totalBlocks,
+      includedEvents: events.length,
+      filteredByConsent,
+      anonymizedEvents,
+      sessionCount: trajectories.length,
+      chainCount: chains.length,
+    },
+  };
+}
+
+function passesConsentFilter(
+  eventConsent: ConsentLevelT,
+  filter: ConsentLevelT | 'all',
+): boolean {
+  if (filter === 'all') return true;
+  if (filter === 'exportable') return eventConsent === 'exportable' || eventConsent === 'anonymized';
+  if (filter === 'anonymized') return eventConsent === 'anonymized' || eventConsent === 'exportable';
+  // filter === 'local-only': pass only local-only events (for operator
+  // inspection / migration flows; still requires explicit choice).
+  return eventConsent === 'local-only';
+}
+
+function sessionFromTurnId(turnId: string): string {
+  // Session = turnId with the trailing numeric counter stripped, if any.
+  // Keeps events from the same conversation grouped regardless of
+  // per-turn suffix differences.
+  const match = turnId.match(/^(.*?)_(\d+)$/);
+  return match ? match[1] : turnId;
+}
+
+/**
+ * Deterministic UUID-v4-shaped identifier derived from the session key.
+ * Stable across re-exports so consumers can idempotently ingest.
+ */
+function stableUuidFromSessionKey(key: string): string {
+  const h = sha256Hex(`trajectory:${key}`).slice(0, 32);
+  // Format as UUID-v4 (8-4-4-4-12). Set version + variant bits.
+  const b = Buffer.from(h, 'hex');
+  b[6] = (b[6] & 0x0f) | 0x40; // version 4
+  b[8] = (b[8] & 0x3f) | 0x80; // variant 10
+  const hex = b.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+function resolveAgentIdentity(
+  rawEnv: NodeJS.ProcessEnv,
+): { agentName: string; ownerName: string; instanceId: string } {
+  return {
+    agentName: rawEnv.MEMPHIS_AGENT_NAME?.trim() || 'memphis',
+    ownerName: rawEnv.MEMPHIS_OWNER_NAME?.trim() || 'operator',
+    instanceId:
+      rawEnv.MEMPHIS_INSTANCE_ID?.trim() || 'unknown-instance',
+  };
+}

--- a/src/trajectory/exporter.ts
+++ b/src/trajectory/exporter.ts
@@ -212,6 +212,13 @@ function buildPayload(data: Record<string, unknown>, consent: ConsentLevelT): Re
   if (source !== undefined) payload.source = source;
   if (memoryId !== undefined) payload.memory_id = memoryId;
   if (data.type !== undefined) payload.block_type = data.type;
+  // Thread session-binding fields so the grouping pass can read them.
+  // Writers haven't started stamping these yet (extension of N8) but
+  // we're forward-compatible when they do.
+  const cid = data.conversation_id ?? (data as { conversationId?: unknown }).conversationId;
+  if (typeof cid === 'string' && cid.length > 0) payload.conversation_id = cid;
+  const sid = data.session_id ?? (data as { sessionId?: unknown }).sessionId;
+  if (typeof sid === 'string' && sid.length > 0) payload.session_id = sid;
   return payload;
 }
 
@@ -220,13 +227,30 @@ function sha256Hex(input: string): string {
 }
 
 function surfaceForChain(chain: string): TrajectorySurfaceT {
-  // Heuristic mapping chain → trajectory surface. All durable-memory
-  // chains map to 'system' unless the block carries an explicit
-  // surface tag in `data.source`; the frame-level propagation of
-  // richer surface tracking is Y2 scope.
+  // Chain-only fallback. Prefer `resolveBlockSurface(data, chain)` which
+  // inspects `data.source` first — CLI reflect/insight paths write with
+  // `source: 'cli.reflect'` etc. and those must not flatten to 'mcp'.
   if (chain === 'system' || chain === 'collective' || chain === 'proactive') return 'system';
   if (chain === 'insights' || chain === 'reflections' || chain === 'patterns') return 'scheduler';
   return 'mcp';
+}
+
+function resolveBlockSurface(
+  data: Record<string, unknown>,
+  chain: string,
+): TrajectorySurfaceT {
+  // Block writers stamp `data.source` with their surface (mcp, cli.*,
+  // http.*, telegram, scheduler, ...). Map common prefixes onto the
+  // trajectory surface enum; fall back to chain-based heuristic when
+  // source is absent or doesn't match a recognized surface family.
+  const raw = typeof data.source === 'string' ? data.source.toLowerCase() : '';
+  if (raw.startsWith('cli.') || raw === 'terminal' || raw === 'operator') return 'cli';
+  if (raw.startsWith('http.') || raw === 'http') return 'http';
+  if (raw === 'telegram' || raw.startsWith('telegram.')) return 'telegram';
+  if (raw === 'scheduler' || raw.startsWith('scheduler.')) return 'scheduler';
+  if (raw === 'system' || raw.startsWith('system.')) return 'system';
+  if (raw === 'mcp' || raw.startsWith('mcp.')) return 'mcp';
+  return surfaceForChain(chain);
 }
 
 /**
@@ -284,7 +308,11 @@ export async function exportTrajectories(
         const ts = typeof block.timestamp === 'string' ? Date.parse(block.timestamp) : NaN;
         if (!Number.isNaN(ts) && ts < since) continue;
       }
-      const surface = surfaceForChain(chain);
+      // Prefer block-level data.source for surface attribution —
+      // chain-only heuristic mislabels CLI reflect / telegram etc. writes
+      // that share the journal chain with agent traces.
+      const blockData = (block.data ?? {}) as Record<string, unknown>;
+      const surface = resolveBlockSurface(blockData, chain);
       const mapped = mapBlockToEvent(block, chain, surface);
       if (!mapped.event) {
         skipped.push({
@@ -304,14 +332,12 @@ export async function exportTrajectories(
     }
   }
 
-  // Group into trajectories by turnId's session slice. Turn IDs look
-  // like 'turn_<sessionBase>_<counter>' in practice; we split on the
-  // last underscore to approximate session boundaries. Events with
-  // null turnId all land in the 'unbound' trajectory.
+  // Group into trajectories. Priority: block `data.conversation_id` →
+  // `data.session_id` → per-turn bucket. See `sessionFromEvent`.
   const bySession = new Map<string, TrajectoryEventT[]>();
   for (const ev of events) {
-    const sessionKey = ev.turnId ? sessionFromTurnId(ev.turnId) : null;
-    const bucket = sessionKey ?? '__unbound__';
+    const sessionKey = sessionFromEvent(ev);
+    const bucket = sessionKey || '__unbound__';
     const arr = bySession.get(bucket) ?? [];
     arr.push(ev);
     bySession.set(bucket, arr);
@@ -346,13 +372,27 @@ export async function exportTrajectories(
 
   // Validate each via the schema before returning — defense-in-depth
   // so a schema drift in this file is caught at export time, not by
-  // downstream consumers.
+  // downstream consumers. Parse failures are logged to `skipped` per the
+  // exporter's graceful-degradation contract; one bad block must never
+  // abort the whole export.
+  const validTrajectories: TrajectoryT[] = [];
   for (const traj of trajectories) {
-    Trajectory.parse(traj);
+    try {
+      Trajectory.parse(traj);
+      validTrajectories.push(traj);
+    } catch (err) {
+      skipped.push({
+        chain: 'trajectory',
+        blockIndex: -1,
+        reason: `schema-validation-failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+    }
   }
 
   return {
-    trajectories,
+    trajectories: validTrajectories,
     skipped,
     summary: {
       totalEvents: totalBlocks,
@@ -377,12 +417,28 @@ function passesConsentFilter(
   return eventConsent === 'local-only';
 }
 
-function sessionFromTurnId(turnId: string): string {
-  // Session = turnId with the trailing numeric counter stripped, if any.
-  // Keeps events from the same conversation grouped regardless of
-  // per-turn suffix differences.
-  const match = turnId.match(/^(.*?)_(\d+)$/);
-  return match ? match[1] : turnId;
+function sessionFromEvent(ev: TrajectoryEventT): string {
+  // Grouping priority:
+  //   1. `data.conversation_id` / `data.session_id` stamped by the caller
+  //      — not yet persisted by durable-memory writers (extension of N8),
+  //      but honor it now so future blocks group correctly without another
+  //      exporter change.
+  //   2. Fallback: turnId itself. Runtime generates a new UUID per turn
+  //      (see `generateTurnId` in src/gateway/turn-runtime.ts) — blocks
+  //      from different turns of the same conversation share no common
+  //      prefix, so each turn becomes its own 1-event trajectory. This
+  //      is the documented v1 behavior; multi-turn grouping awaits
+  //      conversation-id plumbing into block payloads.
+  const payload = ev.payload as Record<string, unknown> | undefined;
+  const metadata = (payload?.metadata as Record<string, unknown> | undefined) ?? undefined;
+  for (const src of [payload, metadata]) {
+    if (!src) continue;
+    const cid = src.conversation_id ?? src.conversationId;
+    if (typeof cid === 'string' && cid.length > 0) return `conversation:${cid}`;
+    const sid = src.session_id ?? src.sessionId;
+    if (typeof sid === 'string' && sid.length > 0) return `session:${sid}`;
+  }
+  return ev.turnId ? `turn:${ev.turnId}` : '';
 }
 
 /**

--- a/src/trajectory/exporter.ts
+++ b/src/trajectory/exporter.ts
@@ -253,7 +253,9 @@ function resolveBlockSurface(
   // trajectory surface enum; fall back to chain-based heuristic when
   // source is absent or doesn't match a recognized surface family.
   const raw = typeof data.source === 'string' ? data.source.toLowerCase() : '';
-  if (raw.startsWith('cli.') || raw === 'terminal' || raw === 'operator') return 'cli';
+  if (raw === 'cli' || raw.startsWith('cli.') || raw === 'terminal' || raw === 'operator') {
+    return 'cli';
+  }
   if (raw.startsWith('http.') || raw === 'http') return 'http';
   if (raw === 'telegram' || raw.startsWith('telegram.')) return 'telegram';
   if (raw === 'scheduler' || raw.startsWith('scheduler.')) return 'scheduler';
@@ -426,12 +428,15 @@ function passesConsentFilter(
   eventConsent: ConsentLevelT,
   filter: ConsentLevelT | 'all',
 ): boolean {
+  // Each filter level selects exactly the events stamped at that level.
+  // Earlier revisions collapsed `exportable` and `anonymized` into the
+  // same set, which broke consumers that want only anonymized events
+  // (or only exportable non-anonymized ones, e.g. exportable plaintext
+  // corpora). `all` still unions everything. `local-only` is an
+  // operator-only inspection/migration flow — kept as an explicit
+  // single-level pass.
   if (filter === 'all') return true;
-  if (filter === 'exportable') return eventConsent === 'exportable' || eventConsent === 'anonymized';
-  if (filter === 'anonymized') return eventConsent === 'anonymized' || eventConsent === 'exportable';
-  // filter === 'local-only': pass only local-only events (for operator
-  // inspection / migration flows; still requires explicit choice).
-  return eventConsent === 'local-only';
+  return eventConsent === filter;
 }
 
 function sessionFromEvent(ev: TrajectoryEventT): string {

--- a/tests/unit/trajectory-exporter.test.ts
+++ b/tests/unit/trajectory-exporter.test.ts
@@ -49,6 +49,32 @@ describe('trajectory exporter', () => {
     expect(mapped.reason).toMatch(/invalid timestamp/);
   });
 
+  it('consent filter selects exactly one level (exportable vs anonymized stay separate)', async () => {
+    const blocks: Block[] = [
+      makeBlock({ index: 1, hash: 'a'.repeat(64), data: { content: 'ok', consent: 'exportable' } }),
+      makeBlock({
+        index: 2,
+        hash: 'b'.repeat(64),
+        prev_hash: 'a'.repeat(64),
+        data: { content: 'hidden', consent: 'anonymized' },
+      }),
+    ];
+    const res = await exportTrajectories({
+      chains: ['journal'],
+      consent: 'exportable',
+      rawEnv: { MEMPHIS_EXPORT_CONFIRM: '1' } as NodeJS.ProcessEnv,
+      query: async ({ chain }) => ({ chain: chain!, count: blocks.length, blocks }),
+    });
+    expect(res.summary.includedEvents).toBe(1);
+    expect(res.summary.filteredByConsent).toBe(1);
+  });
+
+  it('plain source "cli" maps to cli surface', () => {
+    const plain = makeBlock({ data: { content: 'x', source: 'cli', consent: 'exportable' } });
+    const mapped = mapBlockToEvent(plain, 'journal', 'cli');
+    expect(mapped.event?.surface).toBe('cli');
+  });
+
   it('derives surface from block data.source when present (not just chain)', () => {
     const cliBlock = makeBlock({
       data: { content: 'reflected', source: 'cli.reflect', consent: 'exportable' },

--- a/tests/unit/trajectory-exporter.test.ts
+++ b/tests/unit/trajectory-exporter.test.ts
@@ -42,6 +42,13 @@ describe('trajectory exporter', () => {
     expect(mapped.event?.provenance.prevHash).toBe('0'.repeat(64));
   });
 
+  it('rejects blocks with invalid timestamps at mapping time', () => {
+    const bad = makeBlock({ timestamp: 'not-a-date' });
+    const mapped = mapBlockToEvent(bad, 'journal', 'cli');
+    expect(mapped.event).toBeNull();
+    expect(mapped.reason).toMatch(/invalid timestamp/);
+  });
+
   it('derives surface from block data.source when present (not just chain)', () => {
     const cliBlock = makeBlock({
       data: { content: 'reflected', source: 'cli.reflect', consent: 'exportable' },

--- a/tests/unit/trajectory-exporter.test.ts
+++ b/tests/unit/trajectory-exporter.test.ts
@@ -42,6 +42,67 @@ describe('trajectory exporter', () => {
     expect(mapped.event?.provenance.prevHash).toBe('0'.repeat(64));
   });
 
+  it('derives surface from block data.source when present (not just chain)', () => {
+    const cliBlock = makeBlock({
+      data: { content: 'reflected', source: 'cli.reflect', consent: 'exportable' },
+    });
+    expect(mapBlockToEvent(cliBlock, 'journal', 'cli').event?.surface).toBe('cli');
+
+    const telegramBlock = makeBlock({
+      data: { content: 'chat', source: 'telegram', consent: 'exportable' },
+    });
+    // We pass 'telegram' as surface here since mapBlockToEvent takes it
+    // as an arg; verify surfaceForChain + resolveBlockSurface through
+    // the full exporter path below.
+    expect(mapBlockToEvent(telegramBlock, 'journal', 'telegram').event?.surface).toBe('telegram');
+  });
+
+  it('groups by conversation_id when present, per-turn otherwise', async () => {
+    const blocks: Block[] = [
+      makeBlock({
+        index: 1,
+        hash: 'a'.repeat(64),
+        data: {
+          content: 'turn1-event1',
+          consent: 'exportable',
+          turn_id: 'uuid-turn-1',
+          conversation_id: 'conv-xyz',
+        },
+      }),
+      makeBlock({
+        index: 2,
+        hash: 'b'.repeat(64),
+        prev_hash: 'a'.repeat(64),
+        data: {
+          content: 'turn2-event1',
+          consent: 'exportable',
+          turn_id: 'uuid-turn-2',
+          conversation_id: 'conv-xyz',
+        },
+      }),
+      makeBlock({
+        index: 3,
+        hash: 'c'.repeat(64),
+        prev_hash: 'b'.repeat(64),
+        data: {
+          content: 'turn3-other',
+          consent: 'exportable',
+          turn_id: 'uuid-turn-3',
+        },
+      }),
+    ];
+    const result = await exportTrajectories({
+      chains: ['journal'],
+      rawEnv: { MEMPHIS_EXPORT_CONFIRM: '1' } as NodeJS.ProcessEnv,
+      query: async ({ chain }) => ({ chain: chain!, count: blocks.length, blocks }),
+    });
+    // Two blocks with the same conv_id must share a trajectory; the
+    // unrelated block becomes its own per-turn bucket.
+    expect(result.trajectories.length).toBe(2);
+    const sizes = result.trajectories.map((t) => t.events.length).sort();
+    expect(sizes).toEqual([1, 2]);
+  });
+
   it('captures chain tail hash before consent filter (local-only tip is not hidden)', async () => {
     // Seed chain: [A exportable, B local-only]. Default consent filter is
     // 'exportable' — B gets filtered out but integrity.chainHashes must

--- a/tests/unit/trajectory-exporter.test.ts
+++ b/tests/unit/trajectory-exporter.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Block } from '../../src/memory/chain.js';
+import { exportTrajectories, mapBlockToEvent } from '../../src/trajectory/exporter.js';
+
+function makeBlock(overrides: Partial<Block> = {}): Block {
+  return {
+    index: 1,
+    timestamp: '2026-04-23T12:00:00.000Z',
+    hash: 'h'.repeat(64),
+    prev_hash: 'p'.repeat(64),
+    chain: 'journal',
+    data: {
+      content: 'hello',
+      tags: [],
+      consent: 'exportable',
+    },
+    ...overrides,
+  };
+}
+
+describe('trajectory exporter', () => {
+  it('reads prev_hash from block-level metadata, not payload', () => {
+    const block = makeBlock();
+    const mapped = mapBlockToEvent(block, 'journal', 'cli');
+    expect(mapped.event).not.toBeNull();
+    expect(mapped.event?.provenance.prevHash).toBe('p'.repeat(64));
+  });
+
+  it('falls back to data.prev_hash for legacy seeded blocks', () => {
+    const block = makeBlock({
+      prev_hash: undefined,
+      data: { content: 'legacy', prev_hash: 'd'.repeat(64), consent: 'exportable' },
+    });
+    const mapped = mapBlockToEvent(block, 'journal', 'cli');
+    expect(mapped.event?.provenance.prevHash).toBe('d'.repeat(64));
+  });
+
+  it('uses all-zeros fallback when no prev_hash anywhere (genesis block)', () => {
+    const block = makeBlock({ prev_hash: undefined, data: { content: 'g', consent: 'exportable' } });
+    const mapped = mapBlockToEvent(block, 'journal', 'cli');
+    expect(mapped.event?.provenance.prevHash).toBe('0'.repeat(64));
+  });
+
+  it('captures chain tail hash before consent filter (local-only tip is not hidden)', async () => {
+    // Seed chain: [A exportable, B local-only]. Default consent filter is
+    // 'exportable' — B gets filtered out but integrity.chainHashes must
+    // still reflect B's hash as the true chain tip.
+    const blocks: Block[] = [
+      makeBlock({ index: 1, hash: 'a'.repeat(64), prev_hash: '0'.repeat(64) }),
+      makeBlock({
+        index: 2,
+        hash: 'b'.repeat(64),
+        prev_hash: 'a'.repeat(64),
+        data: { content: 'hidden', consent: 'local-only' },
+      }),
+    ];
+    const result = await exportTrajectories({
+      chains: ['journal'],
+      consent: 'exportable',
+      rawEnv: { MEMPHIS_EXPORT_CONFIRM: '1' } as NodeJS.ProcessEnv,
+      query: async ({ chain }) => ({ chain: chain!, count: blocks.length, blocks }),
+    });
+    expect(result.summary.filteredByConsent).toBe(1);
+    // Tail must be block B's hash — capturing pre-filter.
+    const integrityChainHash = result.trajectories
+      .flatMap((t) => Object.entries(t.integrity?.chainHashes ?? {}))
+      .find(([chain]) => chain === 'journal')?.[1];
+    expect(integrityChainHash).toBe('b'.repeat(64));
+  });
+});


### PR DESCRIPTION
## Summary

Closes Y1 Q1 **N9** (PR C). Completes trajectory-v1 shipping sequence started by N8 (#250).

## Scope

- \`src/trajectory/exporter.ts\` — chain-query-driven mapping, session grouping, consent filtering, anonymization
- \`src/infra/cli/commands/export-trajectories.ts\` + \`src/infra/cli/handlers/export.handler.ts\` — \`memphis export trajectories\`
- \`src/infra/cli/{types,parser,utils/parser}.ts\` — \`--consent\` flag plumbing
- \`src/infra/cli/registry.ts\` — handler registered for \`export\` command

## Features

- **Consent filter** — \`exportable\` (default), \`anonymized\`, \`local-only\`, \`all\`. \`all\` requires \`MEMPHIS_EXPORT_CONFIRM=1\`.
- **Grandfathering** — legacy pre-N8 blocks treated as \`consent=exportable\`, \`turnId=null\` per trajectory-v1 spec.
- **Anonymization** — replaces \`payload.content\` with SHA-256 hex; tags preserved.
- **Output** — one self-describing JSONL per trajectory (\`_meta\` line + events) + \`manifest.json\` with per-chain integrity hashes.
- **Schema validation** — every trajectory runs \`Trajectory.parse()\` before return.

## Test plan

- [x] Typecheck clean (\`npx tsc --noEmit\`)
- [x] eslint clean (autofix ran)
- [x] End-to-end against current local Memphis state:
  - \`--dry-run --json\` → 514 events across 10 chains, 0 skipped
  - \`--out /tmp/t --json\` → 1 trajectory file (JSONL + meta) + manifest written
- [ ] CI quality-gate green
- [ ] Codex review

## Security / scope checks

- [x] Threat surface unchanged (adds read-only export path)
- [x] No new secret storage — anonymization is one-way SHA-256
- [x] \`scripts/secret-scan.sh\` clean (no secrets added; exporter reads existing chain content)
- [x] No arbitrary code execution

## Dependency classification

No new dependencies.

## Backwards compat

- [x] Works against main (pre-N8) via grandfathering default
- [x] No breaking changes to chain / block schema
- [x] New CLI command — additive surface

## Roadmap

- Closes **N9** (Q1)
- Depends on: N8 (#250) for \`turn_id\` + \`consent\` on new blocks
- Unblocks: N10 (Q2 HF-dataset format — extends exporter output mode) + N11 (Q2 \`memphis consent mark\` — reuses same consent semantics)
- Unblocks: lab direction #2 (replay / A-B) per \`memory/next_direction_lab_pivot.md\`