### PR TITLE
feat(tui): tier 0/1/2 dispatch parity with Telegram (S2)

### DIFF
--- a/crates/memphis-tui/src/app.rs
+++ b/crates/memphis-tui/src/app.rs
@@ -4190,6 +4190,21 @@ fn extension_host_command_for_tokens(
                 ActiveCommandKind::Generic,
             )))
         }
+        // Sprint S2 (2026-04-26): tier 0/1/2 dispatch in TUI to match Telegram.
+        // Before this, /tier 0|1|2 fell through to the unsupported-command
+        // notice, leaving the operator without a way to demote tier 3 except
+        // /tier revoke (revoke restores tier 2 by default; cannot reach 0/1).
+        [cmd, sub] if *cmd == "tier" && (*sub == "0" || *sub == "1" || *sub == "2") => {
+            let target_tier: u8 = sub.parse().expect("matched 0/1/2 above");
+            Ok(Some((
+                ExtensionHostCommand {
+                    label: format!("tier {target_tier} set"),
+                    command: "security.tier.set".to_string(),
+                    args: json!({ "tier": target_tier }),
+                },
+                ActiveCommandKind::Generic,
+            )))
+        }
         _ => Ok(None),
     }
 }
@@ -6035,5 +6050,44 @@ mod tests {
             app.stream_trailing_newlines.is_empty(),
             "cancelled event must clear buffered newlines",
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Sprint S2 (2026-04-26) — TUI tier 0/1/2 symmetry with Telegram.
+    // Before this sprint, /tier 0|1|2 fell through to "unsupported
+    // command", leaving the operator without a way to explicitly demote
+    // tier 3 except /tier revoke (which always restores tier 2).
+    // ─────────────────────────────────────────────────────────────────
+    #[test]
+    fn tier_zero_dispatches_to_security_tier_set_with_target_zero() {
+        let tokens = split_command_tokens("tier 0").expect("command tokens");
+        let (command, _kind) = extension_host_command_for_tokens(&tokens)
+            .expect("host mapping parse")
+            .expect("/tier 0 should resolve through the host");
+
+        assert_eq!(command.command, "security.tier.set");
+        assert_eq!(command.args.get("tier").and_then(Value::as_u64), Some(0));
+    }
+
+    #[test]
+    fn tier_one_dispatches_to_security_tier_set_with_target_one() {
+        let tokens = split_command_tokens("tier 1").expect("command tokens");
+        let (command, _kind) = extension_host_command_for_tokens(&tokens)
+            .expect("host mapping parse")
+            .expect("/tier 1 should resolve through the host");
+
+        assert_eq!(command.command, "security.tier.set");
+        assert_eq!(command.args.get("tier").and_then(Value::as_u64), Some(1));
+    }
+
+    #[test]
+    fn tier_two_dispatches_to_security_tier_set_with_target_two() {
+        let tokens = split_command_tokens("tier 2").expect("command tokens");
+        let (command, _kind) = extension_host_command_for_tokens(&tokens)
+            .expect("host mapping parse")
+            .expect("/tier 2 should resolve through the host");
+
+        assert_eq!(command.command, "security.tier.set");
+        assert_eq!(command.args.get("tier").and_then(Value::as_u64), Some(2));
     }
 }

