### PR TITLE
feat(tools): wire 7 registered-but-unwired tools (S1)

### DIFF
--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -17,6 +17,12 @@ import { runMemphisBuild } from '../mcp/tools/build.js';
 import { runMemphisCaseAppend, runMemphisCaseQuery } from '../mcp/tools/case-entry.js';
 import { runMemphisChainQuery } from '../mcp/tools/chain-query.js';
 import { runMemphisCodeRead } from '../mcp/tools/code-read.js';
+import {
+  runMemphisCognitiveModeSet,
+  runMemphisConfigReload,
+  runMemphisConfigSet,
+  runMemphisConfigShow,
+} from '../mcp/tools/config.js';
 import { runMemphisCron } from '../mcp/tools/cron.js';
 import { runMemphisDb } from '../mcp/tools/db.js';
 import { runMemphisDecide } from '../mcp/tools/decide.js';
@@ -30,10 +36,13 @@ import { runMemphisGrep } from '../mcp/tools/grep.js';
 import { runMemphisHealthCheck } from '../mcp/tools/health-check.js';
 import { runMemphisHealth } from '../mcp/tools/health.js';
 import { runMemphisJournal } from '../mcp/tools/journal.js';
+import { runMemphisLoopStep } from '../mcp/tools/loop-step.js';
 import { runMemphisPackage } from '../mcp/tools/package.js';
+import { runMemphisPresence } from '../mcp/tools/presence.js';
 import { runMemphisProviders } from '../mcp/tools/providers.js';
 import { runMemphisRecall } from '../mcp/tools/recall.js';
 import { runMemphisRepair } from '../mcp/tools/repair.js';
+import { runMemphisRestart } from '../mcp/tools/restart.js';
 import { runMemphisSearch } from '../mcp/tools/search.js';
 import { runMemphisSelfModify } from '../mcp/tools/self-modify.js';
 import { runMemphisSoulRead, runMemphisSoulWrite } from '../mcp/tools/soul.js';
