### PR TITLE
feat(memory): tool-executor conversation binding + turnId passthrough (N8.2 follow-up)

### DIFF
--- a/src/gateway/chat-types.ts
+++ b/src/gateway/chat-types.ts
@@ -99,6 +99,17 @@ export type ToolExecutor = {
   execute(call: ChatToolCall): Promise<string>;
   listTools(): ChatToolDefinition[];
   maxParallel?: number;
+  /**
+   * Produce a new executor bound to a specific conversation / session
+   * context. Used by turn-runtime to stamp tool-emitted writes with
+   * the same `conversation_id` / `session_id` as the surrounding
+   * memory-client writes (N8.2). Returning `this` is a valid no-op
+   * for executors that don't care about session binding.
+   *
+   * Shape matches the `MemoryStoreBinding` contract so turn-runtime
+   * can pass the same object to both paths without conversion.
+   */
+  withBinding?(binding: MemoryStoreBinding): ToolExecutor;
 };
 
 export type LoopLimits = {

--- a/src/gateway/memory-client.ts
+++ b/src/gateway/memory-client.ts
@@ -76,6 +76,7 @@ export function createInProcessMemoryClient(
         surface,
         conversationId: binding?.conversationId,
         sessionId: binding?.sessionId,
+        turnId: binding?.turnId,
       });
       if (!result.success) {
         throw new Error(result.error ?? 'memory_store_blocked');

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -68,6 +68,7 @@ export type InProcessToolExecutorDeps = {
    */
   conversationId?: string;
   sessionId?: string;
+  turnId?: string;
 };
 
 function defaultManifest(): SoulManifest {
@@ -189,6 +190,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
           surface: deps.surface,
           conversationId: deps.conversationId,
           sessionId: deps.sessionId,
+          turnId: deps.turnId,
         });
       },
     }),
@@ -1102,5 +1104,19 @@ export function createInProcessToolExecutor(deps: InProcessToolExecutorDeps = {}
       return executeTool(call, deps, runtimeToolMap);
     },
     maxParallel: deps.maxParallel ?? 4,
+    withBinding(binding) {
+      // Tool `execute` closures capture `deps` at construction time
+      // (see `createRuntimeTools(deps)` above; each tool reads
+      // `deps.conversationId` / `deps.sessionId` at execute time).
+      // That means a new binding MUST rebuild the tools — a shallow
+      // clone of `deps` alone won't reach the existing closures.
+      const merged: InProcessToolExecutorDeps = {
+        ...deps,
+        conversationId: binding.conversationId ?? deps.conversationId,
+        sessionId: binding.sessionId ?? deps.sessionId,
+        turnId: binding.turnId ?? deps.turnId,
+      };
+      return createInProcessToolExecutor(merged);
+    },
   };
 }

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -153,6 +153,12 @@ function applyTier3EnvOverride(
 type ToolExecutorLike = {
   execute(call: ChatToolCall): Promise<string>;
   listTools?: () => ChatToolDefinition[];
+  /** Optional per-turn binding (N8.2). Canonical executors implement it. */
+  withBinding?: (binding: {
+    turnId?: string;
+    conversationId?: string;
+    sessionId?: string;
+  }) => ToolExecutorLike;
 };
 
 type TurnPersistenceStatus = {
@@ -757,7 +763,19 @@ export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRun
       options.conversationContext && options.conversationId
         ? await options.conversationContext.getPromptOverlay(options.conversationId)
         : undefined;
-    const rawToolExecutor = normalizeToolExecutor(options.toolExecutor, options.tools);
+    // Bind the tool executor to this turn's conversation so
+    // tool-emitted journal writes (e.g. `memphis_journal` invoked by
+    // the model) land with the same `conversation_id` as memory-client
+    // writes. Executors that don't implement `withBinding` keep their
+    // original deps — backward compat.
+    const boundToolExecutor =
+      options.toolExecutor && options.toolExecutor.withBinding
+        ? options.toolExecutor.withBinding({
+            turnId,
+            conversationId: options.conversationId,
+          })
+        : options.toolExecutor;
+    const rawToolExecutor = normalizeToolExecutor(boundToolExecutor, options.tools);
     const constrainedTools = constrainToolExecutorToSurface(
       rawToolExecutor,
       surfacePolicy,

--- a/src/mcp/tools/journal.ts
+++ b/src/mcp/tools/journal.ts
@@ -15,15 +15,18 @@ export type MemphisJournalInput = {
    */
   surface?: string;
   /**
-   * Conversation / session identifiers — plumbed through to
+   * Conversation / session / turn identifiers — plumbed through to
    * `storeDurableMemory` so the persisted block carries them as
-   * `data.conversation_id` / `data.session_id`. Enables the trajectory
-   * exporter to group per-turn events into multi-turn trajectories
-   * (N8.2). Writers that don't track conversation/session state leave
-   * these undefined; the exporter falls back to per-turn grouping.
+   * `data.conversation_id` / `data.session_id` / `data.turn_id`.
+   * Enables the trajectory exporter to group per-turn events into
+   * multi-turn trajectories (N8.2). Writers that don't track these
+   * state fields leave them undefined; the exporter falls back to
+   * per-turn grouping when conversation/session are missing and to
+   * unlinked when turnId is missing.
    */
   conversationId?: string;
   sessionId?: string;
+  turnId?: string;
 };
 
 export type MemphisJournalOutput = {
@@ -79,5 +82,6 @@ export async function runMemphisJournal(
     surface: input.surface ?? 'mcp',
     conversationId: input.conversationId,
     sessionId: input.sessionId,
+    turnId: input.turnId,
   });
 }


### PR DESCRIPTION
## Summary

Closes two Codex P2 findings on #257 (N8.2) + the known gap noted at v1.6.0 ship time.

1. **`ToolExecutor.withBinding`** — produces a per-turn bound executor whose tool `execute` closures capture the bound `conversation_id` / `session_id` / `turn_id`. Turn-runtime calls this before handing the executor to the agent loop, so tool-emitted `memphis_journal` writes carry the same session binding as memory-client writes. No more per-turn fragmentation of tool-originated memories in the trajectory exporter.

2. **`turnId` passthrough gap** — `MemphisJournalInput` was missing the field; memory-client + tool-executor only passed `conversationId`/`sessionId`. Fixed end-to-end. Scheduled / boot writes still pass undefined → unlinked semantics preserved.

## Dependency policy

- classification:
  - (none) — no new dependencies

## Test plan

- [x] `tests/mcp/tools.test.ts` 6 pass
- [x] `tests/unit/turn-runtime.test.ts` 9 pass
- [x] `tests/unit/durable-memory.turnid.test.ts` 8 pass
- [x] `tests/integration/trajectory-export.e2e.test.ts` 2 pass
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)