--- a/src/infra/tui-host/commands.ts
+++ b/src/infra/tui-host/commands.ts
@@ -697,14 +697,30 @@ function formatRemaining(ms: number): string {
 async function executeSecurityTierStatus(context: TuiHostCommandContext): Promise<unknown> {
   const session = getActiveTier3Session(TUI_TIER_SURFACE, TUI_TIER_ACTOR_ID);
   const remainingMs = session ? getTier3RemainingMs(TUI_TIER_SURFACE, TUI_TIER_ACTOR_ID) : 0;
-  const tier = session ? 3 : 2;
+  // Tier resolution mirrors what `/tier 0|1|2` actually wrote: a tier-3
+  // session wins outright, otherwise consult the
+  // MEMPHIS_SURFACE_TUI_MAX_TOOL_TIER env override (set by the
+  // /tier 0 and /tier 1 paths in executeSecurityTierSet). Without this
+  // step, status would always read "Tier 2" even when the operator had
+  // just downgraded to 0 — Codex finding on PR #284.
+  let tier: 0 | 1 | 2 | 3;
+  if (session) {
+    tier = 3;
+  } else {
+    const override = process.env.MEMPHIS_SURFACE_TUI_MAX_TOOL_TIER;
+    const parsed = override ? Number.parseInt(override, 10) : NaN;
+    tier = parsed === 0 || parsed === 1 ? (parsed as 0 | 1) : 2;
+  }
   assertNotAborted(context.signal);
-  context.emitLine(
-    'info',
-    session
-      ? `Tier ${tier} active for ${formatRemaining(remainingMs)} (expires ${new Date(session.expiresAt).toISOString()}).`
-      : 'Tier 2 (default). No elevation active.',
-  );
+  let line: string;
+  if (session) {
+    line = `Tier 3 active for ${formatRemaining(remainingMs)} (expires ${new Date(session.expiresAt).toISOString()}).`;
+  } else if (tier === 2) {
+    line = 'Tier 2 (default). No elevation active.';
+  } else {
+    line = `Tier ${tier} active (surface override). No tier-3 elevation.`;
+  }
+  context.emitLine('info', line);
   return {
     surface: TUI_TIER_SURFACE,
     actorId: TUI_TIER_ACTOR_ID,

--- a/src/infra/tui-host/commands.ts
+++ b/src/infra/tui-host/commands.ts
@@ -151,6 +151,8 @@ export async function executeTuiHostCommand(
       return executeSecurityTierElevate(args, context);
     case 'security.tier.revoke':
       return executeSecurityTierRevoke(context);
+    case 'security.tier.set':
+      return executeSecurityTierSet(args, context);
     case 'presence.snapshot':
       return executePresenceSnapshot(context);
     case 'system.restart':
@@ -762,6 +764,66 @@ async function executeSecurityTierRevoke(context: TuiHostCommandContext): Promis
     revoked ? 'Tier 3 revoked; default tier 2 restored.' : 'No active tier 3 elevation to revoke.',
   );
   return { revoked, surface: TUI_TIER_SURFACE, actorId: TUI_TIER_ACTOR_ID };
+}
+
+/**
+ * Set the TUI surface to tier 0/1/2. Mirrors the Telegram /tier 0|1|2 path
+ * (`src/gateway/channels/telegram.ts:170-242`):
+ *
+ *   tier 0 → revoke any active tier-3 session, set MAX_TOOL_TIER=0 (safe lock-down).
+ *   tier 1 → revoke any active tier-3 session, set MAX_TOOL_TIER=1 (reduced).
+ *   tier 2 → revoke any active tier-3 session, restore default tier 2.
+ *
+ * Sprint S2 (2026-04-26). Before this, TUI had only `/tier 3 <pass>`,
+ * `/tier status`, and `/tier revoke` — there was no way to step down to
+ * tier 0/1 (revoke restores 2). The Rust TUI now dispatches /tier 0/1/2
+ * to this handler.
+ */
+async function executeSecurityTierSet(
+  args: Record<string, unknown> | undefined,
+  context: TuiHostCommandContext,
+): Promise<unknown> {
+  const tier = optionalNumberArg(args, 'tier');
+  if (tier !== 0 && tier !== 1 && tier !== 2) {
+    throw new Error('security.tier.set requires tier in {0, 1, 2}');
+  }
+
+  const wasTier3 = revokeTier3Session(
+    TUI_TIER_SURFACE,
+    TUI_TIER_ACTOR_ID,
+    'operator-tui-tier-downgrade',
+    process.env,
+  );
+  assertNotAborted(context.signal);
+
+  // Set surface env override matching Telegram pattern. The override is
+  // process-wide for the TUI surface; restart restores defaults.
+  // For tier 2 (default) we DO clear any prior 0/1 override so the
+  // surface returns to baseline policy.
+  if (tier === 2) {
+    delete process.env.MEMPHIS_SURFACE_TUI_MAX_TOOL_TIER;
+  } else {
+    process.env.MEMPHIS_SURFACE_TUI_MAX_TOOL_TIER = String(tier);
+  }
+
+  const messages: Record<0 | 1 | 2, string> = {
+    0: wasTier3
+      ? 'Tier 3 revoked AND tier downgraded to 0 (safe lock-down).'
+      : 'Tier downgraded to 0 (safe lock-down).',
+    1: wasTier3
+      ? 'Tier 3 revoked AND tier set to 1 (reduced operator mode).'
+      : 'Tier set to 1 (reduced operator mode).',
+    2: wasTier3
+      ? 'Tier 3 revoked AND tier 2 restored (default companion mode).'
+      : 'Tier 2 already active (default companion mode).',
+  };
+  context.emitLine('info', messages[tier]);
+  return {
+    surface: TUI_TIER_SURFACE,
+    actorId: TUI_TIER_ACTOR_ID,
+    tier,
+    revokedTier3: wasTier3,
+  };
 }
 
 function getDb() {

--- a/src/infra/tui-host/protocol.ts
+++ b/src/infra/tui-host/protocol.ts
@@ -32,6 +32,7 @@ export const TUI_HOST_CAPABILITIES = [
   'security.tier.status',
   'security.tier.elevate',
   'security.tier.revoke',
+  'security.tier.set',
   'presence.snapshot',
   'system.restart',
 ] as const;


### PR DESCRIPTION
## Summary

Sprint S2. The Rust TUI's `/tier` slash handler covered status / revoke / 3, but **`/tier 0|1|2` fell through to the unsupported-command notice**. Operators on TUI had no way to step down to tier 0 (safe lock-down) or tier 1 (reduced) — the only demote path was `/tier revoke`, which always restores tier 2.

Telegram (`src/gateway/channels/telegram.ts:170-242`) already handles all four tiers correctly. This PR mirrors that shape on the TUI side.

## Changes

- **`crates/memphis-tui/src/app.rs:4193`** — new arm `[cmd, sub] if *cmd == "tier" && (*sub == "0" || *sub == "1" || *sub == "2")` dispatching to a new host command `security.tier.set` with `{tier: N}`.
- **`src/infra/tui-host/protocol.ts`** — `security.tier.set` added to typed allowlist.
- **`src/infra/tui-host/commands.ts`** — new `executeSecurityTierSet` handler:
  - revoke any active tier-3 session for the TUI surface
  - for tier 0/1: set `MEMPHIS_SURFACE_TUI_MAX_TOOL_TIER=N`
  - for tier 2: clear the override (returns to baseline default)
  - emit info line stating whether tier 3 was revoked

## Coverage

3 new Rust tests in `crates/memphis-tui/src/app.rs::tests`:
- `/tier 0` → `security.tier.set` with `args.tier = 0`
- `/tier 1` → `security.tier.set` with `args.tier = 1`
- `/tier 2` → `security.tier.set` with `args.tier = 2`

`cargo test -p memphis-tui --bin memphis-tui` passes (87 total, 3 new green).

## Rubric impact

Tier symmetry (TUI): **4/6 → 6/6** paths.

## Test plan

- [ ] `cargo test -p memphis-tui --bin memphis-tui tier_` — 3 new green
- [ ] `npx vitest run tests/unit/tui-host*` — 11 existing green
- [ ] `npm run typecheck` — clean
- [ ] Manual: TUI session → `/tier 0` → status bar reflects safe lock-down; `/tier 2` → returns to default

## Out of scope (deferred to S6)

The Telegram session log on 2026-04-26 surfaced four follow-ups, all logged in the plan's "Discovered along the way" section:

- Telegram free-text gets `Access denied` after `/tier 3` grant (slash works)
- `/status` shows `Active surfaces: (none)` while gateway is processing
- TUI `/mode A` after first successful `/mode a` → `Broken pipe (os error 32)` (host died, no auto-restart)
- TUI status bar `[Mode:X]` doesn't update after `cognitive.mode` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)