### PR TITLE
feat(cli): memphis consent mark retroactive annotation (N11)

### DIFF
--- a/src/infra/cli/handlers/consent.handler.ts
+++ b/src/infra/cli/handlers/consent.handler.ts
@@ -1,3 +1,4 @@
+import { normalizeChainName } from '../../../config/paths.js';
 import { appendBlock } from '../../storage/chain-adapter.js';
 import { getRecentBlocks } from '../../storage/rust-chain-adapter.js';
 import type { CliContext } from '../context.js';
@@ -47,10 +48,17 @@ async function handleConsentMark(context: CliContext): Promise<boolean> {
   const { chain, id } = context.args;
   const fromIndexRaw = context.args.fromIndex;
   const level = parseConsentLevel(context.args.level);
-  const targetChain = (chain ?? id ?? '').trim();
-  if (!targetChain) {
+  const rawChain = (chain ?? id ?? '').trim();
+  if (!rawChain) {
     throw new Error('consent mark requires --chain <name>');
   }
+  // Canonicalize chain aliases (e.g. `decision` → `decisions`) so the
+  // persisted `target_chain` matches what getRecentBlocks inspected and
+  // what downstream matchers key on. Without this, `--chain decision`
+  // would write an annotation keyed to `decision` while the chain
+  // it actually described was `decisions`, silently invalidating the
+  // retroactive consent mark.
+  const targetChain = normalizeChainName(rawChain) ?? rawChain;
   if (
     typeof fromIndexRaw !== 'number' ||
     !Number.isInteger(fromIndexRaw) ||

--- a/src/infra/cli/handlers/consent.handler.ts
+++ b/src/infra/cli/handlers/consent.handler.ts
@@ -51,10 +51,17 @@ async function handleConsentMark(context: CliContext): Promise<boolean> {
   if (!targetChain) {
     throw new Error('consent mark requires --chain <name>');
   }
-  if (typeof fromIndexRaw !== 'number' || !Number.isFinite(fromIndexRaw) || fromIndexRaw < 0) {
+  if (
+    typeof fromIndexRaw !== 'number' ||
+    !Number.isInteger(fromIndexRaw) ||
+    fromIndexRaw < 0
+  ) {
+    // Reject floats outright. Silent `Math.floor(1.9)` coercion would
+    // expand the annotation range past operator intent and flip consent
+    // on blocks the operator didn't name. Require an explicit integer.
     throw new Error('consent mark requires --from-index <non-negative integer>');
   }
-  const fromIndex = Math.floor(fromIndexRaw);
+  const fromIndex = fromIndexRaw;
 
   // Inspect the target chain to confirm the from-index exists. Avoids
   // silently creating annotations that cover zero blocks because the

--- a/src/infra/cli/handlers/consent.handler.ts
+++ b/src/infra/cli/handlers/consent.handler.ts
@@ -1,0 +1,111 @@
+import { appendBlock } from '../../storage/chain-adapter.js';
+import { getRecentBlocks } from '../../storage/rust-chain-adapter.js';
+import type { CliContext } from '../context.js';
+import type { CommandHandler } from './command-handler.js';
+import { print } from '../utils/render.js';
+
+type ConsentLevel = 'exportable' | 'local-only' | 'anonymized';
+
+function parseConsentLevel(raw: string | undefined): ConsentLevel {
+  if (raw === 'exportable' || raw === 'local-only' || raw === 'anonymized') {
+    return raw;
+  }
+  throw new Error(
+    `--level must be one of exportable|local-only|anonymized; got ${JSON.stringify(raw)}`,
+  );
+}
+
+export const consentCommandHandler: CommandHandler = {
+  name: 'consent',
+  commands: ['consent'],
+  canHandle(context: CliContext): boolean {
+    return context.args.command === 'consent';
+  },
+  async handle(context: CliContext): Promise<boolean> {
+    const { subcommand } = context.args;
+    if (subcommand === 'mark') {
+      return handleConsentMark(context);
+    }
+    throw new Error(`Unknown consent subcommand: ${String(subcommand)}. Available: mark.`);
+  },
+};
+
+/**
+ * `memphis consent mark --chain <name> --from-index <n> --level <exportable|local-only|anonymized>`
+ *
+ * Retroactive consent-level utility for operators who had blocks
+ * written pre-N8 (no consent stamped) or with the wrong consent level.
+ * Chains are append-only, so we don't rewrite existing blocks; instead
+ * we append a single `consent.annotation` block to the journal chain
+ * that downstream consumers (trajectory exporter, recall filters) will
+ * use to override the effective consent on the target range.
+ *
+ * Honors `--dry-run` to preview without appending. Writes are audited
+ * through the normal chain-adapter path.
+ */
+async function handleConsentMark(context: CliContext): Promise<boolean> {
+  const { chain, id } = context.args;
+  const fromIndexRaw = context.args.fromIndex;
+  const level = parseConsentLevel(context.args.level);
+  const targetChain = (chain ?? id ?? '').trim();
+  if (!targetChain) {
+    throw new Error('consent mark requires --chain <name>');
+  }
+  if (typeof fromIndexRaw !== 'number' || !Number.isFinite(fromIndexRaw) || fromIndexRaw < 0) {
+    throw new Error('consent mark requires --from-index <non-negative integer>');
+  }
+  const fromIndex = Math.floor(fromIndexRaw);
+
+  // Inspect the target chain to confirm the from-index exists. Avoids
+  // silently creating annotations that cover zero blocks because the
+  // operator typo'd the index.
+  const blocks = await getRecentBlocks(targetChain, 100000, process.env);
+  const lastIndex = blocks.length > 0 ? blocks[blocks.length - 1].index ?? -1 : -1;
+  if (lastIndex < 0) {
+    throw new Error(`consent mark: chain '${targetChain}' is empty or missing`);
+  }
+  if (fromIndex > lastIndex) {
+    throw new Error(
+      `consent mark: --from-index ${fromIndex} is past the tip of '${targetChain}' (last index: ${lastIndex})`,
+    );
+  }
+  const toIndex = lastIndex;
+
+  const annotationPayload = {
+    type: 'consent.annotation',
+    target_chain: targetChain,
+    from_index: fromIndex,
+    to_index: toIndex,
+    level,
+    // Explicit provenance so downstream consumers can distinguish
+    // retroactive tooling writes from in-turn consent stamps.
+    source: 'cli.consent-mark',
+    issued_at: new Date().toISOString(),
+  };
+
+  if (context.args.dryRun) {
+    print(
+      {
+        ok: true,
+        mode: 'consent.mark.dry-run',
+        annotation: annotationPayload,
+        blocksAffected: toIndex - fromIndex + 1,
+      },
+      context.args.json,
+    );
+    return true;
+  }
+
+  const block = await appendBlock('journal', annotationPayload);
+  print(
+    {
+      ok: true,
+      mode: 'consent.mark',
+      annotation: annotationPayload,
+      block: { chain: 'journal', index: block.index, hash: block.hash },
+      blocksAffected: toIndex - fromIndex + 1,
+    },
+    context.args.json,
+  );
+  return true;
+}

--- a/src/infra/cli/parser.ts
+++ b/src/infra/cli/parser.ts
@@ -145,5 +145,8 @@ export function parseCommand(argv: string[]): CliArgs {
     botToken: readFlagValue(flags, '--bot-token'),
     allowedUserIds: readFlagValue(flags, '--allowed-user-ids'),
     pepperRestore: readFlagValue(flags, '--pepper-restore'),
+    consent: readFlagValue(flags, '--consent'),
+    level: readFlagValue(flags, '--level'),
+    fromIndex: readNumberFlag(flags, '--from-index'),
   };
 }

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -212,6 +212,11 @@ export const CLI_COMMAND_REGISTRY = [
     ['explain'],
     createLazyHandlerLoader(() => import('./handlers/explain.handler.js'), 'explainCommandHandler'),
   ),
+  createCommandRegistration(
+    'consent',
+    ['consent'],
+    createLazyHandlerLoader(() => import('./handlers/consent.handler.js'), 'consentCommandHandler'),
+  ),
 ] as const;
 
 export const CLI_COMPLETION_COMMANDS = [
@@ -300,6 +305,7 @@ export const CLI_NON_COMPLETABLE_COMMANDS = new Set<string | undefined>([
   'skill', // historical alias for `skills`; canonical form is what we complete
   'auth', // namespace — always needs a subcommand
   'config', // namespace — always needs a subcommand
+  'consent', // namespace — always needs a subcommand (e.g. `memphis consent mark`)
 ]);
 
 type CommandKey = string | undefined;

--- a/src/infra/cli/types.ts
+++ b/src/infra/cli/types.ts
@@ -130,4 +130,8 @@ export type CliArgs = {
   cronPattern?: string;
   // Backup restore
   pepperRestore?: string;
+  // Consent mark (N11)
+  consent?: string;
+  level?: string;
+  fromIndex?: number;
 };

--- a/tests/unit/consent-mark.test.ts
+++ b/tests/unit/consent-mark.test.ts
@@ -66,6 +66,24 @@ describe('consent mark CLI', () => {
     ).rejects.toThrow(/past the tip/);
   });
 
+  it('canonicalizes chain aliases so target_chain matches the inspected chain', async () => {
+    appendBlockMock.mockClear();
+    await consentCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({
+        subcommand: 'mark',
+        chain: 'decision',
+        fromIndex: 1,
+        level: 'exportable',
+        json: true,
+      }) as any,
+    );
+    expect(appendBlockMock).toHaveBeenCalledTimes(1);
+    const payload = appendBlockMock.mock.calls[0][1] as Record<string, unknown>;
+    // `decision` is an alias for the canonical `decisions` chain.
+    expect(payload.target_chain).toBe('decisions');
+  });
+
   it('dry-run does not append; normal run appends annotation to journal', async () => {
     appendBlockMock.mockClear();
     // Dry run

--- a/tests/unit/consent-mark.test.ts
+++ b/tests/unit/consent-mark.test.ts
@@ -48,6 +48,15 @@ describe('consent mark CLI', () => {
     ).rejects.toThrow(/requires --chain/);
   });
 
+  it('rejects non-integer --from-index (no silent Math.floor coercion)', async () => {
+    await expect(
+      consentCommandHandler.handle(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mkCtx({ subcommand: 'mark', chain: 'journal', fromIndex: 1.9, level: 'exportable', json: true }) as any,
+      ),
+    ).rejects.toThrow(/non-negative integer/);
+  });
+
   it('rejects --from-index past chain tip', async () => {
     await expect(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/unit/consent-mark.test.ts
+++ b/tests/unit/consent-mark.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/infra/storage/rust-chain-adapter.js', () => ({
+  getRecentBlocks: vi.fn(async () => [
+    { index: 0, hash: 'h0' },
+    { index: 1, hash: 'h1' },
+    { index: 2, hash: 'h2' },
+  ]),
+}));
+
+const appendBlockMock = vi.fn(async () => ({ index: 42, hash: 'annotation-hash' }));
+vi.mock('../../src/infra/storage/chain-adapter.js', () => ({
+  appendBlock: appendBlockMock,
+}));
+
+const { consentCommandHandler } = await import(
+  '../../src/infra/cli/handlers/consent.handler.js'
+);
+
+function mkCtx(args: Record<string, unknown>): {
+  args: Record<string, unknown> & { command: 'consent' };
+  getContainer: () => unknown;
+  getConfig: () => unknown;
+} {
+  return {
+    args: { command: 'consent', ...args },
+    getContainer: () => ({}),
+    getConfig: () => ({}),
+  };
+}
+
+describe('consent mark CLI', () => {
+  it('rejects unknown consent level', async () => {
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      consentCommandHandler.handle(
+        mkCtx({ subcommand: 'mark', chain: 'journal', fromIndex: 0, level: 'bogus', json: true }) as any,
+      ),
+    ).rejects.toThrow(/--level must be one of/);
+  });
+
+  it('rejects missing --chain', async () => {
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      consentCommandHandler.handle(
+        mkCtx({ subcommand: 'mark', fromIndex: 0, level: 'exportable', json: true }) as any,
+      ),
+    ).rejects.toThrow(/requires --chain/);
+  });
+
+  it('rejects --from-index past chain tip', async () => {
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      consentCommandHandler.handle(
+        mkCtx({ subcommand: 'mark', chain: 'journal', fromIndex: 99, level: 'exportable', json: true }) as any,
+      ),
+    ).rejects.toThrow(/past the tip/);
+  });
+
+  it('dry-run does not append; normal run appends annotation to journal', async () => {
+    appendBlockMock.mockClear();
+    // Dry run
+    await consentCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({
+        subcommand: 'mark',
+        chain: 'journal',
+        fromIndex: 1,
+        level: 'local-only',
+        dryRun: true,
+        json: true,
+      }) as any,
+    );
+    expect(appendBlockMock).not.toHaveBeenCalled();
+    // Real run
+    await consentCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({
+        subcommand: 'mark',
+        chain: 'journal',
+        fromIndex: 1,
+        level: 'local-only',
+        dryRun: false,
+        json: true,
+      }) as any,
+    );
+    expect(appendBlockMock).toHaveBeenCalledTimes(1);
+    const [chainArg, payload] = appendBlockMock.mock.calls[0];
+    expect(chainArg).toBe('journal');
+    expect(payload).toMatchObject({
+      type: 'consent.annotation',
+      target_chain: 'journal',
+      from_index: 1,
+      to_index: 2,
+      level: 'local-only',
+      source: 'cli.consent-mark',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `memphis consent mark --chain <name> --from-index <n> --level <exportable|local-only|anonymized>` — retroactive consent utility for pre-N8 blocks
- Appends a `consent.annotation` block to `journal` describing the override range; downstream consumers (trajectory exporter, recall filters) will honor it when reading the target chain
- Validation: level enum, chain required, from-index ≥ 0 and ≤ chain tip, optional `--dry-run`
- Unit tests cover invalid level / missing chain / out-of-range index / dry-run vs append

## Dependency policy

- classification:
  - (none) — no new dependencies

## Test plan

- [x] `tests/unit/consent-mark.test.ts` — 4 cases green
- [x] `tests/unit/cli-registry-consistency.test.ts` — 14 cases green (consent added to CLI_NON_COMPLETABLE_COMMANDS)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)