### PR TITLE
feat(kartograf): Ed25519-signed checkpoint envelope (N40)

### DIFF
--- a/src/kartograf/checkpoint.ts
+++ b/src/kartograf/checkpoint.ts
@@ -1,0 +1,195 @@
+/**
+ * Kartograf checkpoint envelope: canonical shape + Ed25519 sign/verify.
+ *
+ * Every Kartograf checkpoint that ships outside the host machine
+ * (HF Hub, GitHub release, federation peer) is wrapped in this envelope
+ * so consumers can verify:
+ *   1. The ONNX model + tokenizer blobs match their declared sha256
+ *      (tamper detection).
+ *   2. The envelope itself is signed by a known distributor's DID
+ *      (source attribution).
+ *
+ * Signing uses Ed25519 (node:crypto native, no NAPI needed) over the
+ * deterministic JSON canonicalization of the envelope minus the
+ * signature field. The signer's public key is encoded in `signer_did`
+ * as `did:key:ed25519:<hex>`; verify pulls the key material back out.
+ *
+ * This is intentionally independent of the chain-block signing path:
+ * checkpoints aren't durable memory blocks and shouldn't flow through
+ * the chain validator. The spec lives in docs/dev/KARTOGRAF-SPEC.md.
+ */
+
+import { createHash, createPrivateKey, createPublicKey, sign, verify } from 'node:crypto';
+
+export type HeadsConfig = {
+  /** Embedding head dimension (v1 = 256). */
+  embedding_dim: number;
+  /** Zone classifier head class count (v1 = 12 per kartograf_spec_frozen). */
+  zone_classes: number;
+  /** Loss weighting α / (1-α) between InfoNCE and CE. */
+  multitask_alpha: number;
+};
+
+export type TrainingProvenance = {
+  /** ISO-8601 timestamp when training finished. */
+  trained_at: string;
+  /** Corpus version (e.g. 'v1'). */
+  corpus_version: string;
+  /** Hardware profile — 'gtx-960-local' | 'h100-cloud' | etc. */
+  hardware: string;
+  /** Eval metric at checkpoint selection (Recall@10 for v1). */
+  eval_recall_at_10: number;
+  /** Total training steps. */
+  steps: number;
+};
+
+export type CheckpointEnvelope = {
+  /** Spec version — currently 'kartograf-v1'. */
+  version: 'kartograf-v1';
+  /** Base model identity (HF revision pinned). */
+  base_model: string;
+  /** sha256 of the ONNX graph file. */
+  onnx_sha256: string;
+  /** sha256 of the tokenizer bundle. */
+  tokenizer_sha256: string;
+  heads_config: HeadsConfig;
+  training_provenance: TrainingProvenance;
+  /** Distribution trust tier per federation model: 'hf-hub' | 'github-release' | 'file' | 'federation' | 'agora'. */
+  distribution_source: 'hf-hub' | 'github-release' | 'file' | 'federation' | 'agora';
+  /** `did:key:ed25519:<64-hex>` — signer's DID. */
+  signer_did: string;
+  /** Ed25519 signature over canonical JSON of everything above. */
+  signature: string;
+};
+
+export type UnsignedEnvelope = Omit<CheckpointEnvelope, 'signature'>;
+
+const ED25519_DID_PREFIX = 'did:key:ed25519:';
+
+/**
+ * Canonical JSON for signing / verification. Keys are sorted
+ * recursively so the same logical envelope produces identical bytes
+ * on both sides of the wire.
+ */
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalize(v)).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a < b ? -1 : a > b ? 1 : 0,
+  );
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(',')}}`;
+}
+
+/**
+ * Hex-encode a buffer. Matches the `<64-hex>` DID encoding.
+ */
+function hex(buf: Buffer | Uint8Array): string {
+  return Buffer.from(buf).toString('hex');
+}
+
+/**
+ * Wrap raw 32-byte public key material in a PKCS#8-style SPKI DER so
+ * node:crypto can import it via createPublicKey. Ed25519 SPKI prefix
+ * per RFC 8410.
+ */
+function ed25519PublicKeyFromHex(keyHex: string) {
+  if (keyHex.length !== 64) {
+    throw new Error(`expected 32-byte (64-hex) Ed25519 public key, got ${keyHex.length / 2} bytes`);
+  }
+  const raw = Buffer.from(keyHex, 'hex');
+  const spkiPrefix = Buffer.from('302a300506032b6570032100', 'hex');
+  return createPublicKey({ key: Buffer.concat([spkiPrefix, raw]), format: 'der', type: 'spki' });
+}
+
+function ed25519PrivateKeyFromBytes(seed: Buffer) {
+  if (seed.length !== 32) {
+    throw new Error(`expected 32-byte Ed25519 seed, got ${seed.length} bytes`);
+  }
+  const pkcs8Prefix = Buffer.from('302e020100300506032b657004220420', 'hex');
+  return createPrivateKey({
+    key: Buffer.concat([pkcs8Prefix, seed]),
+    format: 'der',
+    type: 'pkcs8',
+  });
+}
+
+/**
+ * Sign an unsigned envelope with a 32-byte Ed25519 seed. Returns the
+ * completed `CheckpointEnvelope` with `signer_did` stamped from the
+ * seed's derived public key and a hex `signature`.
+ */
+export function signCheckpoint(
+  envelope: UnsignedEnvelope,
+  seed: Buffer,
+): CheckpointEnvelope {
+  const privateKey = ed25519PrivateKeyFromBytes(seed);
+  // Derive the public key so signer_did is authoritative relative to
+  // the secret, not operator-provided metadata that could disagree.
+  const publicKey = createPublicKey(privateKey);
+  const rawPub = publicKey.export({ format: 'der', type: 'spki' });
+  // SPKI is 12 bytes prefix + 32 bytes raw public key.
+  const pubHex = hex(rawPub.slice(-32));
+  const withDid: UnsignedEnvelope = {
+    ...envelope,
+    signer_did: `${ED25519_DID_PREFIX}${pubHex}`,
+  };
+  const bytes = Buffer.from(canonicalize(withDid), 'utf8');
+  const sig = sign(null, bytes, privateKey);
+  return { ...withDid, signature: hex(sig) };
+}
+
+export type VerifyResult =
+  | { valid: true; signerDid: string }
+  | { valid: false; reason: string };
+
+/**
+ * Verify a signed checkpoint envelope. Returns `{ valid: true, signerDid }`
+ * on success, `{ valid: false, reason }` otherwise. Never throws — this
+ * runs at model-load time where a broken envelope must degrade to
+ * "refuse to load" rather than crash the host.
+ */
+export function verifyCheckpoint(envelope: CheckpointEnvelope): VerifyResult {
+  try {
+    if (!envelope.signer_did?.startsWith(ED25519_DID_PREFIX)) {
+      return { valid: false, reason: 'signer_did missing ed25519 prefix' };
+    }
+    const pubHex = envelope.signer_did.slice(ED25519_DID_PREFIX.length);
+    if (!/^[0-9a-f]{64}$/i.test(pubHex)) {
+      return { valid: false, reason: 'signer_did public key not 32-byte hex' };
+    }
+    if (!envelope.signature || !/^[0-9a-f]+$/i.test(envelope.signature)) {
+      return { valid: false, reason: 'signature missing or not hex' };
+    }
+    const publicKey = ed25519PublicKeyFromHex(pubHex);
+    const unsigned: Omit<CheckpointEnvelope, 'signature'> = {
+      version: envelope.version,
+      base_model: envelope.base_model,
+      onnx_sha256: envelope.onnx_sha256,
+      tokenizer_sha256: envelope.tokenizer_sha256,
+      heads_config: envelope.heads_config,
+      training_provenance: envelope.training_provenance,
+      distribution_source: envelope.distribution_source,
+      signer_did: envelope.signer_did,
+    };
+    const bytes = Buffer.from(canonicalize(unsigned), 'utf8');
+    const ok = verify(null, bytes, publicKey, Buffer.from(envelope.signature, 'hex'));
+    if (!ok) return { valid: false, reason: 'signature check failed' };
+    return { valid: true, signerDid: envelope.signer_did };
+  } catch (err) {
+    return {
+      valid: false,
+      reason: err instanceof Error ? err.message : 'verify-error',
+    };
+  }
+}
+
+/**
+ * sha256 helper used by producers to stamp `onnx_sha256` /
+ * `tokenizer_sha256` from file contents. Operators can also compute
+ * this externally; this is a convenience for in-process signing.
+ */
+export function sha256Hex(bytes: Buffer | string): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}

--- a/src/kartograf/checkpoint.ts
+++ b/src/kartograf/checkpoint.ts
@@ -62,7 +62,13 @@ export type CheckpointEnvelope = {
   signature: string;
 };
 
-export type UnsignedEnvelope = Omit<CheckpointEnvelope, 'signature'>;
+/**
+ * The producer-facing input type: drop both `signature` and `signer_did`
+ * since `signCheckpoint` derives the DID from the actual signing seed.
+ * Accepting a `signer_did` that could disagree with the signing key
+ * invites footguns (the function would overwrite it silently).
+ */
+export type UnsignedEnvelope = Omit<CheckpointEnvelope, 'signature' | 'signer_did'>;
 
 const ED25519_DID_PREFIX = 'did:key:ed25519:';
 
@@ -131,7 +137,7 @@ export function signCheckpoint(
   const rawPub = publicKey.export({ format: 'der', type: 'spki' });
   // SPKI is 12 bytes prefix + 32 bytes raw public key.
   const pubHex = hex(rawPub.slice(-32));
-  const withDid: UnsignedEnvelope = {
+  const withDid: Omit<CheckpointEnvelope, 'signature'> = {
     ...envelope,
     signer_did: `${ED25519_DID_PREFIX}${pubHex}`,
   };

--- a/tests/unit/kartograf-checkpoint.test.ts
+++ b/tests/unit/kartograf-checkpoint.test.ts
@@ -1,0 +1,88 @@
+import { randomBytes } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  canonicalize,
+  signCheckpoint,
+  verifyCheckpoint,
+  type CheckpointEnvelope,
+  type UnsignedEnvelope,
+} from '../../src/kartograf/checkpoint.js';
+
+function baseUnsigned(): Omit<UnsignedEnvelope, 'signer_did'> & { signer_did?: string } {
+  return {
+    version: 'kartograf-v1',
+    base_model: 'answerdotai/ModernBERT-base@rev-abc123',
+    onnx_sha256: 'a'.repeat(64),
+    tokenizer_sha256: 'b'.repeat(64),
+    heads_config: {
+      embedding_dim: 256,
+      zone_classes: 12,
+      multitask_alpha: 0.7,
+    },
+    training_provenance: {
+      trained_at: '2026-05-15T10:00:00Z',
+      corpus_version: 'v1',
+      hardware: 'gtx-960-local',
+      eval_recall_at_10: 0.82,
+      steps: 12000,
+    },
+    distribution_source: 'hf-hub',
+  };
+}
+
+describe('kartograf checkpoint envelope', () => {
+  it('canonicalize sorts keys deterministically', () => {
+    const a = canonicalize({ b: 2, a: 1, c: [3, { y: 2, x: 1 }] });
+    const b = canonicalize({ c: [3, { x: 1, y: 2 }], a: 1, b: 2 });
+    expect(a).toBe(b);
+  });
+
+  it('signs and round-trip verifies with the derived DID', () => {
+    const seed = randomBytes(32);
+    const unsigned = baseUnsigned() as UnsignedEnvelope;
+    const signed = signCheckpoint(unsigned, seed);
+    expect(signed.signer_did).toMatch(/^did:key:ed25519:[0-9a-f]{64}$/);
+    expect(signed.signature).toMatch(/^[0-9a-f]+$/);
+    const result = verifyCheckpoint(signed);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a tampered envelope', () => {
+    const seed = randomBytes(32);
+    const signed = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seed);
+    const tampered: CheckpointEnvelope = { ...signed, onnx_sha256: 'c'.repeat(64) };
+    const result = verifyCheckpoint(tampered);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.reason).toMatch(/signature/);
+  });
+
+  it('rejects malformed signer_did', () => {
+    const seed = randomBytes(32);
+    const signed = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seed);
+    const broken: CheckpointEnvelope = { ...signed, signer_did: 'did:key:rsa:xyz' };
+    const result = verifyCheckpoint(broken);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.reason).toMatch(/ed25519 prefix/);
+  });
+
+  it('rejects non-hex signature', () => {
+    const seed = randomBytes(32);
+    const signed = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seed);
+    const broken: CheckpointEnvelope = { ...signed, signature: 'not-hex-yo' };
+    const result = verifyCheckpoint(broken);
+    expect(result.valid).toBe(false);
+  });
+
+  it('stamps signer_did derived from the actual seed', () => {
+    const seedA = randomBytes(32);
+    const seedB = randomBytes(32);
+    const aSigned = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seedA);
+    const bSigned = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seedB);
+    expect(aSigned.signer_did).not.toBe(bSigned.signer_did);
+    // Verify with the other signer's key fails.
+    const crossed: CheckpointEnvelope = { ...aSigned, signer_did: bSigned.signer_did };
+    expect(verifyCheckpoint(crossed).valid).toBe(false);
+  });
+});

--- a/tests/unit/kartograf-checkpoint.test.ts
+++ b/tests/unit/kartograf-checkpoint.test.ts
@@ -10,7 +10,7 @@ import {
   type UnsignedEnvelope,
 } from '../../src/kartograf/checkpoint.js';
 
-function baseUnsigned(): Omit<UnsignedEnvelope, 'signer_did'> & { signer_did?: string } {
+function baseUnsigned(): UnsignedEnvelope {
   return {
     version: 'kartograf-v1',
     base_model: 'answerdotai/ModernBERT-base@rev-abc123',
@@ -41,7 +41,7 @@ describe('kartograf checkpoint envelope', () => {
 
   it('signs and round-trip verifies with the derived DID', () => {
     const seed = randomBytes(32);
-    const unsigned = baseUnsigned() as UnsignedEnvelope;
+    const unsigned = baseUnsigned();
     const signed = signCheckpoint(unsigned, seed);
     expect(signed.signer_did).toMatch(/^did:key:ed25519:[0-9a-f]{64}$/);
     expect(signed.signature).toMatch(/^[0-9a-f]+$/);
@@ -51,7 +51,7 @@ describe('kartograf checkpoint envelope', () => {
 
   it('rejects a tampered envelope', () => {
     const seed = randomBytes(32);
-    const signed = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seed);
+    const signed = signCheckpoint(baseUnsigned(), seed);
     const tampered: CheckpointEnvelope = { ...signed, onnx_sha256: 'c'.repeat(64) };
     const result = verifyCheckpoint(tampered);
     expect(result.valid).toBe(false);
@@ -60,7 +60,7 @@ describe('kartograf checkpoint envelope', () => {
 
   it('rejects malformed signer_did', () => {
     const seed = randomBytes(32);
-    const signed = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seed);
+    const signed = signCheckpoint(baseUnsigned(), seed);
     const broken: CheckpointEnvelope = { ...signed, signer_did: 'did:key:rsa:xyz' };
     const result = verifyCheckpoint(broken);
     expect(result.valid).toBe(false);
@@ -69,7 +69,7 @@ describe('kartograf checkpoint envelope', () => {
 
   it('rejects non-hex signature', () => {
     const seed = randomBytes(32);
-    const signed = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seed);
+    const signed = signCheckpoint(baseUnsigned(), seed);
     const broken: CheckpointEnvelope = { ...signed, signature: 'not-hex-yo' };
     const result = verifyCheckpoint(broken);
     expect(result.valid).toBe(false);
@@ -78,8 +78,8 @@ describe('kartograf checkpoint envelope', () => {
   it('stamps signer_did derived from the actual seed', () => {
     const seedA = randomBytes(32);
     const seedB = randomBytes(32);
-    const aSigned = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seedA);
-    const bSigned = signCheckpoint(baseUnsigned() as UnsignedEnvelope, seedB);
+    const aSigned = signCheckpoint(baseUnsigned(), seedA);
+    const bSigned = signCheckpoint(baseUnsigned(), seedB);
     expect(aSigned.signer_did).not.toBe(bSigned.signer_did);
     // Verify with the other signer's key fails.
     const crossed: CheckpointEnvelope = { ...aSigned, signer_did: bSigned.signer_did };


### PR DESCRIPTION
## Summary

- `src/kartograf/checkpoint.ts` — canonical envelope shape + Ed25519 sign/verify for Kartograf checkpoints per KARTOGRAF-SPEC
- Uses node:crypto native Ed25519 (no NAPI plumbing, no coupling to chain-block signer)
- Deterministic JSON canonicalization (recursive key sort) so envelopes sign/verify identically across producers
- `verifyCheckpoint()` never throws — broken envelopes return `{ valid: false, reason }` so model-load degrades safely

Envelope:
- version / base_model / onnx_sha256 / tokenizer_sha256
- heads_config (embedding_dim=256, zone_classes=12, multitask α)
- training_provenance (trained_at, corpus_version, hardware, recall@10, steps)
- distribution_source (hf-hub | github-release | file | federation | agora)
- signer_did (did:key:ed25519:<64-hex>)
- signature (hex Ed25519)

## Dependency policy

- classification:
  - (none) — no new dependencies; uses node:crypto stdlib

## Test plan

- [x] `tests/unit/kartograf-checkpoint.test.ts` — 6 cases green: canonical sort, sign/verify roundtrip, tamper detection, malformed DID, non-hex signature, cross-signer DID rejection
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)