### PR TITLE
fix(kartograf-cli): preserve source artifacts + dry-run side-effect-free (Codex #258 r2)

### DIFF
--- a/src/infra/cli/handlers/kartograf.handler.ts
+++ b/src/infra/cli/handlers/kartograf.handler.ts
@@ -167,10 +167,14 @@ async function handleInstall(context: CliContext): Promise<boolean> {
     'checkpoints',
     slug,
   );
-  mkdirSync(stageDir, { recursive: true });
   const envelopeOut = join(stageDir, 'checkpoint.json');
+  const sourceDir = dirname(read.path);
 
   if (context.args.dryRun) {
+    // Dry-run must be side-effect free. `mkdirSync` BEFORE this branch
+    // was creating the staging directory on a preview command, which
+    // contradicts the `--dry-run` contract. Print what WOULD happen
+    // without touching the filesystem.
     print(
       {
         ok: true,
@@ -186,15 +190,30 @@ async function handleInstall(context: CliContext): Promise<boolean> {
     return true;
   }
 
-  // Before writing the new envelope, clear any prior staged artifacts
-  // from the same stageDir (same signer may publish multiple
-  // checkpoints over time). A checksum-mismatch install in the
-  // previous run must NOT leave stale `model.onnx` / `tokenizer.json`
-  // beside an updated `checkpoint.json` — that's a "mixed state"
-  // hazard where the loader would hash-verify stale bytes against new
-  // envelope values.
-  for (const stale of ['model.onnx', 'tokenizer.json']) {
-    rmSync(join(stageDir, stale), { force: true });
+  // Guard against the "re-install in place" case: `memphis kartograf
+  // install --file <stageDir>/checkpoint.json --source file` would
+  // (before this guard) wipe `model.onnx` / `tokenizer.json` in the
+  // stage dir BEFORE reading them as the source, silently destroying
+  // the operator's good bundle. If source and stage are the same
+  // directory, skip the cleanup — the artifacts already on disk ARE
+  // the ones we want to re-stamp against the envelope.
+  const stageDirReal = resolve(stageDir);
+  const sourceDirReal = resolve(sourceDir);
+  const inPlaceRestage = stageDirReal === sourceDirReal;
+
+  mkdirSync(stageDir, { recursive: true });
+
+  if (!inPlaceRestage) {
+    // Before writing the new envelope, clear any prior staged artifacts
+    // from the same stageDir (same signer may publish multiple
+    // checkpoints over time). A checksum-mismatch install in the
+    // previous run must NOT leave stale `model.onnx` / `tokenizer.json`
+    // beside an updated `checkpoint.json` — that's a "mixed state"
+    // hazard where the loader would hash-verify stale bytes against
+    // new envelope values.
+    for (const stale of ['model.onnx', 'tokenizer.json']) {
+      rmSync(join(stageDir, stale), { force: true });
+    }
   }
   // Copy envelope into the staging dir under its canonical name.
   writeFileSync(envelopeOut, JSON.stringify(read.envelope, null, 2));
@@ -202,7 +221,6 @@ async function handleInstall(context: CliContext): Promise<boolean> {
   // Copy sibling artifacts if present — producer side stamps them
   // with the sha256s the envelope asserts. We re-verify the sha256s
   // here so a misassembled bundle can't sneak past.
-  const sourceDir = dirname(read.path);
   const artifactWarnings: string[] = [];
   for (const [field, fileName] of [
     ['onnx_sha256', 'model.onnx'],

--- a/tests/unit/kartograf-cli.test.ts
+++ b/tests/unit/kartograf-cli.test.ts
@@ -179,6 +179,80 @@ describe('memphis kartograf CLI (N40.2)', () => {
     ).rejects.toThrow(/transport not yet implemented/);
   });
 
+  it('install --dry-run is side-effect free (no stage dir created)', async () => {
+    const dir = tempDir();
+    const seed = randomBytes(32);
+    const onnxBytes = Buffer.from('stub');
+    const tokBytes = Buffer.from('{}');
+    writeFileSync(join(dir, 'model.onnx'), onnxBytes);
+    writeFileSync(join(dir, 'tokenizer.json'), tokBytes);
+    const env = signCheckpoint(
+      unsigned({ onnx_sha256: sha256Hex(onnxBytes), tokenizer_sha256: sha256Hex(tokBytes) }),
+      seed,
+    );
+    const envelopePath = join(dir, 'checkpoint.json');
+    writeFileSync(envelopePath, JSON.stringify(env));
+
+    const dataDir = tempDir('karto-data-');
+    process.env.MEMPHIS_DATA_DIR = dataDir;
+
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await kartografCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({
+        subcommand: 'install',
+        file: envelopePath,
+        source: 'file',
+        dryRun: true,
+        json: true,
+      }) as any,
+    );
+    const out = JSON.parse(spy.mock.calls[0][0] as string);
+    spy.mockRestore();
+    delete process.env.MEMPHIS_DATA_DIR;
+
+    expect(out.mode).toBe('kartograf.install.dry-run');
+    // Dry-run must NOT have created the stage hierarchy.
+    expect(() => readFileSync(join(dataDir, 'kartograf'))).toThrow();
+  });
+
+  it('install --file pointing at the staged dir preserves source artifacts', async () => {
+    // Real data-loss hazard Codex flagged on #258: if operator reruns
+    // install in place, the old rmSync-first logic wiped the source
+    // before reading it. Guard: skip cleanup when sourceDir === stageDir.
+    const seed = randomBytes(32);
+    const onnxBytes = Buffer.from('bytes-to-preserve');
+    const tokBytes = Buffer.from('{"tok":"preserved"}');
+    const env = signCheckpoint(
+      unsigned({ onnx_sha256: sha256Hex(onnxBytes), tokenizer_sha256: sha256Hex(tokBytes) }),
+      seed,
+    );
+
+    const dataDir = tempDir('karto-data-');
+    process.env.MEMPHIS_DATA_DIR = dataDir;
+    const pubHex = env.signer_did.replace('did:key:ed25519:', '');
+    const stageDir = join(dataDir, 'kartograf', 'checkpoints', pubHex.slice(0, 12));
+    mkdirSync(stageDir, { recursive: true });
+    writeFileSync(join(stageDir, 'model.onnx'), onnxBytes);
+    writeFileSync(join(stageDir, 'tokenizer.json'), tokBytes);
+    const envelopePath = join(stageDir, 'checkpoint.json');
+    writeFileSync(envelopePath, JSON.stringify(env));
+
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await kartografCommandHandler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mkCtx({ subcommand: 'install', file: envelopePath, source: 'file', json: true }) as any,
+    );
+    const out = JSON.parse(spy.mock.calls[0][0] as string);
+    spy.mockRestore();
+    delete process.env.MEMPHIS_DATA_DIR;
+
+    expect(out.ok).toBe(true);
+    // Source bundle MUST survive.
+    expect(readFileSync(join(stageDir, 'model.onnx')).toString()).toBe(onnxBytes.toString());
+    expect(readFileSync(join(stageDir, 'tokenizer.json')).toString()).toBe(tokBytes.toString());
+  });
+
   it('install rejects --source agora until Y2+ transport lands', async () => {
     const dir = tempDir();
     writeFileSync(join(dir, 'placeholder.json'), '{}');


### PR DESCRIPTION
## Summary

Post-v1.6.0 follow-up. Two Codex findings on the kartograf CLI (#258) that landed post-merge.

**P1 — Data-loss hazard:** \`memphis kartograf install --file <stageDir>/checkpoint.json --source file\` wiped the stageDir's own \`model.onnx\` / \`tokenizer.json\` via the unconditional \`rmSync\` BEFORE reading them as source. Fix: skip cleanup when \`resolve(stageDir) === resolve(sourceDir)\` — the on-disk artifacts already ARE the ones we want to re-stamp.

**P2 — Dry-run side effect:** \`mkdirSync(stageDir)\` ran before the \`--dry-run\` guard. Moved it (and the cleanup loop) after.

## Dependency policy

- classification:
  - (none) — no new dependencies

## Test plan

- [x] 2 new tests: in-place reinstall preserves files, dry-run creates nothing
- [x] All 10 kartograf CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)