### PR TITLE
feat(cli): memphis kartograf verify/install CLI surface (N40.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ data/security-audit-archives/
 data/vault-bak-*/
 data/retrieval-benchmark-corpus-v*.json
 data/retrieval-benchmark-overlays/
+
+# Python compiled bytecode (corpus + training tools)
+tools/**/__pycache__/
+*.pyc

--- a/src/infra/cli/handlers/kartograf.handler.ts
+++ b/src/infra/cli/handlers/kartograf.handler.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
 import { getDataDir } from '../../../config/paths.js';
@@ -124,12 +124,14 @@ async function handleInstall(context: CliContext): Promise<boolean> {
       `--source must be one of ${[...ALLOWED_SOURCES].join('|')}; got ${JSON.stringify(source)}`,
     );
   }
-  if (source === 'hf-hub' || source === 'github-release') {
-    // Network pull is Q2 scope — the verify primitive ships now so
-    // operators can exercise `file` / `federation` today and graduate
-    // to network sources when the producer side lands.
+  if (source === 'hf-hub' || source === 'github-release' || source === 'agora') {
+    // Network / federated transports are Y2+ scope per
+    // docs/dev/KARTOGRAF-SPEC.md. The verify primitive ships now so
+    // operators can exercise `file` / `federation` today; agora
+    // specifically is gated to an explicit "not implemented" error
+    // rather than silently falling back to local-file staging.
     throw new Error(
-      `--source ${source} requires network fetch not yet implemented. ` +
+      `--source ${source} transport not yet implemented (Y2+ per KARTOGRAF-SPEC). ` +
         `For local testing pass --source file with a local envelope path.`,
     );
   }
@@ -184,6 +186,16 @@ async function handleInstall(context: CliContext): Promise<boolean> {
     return true;
   }
 
+  // Before writing the new envelope, clear any prior staged artifacts
+  // from the same stageDir (same signer may publish multiple
+  // checkpoints over time). A checksum-mismatch install in the
+  // previous run must NOT leave stale `model.onnx` / `tokenizer.json`
+  // beside an updated `checkpoint.json` — that's a "mixed state"
+  // hazard where the loader would hash-verify stale bytes against new
+  // envelope values.
+  for (const stale of ['model.onnx', 'tokenizer.json']) {
+    rmSync(join(stageDir, stale), { force: true });
+  }
   // Copy envelope into the staging dir under its canonical name.
   writeFileSync(envelopeOut, JSON.stringify(read.envelope, null, 2));
 

--- a/src/infra/cli/handlers/kartograf.handler.ts
+++ b/src/infra/cli/handlers/kartograf.handler.ts
@@ -1,0 +1,237 @@
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+import { getDataDir } from '../../../config/paths.js';
+import {
+  sha256Hex,
+  verifyCheckpoint,
+  type CheckpointEnvelope,
+} from '../../../kartograf/checkpoint.js';
+import type { CliContext } from '../context.js';
+import type { CommandHandler } from './command-handler.js';
+import { print } from '../utils/render.js';
+
+/**
+ * `memphis kartograf verify <path>` / `memphis kartograf install <path> --source <tier>`
+ *
+ * Thin CLI wrappers over `src/kartograf/checkpoint.ts` so operators can
+ * test the signed-distribution loop before real Kartograf checkpoints
+ * exist. Load paths in Q2 will import from these same primitives.
+ *
+ * Install semantics (Q1 local-path only):
+ *   1. Read envelope JSON from source path.
+ *   2. Verify signature via `verifyCheckpoint`.
+ *   3. If tier is `file` or `federation`, copy envelope + sibling
+ *      artifacts (*.onnx, *.tokenizer.json) into
+ *      `<data-dir>/kartograf/checkpoints/<signer-did-short>/`.
+ *   4. Refuse install on verify failure.
+ *
+ * URL sources (`--source hf-hub` / `github-release`) are out of scope
+ * for this PR — the verify primitive + CLI surface ship now, network
+ * pull lands with the actual Kartograf checkpoint producer in Q2.
+ */
+export const kartografCommandHandler: CommandHandler = {
+  name: 'kartograf',
+  commands: ['kartograf'],
+  canHandle(context: CliContext): boolean {
+    return context.args.command === 'kartograf';
+  },
+  async handle(context: CliContext): Promise<boolean> {
+    const { subcommand } = context.args;
+    if (subcommand === 'verify') return handleVerify(context);
+    if (subcommand === 'install') return handleInstall(context);
+    throw new Error(
+      `Unknown kartograf subcommand: ${String(subcommand)}. Available: verify, install.`,
+    );
+  },
+};
+
+type ParsedEnvelope =
+  | { ok: true; envelope: CheckpointEnvelope; path: string }
+  | { ok: false; error: string; path: string };
+
+function readEnvelopeFrom(sourcePath: string): ParsedEnvelope {
+  const resolved = resolve(sourcePath);
+  try {
+    const raw = readFileSync(resolved, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { ok: false, error: 'envelope is not a JSON object', path: resolved };
+    }
+    return { ok: true, envelope: parsed as CheckpointEnvelope, path: resolved };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      path: resolved,
+    };
+  }
+}
+
+async function handleVerify(context: CliContext): Promise<boolean> {
+  const sourcePath = (context.args.file ?? context.args.target ?? '').trim();
+  if (!sourcePath) {
+    throw new Error('kartograf verify requires --file <path> (or positional <path>)');
+  }
+  const read = readEnvelopeFrom(sourcePath);
+  if (!read.ok) {
+    print(
+      { ok: false, mode: 'kartograf.verify', path: read.path, error: read.error },
+      context.args.json,
+    );
+    return true;
+  }
+  const result = verifyCheckpoint(read.envelope);
+  print(
+    {
+      ok: result.valid,
+      mode: 'kartograf.verify',
+      path: read.path,
+      version: read.envelope.version,
+      distributionSource: read.envelope.distribution_source,
+      onnxSha256: read.envelope.onnx_sha256,
+      tokenizerSha256: read.envelope.tokenizer_sha256,
+      signerDid: result.valid ? result.signerDid : null,
+      reason: result.valid ? null : result.reason,
+    },
+    context.args.json,
+  );
+  return true;
+}
+
+const ALLOWED_SOURCES = new Set([
+  'hf-hub',
+  'github-release',
+  'file',
+  'federation',
+  'agora',
+]);
+
+function shortSignerSlug(signerDid: string): string {
+  // did:key:ed25519:<64-hex> → last 12 hex chars, safe for filenames.
+  const hex = signerDid.replace('did:key:ed25519:', '');
+  return hex.length >= 12 ? hex.slice(0, 12) : 'unknown';
+}
+
+async function handleInstall(context: CliContext): Promise<boolean> {
+  const sourcePath = (context.args.file ?? context.args.target ?? '').trim();
+  if (!sourcePath) {
+    throw new Error('kartograf install requires --file <path> (or positional <path>)');
+  }
+  const source = (context.args.source ?? 'file').trim();
+  if (!ALLOWED_SOURCES.has(source)) {
+    throw new Error(
+      `--source must be one of ${[...ALLOWED_SOURCES].join('|')}; got ${JSON.stringify(source)}`,
+    );
+  }
+  if (source === 'hf-hub' || source === 'github-release') {
+    // Network pull is Q2 scope — the verify primitive ships now so
+    // operators can exercise `file` / `federation` today and graduate
+    // to network sources when the producer side lands.
+    throw new Error(
+      `--source ${source} requires network fetch not yet implemented. ` +
+        `For local testing pass --source file with a local envelope path.`,
+    );
+  }
+
+  const read = readEnvelopeFrom(sourcePath);
+  if (!read.ok) {
+    print(
+      { ok: false, mode: 'kartograf.install', path: read.path, error: read.error },
+      context.args.json,
+    );
+    return true;
+  }
+  const verify = verifyCheckpoint(read.envelope);
+  if (!verify.valid) {
+    // Verification failure MUST block install so a tampered envelope
+    // can't land on disk where the model loader would later trust it.
+    print(
+      {
+        ok: false,
+        mode: 'kartograf.install',
+        path: read.path,
+        reason: verify.reason,
+      },
+      context.args.json,
+    );
+    return true;
+  }
+
+  const slug = shortSignerSlug(verify.signerDid);
+  const stageDir = join(
+    getDataDir(process.env),
+    'kartograf',
+    'checkpoints',
+    slug,
+  );
+  mkdirSync(stageDir, { recursive: true });
+  const envelopeOut = join(stageDir, 'checkpoint.json');
+
+  if (context.args.dryRun) {
+    print(
+      {
+        ok: true,
+        mode: 'kartograf.install.dry-run',
+        path: read.path,
+        stageDir,
+        envelopeOut,
+        signerDid: verify.signerDid,
+        distributionSource: read.envelope.distribution_source,
+      },
+      context.args.json,
+    );
+    return true;
+  }
+
+  // Copy envelope into the staging dir under its canonical name.
+  writeFileSync(envelopeOut, JSON.stringify(read.envelope, null, 2));
+
+  // Copy sibling artifacts if present — producer side stamps them
+  // with the sha256s the envelope asserts. We re-verify the sha256s
+  // here so a misassembled bundle can't sneak past.
+  const sourceDir = dirname(read.path);
+  const artifactWarnings: string[] = [];
+  for (const [field, fileName] of [
+    ['onnx_sha256', 'model.onnx'],
+    ['tokenizer_sha256', 'tokenizer.json'],
+  ] as const) {
+    const candidate = join(sourceDir, fileName);
+    const expected = read.envelope[field];
+    try {
+      const bytes = readFileSync(candidate);
+      const actual = sha256Hex(bytes);
+      if (actual !== expected) {
+        artifactWarnings.push(
+          `${fileName}: sha256 mismatch (expected ${expected.slice(0, 12)}..., ` +
+            `got ${actual.slice(0, 12)}...) — artifact not copied`,
+        );
+        continue;
+      }
+      copyFileSync(candidate, join(stageDir, fileName));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        artifactWarnings.push(`${fileName}: not found beside envelope — skipped`);
+      } else {
+        artifactWarnings.push(
+          `${fileName}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  print(
+    {
+      ok: true,
+      mode: 'kartograf.install',
+      path: read.path,
+      stageDir,
+      envelopeOut,
+      signerDid: verify.signerDid,
+      distributionSource: read.envelope.distribution_source,
+      artifactWarnings,
+    },
+    context.args.json,
+  );
+  return true;
+}

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -222,6 +222,14 @@ export const CLI_COMMAND_REGISTRY = [
     ['consent'],
     createLazyHandlerLoader(() => import('./handlers/consent.handler.js'), 'consentCommandHandler'),
   ),
+  createCommandRegistration(
+    'kartograf',
+    ['kartograf'],
+    createLazyHandlerLoader(
+      () => import('./handlers/kartograf.handler.js'),
+      'kartografCommandHandler',
+    ),
+  ),
 ] as const;
 
 export const CLI_COMPLETION_COMMANDS = [
@@ -311,6 +319,7 @@ export const CLI_NON_COMPLETABLE_COMMANDS = new Set<string | undefined>([
   'auth', // namespace — always needs a subcommand
   'config', // namespace — always needs a subcommand
   'consent', // namespace — always needs a subcommand (e.g. `memphis consent mark`)
+  'kartograf', // namespace — always needs a subcommand (e.g. `memphis kartograf verify`)
   'export', // namespace — always needs a subcommand (e.g. `memphis export trajectories`)
 ]);
 

--- a/tests/unit/kartograf-cli.test.ts
+++ b/tests/unit/kartograf-cli.test.ts
@@ -109,6 +109,60 @@ describe('memphis kartograf CLI (N40.2)', () => {
     expect(out.reason).toMatch(/signature/);
   });
 
+  it('install removes stale artifacts before staging new ones (P1 safety)', async () => {
+    const dir = tempDir();
+    const dataDir = tempDir('karto-data-');
+    process.env.MEMPHIS_DATA_DIR = dataDir;
+
+    const seed = randomBytes(32);
+    const onnx1 = Buffer.from('first-onnx');
+    const tok1 = Buffer.from('{"first":"tokenizer"}');
+    writeFileSync(join(dir, 'model.onnx'), onnx1);
+    writeFileSync(join(dir, 'tokenizer.json'), tok1);
+    const env1 = signCheckpoint(
+      unsigned({ onnx_sha256: sha256Hex(onnx1), tokenizer_sha256: sha256Hex(tok1) }),
+      seed,
+    );
+    writeFileSync(join(dir, 'checkpoint.json'), JSON.stringify(env1));
+    const log1 = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await kartografCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({ subcommand: 'install', file: join(dir, 'checkpoint.json'), source: 'file', json: true }) as any,
+    );
+    const out1 = JSON.parse(log1.mock.calls[0][0] as string);
+    log1.mockRestore();
+
+    // Round 2: same signer, env bumps, but on-disk onnx is tampered
+    // vs the new envelope's declared hash. Prior round's model.onnx
+    // must be cleared — otherwise the staging dir carries round-1
+    // bytes next to round-2 envelope (mixed-state hazard the P1
+    // finding called out).
+    const onnx2Expected = Buffer.from('second-onnx-correct');
+    writeFileSync(join(dir, 'tokenizer.json'), tok1);
+    writeFileSync(join(dir, 'model.onnx'), 'tampered-bytes');
+    const env2 = signCheckpoint(
+      unsigned({ onnx_sha256: sha256Hex(onnx2Expected), tokenizer_sha256: sha256Hex(tok1) }),
+      seed,
+    );
+    writeFileSync(join(dir, 'checkpoint.json'), JSON.stringify(env2));
+    const log2 = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await kartografCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({ subcommand: 'install', file: join(dir, 'checkpoint.json'), source: 'file', json: true }) as any,
+    );
+    const out2 = JSON.parse(log2.mock.calls[0][0] as string);
+    log2.mockRestore();
+    delete process.env.MEMPHIS_DATA_DIR;
+
+    expect(out2.ok).toBe(true);
+    // Stale first-round onnx cleared — not coexisting with env2.
+    expect(() => readFileSync(join(out1.stageDir, 'model.onnx'))).toThrow();
+    // Tokenizer still matches so it's restaged in round 2.
+    expect(readFileSync(join(out2.stageDir, 'tokenizer.json')).toString()).toBe(
+      tok1.toString(),
+    );
+  });
+
   it('install rejects unimplemented network sources with actionable message', async () => {
     const dir = tempDir();
     writeFileSync(join(dir, 'placeholder.json'), '{}');
@@ -122,7 +176,23 @@ describe('memphis kartograf CLI (N40.2)', () => {
           json: true,
         }) as any,
       ),
-    ).rejects.toThrow(/network fetch not yet implemented/);
+    ).rejects.toThrow(/transport not yet implemented/);
+  });
+
+  it('install rejects --source agora until Y2+ transport lands', async () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, 'placeholder.json'), '{}');
+    await expect(
+      kartografCommandHandler.handle(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mkCtx({
+          subcommand: 'install',
+          file: join(dir, 'placeholder.json'),
+          source: 'agora',
+          json: true,
+        }) as any,
+      ),
+    ).rejects.toThrow(/transport not yet implemented/);
   });
 
   it('install stages envelope + matching artifacts into data dir', async () => {

--- a/tests/unit/kartograf-cli.test.ts
+++ b/tests/unit/kartograf-cli.test.ts
@@ -1,0 +1,202 @@
+import { randomBytes } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { kartografCommandHandler } from '../../src/infra/cli/handlers/kartograf.handler.js';
+import {
+  sha256Hex,
+  signCheckpoint,
+  type UnsignedEnvelope,
+} from '../../src/kartograf/checkpoint.js';
+
+function tempDir(prefix = 'karto-cli-') {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function unsigned(over: Partial<UnsignedEnvelope> = {}): UnsignedEnvelope {
+  return {
+    version: 'kartograf-v1',
+    base_model: 'answerdotai/ModernBERT-base@rev-abc123',
+    onnx_sha256: 'a'.repeat(64),
+    tokenizer_sha256: 'b'.repeat(64),
+    heads_config: { embedding_dim: 256, zone_classes: 12, multitask_alpha: 0.7 },
+    training_provenance: {
+      trained_at: '2026-05-15T10:00:00Z',
+      corpus_version: 'v1',
+      hardware: 'gtx-960-local',
+      eval_recall_at_10: 0.82,
+      steps: 12000,
+    },
+    distribution_source: 'file',
+    ...over,
+  };
+}
+
+function mkCtx(args: Record<string, unknown>): {
+  args: Record<string, unknown> & { command: 'kartograf' };
+  getContainer: () => unknown;
+  getConfig: () => unknown;
+} {
+  return {
+    args: { command: 'kartograf', ...args },
+    getContainer: () => ({}),
+    getConfig: () => ({}),
+  };
+}
+
+describe('memphis kartograf CLI (N40.2)', () => {
+  it('verify succeeds on a freshly signed envelope', async () => {
+    const dir = tempDir();
+    const seed = randomBytes(32);
+    const envelope = signCheckpoint(unsigned(), seed);
+    const envelopePath = join(dir, 'checkpoint.json');
+    writeFileSync(envelopePath, JSON.stringify(envelope));
+    // Capture stdout via console spy
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await kartografCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({ subcommand: 'verify', file: envelopePath, json: true }) as any,
+    );
+    const out = JSON.parse(spy.mock.calls[0][0] as string);
+    spy.mockRestore();
+    expect(out.ok).toBe(true);
+    expect(out.mode).toBe('kartograf.verify');
+    expect(out.signerDid).toMatch(/^did:key:ed25519:/);
+  });
+
+  it('verify fails with reason on tampered envelope', async () => {
+    const dir = tempDir();
+    const seed = randomBytes(32);
+    const signed = signCheckpoint(unsigned(), seed);
+    // Tamper after signing
+    const tampered = { ...signed, onnx_sha256: 'c'.repeat(64) };
+    const envelopePath = join(dir, 'checkpoint.json');
+    writeFileSync(envelopePath, JSON.stringify(tampered));
+
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await kartografCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({ subcommand: 'verify', file: envelopePath, json: true }) as any,
+    );
+    const out = JSON.parse(spy.mock.calls[0][0] as string);
+    spy.mockRestore();
+    expect(out.ok).toBe(false);
+    expect(out.reason).toMatch(/signature/);
+  });
+
+  it('install refuses to stage a tampered envelope', async () => {
+    const dir = tempDir();
+    const seed = randomBytes(32);
+    const tampered = { ...signCheckpoint(unsigned(), seed), onnx_sha256: 'c'.repeat(64) };
+    const envelopePath = join(dir, 'checkpoint.json');
+    writeFileSync(envelopePath, JSON.stringify(tampered));
+
+    const dataDir = tempDir('karto-data-');
+    process.env.MEMPHIS_DATA_DIR = dataDir;
+
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await kartografCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({ subcommand: 'install', file: envelopePath, source: 'file', json: true }) as any,
+    );
+    const out = JSON.parse(spy.mock.calls[0][0] as string);
+    spy.mockRestore();
+    delete process.env.MEMPHIS_DATA_DIR;
+    expect(out.ok).toBe(false);
+    expect(out.reason).toMatch(/signature/);
+  });
+
+  it('install rejects unimplemented network sources with actionable message', async () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, 'placeholder.json'), '{}');
+    await expect(
+      kartografCommandHandler.handle(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mkCtx({
+          subcommand: 'install',
+          file: join(dir, 'placeholder.json'),
+          source: 'hf-hub',
+          json: true,
+        }) as any,
+      ),
+    ).rejects.toThrow(/network fetch not yet implemented/);
+  });
+
+  it('install stages envelope + matching artifacts into data dir', async () => {
+    const dir = tempDir();
+    const seed = randomBytes(32);
+    const onnxBytes = Buffer.from('fake-onnx-bytes');
+    const tokBytes = Buffer.from('{"tokenizer":"fake"}');
+    writeFileSync(join(dir, 'model.onnx'), onnxBytes);
+    writeFileSync(join(dir, 'tokenizer.json'), tokBytes);
+    const envelope = signCheckpoint(
+      unsigned({
+        onnx_sha256: sha256Hex(onnxBytes),
+        tokenizer_sha256: sha256Hex(tokBytes),
+      }),
+      seed,
+    );
+    const envelopePath = join(dir, 'checkpoint.json');
+    writeFileSync(envelopePath, JSON.stringify(envelope));
+
+    const dataDir = tempDir('karto-data-');
+    process.env.MEMPHIS_DATA_DIR = dataDir;
+
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await kartografCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({ subcommand: 'install', file: envelopePath, source: 'file', json: true }) as any,
+    );
+    const out = JSON.parse(spy.mock.calls[0][0] as string);
+    spy.mockRestore();
+    delete process.env.MEMPHIS_DATA_DIR;
+
+    expect(out.ok).toBe(true);
+    expect(out.artifactWarnings).toEqual([]);
+    // Re-read the staged envelope and confirm it matches the input.
+    const stagedEnvelope = JSON.parse(readFileSync(out.envelopeOut, 'utf8'));
+    expect(stagedEnvelope.signer_did).toBe(envelope.signer_did);
+  });
+
+  it('install warns (non-fatal) when artifact sha256 mismatches envelope', async () => {
+    const dir = tempDir();
+    const seed = randomBytes(32);
+    // Write a truthful onnx but a TAMPERED tokenizer
+    const onnxBytes = Buffer.from('fake-onnx-bytes');
+    writeFileSync(join(dir, 'model.onnx'), onnxBytes);
+    writeFileSync(join(dir, 'tokenizer.json'), 'tampered-content');
+    const envelope = signCheckpoint(
+      unsigned({
+        onnx_sha256: sha256Hex(onnxBytes),
+        tokenizer_sha256: sha256Hex('correct-content'),
+      }),
+      seed,
+    );
+    const envelopePath = join(dir, 'checkpoint.json');
+    writeFileSync(envelopePath, JSON.stringify(envelope));
+
+    const dataDir = tempDir('karto-data-');
+    process.env.MEMPHIS_DATA_DIR = dataDir;
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await kartografCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({ subcommand: 'install', file: envelopePath, source: 'file', json: true }) as any,
+    );
+    const out = JSON.parse(spy.mock.calls[0][0] as string);
+    spy.mockRestore();
+    delete process.env.MEMPHIS_DATA_DIR;
+
+    expect(out.ok).toBe(true);
+    // Envelope is still valid (signature + declared sha256s match by canonical form);
+    // tokenizer warning surfaces because the on-disk bytes don't match.
+    const joined = (out.artifactWarnings as string[]).join(' | ');
+    expect(joined).toMatch(/tokenizer\.json.*sha256 mismatch/);
+  });
+});
+
+// `mkdirSync` is imported for type-level readability in test helpers;
+// reference it so noUnusedLocals doesn't fire in some strict configs.
+void mkdirSync;


### PR DESCRIPTION
## Summary

Operator-facing side of the signed-checkpoint loop — makes N40 primitives usable end-to-end before real Kartograf checkpoints exist.

- `memphis kartograf verify --file <path>` — read, verify signature, report
- `memphis kartograf install --file <path> --source <tier>` — verify, then stage envelope + sibling `model.onnx` / `tokenizer.json` into `<data-dir>/kartograf/checkpoints/<signer-slug>/`
- Artifact sha256 mismatches surface as non-fatal `artifactWarnings` (bundle not copied)
- Verify failure BLOCKS install — tampered envelopes can't land on disk
- `hf-hub` / `github-release` sources throw an actionable "not yet implemented" error; those ship with the Q2 producer

## Dependency policy

- classification:
  - (none) — no new dependencies; uses node:crypto + node:fs stdlib

## Test plan

- [x] `tests/unit/kartograf-cli.test.ts` — 6 passed (verify ok, verify tampered, install tampered blocked, install unimplemented source errors, install happy path, install artifact mismatch warns)
- [x] `tests/unit/cli-registry-consistency.test.ts` — 14 passed
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)