@@ -959,6 +968,167 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       },
       async execute(input) {
         return runMemphisHealthCheck(input);
+      },
+    }),
+    // ─────────────────────────────────────────────────────────────────
+    // S1 (sprint 2026-04-26): wire 7 tools that lived only as MCP tools.
+    // Each thin-wraps the existing `runMemphis*` function from src/mcp/tools/.
+    // The runtime path (TUI / Telegram / chat / CLI) now sees them too.
+    //
+    // Design note: keep these as JSON.stringify(returnValue) — the runtime
+    // contract for `execute(input): Promise<string>` requires a string, and
+    // the MCP helpers return structured objects.
+    // ─────────────────────────────────────────────────────────────────
+    buildTool({
+      name: 'memphis_config_show',
+      description: 'Show current runtime config (redacted view of hot-reloadable env)',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', description: 'Optional single config key to inspect' },
+        },
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput(args) {
+        return { key: optionalString(args, 'key') };
+      },
+      async execute(input) {
+        return JSON.stringify(runMemphisConfigShow(input));
+      },
+    }),
+    buildTool({
+      name: 'memphis_config_set',
+      description:
+        'Set a single config key/value. Cold fields refuse; secret fields require operator passphrase.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', description: 'Config key (must be in known-fields whitelist)' },
+          value: { type: 'string', description: 'New value' },
+          passphrase: { type: 'string', description: 'Operator passphrase if key is secret' },
+        },
+        required: ['key', 'value'],
+      },
+      isReadOnly: false,
+      validateInput(args) {
+        return {
+          key: requiredString(args, 'key'),
+          value: requiredString(args, 'value'),
+          passphrase: optionalString(args, 'passphrase'),
+        };
+      },
+      async execute(input) {
+        return JSON.stringify(runMemphisConfigSet(input));
+      },
+    }),
+    buildTool({
+      name: 'memphis_config_reload',
+      description: 'Re-read .env and hot-swap mutable fields (cold fields refuse — restart needed)',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+      isReadOnly: false,
+      validateInput() {
+        return {};
+      },
+      async execute() {
+        return JSON.stringify(await runMemphisConfigReload());
+      },
+    }),
+    buildTool({
+      name: 'memphis_cognitive_mode_set',
+      description:
+        'Switch cognitive mode (A–E: ConsciousCapture / InferredDecisions / PredictivePatterns / CollectiveCoord / MetaCognitiveRef). Requires operator passphrase.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          mode: { type: 'string', description: 'Target mode: A | B | C | D | E' },
+          passphrase: { type: 'string', description: 'Operator passphrase' },
+        },
+        required: ['mode'],
+      },
+      isReadOnly: false,
+      validateInput(args) {
+        return {
+          mode: requiredString(args, 'mode'),
+          passphrase: optionalString(args, 'passphrase'),
+        };
+      },
+      async execute(input) {
+        return JSON.stringify(await runMemphisCognitiveModeSet(input));
+      },
+    }),
+    buildTool({
+      name: 'memphis_presence',
+      description: 'Cross-surface presence snapshot (TUI / Telegram / HTTP / CLI activity)',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput() {
+        return {};
+      },
+      async execute() {
+        return JSON.stringify(runMemphisPresence());
+      },
+    }),
+    buildTool({
+      name: 'memphis_loop_step',
+      description:
+        'Cognitive loop enforcement step (Rust LoopEngine via NAPI, TS fallback if bridge unavailable)',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          state: { type: 'object', description: 'Current loop state' },
+          action: { type: 'object', description: 'Proposed action' },
+          limits: { type: 'object', description: 'Optional override limits' },
+        },
+        required: ['state', 'action'],
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput(args) {
+        return {
+          state: requiredRecord(args, 'state'),
+          action: requiredRecord(args, 'action'),
+          limits: args.limits as Record<string, unknown> | undefined,
+        };
+      },
+      async execute(input) {
+        return JSON.stringify(
+          runMemphisLoopStep(
+            input as unknown as Parameters<typeof runMemphisLoopStep>[0],
+          ),
+        );
+      },
+    }),
+    buildTool({
+      name: 'memphis_restart',
+      description:
+        'Request a self-restart of the Memphis daemon. Requires operator passphrase (no per-surface tier-3 session is minted via tools).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          reason: { type: 'string', description: 'Reason for the restart (audited)' },
+          actor_id: { type: 'string', description: 'Actor identifier (audit context)' },
+          passphrase: { type: 'string', description: 'Operator passphrase' },
+        },
+      },
+      isReadOnly: false,
+      isDestructive: true,
+      validateInput(args) {
+        return {
+          reason: optionalString(args, 'reason'),
+          actor_id: optionalString(args, 'actor_id'),
+          passphrase: optionalString(args, 'passphrase'),
+        };
+      },
+      async execute(input) {
+        return JSON.stringify(await runMemphisRestart(input));
       },
     }),
   ];

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -994,7 +994,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         return { key: optionalString(args, 'key') };
       },
       async execute(input) {
-        return JSON.stringify(runMemphisConfigShow(input));
+        return runMemphisConfigShow(input);
       },
     }),
     buildTool({
@@ -1012,14 +1012,22 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       },
       isReadOnly: false,
       validateInput(args) {
+        const value = args.value;
+        if (typeof value !== 'string') {
+          throw new AppError('VALIDATION_ERROR', 'tool value must be a string', 400);
+        }
         return {
           key: requiredString(args, 'key'),
-          value: requiredString(args, 'value'),
+          // empty string is intentionally allowed — the LLM uses
+          // `memphis_config_set { key: 'X', value: '' }` to clear a
+          // mutable config field. requiredString rejected those; field
+          // validation lives in runMemphisConfigSet itself.
+          value,
           passphrase: optionalString(args, 'passphrase'),
         };
       },
       async execute(input) {
-        return JSON.stringify(runMemphisConfigSet(input));
+        return runMemphisConfigSet(input);
       },
     }),
     buildTool({
@@ -1034,7 +1042,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         return {};
       },
       async execute() {
-        return JSON.stringify(await runMemphisConfigReload());
+        return runMemphisConfigReload();
       },
     }),
     buildTool({
@@ -1057,7 +1065,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         };
       },
       async execute(input) {
-        return JSON.stringify(await runMemphisCognitiveModeSet(input));
+        return runMemphisCognitiveModeSet(input);
       },
     }),
     buildTool({
@@ -1073,7 +1081,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         return {};
       },
       async execute() {
-        return JSON.stringify(runMemphisPresence());
+        return runMemphisPresence();
       },
     }),
     buildTool({
@@ -1099,10 +1107,8 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         };
       },
       async execute(input) {
-        return JSON.stringify(
-          runMemphisLoopStep(
-            input as unknown as Parameters<typeof runMemphisLoopStep>[0],
-          ),
+        return runMemphisLoopStep(
+          input as unknown as Parameters<typeof runMemphisLoopStep>[0],
         );
       },
     }),
@@ -1128,7 +1134,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         };
       },
       async execute(input) {
-        return JSON.stringify(await runMemphisRestart(input));
+        return runMemphisRestart(input);
       },
     }),
   ];

