### PR TITLE
feat(cli): memphis tier status — unified view across surfaces

### DIFF
--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -256,6 +256,21 @@ workflow:
 
 ---
 
+### tier
+
+Read-only inspection of tier-3 elevation sessions across surfaces (TUI, Telegram, Matrix, HTTP). Tier-3 sessions are minted by `/tier 3 <pass>` slash commands inside TUI/Telegram and grant 3-hour permission elevation (unrestricted FS, sudo, autonomy=full); this command does NOT mint or revoke sessions, only enumerates active ones.
+
+syntax: `memphis tier <status> [--json]`
+
+workflow:
+
+- `tier status`: Human-readable list of active sessions with surface, actorId, granted/expires timestamps, and remaining time.
+- `tier status --json`: Machine-readable JSON `{ ok, count, sessions[], asOf }` for scripting.
+
+The command queries the daemon at `http://${HOST}:${PORT}/v1/ops/tier3/sessions` (auth-token gated). If the daemon is not running, the command surfaces an actionable error including the systemctl start hint.
+
+---
+
 ## Chain
 
 ### chain import_json

--- a/src/infra/cli/handlers/tier.handler.ts
+++ b/src/infra/cli/handlers/tier.handler.ts
@@ -1,0 +1,142 @@
+/**
+ * `memphis tier` — read-only inspection of tier-3 elevation sessions.
+ *
+ * Tier-3 sessions live in the daemon's in-process Map
+ * (`src/security/tier3-session.ts:39 sessions`). The CLI is a separate
+ * node process from `memphis serve`, so it cannot read that Map directly.
+ * This handler queries the new `GET /v1/ops/tier3/sessions` HTTP endpoint
+ * and renders human or JSON output.
+ *
+ * Subcommands (forward-compat — only `status` today):
+ *   memphis tier                 # alias for status
+ *   memphis tier status          # human format
+ *   memphis tier status --json   # JSON format
+ *
+ * Surfaced after a 2026-04-26 operator session where there was no way to
+ * see "which surfaces have an active tier-3 session right now" without
+ * digging through the audit chain.
+ */
+
+import type { CommandHandler } from './command-handler.js';
+import type { CliContext } from '../context.js';
+
+interface Tier3SessionSnapshot {
+  surface: string;
+  actorId: string;
+  grantedAt: string;
+  expiresAt: string;
+  remainingMs: number;
+}
+
+interface Tier3SessionsResponse {
+  ok: boolean;
+  count: number;
+  sessions: Tier3SessionSnapshot[];
+  asOf: string;
+}
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return 'expired';
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h${String(m).padStart(2, '0')}m${String(s).padStart(2, '0')}s`;
+  if (m > 0) return `${m}m${String(s).padStart(2, '0')}s`;
+  return `${s}s`;
+}
+
+function renderHuman(payload: Tier3SessionsResponse): string {
+  const lines: string[] = [];
+  lines.push(`Tier-3 sessions: ${payload.count} active`);
+  for (const s of payload.sessions) {
+    lines.push(`  [${s.surface}:${s.actorId}]`);
+    lines.push(`    granted:    ${s.grantedAt}`);
+    lines.push(`    expires:    ${s.expiresAt} (in ${formatRemaining(s.remainingMs)})`);
+    lines.push(`    surface:    ${s.surface}`);
+    lines.push(`    actorId:    ${s.actorId}`);
+  }
+  if (payload.count === 0) {
+    lines.push('  (no active sessions — use TUI or Telegram /tier 3 <pass> to elevate)');
+  }
+  return lines.join('\n');
+}
+
+async function handleTierStatus(context: CliContext): Promise<boolean> {
+  const config = context.getConfig();
+  const url = `http://${config.HOST}:${config.PORT}/v1/ops/tier3/sessions`;
+  const token = config.MEMPHIS_API_TOKEN;
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, { headers });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === 'ECONNREFUSED' || (error as Error)?.message?.includes('ECONNREFUSED')) {
+      console.error(
+        'Tier-3 status unavailable — Memphis daemon is not running.\n' +
+          'Start it with: systemctl --user start memphis (or: memphis serve)',
+      );
+      return true;
+    }
+    console.error(
+      `Failed to reach daemon at ${url}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return true;
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    console.error(
+      `Unauthorized (${response.status}) — check MEMPHIS_API_TOKEN matches the daemon value.\n` +
+        'The token is read from .env at the install root; the daemon reads the same file.',
+    );
+    return true;
+  }
+
+  if (!response.ok) {
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      /* swallow */
+    }
+    console.error(`Daemon returned ${response.status}: ${body || '(empty body)'}`);
+    return true;
+  }
+
+  let payload: Tier3SessionsResponse;
+  try {
+    payload = (await response.json()) as Tier3SessionsResponse;
+  } catch (error) {
+    console.error(
+      `Daemon returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return true;
+  }
+
+  if (context.args.json) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    console.log(renderHuman(payload));
+  }
+  return true;
+}
+
+async function handleTierCommand(context: CliContext): Promise<boolean> {
+  const sub = context.args.subcommand;
+  if (sub === 'status' || !sub) {
+    return handleTierStatus(context);
+  }
+  console.error(`Unknown tier subcommand: ${sub}`);
+  console.error('Usage: memphis tier <status>');
+  return true;
+}
+
+export const tierCommandHandler: CommandHandler = {
+  name: 'tier',
+  commands: ['tier'],
+  canHandle: (context: CliContext) => context.args.command === 'tier',
+  handle: handleTierCommand,
+};

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -195,6 +195,11 @@ export const CLI_COMMAND_REGISTRY = [
     ),
   ),
   createCommandRegistration(
+    'tier',
+    ['tier'],
+    createLazyHandlerLoader(() => import('./handlers/tier.handler.js'), 'tierCommandHandler'),
+  ),
+  createCommandRegistration(
     'evolve',
     ['evolve'],
     createLazyHandlerLoader(() => import('./handlers/evolve.handler.js'), 'evolveCommandHandler'),
@@ -285,6 +290,7 @@ export const CLI_COMPLETION_COMMANDS = [
   'kill-zombies',
   'onboarding',
   'operator',
+  'tier',
   'evolve',
   'secret',
   'telegram',

--- a/src/infra/http/auth-policy.ts
+++ b/src/infra/http/auth-policy.ts
@@ -11,6 +11,7 @@ export const apiAuthPolicy: EndpointAuthPolicy[] = [
   { method: 'GET', path: '/v1/providers/health', requiresAuth: false },
   { method: 'GET', path: '/v1/metrics', requiresAuth: true },
   { method: 'GET', path: '/v1/ops/status', requiresAuth: true },
+  { method: 'GET', path: '/v1/ops/tier3/sessions', requiresAuth: true },
   { method: 'GET', path: '/v1/sessions', requiresAuth: true },
   { method: 'GET', path: '/v1/sessions/:sessionId/events', requiresAuth: true },
   { method: 'GET', path: '/v1/chat/dispatch/:workId', requiresAuth: true },

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -670,6 +670,34 @@ export function createHttpServer(
     };
   });
 
+  // GET /v1/ops/tier3/sessions — read-only enumeration of active tier-3
+  // sessions across surfaces (telegram / tui / matrix / http / cli).
+  //
+  // Reads the in-process sessions map from src/security/tier3-session.ts.
+  // Side effect on read: expired sessions are evicted and audited
+  // (mirrors getActiveTier3Session's lazy-eviction policy).
+  //
+  // Feeds `memphis tier status` and `memphis tier status --json`. CLI
+  // is a separate process from the daemon so the only way to see this
+  // state is over HTTP.
+  app.get('/v1/ops/tier3/sessions', async () => {
+    const { listActiveTier3Sessions } = await import('../../security/tier3-session.js');
+    const now = Date.now();
+    const sessions = listActiveTier3Sessions(process.env).map((s) => ({
+      surface: s.surface,
+      actorId: s.actorId,
+      grantedAt: new Date(s.grantedAt).toISOString(),
+      expiresAt: new Date(s.expiresAt).toISOString(),
+      remainingMs: Math.max(0, s.expiresAt - now),
+    }));
+    return {
+      ok: true,
+      count: sessions.length,
+      sessions,
+      asOf: new Date(now).toISOString(),
+    };
+  });
+
   // GET /v1/ops/config/show — redacted view of the current hot-reloadable env
   // surface + field classification. Never echoes secret values.
   //

--- a/src/security/tier3-session.ts
+++ b/src/security/tier3-session.ts
@@ -246,6 +246,53 @@ export function hasAnyActiveTier3Session(rawEnv: NodeJS.ProcessEnv = process.env
 }
 
 /**
+ * Snapshot of every currently-active tier-3 session in this process.
+ *
+ * Side effect: evicts (and audits) any session whose deadline has passed,
+ * matching the behavior of `getActiveTier3Session` and
+ * `hasAnyActiveTier3Session` for individual reads.
+ *
+ * Used by the HTTP `/v1/ops/tier3/sessions` endpoint to feed the
+ * `memphis tier status` CLI. Not intended for routing/policy decisions —
+ * those should go through `getActiveTier3Session(surface, actorId)`.
+ */
+export function listActiveTier3Sessions(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): Tier3Session[] {
+  const current = now();
+  const active: Tier3Session[] = [];
+  // Two-phase to keep audit-log emission idempotent: first collect alive
+  // and dead, then evict + audit dead. Mirrors hasAnyActiveTier3Session's
+  // delete-and-audit shape but enumerates everything before returning so
+  // the caller sees a stable snapshot.
+  const expired: Array<[string, Tier3Session]> = [];
+  for (const [key, session] of sessions) {
+    if (session.expiresAt > current) {
+      active.push(session);
+    } else {
+      expired.push([key, session]);
+    }
+  }
+  for (const [key, session] of expired) {
+    sessions.delete(key);
+    writeSecurityAudit(
+      {
+        action: 'tier3-expire',
+        status: 'allowed',
+        details: {
+          surface: session.surface,
+          actorId: session.actorId,
+          grantedAt: new Date(session.grantedAt).toISOString(),
+          expiredAt: new Date(session.expiresAt).toISOString(),
+        },
+      },
+      rawEnv,
+    );
+  }
+  return active;
+}
+
+/**
  * Build the rawEnv overrides that should be merged into turn-runtime
  * processing when a tier-3 session is active. Returns an empty object if
  * no session is active.

--- a/tests/unit/cli.tier.handler.test.ts
+++ b/tests/unit/cli.tier.handler.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for `memphis tier status` CLI handler.
+ *
+ * The handler queries the daemon over HTTP (sessions live in the daemon's
+ * in-process Map), so we mock global `fetch` to drive every code path
+ * without standing up a real server.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CliContext } from '../../src/infra/cli/context.js';
+import { tierCommandHandler } from '../../src/infra/cli/handlers/tier.handler.js';
+
+interface ConsoleSpy {
+  log: ReturnType<typeof vi.spyOn>;
+  error: ReturnType<typeof vi.spyOn>;
+}
+
+let consoleSpy: ConsoleSpy;
+
+beforeEach(() => {
+  consoleSpy = {
+    log: vi.spyOn(console, 'log').mockImplementation(() => undefined),
+    error: vi.spyOn(console, 'error').mockImplementation(() => undefined),
+  };
+});
+
+afterEach(() => {
+  consoleSpy.log.mockRestore();
+  consoleSpy.error.mockRestore();
+  vi.restoreAllMocks();
+});
+
+function buildContext(opts: {
+  json?: boolean;
+  subcommand?: string;
+  token?: string;
+} = {}): CliContext {
+  return {
+    argv: [],
+    args: {
+      command: 'tier',
+      subcommand: opts.subcommand ?? 'status',
+      json: opts.json ?? false,
+    } as CliContext['args'],
+    getConfig: () =>
+      ({
+        HOST: '127.0.0.1',
+        PORT: 3100,
+        MEMPHIS_API_TOKEN: opts.token ?? 'test-token',
+      }) as ReturnType<CliContext['getConfig']>,
+    getContainer: () => ({}) as ReturnType<CliContext['getContainer']>,
+  };
+}
+
+function mockFetchResolve(payload: unknown, status = 200): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify(payload), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+}
+
+function mockFetchReject(error: Error): void {
+  vi.stubGlobal('fetch', vi.fn(async () => Promise.reject(error)));
+}
+
+describe('memphis tier status', () => {
+  it('prints human-format output with empty sessions list', async () => {
+    mockFetchResolve({
+      ok: true,
+      count: 0,
+      sessions: [],
+      asOf: '2026-04-26T12:00:00.000Z',
+    });
+
+    await tierCommandHandler.handle(buildContext());
+
+    const output = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Tier-3 sessions: 0 active');
+    expect(output).toContain('(no active sessions');
+  });
+
+  it('prints human-format output with one populated session', async () => {
+    mockFetchResolve({
+      ok: true,
+      count: 1,
+      sessions: [
+        {
+          surface: 'telegram',
+          actorId: '1316033647',
+          grantedAt: '2026-04-26T11:30:00.000Z',
+          expiresAt: '2026-04-26T14:30:00.000Z',
+          remainingMs: 6420000,
+        },
+      ],
+      asOf: '2026-04-26T12:43:00.000Z',
+    });
+
+    await tierCommandHandler.handle(buildContext());
+
+    const output = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Tier-3 sessions: 1 active');
+    expect(output).toContain('[telegram:1316033647]');
+    expect(output).toContain('granted:');
+    expect(output).toContain('expires:');
+    expect(output).toContain('1h47m'); // 6420000ms ≈ 1h47m
+  });
+
+  it('--json flag emits parseable JSON with the expected shape', async () => {
+    const payload = {
+      ok: true,
+      count: 1,
+      sessions: [
+        {
+          surface: 'tui',
+          actorId: 'local',
+          grantedAt: '2026-04-26T13:00:00.000Z',
+          expiresAt: '2026-04-26T16:00:00.000Z',
+          remainingMs: 10800000,
+        },
+      ],
+      asOf: '2026-04-26T13:00:01.000Z',
+    };
+    mockFetchResolve(payload);
+
+    await tierCommandHandler.handle(buildContext({ json: true }));
+
+    const output = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({
+      ok: true,
+      count: 1,
+      sessions: [{ surface: 'tui', actorId: 'local' }],
+    });
+  });
+
+  it('surfaces actionable error when daemon refuses connection', async () => {
+    const err = new Error('fetch failed: connect ECONNREFUSED 127.0.0.1:3100');
+    mockFetchReject(err);
+
+    await tierCommandHandler.handle(buildContext());
+
+    const errOutput = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(errOutput).toContain('Memphis daemon is not running');
+    expect(errOutput).toContain('systemctl --user start memphis');
+  });
+
+  it('maps 401 response to "check MEMPHIS_API_TOKEN" message', async () => {
+    mockFetchResolve({ ok: false }, 401);
+
+    await tierCommandHandler.handle(buildContext());
+
+    const errOutput = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(errOutput).toContain('Unauthorized (401)');
+    expect(errOutput).toContain('MEMPHIS_API_TOKEN');
+  });
+
+  it('rejects unknown subcommand with usage hint', async () => {
+    await tierCommandHandler.handle(buildContext({ subcommand: 'bogus' }));
+
+    const errOutput = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(errOutput).toContain('Unknown tier subcommand: bogus');
+    expect(errOutput).toContain('Usage: memphis tier <status>');
+  });
+});

--- a/tests/unit/tier3-session.test.ts
+++ b/tests/unit/tier3-session.test.ts
@@ -20,11 +20,13 @@ import {
 } from '../../src/infra/auth/operator-gate.js';
 import {
   __resetTier3SessionsForTests,
+  __seedTier3SessionForTests,
   TIER_3_TTL_MS,
   buildTier3EnvOverride,
   getActiveTier3Session,
   getTier3RemainingMs,
   hasAnyActiveTier3Session,
+  listActiveTier3Sessions,
   requestTier3Elevation,
   revokeTier3Session,
 } from '../../src/security/tier3-session.js';
@@ -325,5 +327,43 @@ describe('buildTier3EnvOverride', () => {
       MEMPHIS_AUTONOMY_MODE: 'full',
       MEMPHIS_TIER3_FS_UNRESTRICTED: 'true',
     });
+  });
+});
+
+describe('listActiveTier3Sessions', () => {
+  it('returns empty array when no sessions are seeded', () => {
+    expect(listActiveTier3Sessions(testEnv)).toEqual([]);
+  });
+
+  it('returns one entry per seeded session across surfaces', () => {
+    __seedTier3SessionForTests('telegram', '1316033647');
+    __seedTier3SessionForTests('tui', 'local');
+    const result = listActiveTier3Sessions(testEnv);
+    expect(result).toHaveLength(2);
+    const surfaces = result.map((s) => s.surface).sort();
+    expect(surfaces).toEqual(['telegram', 'tui']);
+  });
+
+  it('evicts expired sessions on read and audits each eviction once', () => {
+    vi.useFakeTimers();
+    const start = new Date('2026-04-13T10:00:00Z').getTime();
+    vi.setSystemTime(start);
+
+    __seedTier3SessionForTests('telegram', 'a', 1000);
+    __seedTier3SessionForTests('tui', 'b', TIER_3_TTL_MS);
+
+    vi.setSystemTime(start + 5000); // first session expired, second still alive
+    const result = listActiveTier3Sessions(testEnv);
+    expect(result).toHaveLength(1);
+    expect(result[0].surface).toBe('tui');
+
+    const expireEvents = readAuditLines().filter((e) => e.action === 'tier3-expire');
+    expect(expireEvents).toHaveLength(1);
+    expect(expireEvents[0].details?.surface).toBe('telegram');
+
+    // Second call must NOT re-audit the same eviction (idempotency).
+    listActiveTier3Sessions(testEnv);
+    const expireAgain = readAuditLines().filter((e) => e.action === 'tier3-expire');
+    expect(expireAgain).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Adds read-only inspection of tier-3 elevation sessions across surfaces (telegram / tui / matrix / http / cli) via a new CLI command and HTTP endpoint. Companion to **#281** (system-prompt tier-3 clarification).

## Why

Surfaced after a 2026-04-26 operator session: tier-3 elevation worked from TUI and Telegram, but there was no way to ask _"which surfaces have an active session right now?"_ without grepping the audit chain. The events are all there, but reading them is several steps and noisy.

## Changes

- **`src/security/tier3-session.ts`** — new exported `listActiveTier3Sessions(rawEnv)`. Two-phase: collect alive + expired, evict expired with one audit each, return alive snapshot. Mirrors lazy-eviction policy of `getActiveTier3Session` / `hasAnyActiveTier3Session`.
- **`src/infra/http/server.ts`** — new `GET /v1/ops/tier3/sessions` adjacent to `/v1/ops/status`. Returns `{ ok, count, sessions: [{surface, actorId, grantedAt, expiresAt, remainingMs}], asOf }`. Read-only; no body.
- **`src/infra/http/auth-policy.ts`** — new policy row gating the endpoint behind `MEMPHIS_API_TOKEN`.
- **`src/infra/cli/handlers/tier.handler.ts`** (new) — CLI handler with `status` subcommand (default). Fetches the endpoint, prints human format by default or `--json`. Error handling: ECONNREFUSED → _"Memphis daemon is not running"_, 401/403 → _"check MEMPHIS_API_TOKEN"_.
- **`src/infra/cli/registry.ts`** — register tier handler + add to `CLI_COMPLETION_COMMANDS`.
- **`CLI_COMMANDS.md`** — documented next to `secret`/`vault`.

## Output formats

**Human:**
```
Tier-3 sessions: 1 active
  [telegram:1316033647]
    granted:    2026-04-26T11:30:00Z
    expires:    2026-04-26T14:30:00Z (in 1h47m00s)
    surface:    telegram
    actorId:    1316033647
```

**JSON (`--json`):**
```json
{
  "ok": true,
  "count": 1,
  "sessions": [{
    "surface": "telegram",
    "actorId": "1316033647",
    "grantedAt": "2026-04-26T11:30:00Z",
    "expiresAt": "2026-04-26T14:30:00Z",
    "remainingMs": 6420000
  }],
  "asOf": "2026-04-26T12:43:00Z"
}
```

## Coverage

- 3 new cases in `tests/unit/tier3-session.test.ts` for `listActiveTier3Sessions` (empty, multi-surface, evict-on-read idempotency)
- 6 cases in `tests/unit/cli.tier.handler.test.ts` (empty, populated, `--json`, ECONNREFUSED, 401, unknown subcommand)
- 21 tier-related cases total green

## Test plan

- [ ] `npx vitest run tests/unit/tier3-session.test.ts tests/unit/cli.tier.handler.test.ts` — 21 green
- [ ] `npm run typecheck` — clean
- [ ] Manual (post-merge + daemon restart): `memphis tier status` → `count: 0`. In another terminal: TUI `/tier 3 <pass>` or Telegram `/tier 3 <pass>`. Re-run → 1 session shown with remaining time.
- [ ] Negative: stop daemon → `memphis tier status` shows actionable "daemon not running" message.

## Forward-compat

`tier` command starts with one subcommand `status`. Future `tier revoke` etc. plug into the same dispatch. Out of scope for this PR.

## Related

- **#281** — system-prompt tier-3 clarification. The new prompt block forward-references this command. Either order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)