### PR TITLE
fix(logging): pino destination rotation — 10 MiB threshold + 5 archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- **Pino log rotation** — `src/infra/logging/log-rotation.ts` rotates `~/.memphis/logs/memphis.log` at 10 MiB into gzipped archives under `archives/` and prunes to the 5 newest by mtime. Triggered pre-`pino.destination` open in `getFileStream()` so each restart starts on a fresh file. Tunable via `MEMPHIS_LOG_ROTATE_BYTES` (64 KiB–100 MiB), `MEMPHIS_LOG_ROTATE_KEEP` (1–100); opt-out via `MEMPHIS_LOG_ROTATE=disabled`. Closes the unbounded-growth gap that left `memphis.log` at 36 MiB on operator boxes after ~13 days.
+
 ## v1.6.0 - 2026-04-23
 
 Y1 Q1 foundation — compressed sprint shipped the write → export → train → verify loop end-to-end, ~6 weeks ahead of the Q1 calendar close (2026-07-31). Operators can exercise the full Kartograf distribution path today against the training stub; real Kartograf training replaces the stub body in Q2 without CLI or consumer changes.

--- a/docs/operator/CONFIGURATION.md
+++ b/docs/operator/CONFIGURATION.md
@@ -243,6 +243,14 @@ Cross-reference: [SECURITY.md](../SECURITY.md), [TROUBLESHOOTING.md](./TROUBLESH
 | `MEMPHIS_QUEUE_WAL_PATH`                 | string | —           | Custom WAL file path                                             |
 | `MEMPHIS_QUEUE_WAL_MAX_BYTES`            | int    | `10485760`  | WAL max size (1MiB–1GiB)                                         |
 | `MEMPHIS_MAX_PENDING_TASKS`              | int    | `100`       | Max pending tasks in queue                                       |
+| `MEMPHIS_LOG_FILE`                       | string | `~/.memphis/logs/memphis.log` | Pino destination path; `none` disables file logging |
+| `MEMPHIS_LOG_ROTATE`                     | enum   | enabled     | Set to `disabled`/`off`/`false`/`0` to skip rotation             |
+| `MEMPHIS_LOG_ROTATE_BYTES`               | int    | `10485760`  | Rotate threshold for `memphis.log` (64KiB–100MiB)                |
+| `MEMPHIS_LOG_ROTATE_KEEP`                | int    | `5`         | Number of gzipped archives to retain (1–100)                     |
+
+> Run a **single runtime per `MEMPHIS_LOG_FILE`**. Rotation uses
+> `renameSync` + gzip on startup; if a second process holds the file FD
+> open at that moment, the gzipped archive may capture a partial flush.
 
 ---
 

--- a/docs/operator/CONFIGURATION.md
+++ b/docs/operator/CONFIGURATION.md
@@ -247,7 +247,7 @@ Cross-reference: [SECURITY.md](../SECURITY.md), [TROUBLESHOOTING.md](./TROUBLESH
 | `MEMPHIS_LOG_ROTATE`                     | enum   | enabled     | Set to `disabled`/`off`/`false`/`0` to skip rotation             |
 | `MEMPHIS_LOG_ROTATE_BYTES`               | int    | `10485760`  | Rotate threshold for `memphis.log` (64KiB–100MiB)                |
 | `MEMPHIS_LOG_ROTATE_KEEP`                | int    | `5`         | Number of gzipped archives to retain (1–100)                     |
-| `MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES`     | int    | `268435456` | Hard cap on log size fed to sync gzip (1 MiB–4 GiB). Above this, rotation is skipped with a stderr hint so the operator can compress / truncate manually instead of OOM-ing the runtime at startup. |
+| `MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES`     | int    | `67108864`  | Hard cap on log size fed to sync gzip (1 MiB–4 GiB). Default is 64 MiB → ~75 MiB peak heap during compression, safe on slim reference boxes. Above the cap, rotation is skipped with a stderr hint so the operator can compress / truncate manually instead of OOM-ing the runtime at startup. |
 
 > Run a **single runtime per `MEMPHIS_LOG_FILE`**. Rotation uses
 > `renameSync` + gzip on startup; if a second process holds the file FD

--- a/docs/operator/CONFIGURATION.md
+++ b/docs/operator/CONFIGURATION.md
@@ -247,6 +247,7 @@ Cross-reference: [SECURITY.md](../SECURITY.md), [TROUBLESHOOTING.md](./TROUBLESH
 | `MEMPHIS_LOG_ROTATE`                     | enum   | enabled     | Set to `disabled`/`off`/`false`/`0` to skip rotation             |
 | `MEMPHIS_LOG_ROTATE_BYTES`               | int    | `10485760`  | Rotate threshold for `memphis.log` (64KiB–100MiB)                |
 | `MEMPHIS_LOG_ROTATE_KEEP`                | int    | `5`         | Number of gzipped archives to retain (1–100)                     |
+| `MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES`     | int    | `268435456` | Hard cap on log size fed to sync gzip (1 MiB–4 GiB). Above this, rotation is skipped with a stderr hint so the operator can compress / truncate manually instead of OOM-ing the runtime at startup. |
 
 > Run a **single runtime per `MEMPHIS_LOG_FILE`**. Rotation uses
 > `renameSync` + gzip on startup; if a second process holds the file FD

--- a/src/infra/logging/log-rotation.ts
+++ b/src/infra/logging/log-rotation.ts
@@ -1,0 +1,173 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+const DEFAULT_ROTATE_BYTES = 10 * 1024 * 1024;
+const MIN_ROTATE_BYTES = 64 * 1024;
+// Capped at 100 MiB: rotation does readFileSync + gzipSync, so the whole
+// file lives in heap during compression. A 1 GiB cap was a footgun on
+// low-RAM operator boxes (~2.5 GiB resident during rotation). If a
+// future use case truly needs larger logs, switch to a streaming gzip
+// path (createReadStream → createGzip → createWriteStream).
+const MAX_ROTATE_BYTES = 100 * 1024 * 1024;
+const DEFAULT_KEEP_ARCHIVES = 5;
+const MIN_KEEP_ARCHIVES = 1;
+const MAX_KEEP_ARCHIVES = 100;
+
+export function resolveLogRotateBytes(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.MEMPHIS_LOG_ROTATE_BYTES;
+  if (!raw) return DEFAULT_ROTATE_BYTES;
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_ROTATE_BYTES;
+  if (parsed < MIN_ROTATE_BYTES) return MIN_ROTATE_BYTES;
+  if (parsed > MAX_ROTATE_BYTES) return MAX_ROTATE_BYTES;
+  return parsed;
+}
+
+export function resolveLogKeepArchives(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.MEMPHIS_LOG_ROTATE_KEEP;
+  if (!raw) return DEFAULT_KEEP_ARCHIVES;
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_KEEP_ARCHIVES;
+  if (parsed < MIN_KEEP_ARCHIVES) return MIN_KEEP_ARCHIVES;
+  if (parsed > MAX_KEEP_ARCHIVES) return MAX_KEEP_ARCHIVES;
+  return parsed;
+}
+
+export function logRotationDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.MEMPHIS_LOG_ROTATE?.trim().toLowerCase();
+  return raw === 'disabled' || raw === 'off' || raw === 'false' || raw === '0';
+}
+
+export interface LogRotationResult {
+  rotated: boolean;
+  archivePath?: string;
+  bytesArchived?: number;
+  prunedArchives?: number;
+}
+
+function isoStampForFilename(): string {
+  return new Date().toISOString().replace(/:/g, '-');
+}
+
+function nextAvailableArchivePath(archiveDir: string, baseName: string, stamp: string): string {
+  const candidate = join(archiveDir, `${baseName}-${stamp}.gz`);
+  if (!existsSync(candidate)) return candidate;
+  for (let i = 1; i < 1000; i += 1) {
+    const next = join(archiveDir, `${baseName}-${stamp}-${i}.gz`);
+    if (!existsSync(next)) return next;
+  }
+  throw new Error(
+    `log rotation: could not find a unique archive name after 1000 attempts for stamp ${stamp}`,
+  );
+}
+
+function sizeOfFile(path: string): number {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+function pruneOldArchives(archiveDir: string, baseName: string, keep: number): number {
+  let entries: string[];
+  try {
+    entries = readdirSync(archiveDir);
+  } catch {
+    return 0;
+  }
+  const candidates = entries
+    .filter((name) => name.startsWith(`${baseName}-`) && name.endsWith('.gz'))
+    .map((name) => {
+      const full = join(archiveDir, name);
+      let mtime = 0;
+      try {
+        mtime = statSync(full).mtimeMs;
+      } catch {
+        // best-effort
+      }
+      return { full, mtime };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+
+  const surplus = candidates.slice(keep);
+  let pruned = 0;
+  for (const entry of surplus) {
+    try {
+      unlinkSync(entry.full);
+      pruned += 1;
+    } catch {
+      // best-effort
+    }
+  }
+  return pruned;
+}
+
+export function maybeRotateLogFile(
+  logPath: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): LogRotationResult {
+  if (logRotationDisabled(rawEnv)) return { rotated: false };
+  if (!existsSync(logPath)) return { rotated: false };
+
+  const size = sizeOfFile(logPath);
+  const threshold = resolveLogRotateBytes(rawEnv);
+  if (size < threshold) return { rotated: false };
+
+  const dir = dirname(logPath);
+  const fileName = basename(logPath);
+  const dotIdx = fileName.lastIndexOf('.');
+  const baseName = dotIdx > 0 ? fileName.slice(0, dotIdx) : fileName;
+  const archiveDir = join(dir, 'archives');
+
+  try {
+    mkdirSync(archiveDir, { recursive: true });
+  } catch {
+    return { rotated: false };
+  }
+
+  const stamp = isoStampForFilename();
+  const finalPath = nextAvailableArchivePath(archiveDir, baseName, stamp);
+  const stagedPath = finalPath.replace(/\.gz$/, '');
+
+  try {
+    renameSync(logPath, stagedPath);
+  } catch {
+    return { rotated: false };
+  }
+
+  try {
+    const data = readFileSync(stagedPath);
+    const gz = gzipSync(data, { level: 6 });
+    writeFileSync(finalPath, gz);
+    unlinkSync(stagedPath);
+  } catch {
+    try {
+      renameSync(stagedPath, logPath);
+    } catch {
+      // staged file is lost; nothing more we can do
+    }
+    return { rotated: false };
+  }
+
+  try {
+    writeFileSync(logPath, '', 'utf8');
+  } catch {
+    // best-effort: a subsequent append will create the file
+  }
+
+  const keep = resolveLogKeepArchives(rawEnv);
+  const prunedArchives = pruneOldArchives(archiveDir, baseName, keep);
+
+  return { rotated: true, archivePath: finalPath, bytesArchived: size, prunedArchives };
+}

--- a/src/infra/logging/log-rotation.ts
+++ b/src/infra/logging/log-rotation.ts
@@ -22,6 +22,16 @@ const MAX_ROTATE_BYTES = 100 * 1024 * 1024;
 const DEFAULT_KEEP_ARCHIVES = 5;
 const MIN_KEEP_ARCHIVES = 1;
 const MAX_KEEP_ARCHIVES = 100;
+// Hard cap on the size we'll feed to readFileSync+gzipSync. The trigger
+// threshold (MEMPHIS_LOG_ROTATE_BYTES) only governs WHEN to rotate; if a
+// pre-existing log was already much larger (older builds without
+// rotation, or after running with MEMPHIS_LOG_ROTATE=disabled), we must
+// not allocate hundreds of MiB synchronously and OOM the operator box
+// before logging initializes. Above this cap rotation is skipped with a
+// stderr hint so operators can compress / truncate manually.
+const DEFAULT_MAX_INPUT_BYTES = 256 * 1024 * 1024;
+const MIN_MAX_INPUT_BYTES = 1024 * 1024;
+const MAX_MAX_INPUT_BYTES = 4 * 1024 * 1024 * 1024;
 
 export function resolveLogRotateBytes(env: NodeJS.ProcessEnv = process.env): number {
   const raw = env.MEMPHIS_LOG_ROTATE_BYTES;
@@ -40,6 +50,16 @@ export function resolveLogKeepArchives(env: NodeJS.ProcessEnv = process.env): nu
   if (!Number.isFinite(parsed)) return DEFAULT_KEEP_ARCHIVES;
   if (parsed < MIN_KEEP_ARCHIVES) return MIN_KEEP_ARCHIVES;
   if (parsed > MAX_KEEP_ARCHIVES) return MAX_KEEP_ARCHIVES;
+  return parsed;
+}
+
+export function resolveLogMaxInputBytes(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES;
+  if (!raw) return DEFAULT_MAX_INPUT_BYTES;
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_MAX_INPUT_BYTES;
+  if (parsed < MIN_MAX_INPUT_BYTES) return MIN_MAX_INPUT_BYTES;
+  if (parsed > MAX_MAX_INPUT_BYTES) return MAX_MAX_INPUT_BYTES;
   return parsed;
 }
 
@@ -132,6 +152,20 @@ export function maybeRotateLogFile(
   const size = sizeOfFile(logPath);
   const threshold = resolveLogRotateBytes(rawEnv);
   if (size < threshold) return { rotated: false };
+
+  const maxInput = resolveLogMaxInputBytes(rawEnv);
+  if (size > maxInput) {
+    try {
+      process.stderr.write(
+        `[memphis] log rotation skipped: ${logPath} is ${size} bytes ` +
+          `(> MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES=${maxInput}); ` +
+          `compress externally (e.g. \`gzip ${logPath}\`) or truncate to recover.\n`,
+      );
+    } catch {
+      // best-effort: never let stderr failure break logger startup
+    }
+    return { rotated: false };
+  }
 
   const dir = dirname(logPath);
   const fileName = basename(logPath);

--- a/src/infra/logging/log-rotation.ts
+++ b/src/infra/logging/log-rotation.ts
@@ -87,7 +87,16 @@ function pruneOldArchives(archiveDir: string, baseName: string, keep: number): n
     return 0;
   }
   const candidates = entries
-    .filter((name) => name.startsWith(`${baseName}-`) && name.endsWith('.gz'))
+    .filter((name) => {
+      if (!name.endsWith('.gz')) return false;
+      const prefix = `${baseName}-`;
+      if (!name.startsWith(prefix)) return false;
+      // After the prefix, the suffix must begin with an ISO date (4-digit
+      // year). Without this guard `baseName="memphis"` would also match
+      // sibling loggers' archives like `memphis-api-2026-…gz` and prune
+      // another logger's history when KEEP is small.
+      return /^\d{4}-\d{2}-\d{2}T/.test(name.slice(prefix.length));
+    })
     .map((name) => {
       const full = join(archiveDir, name);
       let mtime = 0;

--- a/src/infra/logging/log-rotation.ts
+++ b/src/infra/logging/log-rotation.ts
@@ -29,7 +29,13 @@ const MAX_KEEP_ARCHIVES = 100;
 // not allocate hundreds of MiB synchronously and OOM the operator box
 // before logging initializes. Above this cap rotation is skipped with a
 // stderr hint so operators can compress / truncate manually.
-const DEFAULT_MAX_INPUT_BYTES = 256 * 1024 * 1024;
+//
+// Default tightened to 64 MiB: peak heap during gzip is roughly file
+// size + compressed output (~1.1×). 64 MiB → ~75 MiB peak which is safe
+// even on the i3-2120 reference box (1 GiB free). Operators with larger
+// expected logs raise via MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES; the
+// higher-cost streaming path is intentionally not the default.
+const DEFAULT_MAX_INPUT_BYTES = 64 * 1024 * 1024;
 const MIN_MAX_INPUT_BYTES = 1024 * 1024;
 const MAX_MAX_INPUT_BYTES = 4 * 1024 * 1024 * 1024;
 
@@ -106,16 +112,18 @@ function pruneOldArchives(archiveDir: string, baseName: string, keep: number): n
   } catch {
     return 0;
   }
+  // Anchor the WHOLE archive pattern, not just the prefix. The format
+  // written by nextAvailableArchivePath is `${stamp}.gz` or
+  // `${stamp}-${i}.gz` where stamp = ISO-8601 with `:` → `-`. Anchoring
+  // only the prefix matched contrived sibling names like
+  // `memphis-2026-04-25Tfoo.gz` and could prune another logger's
+  // archives in shared `archives/` layouts.
+  const archivePattern = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z(?:-\d+)?\.gz$/;
   const candidates = entries
     .filter((name) => {
-      if (!name.endsWith('.gz')) return false;
       const prefix = `${baseName}-`;
       if (!name.startsWith(prefix)) return false;
-      // After the prefix, the suffix must begin with an ISO date (4-digit
-      // year). Without this guard `baseName="memphis"` would also match
-      // sibling loggers' archives like `memphis-api-2026-…gz` and prune
-      // another logger's history when KEEP is small.
-      return /^\d{4}-\d{2}-\d{2}T/.test(name.slice(prefix.length));
+      return archivePattern.test(name.slice(prefix.length));
     })
     .map((name) => {
       const full = join(archiveDir, name);

--- a/src/infra/logging/pino.ts
+++ b/src/infra/logging/pino.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 
 import pino, { type DestinationStream, type Logger, type LoggerOptions } from 'pino';
 
+import { maybeRotateLogFile } from './log-rotation.js';
+
 /**
  * Registry of every Pino logger created via `createPinoLogger` so that a
  * `LOG_LEVEL` post-apply hook can walk them and update each one's `.level`
@@ -64,6 +66,15 @@ function getFileStream(): DestinationStream | null {
   if (!logPath) {
     sharedFileStream = null;
     return null;
+  }
+  try {
+    // Rotate before opening the destination so a single long-lived
+    // process doesn't grow memphis.log unboundedly across restarts.
+    // sonic-boom holds an open FD; pre-open rotation guarantees the
+    // new process writes to a fresh file.
+    maybeRotateLogFile(logPath);
+  } catch {
+    // best-effort: rotation failure must never block logger startup
   }
   try {
     sharedFileStream = pino.destination({ dest: logPath, sync: false, mkdir: true });

--- a/tests/unit/log-rotation.test.ts
+++ b/tests/unit/log-rotation.test.ts
@@ -75,7 +75,7 @@ describe('maybeRotateLogFile', () => {
     mkdirSync(archiveDir, { recursive: true });
     const now = Date.now();
     for (let i = 0; i < 5; i += 1) {
-      const p = join(archiveDir, `memphis-old-${i}.gz`);
+      const p = join(archiveDir, `memphis-2026-04-2${i}T10-00-00.000Z.gz`);
       writeFileSync(p, Buffer.from([0x1f, 0x8b, 0x08]));
       const t = (now - (5 - i) * 60_000) / 1000;
       utimesSync(p, t, t);
@@ -94,6 +94,45 @@ describe('maybeRotateLogFile', () => {
 
     const remaining = readdirSync(archiveDir).filter((n) => n.endsWith('.gz'));
     expect(remaining.length).toBe(2);
+  });
+
+  it('does not prune sibling loggers archives that share a prefix', () => {
+    // Multiple loggers under the same archives/ dir is a supported layout
+    // (e.g. memphis.log + memphis-api.log). Pruning memphis.log archives
+    // must leave memphis-api-*.gz untouched, otherwise one logger silently
+    // destroys another's retention window.
+    const { logPath, archiveDir } = fixture();
+    mkdirSync(archiveDir, { recursive: true });
+    const now = Date.now();
+
+    for (let i = 0; i < 3; i += 1) {
+      const p = join(archiveDir, `memphis-api-2026-04-2${i}T10-00-00.000Z.gz`);
+      writeFileSync(p, Buffer.from([0x1f, 0x8b, 0x08]));
+      const t = (now - (3 - i) * 60_000) / 1000;
+      utimesSync(p, t, t);
+    }
+    for (let i = 0; i < 4; i += 1) {
+      const p = join(archiveDir, `memphis-2026-04-2${i}T10-00-00.000Z.gz`);
+      writeFileSync(p, Buffer.from([0x1f, 0x8b, 0x08]));
+      const t = (now - (4 - i) * 30_000) / 1000;
+      utimesSync(p, t, t);
+    }
+
+    const line = `${JSON.stringify({ level: 30, msg: 'x' })}\n`;
+    writeFileSync(logPath, line.repeat(3000));
+
+    const env = {
+      ...smallThresholdEnv(),
+      MEMPHIS_LOG_ROTATE_KEEP: '1',
+    } as NodeJS.ProcessEnv;
+    const result = maybeRotateLogFile(logPath, env);
+    expect(result.rotated).toBe(true);
+
+    const remaining = readdirSync(archiveDir).filter((n) => n.endsWith('.gz')).sort();
+    const sibling = remaining.filter((n) => n.startsWith('memphis-api-'));
+    const own = remaining.filter((n) => /^memphis-\d/.test(n));
+    expect(sibling.length).toBe(3);
+    expect(own.length).toBe(1);
   });
 
   it('skips rotation when MEMPHIS_LOG_ROTATE=disabled', () => {

--- a/tests/unit/log-rotation.test.ts
+++ b/tests/unit/log-rotation.test.ts
@@ -1,0 +1,157 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gunzipSync } from 'node:zlib';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  logRotationDisabled,
+  maybeRotateLogFile,
+  resolveLogKeepArchives,
+  resolveLogRotateBytes,
+} from '../../src/infra/logging/log-rotation.js';
+
+function fixture(): { dir: string; logPath: string; archiveDir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'mv4-log-rot-'));
+  const logPath = join(dir, 'memphis.log');
+  const archiveDir = join(dir, 'archives');
+  return { dir, logPath, archiveDir };
+}
+
+function smallThresholdEnv(): NodeJS.ProcessEnv {
+  return { MEMPHIS_LOG_ROTATE_BYTES: String(64 * 1024) } as NodeJS.ProcessEnv;
+}
+
+describe('maybeRotateLogFile', () => {
+  it('is a no-op when the log file does not exist', () => {
+    const { logPath } = fixture();
+    const result = maybeRotateLogFile(logPath, smallThresholdEnv());
+    expect(result.rotated).toBe(false);
+  });
+
+  it('is a no-op when the log is below threshold', () => {
+    const { logPath } = fixture();
+    writeFileSync(logPath, 'tiny\n');
+    const result = maybeRotateLogFile(logPath, smallThresholdEnv());
+    expect(result.rotated).toBe(false);
+  });
+
+  it('rotates a log over threshold and writes a .gz archive', () => {
+    const { logPath, archiveDir } = fixture();
+    const line = `${JSON.stringify({ level: 30, msg: 'x' })}\n`;
+    const bigContent = line.repeat(3000);
+    writeFileSync(logPath, bigContent);
+    expect(statSync(logPath).size).toBeGreaterThan(64 * 1024);
+
+    const result = maybeRotateLogFile(logPath, smallThresholdEnv());
+    expect(result.rotated).toBe(true);
+    expect(result.archivePath).toBeDefined();
+    expect(result.archivePath!.endsWith('.gz')).toBe(true);
+    expect(existsSync(result.archivePath!)).toBe(true);
+
+    const archives = readdirSync(archiveDir).filter((n) => n.endsWith('.gz'));
+    expect(archives.length).toBe(1);
+    expect(archives[0]!.startsWith('memphis-')).toBe(true);
+
+    const decompressed = gunzipSync(readFileSync(result.archivePath!)).toString('utf8');
+    expect(decompressed).toBe(bigContent);
+
+    expect(existsSync(logPath)).toBe(true);
+    expect(readFileSync(logPath, 'utf8')).toBe('');
+  });
+
+  it('prunes old archives keeping only N newest', () => {
+    const { logPath, archiveDir } = fixture();
+    mkdirSync(archiveDir, { recursive: true });
+    const now = Date.now();
+    for (let i = 0; i < 5; i += 1) {
+      const p = join(archiveDir, `memphis-old-${i}.gz`);
+      writeFileSync(p, Buffer.from([0x1f, 0x8b, 0x08]));
+      const t = (now - (5 - i) * 60_000) / 1000;
+      utimesSync(p, t, t);
+    }
+
+    const line = `${JSON.stringify({ level: 30, msg: 'x' })}\n`;
+    writeFileSync(logPath, line.repeat(3000));
+
+    const env = {
+      ...smallThresholdEnv(),
+      MEMPHIS_LOG_ROTATE_KEEP: '2',
+    } as NodeJS.ProcessEnv;
+    const result = maybeRotateLogFile(logPath, env);
+    expect(result.rotated).toBe(true);
+    expect(result.prunedArchives).toBeGreaterThanOrEqual(4);
+
+    const remaining = readdirSync(archiveDir).filter((n) => n.endsWith('.gz'));
+    expect(remaining.length).toBe(2);
+  });
+
+  it('skips rotation when MEMPHIS_LOG_ROTATE=disabled', () => {
+    const { logPath } = fixture();
+    const line = `${JSON.stringify({ level: 30, msg: 'x' })}\n`;
+    writeFileSync(logPath, line.repeat(3000));
+    const env = {
+      ...smallThresholdEnv(),
+      MEMPHIS_LOG_ROTATE: 'disabled',
+    } as NodeJS.ProcessEnv;
+    const result = maybeRotateLogFile(logPath, env);
+    expect(result.rotated).toBe(false);
+    expect(statSync(logPath).size).toBeGreaterThan(64 * 1024);
+  });
+
+  it('clamps rotate-bytes and keep-archives to allowed ranges', () => {
+    expect(
+      resolveLogRotateBytes({ MEMPHIS_LOG_ROTATE_BYTES: '1' } as NodeJS.ProcessEnv),
+    ).toBe(64 * 1024);
+    expect(
+      resolveLogRotateBytes({
+        MEMPHIS_LOG_ROTATE_BYTES: String(10 * 1024 * 1024 * 1024),
+      } as NodeJS.ProcessEnv),
+    ).toBe(100 * 1024 * 1024);
+    expect(resolveLogKeepArchives({ MEMPHIS_LOG_ROTATE_KEEP: '0' } as NodeJS.ProcessEnv)).toBe(1);
+    expect(
+      resolveLogKeepArchives({ MEMPHIS_LOG_ROTATE_KEEP: '500' } as NodeJS.ProcessEnv),
+    ).toBe(100);
+  });
+
+  it('leaves the log untouched when the archive dir cannot be created', () => {
+    const { dir, logPath, archiveDir } = fixture();
+    // Plant a regular file at the exact path mkdirSync would use for the
+    // archive dir; mkdirSync(..., {recursive:true}) raises ENOTDIR and the
+    // rotation must bail out cleanly without renaming the live log.
+    writeFileSync(archiveDir, 'not-a-dir');
+
+    const line = `${JSON.stringify({ level: 30, msg: 'x' })}\n`;
+    const original = line.repeat(3000);
+    writeFileSync(logPath, original);
+
+    const result = maybeRotateLogFile(logPath, smallThresholdEnv());
+    expect(result.rotated).toBe(false);
+    expect(existsSync(logPath)).toBe(true);
+    expect(readFileSync(logPath, 'utf8')).toBe(original);
+    // archiveDir blocker still in place — nothing materialized
+    expect(statSync(archiveDir).isFile()).toBe(true);
+    void dir;
+  });
+
+  it('logRotationDisabled accepts disabled/off/false/0', () => {
+    for (const v of ['disabled', 'off', 'false', '0', 'DISABLED', 'Off']) {
+      expect(logRotationDisabled({ MEMPHIS_LOG_ROTATE: v } as NodeJS.ProcessEnv)).toBe(true);
+    }
+    for (const v of ['enabled', 'on', '1', '', undefined]) {
+      expect(
+        logRotationDisabled({ MEMPHIS_LOG_ROTATE: v as string } as NodeJS.ProcessEnv),
+      ).toBe(false);
+    }
+  });
+});

--- a/tests/unit/log-rotation.test.ts
+++ b/tests/unit/log-rotation.test.ts
@@ -18,6 +18,7 @@ import {
   logRotationDisabled,
   maybeRotateLogFile,
   resolveLogKeepArchives,
+  resolveLogMaxInputBytes,
   resolveLogRotateBytes,
 } from '../../src/infra/logging/log-rotation.js';
 
@@ -135,6 +136,39 @@ describe('maybeRotateLogFile', () => {
     expect(own.length).toBe(1);
   });
 
+  it('skips rotation and warns when log size exceeds MAX_INPUT_BYTES cap', () => {
+    const { logPath } = fixture();
+    const line = `${JSON.stringify({ level: 30, msg: 'x' })}\n`;
+    // The MIN clamp on MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES is 1 MiB, so the
+    // smallest cap the test can effectively configure is 1 MiB. Make the
+    // fixture larger than that so the bail path actually fires.
+    const minCap = 1024 * 1024;
+    const oversized = line.repeat(60_000);
+    writeFileSync(logPath, oversized);
+    expect(statSync(logPath).size).toBeGreaterThan(minCap);
+
+    let captured = '';
+    const origWrite = process.stderr.write.bind(process.stderr);
+    (process.stderr.write as unknown) = (chunk: string | Uint8Array): boolean => {
+      captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+      return true;
+    };
+    let result;
+    try {
+      const env = {
+        ...smallThresholdEnv(),
+        MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES: String(minCap),
+      } as NodeJS.ProcessEnv;
+      result = maybeRotateLogFile(logPath, env);
+    } finally {
+      (process.stderr.write as unknown) = origWrite;
+    }
+    expect(result!.rotated).toBe(false);
+    expect(statSync(logPath).size).toBeGreaterThan(minCap);
+    expect(captured).toContain('log rotation skipped');
+    expect(captured).toContain('MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES');
+  });
+
   it('skips rotation when MEMPHIS_LOG_ROTATE=disabled', () => {
     const { logPath } = fixture();
     const line = `${JSON.stringify({ level: 30, msg: 'x' })}\n`;
@@ -161,6 +195,14 @@ describe('maybeRotateLogFile', () => {
     expect(
       resolveLogKeepArchives({ MEMPHIS_LOG_ROTATE_KEEP: '500' } as NodeJS.ProcessEnv),
     ).toBe(100);
+    expect(
+      resolveLogMaxInputBytes({ MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES: '1' } as NodeJS.ProcessEnv),
+    ).toBe(1024 * 1024);
+    expect(
+      resolveLogMaxInputBytes({
+        MEMPHIS_LOG_ROTATE_MAX_INPUT_BYTES: String(100 * 1024 * 1024 * 1024),
+      } as NodeJS.ProcessEnv),
+    ).toBe(4 * 1024 * 1024 * 1024);
   });
 
   it('leaves the log untouched when the archive dir cannot be created', () => {

--- a/tests/unit/log-rotation.test.ts
+++ b/tests/unit/log-rotation.test.ts
@@ -97,6 +97,48 @@ describe('maybeRotateLogFile', () => {
     expect(remaining.length).toBe(2);
   });
 
+  it('ignores files matching the date-prefix but not the full ISO archive pattern', () => {
+    // The original prefix-only anchor (^\d{4}-\d{2}-\d{2}T) matched
+    // contrived sibling filenames like `memphis-2026-04-25Tfoo.gz`. The
+    // tightened pattern requires the full ISO timestamp + .gz tail,
+    // closing that escape hatch.
+    const { logPath, archiveDir } = fixture();
+    mkdirSync(archiveDir, { recursive: true });
+    const now = Date.now();
+
+    // Decoy that LOOKS like ours by date prefix but isn't a real archive.
+    const decoy = join(archiveDir, 'memphis-2026-04-25Tfoo.gz');
+    writeFileSync(decoy, Buffer.from([0x1f, 0x8b, 0x08]));
+    utimesSync(decoy, (now - 600_000) / 1000, (now - 600_000) / 1000);
+
+    // Real own archives.
+    for (let i = 0; i < 3; i += 1) {
+      const p = join(archiveDir, `memphis-2026-04-2${i}T10-00-00.000Z.gz`);
+      writeFileSync(p, Buffer.from([0x1f, 0x8b, 0x08]));
+      const t = (now - (3 - i) * 30_000) / 1000;
+      utimesSync(p, t, t);
+    }
+
+    const line = `${JSON.stringify({ level: 30, msg: 'x' })}\n`;
+    writeFileSync(logPath, line.repeat(3000));
+
+    const env = {
+      ...smallThresholdEnv(),
+      MEMPHIS_LOG_ROTATE_KEEP: '1',
+    } as NodeJS.ProcessEnv;
+    const result = maybeRotateLogFile(logPath, env);
+    expect(result.rotated).toBe(true);
+
+    const remaining = readdirSync(archiveDir).filter((n) => n.endsWith('.gz')).sort();
+    // Decoy must survive: not a real archive, regex no longer matches.
+    expect(remaining).toContain('memphis-2026-04-25Tfoo.gz');
+    // Real archives: only the newest 1 of (3 pre-existing + 1 just-rotated) survives.
+    const real = remaining.filter((n) =>
+      /^memphis-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z(?:-\d+)?\.gz$/.test(n),
+    );
+    expect(real.length).toBe(1);
+  });
+
   it('does not prune sibling loggers archives that share a prefix', () => {
     // Multiple loggers under the same archives/ dir is a supported layout
     // (e.g. memphis.log + memphis-api.log). Pruning memphis.log archives


### PR DESCRIPTION
## Summary

- **Pino destination rotation** — `getFileStream()` now calls `maybeRotateLogFile()` immediately before opening `pino.destination()`. If `~/.memphis/logs/memphis.log` exceeds the threshold, it is renamed, gzipped into `archives/memphis-<iso>.gz`, and the live log is reset to empty. Sonic-boom races avoided by rotating pre-open: each restart writes to a fresh inode.
- **Tunable** via `MEMPHIS_LOG_ROTATE_BYTES` (default 10 MiB, clamped to 64 KiB–100 MiB to keep `gzipSync` heap bounded), `MEMPHIS_LOG_ROTATE_KEEP` (default 5, clamped 1–100), and `MEMPHIS_LOG_ROTATE=disabled` opt-out. Rotation failures are swallowed best-effort and never block logger startup.
- **Behavior change** — operator boxes will see a new `~/.memphis/logs/archives/` directory created on the first rotation after upgrade. Existing oversized `memphis.log` files are rotated automatically on next restart. Opt out with `MEMPHIS_LOG_ROTATE=disabled` if archives are managed externally.
- **Why** — `memphis.log` had no rotation; on a long-running operator box the file grew to 36 MiB after ~13 days, degrading every process that scans/tails it. Pattern mirrors the existing `audit-rotation.ts` (5 MiB threshold for `security-audit.jsonl`) for consistency.
- **Cross-process caveat** — documented in `CONFIGURATION.md`: run a single runtime per `MEMPHIS_LOG_FILE`, since `renameSync` on a file held open by another process produces a partial-flush archive on Linux.

## Test plan

- [x] `npx vitest run tests/unit/log-rotation.test.ts` — **8/8 pass** (no-op below threshold; no-op on missing file; rotate + gzip roundtrip; mtime-based pruning to N newest; `MEMPHIS_LOG_ROTATE=disabled` opt-out; clamp `BYTES`/`KEEP` to allowed range; `logRotationDisabled` parser case-insensitive; `renameSync`/`mkdirSync` failure leaves live log untouched).
- [x] Adjacent logger sweep — `tests/unit/{audit-rotation,audit-rotation-collision,logger,logger-hot-swap,logger-serialization,contextual-logger,missing-handlers-and-hotswap}.test.ts` — **36/36 still pass** (44/44 total across the logger surface).
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npm run lint` — 0 errors on this PR's files (the 18 pre-existing warnings live in unrelated `consent-mark.test.ts` + `kartograf-cli.test.ts` files and are out of scope).
- [ ] Manual operator-box smoke: restart `memphis.service` on a box where `memphis.log > 10 MiB`, verify `archives/memphis-<iso>.gz` is created and `memphis.log` reset to 0 bytes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