--- a/tests/unit/tool-executor-runtime-coverage.test.ts
+++ b/tests/unit/tool-executor-runtime-coverage.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit test: runtime executor (in-process) exposes the same tools as the
+ * registry, modulo feature-flagged ones.
+ *
+ * Surfaced after a 2026-04-26 deep search (sprint S1): seven tools were
+ * declared in `tool-registry.ts` but had no runtime handler — the LLM
+ * could see them in auto-generated docs but tool calls would land
+ * "tool not found". This test pins the contract that for every
+ * registered, feature-flag-allowed tool there IS a runtime handler.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { createInProcessToolExecutor } from '../../src/gateway/tool-executor.js';
+import { getToolNames } from '../../src/gateway/tool-registry.js';
+
+describe('runtime tool executor coverage', () => {
+  it('exposes every registered (non-experimental) tool as a runtime handler', () => {
+    const executor = createInProcessToolExecutor();
+    const runtimeNames = new Set(executor.listTools().map((t) => t.name));
+    const registryNames = getToolNames();
+
+    const missing = registryNames.filter((n) => !runtimeNames.has(n));
+    expect(missing).toEqual([]);
+  });
+
+  it('exposes the seven tools wired in sprint S1', () => {
+    const executor = createInProcessToolExecutor();
+    const names = new Set(executor.listTools().map((t) => t.name));
+
+    // S1 (2026-04-26) deep-search finding: these were in registry but
+    // not in createRuntimeTools, which left them invisible to TUI/Telegram
+    // chat surfaces (only MCP could see them). Now thin-wrapped.
+    expect(names.has('memphis_config_show')).toBe(true);
+    expect(names.has('memphis_config_set')).toBe(true);
+    expect(names.has('memphis_config_reload')).toBe(true);
+    expect(names.has('memphis_cognitive_mode_set')).toBe(true);
+    expect(names.has('memphis_presence')).toBe(true);
+    expect(names.has('memphis_loop_step')).toBe(true);
+    expect(names.has('memphis_restart')).toBe(true);
+  });
+
+  it('exposes experimental-feature-gated tools when MEMPHIS_FEATURES flag is set', () => {
+    const executor = createInProcessToolExecutor({
+      rawEnv: { ...process.env, MEMPHIS_FEATURES: 'experimental-tools' },
+    });
+    const names = new Set(executor.listTools().map((t) => t.name));
+
+    const flagged = getToolNames({ MEMPHIS_FEATURES: 'experimental-tools' });
+    const missing = flagged.filter((n) => !names.has(n));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint S1 of the full-refactor roadmap. Wires seven tools that were declared in `src/gateway/tool-registry.ts` but had no runtime handler — the LLM saw them in auto-generated docs but tool calls landed _"tool not found"_ on TUI / Telegram / chat surfaces.

Operator confirmation 2026-04-26: bot answered _"I see no tier-3 tools — tier 3 isn't useful"_ while running with `maxToolTier=2`. Surface policy was correct; the gap was missing runtime handlers.

## Why these seven

All already implemented as `runMemphis*` helpers under `src/mcp/tools/`. They were reachable by the MCP server but invisible to the in-process executor used by TUI/Telegram chat. This PR thin-wraps each into `createRuntimeTools()` — no logic duplication.

| Tool | Tier | Capabilities | Notes |
|---|---|---|---|
| `memphis_config_show` | 0 | read | Redacted env view |
| `memphis_config_set` | 2 | write | `setDotEnvValues` + hot-reload; passphrase for secrets |
| `memphis_config_reload` | 2 | write | Re-read .env, swap hot fields |
| `memphis_cognitive_mode_set` | 2 | write | Switch cognitive mode A-E; passphrase required |
| `memphis_presence` | 0 | read | Cross-surface activity snapshot |
| `memphis_loop_step` | 0 | read | Rust `LoopEngine` enforcement (NAPI, TS fallback) |
| `memphis_restart` | 2 | write | Graceful self-restart; passphrase required |

## Coverage

`tests/unit/tool-executor-runtime-coverage.test.ts` (3 new cases):
1. Every `getToolNames()` entry has a runtime handler — pins the contract that registry ↔ executor parity must hold.
2. The seven S1 tools appear by name in `listTools()`.
3. Feature-flagged experimental tools surface when `MEMPHIS_FEATURES=experimental-tools` is set.

## Rubric impact

> Sprint backlog rubric:
> 1. Tools wired (X/37): **30/37 → 37/37** (after experimental flags) / 30/30 → 30/30 active default

## Test plan

- [ ] `npx vitest run tests/unit/tool-executor-runtime-coverage.test.ts` — 3 green
- [ ] `npx vitest run tests/unit/tool-registry.test.ts` — existing 60 green
- [ ] `npm run typecheck` — clean
- [ ] Manual (post-merge + daemon restart): TUI session → bot can invoke `memphis_config_show` and gets a redacted env back; previously this returned _"tool not found"_

## Out of scope

- TUI tier symmetry (`/tier 0|1|2` in Rust TUI) — sprint S2
- `memphis_self_describe` tool + system-prompt `<capabilities>` block — sprint S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)