### PR TITLE
fix(s6): chat error diagnostics + memphis tier revoke CLI

### DIFF
--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -258,16 +258,20 @@ workflow:
 
 ### tier
 
-Read-only inspection of tier-3 elevation sessions across surfaces (TUI, Telegram, Matrix, HTTP). Tier-3 sessions are minted by `/tier 3 <pass>` slash commands inside TUI/Telegram and grant 3-hour permission elevation (unrestricted FS, sudo, autonomy=full); this command does NOT mint or revoke sessions, only enumerates active ones.
+Inspect and revoke tier-3 elevation sessions across surfaces (TUI, Telegram, Matrix, HTTP). Tier-3 sessions are minted by `/tier 3 <pass>` slash commands inside TUI/Telegram and grant 3-hour permission elevation (unrestricted FS, sudo, autonomy=full).
 
-syntax: `memphis tier <status> [--json]`
+syntax:
+- `memphis tier <status> [--json]`
+- `memphis tier revoke [--surface <name> --actor <id>] [--json]`
 
 workflow:
 
 - `tier status`: Human-readable list of active sessions with surface, actorId, granted/expires timestamps, and remaining time.
 - `tier status --json`: Machine-readable JSON `{ ok, count, sessions[], asOf }` for scripting.
+- `tier revoke`: Revoke ALL active tier-3 sessions (default).
+- `tier revoke --surface telegram --actor 12345`: Revoke a specific session. Both flags must be supplied together.
 
-The command queries the daemon at `http://${HOST}:${PORT}/v1/ops/tier3/sessions` (auth-token gated). If the daemon is not running, the command surfaces an actionable error including the systemctl start hint.
+`tier status` queries `GET /v1/ops/tier3/sessions`; `tier revoke` calls `POST /v1/ops/tier3/revoke`. Both are auth-token gated. If the daemon is not running, the command surfaces an actionable error including the systemctl start hint.
 
 ---
 

--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -271,6 +271,24 @@ The command queries the daemon at `http://${HOST}:${PORT}/v1/ops/tier3/sessions`
 
 ---
 
+### tools
+
+Read-only inventory of runtime capabilities — what the LLM can dispatch RIGHT NOW on a given surface. Companion to the `memphis_self_describe` tier-0 tool. Surfaced after a 2026-04-26 operator session where the bot was hallucinating its capabilities; this gives operators a CLI to verify what's actually wired.
+
+syntax: `memphis tools <list|describe> [--tier 0|1|2|3] [--surface <name>] [<tool-name>] [--json]`
+
+workflow:
+
+- `tools list`: Human-readable inventory grouped by tier with availability marks (✓/✗), capabilities, and feature-flag annotations. Header line shows surface, effective tier, cognitive mode, and total available/registered counts.
+- `tools list --tier 0`: Filter to a single tier.
+- `tools list --surface telegram`: Apply a specific surface's policy when computing availability (defaults to a generic CLI surface).
+- `tools list --json`: Machine-readable shape `{ surface, surfacePolicy, effectiveTier, cognitive, tools[], toolsAvailable, toolsRegistered, featureFlags, asOf }`.
+- `tools describe <name>`: Single-tool detail (tier, capabilities, feature flag, availability, full description).
+
+Queries `http://${HOST}:${PORT}/v1/ops/capabilities` (auth-token gated).
+
+---
+
 ## Chain
 
 ### chain import_json

--- a/crates/memphis-operator/src/chat.rs
+++ b/crates/memphis-operator/src/chat.rs
@@ -33,7 +33,7 @@ const GENESIS_PREV_HASH: &str = "00000000000000000000000000000000000000000000000
 const CHAT_MAX_MESSAGES_DEFAULT: usize = 40;
 const CHAT_MAX_STEPS_DEFAULT: usize = 32;
 const CHAT_MAX_TOOL_CALLS_DEFAULT: usize = 16;
-const CHAT_MAX_ERRORS_DEFAULT: usize = 4;
+const CHAT_MAX_ERRORS_DEFAULT: usize = 8;
 
 /// Read a `usize` limit from the environment, falling back to `default`.
 /// A zero or malformed value falls back so operators cannot accidentally
@@ -288,6 +288,10 @@ impl OperatorRuntime {
 
         let mut tool_calls_used = 0usize;
         let mut errors = 0usize;
+        // (tool_name, first_line_of_error) — kept for diagnostics on abort.
+        // Without this, "exceeded recoverable error limit" was opaque and
+        // operators had to dig through logs to know which tool failed.
+        let mut error_trail: Vec<(String, String)> = Vec::new();
 
         loop {
             ensure_chat_not_cancelled(cancel_flag)?;
@@ -403,10 +407,29 @@ impl OperatorRuntime {
                         Ok(result) => result,
                         Err(error) => {
                             errors += 1;
+                            let first_line = error
+                                .to_string()
+                                .lines()
+                                .next()
+                                .unwrap_or("")
+                                .trim()
+                                .to_string();
+                            error_trail.push((tool_call.name.clone(), first_line));
                             if errors > chat_max_errors() {
-                                return Err(OperatorError::Message(
-                                    "native rust chat exceeded recoverable error limit".to_string(),
-                                ));
+                                let trail = error_trail
+                                    .iter()
+                                    .map(|(name, msg)| {
+                                        if msg.is_empty() {
+                                            name.clone()
+                                        } else {
+                                            format!("{name}: {msg}")
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("; ");
+                                return Err(OperatorError::Message(format!(
+                                    "native rust chat exceeded recoverable error limit ({errors} errors). Trail: {trail}"
+                                )));
                             }
                             let error_json = json!({ "error": error.to_string() }).to_string();
                             (

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -158,6 +158,51 @@ function tierDescription(tier: ToolTier): string {
  * incorrectly concluded "tier 3 isn't useful" — leaving the operator unsure
  * whether the elevation had actually happened.
  */
+/**
+ * Render a per-turn `<capabilities>` block summarizing what the LLM can
+ * actually do on the current surface. Surfaced after a 2026-04-26 operator
+ * session where the bot answered "I have only tier 0 tools" while running
+ * with `maxToolTier=2`.
+ *
+ * The block is a SHORT pointer — it does NOT enumerate every tool (the
+ * `<tool>` blocks rendered above already do that). It tells the LLM:
+ *   1. how many tools it can dispatch right now,
+ *   2. that `memphis_self_describe` is the source of truth for "what can
+ *      you do" questions (pre-empts hallucination from training data),
+ *   3. that tier 3 elevation is a permissions flip, not a new tool tier
+ *      (cross-references <tier_system>).
+ *
+ * Token cost: ~10-15 lines. Cheap relative to the full per-tool docs.
+ */
+function renderCapabilitiesBlock(toolNames: string[]): string {
+  const lines = [
+    'CAPABILITIES — what you can actually do RIGHT NOW (read this before',
+    'answering "what can you do" questions; do NOT guess from training data):',
+    '',
+    `- Available tools this turn: ${toolNames.length}.`,
+    '- The full <tool> blocks above show name, tier, capabilities, and',
+    '  input shape for each one. That list is authoritative for THIS turn.',
+    '- For runtime self-introspection (active surface, effective tier,',
+    '  cognitive mode, full tool inventory with availability per tier,',
+    '  active feature flags, cross-surface tier-3 sessions) call the',
+    '  `memphis_self_describe` tool. It returns structured JSON the',
+    '  operator can read in TUI / Telegram / HTTP / CLI.',
+    '- Tier 3 elevation: see <tier_system> below. Tier 3 does NOT add new',
+    '  tools — it lifts permissions on the existing tier-2 set.',
+  ];
+  if (toolNames.includes('memphis_self_describe')) {
+    lines.push(
+      '- `memphis_self_describe` is in your available-tools list above.',
+    );
+  } else {
+    lines.push(
+      '- NOTE: `memphis_self_describe` is NOT available on this surface.',
+      '  Answer capability questions from the <tool> blocks above only.',
+    );
+  }
+  return lines.join('\n');
+}
+
 function renderTierSystemBlock(): string {
   return [
     'TIER SYSTEM — how authorization works at runtime:',
@@ -924,6 +969,9 @@ SELF-MODIFY GUARDS:
   to remote requires explicit human review + push by the repo owner.
   There is no auto-push on the release pipeline.
 </safety_invariants>
+<capabilities>
+${renderCapabilitiesBlock(tools)}
+</capabilities>
 <tier_system>
 ${renderTierSystemBlock()}
 </tier_system>

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -17,6 +17,12 @@ import { runMemphisBuild } from '../mcp/tools/build.js';
 import { runMemphisCaseAppend, runMemphisCaseQuery } from '../mcp/tools/case-entry.js';
 import { runMemphisChainQuery } from '../mcp/tools/chain-query.js';
 import { runMemphisCodeRead } from '../mcp/tools/code-read.js';
+import {
+  runMemphisCognitiveModeSet,
+  runMemphisConfigReload,
+  runMemphisConfigSet,
+  runMemphisConfigShow,
+} from '../mcp/tools/config.js';
 import { runMemphisCron } from '../mcp/tools/cron.js';
 import { runMemphisDb } from '../mcp/tools/db.js';
 import { runMemphisDecide } from '../mcp/tools/decide.js';
@@ -30,10 +36,13 @@ import { runMemphisGrep } from '../mcp/tools/grep.js';
 import { runMemphisHealthCheck } from '../mcp/tools/health-check.js';
 import { runMemphisHealth } from '../mcp/tools/health.js';
 import { runMemphisJournal } from '../mcp/tools/journal.js';
+import { runMemphisLoopStep } from '../mcp/tools/loop-step.js';
 import { runMemphisPackage } from '../mcp/tools/package.js';
+import { runMemphisPresence } from '../mcp/tools/presence.js';
 import { runMemphisProviders } from '../mcp/tools/providers.js';
 import { runMemphisRecall } from '../mcp/tools/recall.js';
 import { runMemphisRepair } from '../mcp/tools/repair.js';
+import { runMemphisRestart } from '../mcp/tools/restart.js';
 import { runMemphisSearch } from '../mcp/tools/search.js';
 import { runMemphisSelfModify } from '../mcp/tools/self-modify.js';
 import { runMemphisSoulRead, runMemphisSoulWrite } from '../mcp/tools/soul.js';
@@ -959,6 +968,167 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       },
       async execute(input) {
         return runMemphisHealthCheck(input);
+      },
+    }),
+    // ─────────────────────────────────────────────────────────────────
+    // S1 (sprint 2026-04-26): wire 7 tools that lived only as MCP tools.
+    // Each thin-wraps the existing `runMemphis*` function from src/mcp/tools/.
+    // The runtime path (TUI / Telegram / chat / CLI) now sees them too.
+    //
+    // Design note: keep these as JSON.stringify(returnValue) — the runtime
+    // contract for `execute(input): Promise<string>` requires a string, and
+    // the MCP helpers return structured objects.
+    // ─────────────────────────────────────────────────────────────────
+    buildTool({
+      name: 'memphis_config_show',
+      description: 'Show current runtime config (redacted view of hot-reloadable env)',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', description: 'Optional single config key to inspect' },
+        },
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput(args) {
+        return { key: optionalString(args, 'key') };
+      },
+      async execute(input) {
+        return JSON.stringify(runMemphisConfigShow(input));
+      },
+    }),
+    buildTool({
+      name: 'memphis_config_set',
+      description:
+        'Set a single config key/value. Cold fields refuse; secret fields require operator passphrase.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          key: { type: 'string', description: 'Config key (must be in known-fields whitelist)' },
+          value: { type: 'string', description: 'New value' },
+          passphrase: { type: 'string', description: 'Operator passphrase if key is secret' },
+        },
+        required: ['key', 'value'],
+      },
+      isReadOnly: false,
+      validateInput(args) {
+        return {
+          key: requiredString(args, 'key'),
+          value: requiredString(args, 'value'),
+          passphrase: optionalString(args, 'passphrase'),
+        };
+      },
+      async execute(input) {
+        return JSON.stringify(runMemphisConfigSet(input));
+      },
+    }),
+    buildTool({
+      name: 'memphis_config_reload',
+      description: 'Re-read .env and hot-swap mutable fields (cold fields refuse — restart needed)',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+      isReadOnly: false,
+      validateInput() {
+        return {};
+      },
+      async execute() {
+        return JSON.stringify(await runMemphisConfigReload());
+      },
+    }),
+    buildTool({
+      name: 'memphis_cognitive_mode_set',
+      description:
+        'Switch cognitive mode (A–E: ConsciousCapture / InferredDecisions / PredictivePatterns / CollectiveCoord / MetaCognitiveRef). Requires operator passphrase.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          mode: { type: 'string', description: 'Target mode: A | B | C | D | E' },
+          passphrase: { type: 'string', description: 'Operator passphrase' },
+        },
+        required: ['mode'],
+      },
+      isReadOnly: false,
+      validateInput(args) {
+        return {
+          mode: requiredString(args, 'mode'),
+          passphrase: optionalString(args, 'passphrase'),
+        };
+      },
+      async execute(input) {
+        return JSON.stringify(await runMemphisCognitiveModeSet(input));
+      },
+    }),
+    buildTool({
+      name: 'memphis_presence',
+      description: 'Cross-surface presence snapshot (TUI / Telegram / HTTP / CLI activity)',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput() {
+        return {};
+      },
+      async execute() {
+        return JSON.stringify(runMemphisPresence());
+      },
+    }),
+    buildTool({
+      name: 'memphis_loop_step',
+      description:
+        'Cognitive loop enforcement step (Rust LoopEngine via NAPI, TS fallback if bridge unavailable)',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          state: { type: 'object', description: 'Current loop state' },
+          action: { type: 'object', description: 'Proposed action' },
+          limits: { type: 'object', description: 'Optional override limits' },
+        },
+        required: ['state', 'action'],
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput(args) {
+        return {
+          state: requiredRecord(args, 'state'),
+          action: requiredRecord(args, 'action'),
+          limits: args.limits as Record<string, unknown> | undefined,
+        };
+      },
+      async execute(input) {
+        return JSON.stringify(
+          runMemphisLoopStep(
+            input as unknown as Parameters<typeof runMemphisLoopStep>[0],
+          ),
+        );
+      },
+    }),
+    buildTool({
+      name: 'memphis_restart',
+      description:
+        'Request a self-restart of the Memphis daemon. Requires operator passphrase (no per-surface tier-3 session is minted via tools).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          reason: { type: 'string', description: 'Reason for the restart (audited)' },
+          actor_id: { type: 'string', description: 'Actor identifier (audit context)' },
+          passphrase: { type: 'string', description: 'Operator passphrase' },
+        },
+      },
+      isReadOnly: false,
+      isDestructive: true,
+      validateInput(args) {
+        return {
+          reason: optionalString(args, 'reason'),
+          actor_id: optionalString(args, 'actor_id'),
+          passphrase: optionalString(args, 'passphrase'),
+        };
+      },
+      async execute(input) {
+        return JSON.stringify(await runMemphisRestart(input));
       },
     }),
   ];

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -994,7 +994,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         return { key: optionalString(args, 'key') };
       },
       async execute(input) {
-        return JSON.stringify(runMemphisConfigShow(input));
+        return runMemphisConfigShow(input);
       },
     }),
     buildTool({
@@ -1012,14 +1012,22 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       },
       isReadOnly: false,
       validateInput(args) {
+        const value = args.value;
+        if (typeof value !== 'string') {
+          throw new AppError('VALIDATION_ERROR', 'tool value must be a string', 400);
+        }
         return {
           key: requiredString(args, 'key'),
-          value: requiredString(args, 'value'),
+          // empty string is intentionally allowed — the LLM uses
+          // `memphis_config_set { key: 'X', value: '' }` to clear a
+          // mutable config field. requiredString rejected those; field
+          // validation lives in runMemphisConfigSet itself.
+          value,
           passphrase: optionalString(args, 'passphrase'),
         };
       },
       async execute(input) {
-        return JSON.stringify(runMemphisConfigSet(input));
+        return runMemphisConfigSet(input);
       },
     }),
     buildTool({
@@ -1034,7 +1042,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         return {};
       },
       async execute() {
-        return JSON.stringify(await runMemphisConfigReload());
+        return runMemphisConfigReload();
       },
     }),
     buildTool({
@@ -1057,7 +1065,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         };
       },
       async execute(input) {
-        return JSON.stringify(await runMemphisCognitiveModeSet(input));
+        return runMemphisCognitiveModeSet(input);
       },
     }),
     buildTool({
@@ -1073,7 +1081,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         return {};
       },
       async execute() {
-        return JSON.stringify(runMemphisPresence());
+        return runMemphisPresence();
       },
     }),
     buildTool({
@@ -1099,10 +1107,8 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         };
       },
       async execute(input) {
-        return JSON.stringify(
-          runMemphisLoopStep(
-            input as unknown as Parameters<typeof runMemphisLoopStep>[0],
-          ),
+        return runMemphisLoopStep(
+          input as unknown as Parameters<typeof runMemphisLoopStep>[0],
         );
       },
     }),
@@ -1128,7 +1134,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         };
       },
       async execute(input) {
-        return JSON.stringify(await runMemphisRestart(input));
+        return runMemphisRestart(input);
       },
     }),
   ];

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -1159,7 +1159,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       },
       async execute(input) {
         const surface = input.surface ?? deps.surface ?? 'mcp';
-        return JSON.stringify(runMemphisSelfDescribe({ ...input, surface }, deps.rawEnv));
+        return runMemphisSelfDescribe({ ...input, surface }, deps.rawEnv);
       },
     }),
   ];

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -44,6 +44,7 @@ import { runMemphisRecall } from '../mcp/tools/recall.js';
 import { runMemphisRepair } from '../mcp/tools/repair.js';
 import { runMemphisRestart } from '../mcp/tools/restart.js';
 import { runMemphisSearch } from '../mcp/tools/search.js';
+import { runMemphisSelfDescribe } from '../mcp/tools/self-describe.js';
 import { runMemphisSelfModify } from '../mcp/tools/self-modify.js';
 import { runMemphisSoulRead, runMemphisSoulWrite } from '../mcp/tools/soul.js';
 import { runMemphisSystemInfo } from '../mcp/tools/system-info.js';
@@ -1135,6 +1136,30 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       },
       async execute(input) {
         return runMemphisRestart(input);
+      },
+    }),
+    buildTool({
+      name: 'memphis_self_describe',
+      description:
+        'Runtime self-introspection — returns active surface policy, effective tier (with tier-3 session info), cognitive mode, full tool inventory with availability, feature flags, and cross-surface tier-3 sessions. Use this BEFORE answering "what can you do" — never hallucinate capabilities from training data.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          surface: { type: 'string', description: 'Override active surface name' },
+          actorId: { type: 'string', description: 'Actor id for tier-3 lookup' },
+        },
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput(args) {
+        return {
+          surface: optionalString(args, 'surface'),
+          actorId: optionalString(args, 'actorId'),
+        };
+      },
+      async execute(input) {
+        const surface = input.surface ?? deps.surface ?? 'mcp';
+        return JSON.stringify(runMemphisSelfDescribe({ ...input, surface }, deps.rawEnv));
       },
     }),
   ];

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -101,6 +101,20 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
       })
       .strict(),
   },
+  memphis_self_describe: {
+    name: 'memphis_self_describe',
+    tier: 0,
+    capabilities: ['read'],
+    description:
+      'Runtime self-introspection — returns active surface policy, effective tier (with tier-3 session info), cognitive mode, full tool inventory with availability, feature flags, and cross-surface tier-3 sessions. Use this BEFORE answering "what can you do" — never hallucinate capabilities from training data.',
+    inputSchema: z
+      .object({
+        surface: z.string().optional(),
+        actorId: z.string().optional(),
+        approval_request_id: z.string().optional(),
+      })
+      .strict(),
+  },
   memphis_repair: {
     name: 'memphis_repair',
     tier: 0,

--- a/src/infra/cli/handlers/tier.handler.ts
+++ b/src/infra/cli/handlers/tier.handler.ts
@@ -7,10 +7,13 @@
  * This handler queries the new `GET /v1/ops/tier3/sessions` HTTP endpoint
  * and renders human or JSON output.
  *
- * Subcommands (forward-compat — only `status` today):
+ * Subcommands:
  *   memphis tier                 # alias for status
  *   memphis tier status          # human format
  *   memphis tier status --json   # JSON format
+ *   memphis tier revoke          # revoke ALL active tier-3 sessions
+ *   memphis tier revoke --surface telegram --actor 12345
+ *                                # revoke a specific session
  *
  * Surfaced after a 2026-04-26 operator session where there was no way to
  * see "which surfaces have an active tier-3 session right now" without
@@ -124,13 +127,104 @@ async function handleTierStatus(context: CliContext): Promise<boolean> {
   return true;
 }
 
+function parseFlag(argv: string[], name: string): string | undefined {
+  const idx = argv.indexOf(name);
+  if (idx < 0 || idx + 1 >= argv.length) return undefined;
+  return argv[idx + 1];
+}
+
+async function handleTierRevoke(context: CliContext): Promise<boolean> {
+  const config = context.getConfig();
+  const url = `http://${config.HOST}:${config.PORT}/v1/ops/tier3/revoke`;
+  const token = config.MEMPHIS_API_TOKEN;
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    Accept: 'application/json',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const surface = parseFlag(context.argv, '--surface');
+  const actorId = parseFlag(context.argv, '--actor') ?? parseFlag(context.argv, '--actorId');
+  let body: Record<string, unknown>;
+  if (surface || actorId) {
+    if (!surface || !actorId) {
+      console.error('--surface and --actor must be supplied together');
+      return true;
+    }
+    body = { surface, actorId };
+  } else {
+    body = { all: true };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === 'ECONNREFUSED' || (error as Error)?.message?.includes('ECONNREFUSED')) {
+      console.error(
+        'Tier-3 revoke unavailable — Memphis daemon is not running.\n' +
+          'Start it with: systemctl --user start memphis (or: memphis serve)',
+      );
+      return true;
+    }
+    console.error(
+      `Failed to reach daemon at ${url}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return true;
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    console.error(
+      `Unauthorized (${response.status}) — check MEMPHIS_API_TOKEN matches the daemon value.`,
+    );
+    return true;
+  }
+
+  let payload: { ok: boolean; revoked?: number; scope?: string; error?: string };
+  try {
+    payload = (await response.json()) as typeof payload;
+  } catch (error) {
+    console.error(
+      `Daemon returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return true;
+  }
+
+  if (response.status === 404) {
+    console.error(payload.error ?? `No active tier-3 session for surface=${surface} actor=${actorId}`);
+    return true;
+  }
+  if (!response.ok || !payload.ok) {
+    console.error(`Daemon returned ${response.status}: ${payload.error ?? '(unknown error)'}`);
+    return true;
+  }
+
+  if (context.args.json) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    const count = payload.revoked ?? 0;
+    if (count === 0) {
+      console.log('No active tier-3 sessions to revoke.');
+    } else if (payload.scope === 'all') {
+      console.log(`Revoked ${count} tier-3 session${count === 1 ? '' : 's'}.`);
+    } else {
+      console.log(`Revoked tier-3 session for surface=${surface} actor=${actorId}.`);
+    }
+  }
+  return true;
+}
+
 async function handleTierCommand(context: CliContext): Promise<boolean> {
   const sub = context.args.subcommand;
   if (sub === 'status' || !sub) {
     return handleTierStatus(context);
   }
+  if (sub === 'revoke') {
+    return handleTierRevoke(context);
+  }
   console.error(`Unknown tier subcommand: ${sub}`);
-  console.error('Usage: memphis tier <status>');
+  console.error('Usage: memphis tier <status|revoke>');
   return true;
 }
 

--- a/src/infra/cli/handlers/tier.handler.ts
+++ b/src/infra/cli/handlers/tier.handler.ts
@@ -130,7 +130,12 @@ async function handleTierStatus(context: CliContext): Promise<boolean> {
 function parseFlag(argv: string[], name: string): string | undefined {
   const idx = argv.indexOf(name);
   if (idx < 0 || idx + 1 >= argv.length) return undefined;
-  return argv[idx + 1];
+  // Reject the next token if it's another flag — `--surface --actor 123`
+  // would otherwise bind `--actor` as the surface value, then fail on
+  // the daemon side with a confusing 400. Codex P2 finding on PR #288.
+  const value = argv[idx + 1];
+  if (value === undefined || value.startsWith('--')) return undefined;
+  return value;
 }
 
 async function handleTierRevoke(context: CliContext): Promise<boolean> {
@@ -192,7 +197,18 @@ async function handleTierRevoke(context: CliContext): Promise<boolean> {
   }
 
   if (response.status === 404) {
-    console.error(payload.error ?? `No active tier-3 session for surface=${surface} actor=${actorId}`);
+    // The server emits 404 with `error: "no active tier-3 session …"`
+    // when the (surface, actorId) tuple has no session. A bare 404 with
+    // no payload.error means routing failure — point at that instead of
+    // a synthetic "no active session" line so operators don't think
+    // they have a state-mismatch when the endpoint isn't even reachable.
+    if (typeof payload.error === 'string' && payload.error.includes('no active tier-3 session')) {
+      console.error(payload.error);
+    } else {
+      console.error(
+        `Daemon returned 404 at ${url}: ${payload.error ?? 'endpoint not registered (does the daemon include PR #288?)'}`,
+      );
+    }
     return true;
   }
   if (!response.ok || !payload.ok) {

--- a/src/infra/cli/handlers/tools.handler.ts
+++ b/src/infra/cli/handlers/tools.handler.ts
@@ -49,8 +49,11 @@ async function fetchCapabilities(
   context: CliContext,
 ): Promise<CapabilitiesResponse | null> {
   const config = context.getConfig();
-  const surface = parseSurfaceFlag(context.argv);
-  const params = surface ? `?surface=${encodeURIComponent(surface)}` : '';
+  // Default to the cli surface so the operator sees what *they* can run,
+  // not what the daemon's default `mcp` surface would expose. Operators
+  // override with `--surface telegram|tui|...` to inspect peer surfaces.
+  const surface = parseSurfaceFlag(context.argv) ?? 'cli';
+  const params = `?surface=${encodeURIComponent(surface)}`;
   const url = `http://${config.HOST}:${config.PORT}/v1/ops/capabilities${params}`;
   const headers: Record<string, string> = { Accept: 'application/json' };
   if (config.MEMPHIS_API_TOKEN) {

--- a/src/infra/cli/handlers/tools.handler.ts
+++ b/src/infra/cli/handlers/tools.handler.ts
@@ -1,0 +1,228 @@
+/**
+ * `memphis tools` — read-only operator-facing inventory of runtime
+ * capabilities. Companion to `memphis_self_describe` tool.
+ *
+ * Subcommands:
+ *   memphis tools list                    # all available tools (human)
+ *   memphis tools list --json             # all (JSON)
+ *   memphis tools list --tier 0           # filter by tier
+ *   memphis tools list --surface telegram # apply specific surface policy
+ *   memphis tools describe <name>         # single tool detail
+ *
+ * Queries the daemon's `GET /v1/ops/capabilities` (auth-token gated).
+ * Surfaced after a 2026-04-26 operator session where the bot was
+ * hallucinating its capabilities — operators now have a CLI to verify
+ * what's actually wired and exposed at any given surface.
+ */
+
+import type { CommandHandler } from './command-handler.js';
+import type { CliContext } from '../context.js';
+
+interface ToolView {
+  name: string;
+  tier: 0 | 1 | 2 | 3;
+  capabilities: string[];
+  description: string;
+  featureFlag: string | null;
+  available: boolean;
+}
+
+interface CapabilitiesResponse {
+  surface: string;
+  surfacePolicy: { maxToolTier: number };
+  effectiveTier: 0 | 1 | 2 | 3;
+  cognitive: { mode: string; name: string };
+  tools: ToolView[];
+  toolsAvailable: number;
+  toolsRegistered: number;
+  featureFlags: string[];
+  asOf: string;
+}
+
+function parseSurfaceFlag(argv: string[]): string | undefined {
+  const idx = argv.indexOf('--surface');
+  if (idx < 0 || idx + 1 >= argv.length) return undefined;
+  return argv[idx + 1];
+}
+
+async function fetchCapabilities(
+  context: CliContext,
+): Promise<CapabilitiesResponse | null> {
+  const config = context.getConfig();
+  const surface = parseSurfaceFlag(context.argv);
+  const params = surface ? `?surface=${encodeURIComponent(surface)}` : '';
+  const url = `http://${config.HOST}:${config.PORT}/v1/ops/capabilities${params}`;
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (config.MEMPHIS_API_TOKEN) {
+    headers.Authorization = `Bearer ${config.MEMPHIS_API_TOKEN}`;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, { headers });
+  } catch (error) {
+    if (
+      (error as NodeJS.ErrnoException)?.code === 'ECONNREFUSED' ||
+      (error as Error)?.message?.includes('ECONNREFUSED')
+    ) {
+      console.error(
+        'Capabilities unavailable — Memphis daemon is not running.\n' +
+          'Start it with: systemctl --user start memphis (or: memphis serve)',
+      );
+      return null;
+    }
+    console.error(
+      `Failed to reach daemon at ${url}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    console.error(
+      `Unauthorized (${response.status}) — check MEMPHIS_API_TOKEN matches the daemon value.`,
+    );
+    return null;
+  }
+
+  if (!response.ok) {
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      /* swallow */
+    }
+    console.error(`Daemon returned ${response.status}: ${body || '(empty body)'}`);
+    return null;
+  }
+
+  try {
+    return (await response.json()) as CapabilitiesResponse;
+  } catch (error) {
+    console.error(
+      `Daemon returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
+function renderListHuman(
+  payload: CapabilitiesResponse,
+  filter: { tier?: number },
+): string {
+  const lines: string[] = [];
+  lines.push(
+    `Surface: ${payload.surface}  ·  effective tier: ${payload.effectiveTier}  ·  ` +
+      `cognitive mode: ${payload.cognitive.mode} (${payload.cognitive.name})`,
+  );
+  lines.push(
+    `Tools: ${payload.toolsAvailable}/${payload.toolsRegistered} available  ·  ` +
+      `feature flags: ${payload.featureFlags.length > 0 ? payload.featureFlags.join(', ') : '(none)'}`,
+  );
+  lines.push('');
+
+  const filtered = payload.tools
+    .filter((t) => (filter.tier === undefined ? true : t.tier === filter.tier))
+    .sort((a, b) => a.tier - b.tier || a.name.localeCompare(b.name));
+
+  if (filtered.length === 0) {
+    lines.push('(no tools match the filter)');
+    return lines.join('\n');
+  }
+
+  let currentTier: number | null = null;
+  for (const t of filtered) {
+    if (t.tier !== currentTier) {
+      currentTier = t.tier;
+      lines.push(`tier ${t.tier}:`);
+    }
+    const availMark = t.available ? '✓' : '✗';
+    const flagMark = t.featureFlag ? ` [flag:${t.featureFlag}]` : '';
+    const caps = t.capabilities.length > 0 ? t.capabilities.join(',') : '-';
+    lines.push(`  ${availMark} ${t.name.padEnd(30)} ${caps.padEnd(18)}${flagMark}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Pull `--tier <N>` out of context.argv. Not in CliArgs because it's a
+ * tools-handler-local flag; parser.ts already passes it through verbatim.
+ */
+function parseTierFlag(argv: string[]): number | undefined {
+  const idx = argv.indexOf('--tier');
+  if (idx < 0 || idx + 1 >= argv.length) return undefined;
+  const n = Number(argv[idx + 1]);
+  if (n >= 0 && n <= 3 && Number.isInteger(n)) return n;
+  return undefined;
+}
+
+async function handleToolsList(context: CliContext): Promise<boolean> {
+  const payload = await fetchCapabilities(context);
+  if (!payload) return true;
+
+  const filter: { tier?: number } = {};
+  const tierFlag = parseTierFlag(context.argv);
+  if (tierFlag !== undefined) filter.tier = tierFlag;
+
+  if (context.args.json) {
+    console.log(
+      JSON.stringify(
+        filter.tier !== undefined
+          ? { ...payload, tools: payload.tools.filter((t) => t.tier === filter.tier) }
+          : payload,
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(renderListHuman(payload, filter));
+  }
+  return true;
+}
+
+async function handleToolsDescribe(context: CliContext): Promise<boolean> {
+  const target = typeof context.args.target === 'string' ? context.args.target : undefined;
+  if (!target) {
+    console.error('Usage: memphis tools describe <tool-name>');
+    return true;
+  }
+
+  const payload = await fetchCapabilities(context);
+  if (!payload) return true;
+
+  const tool = payload.tools.find((t) => t.name === target);
+  if (!tool) {
+    console.error(`Tool not found in registry: ${target}`);
+    console.error('Use `memphis tools list` to see all registered tools.');
+    return true;
+  }
+
+  if (context.args.json) {
+    console.log(JSON.stringify(tool, null, 2));
+    return true;
+  }
+
+  console.log(`Tool:         ${tool.name}`);
+  console.log(`Tier:         ${tool.tier}`);
+  console.log(`Capabilities: ${tool.capabilities.join(', ') || '-'}`);
+  console.log(`Feature flag: ${tool.featureFlag ?? '(none)'}`);
+  console.log(`Available:    ${tool.available ? 'yes' : 'no'} (surface=${payload.surface})`);
+  console.log('');
+  console.log(tool.description);
+  return true;
+}
+
+async function handleToolsCommand(context: CliContext): Promise<boolean> {
+  const sub = context.args.subcommand;
+  if (sub === 'list' || !sub) return handleToolsList(context);
+  if (sub === 'describe') return handleToolsDescribe(context);
+  console.error(`Unknown tools subcommand: ${sub}`);
+  console.error('Usage: memphis tools <list|describe>');
+  return true;
+}
+
+export const toolsCommandHandler: CommandHandler = {
+  name: 'tools',
+  commands: ['tools'],
+  canHandle: (context: CliContext) => context.args.command === 'tools',
+  handle: handleToolsCommand,
+};

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -200,6 +200,11 @@ export const CLI_COMMAND_REGISTRY = [
     createLazyHandlerLoader(() => import('./handlers/tier.handler.js'), 'tierCommandHandler'),
   ),
   createCommandRegistration(
+    'tools',
+    ['tools'],
+    createLazyHandlerLoader(() => import('./handlers/tools.handler.js'), 'toolsCommandHandler'),
+  ),
+  createCommandRegistration(
     'evolve',
     ['evolve'],
     createLazyHandlerLoader(() => import('./handlers/evolve.handler.js'), 'evolveCommandHandler'),
@@ -291,6 +296,7 @@ export const CLI_COMPLETION_COMMANDS = [
   'onboarding',
   'operator',
   'tier',
+  'tools',
   'evolve',
   'secret',
   'telegram',

--- a/src/infra/http/auth-policy.ts
+++ b/src/infra/http/auth-policy.ts
@@ -12,6 +12,7 @@ export const apiAuthPolicy: EndpointAuthPolicy[] = [
   { method: 'GET', path: '/v1/metrics', requiresAuth: true },
   { method: 'GET', path: '/v1/ops/status', requiresAuth: true },
   { method: 'GET', path: '/v1/ops/tier3/sessions', requiresAuth: true },
+  { method: 'GET', path: '/v1/ops/capabilities', requiresAuth: true },
   { method: 'GET', path: '/v1/sessions', requiresAuth: true },
   { method: 'GET', path: '/v1/sessions/:sessionId/events', requiresAuth: true },
   { method: 'GET', path: '/v1/chat/dispatch/:workId', requiresAuth: true },

--- a/src/infra/http/auth-policy.ts
+++ b/src/infra/http/auth-policy.ts
@@ -12,6 +12,7 @@ export const apiAuthPolicy: EndpointAuthPolicy[] = [
   { method: 'GET', path: '/v1/metrics', requiresAuth: true },
   { method: 'GET', path: '/v1/ops/status', requiresAuth: true },
   { method: 'GET', path: '/v1/ops/tier3/sessions', requiresAuth: true },
+  { method: 'POST', path: '/v1/ops/tier3/revoke', requiresAuth: true },
   { method: 'GET', path: '/v1/ops/capabilities', requiresAuth: true },
   { method: 'GET', path: '/v1/sessions', requiresAuth: true },
   { method: 'GET', path: '/v1/sessions/:sessionId/events', requiresAuth: true },

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -698,6 +698,20 @@ export function createHttpServer(
     };
   });
 
+  // GET /v1/ops/capabilities — runtime self-introspection (S3, sprint
+  // 2026-04-26). Returns the same payload as the `memphis_self_describe`
+  // tool so the operator-facing CLI (`memphis tools list/describe`) and
+  // future GUI surfaces share one source of truth. Auth-token gated like
+  // the rest of /v1/ops/*.
+  app.get('/v1/ops/capabilities', async (request) => {
+    const { runMemphisSelfDescribe } = await import('../../mcp/tools/self-describe.js');
+    const query = request.query as { surface?: string; actorId?: string } | undefined;
+    return runMemphisSelfDescribe(
+      { surface: query?.surface, actorId: query?.actorId },
+      process.env,
+    );
+  });
+
   // GET /v1/ops/config/show — redacted view of the current hot-reloadable env
   // surface + field classification. Never echoes secret values.
   //

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -712,6 +712,55 @@ export function createHttpServer(
     );
   });
 
+  // POST /v1/ops/tier3/revoke — revoke an active tier-3 session.
+  // Body shape:
+  //   { surface, actorId } — revoke the specific session (404 if missing)
+  //   { all: true }        — revoke every active session (returns count)
+  //
+  // Auth: MEMPHIS_API_TOKEN (same gate as the GET sister). No operator
+  // passphrase needed — revoke is always a *downgrade* from tier 3 and
+  // mirrors what TUI / Telegram do for free-text `/tier 0|2`.
+  app.post('/v1/ops/tier3/revoke', async (request, reply) => {
+    const { listActiveTier3Sessions, revokeTier3Session } = await import(
+      '../../security/tier3-session.js'
+    );
+    const body = (request.body ?? {}) as { surface?: string; actorId?: string; all?: boolean };
+    const reason = 'operator-cli-revoke';
+    if (body.all === true) {
+      const snapshot = listActiveTier3Sessions(process.env);
+      let revoked = 0;
+      for (const s of snapshot) {
+        if (revokeTier3Session(s.surface, s.actorId, reason, process.env)) revoked += 1;
+      }
+      return { ok: true, revoked, scope: 'all' };
+    }
+    const validSurfaces = ['tui', 'telegram', 'matrix', 'http', 'cli'] as const;
+    if (
+      typeof body.surface !== 'string' ||
+      typeof body.actorId !== 'string' ||
+      !(validSurfaces as readonly string[]).includes(body.surface)
+    ) {
+      return reply.code(400).send({
+        ok: false,
+        error:
+          'tier3 revoke requires { surface, actorId } (surface ∈ tui|telegram|matrix|http|cli) or { all: true }',
+      });
+    }
+    const wasActive = revokeTier3Session(
+      body.surface as (typeof validSurfaces)[number],
+      body.actorId,
+      reason,
+      process.env,
+    );
+    if (!wasActive) {
+      return reply.code(404).send({
+        ok: false,
+        error: `no active tier-3 session for surface=${body.surface} actorId=${body.actorId}`,
+      });
+    }
+    return { ok: true, revoked: 1, surface: body.surface, actorId: body.actorId };
+  });
+
   // GET /v1/ops/config/show — redacted view of the current hot-reloadable env
   // surface + field classification. Never echoes secret values.
   //

--- a/src/mcp/tools/self-describe.ts
+++ b/src/mcp/tools/self-describe.ts
@@ -1,0 +1,160 @@
+/**
+ * `memphis_self_describe` — runtime self-introspection.
+ *
+ * Surfaced after a 2026-04-26 operator session where the bot answered
+ * "I see no tier-3 tools — tier 3 isn't useful" and "I have only tier 0
+ * tools" while running with `maxToolTier=2`. The bot was hallucinating
+ * its capabilities from training data instead of reading runtime state.
+ *
+ * This helper returns a structured snapshot the LLM (and operator-facing
+ * surfaces) can rely on:
+ *
+ *   - active surface name + policy (maxToolTier, allow flags)
+ *   - effective tier (with active tier-3 session info if any)
+ *   - cognitive mode + config
+ *   - full availableTools list with name + tier + capabilities + featureFlag
+ *   - active feature flags (MEMPHIS_FEATURES)
+ *   - cross-surface tier-3 sessions snapshot (PR #282 helper)
+ *
+ * Privacy: NO secret values; only structure + tier classifications.
+ * The returned data is safe to render in operator-facing surfaces and
+ * to feed back into the system prompt.
+ */
+
+import { getCognitiveModeConfig, type CognitiveMode } from '../../cognitive/modes.js';
+import {
+  isToolAllowedForSurface,
+  resolveSurfacePolicy,
+  type SurfacePolicy,
+} from '../../gateway/surface-policy.js';
+import { getToolMeta, getToolNames } from '../../gateway/tool-registry.js';
+import { listEnabledFeatureFlags } from '../../infra/features/flags.js';
+import {
+  getActiveTier3Session,
+  listActiveTier3Sessions,
+} from '../../security/tier3-session.js';
+import { getCognitiveMode } from '../../soul/manifest.js';
+
+export interface MemphisSelfDescribeInput {
+  /** Override surface name. Defaults to `'mcp'` when called from MCP server. */
+  surface?: string;
+  /** Actor id used for tier-3 lookup on the resolved surface. Defaults `'local'`. */
+  actorId?: string;
+}
+
+export interface MemphisSelfDescribeOutput {
+  surface: string;
+  surfacePolicy: SurfacePolicy;
+  effectiveTier: 0 | 1 | 2 | 3;
+  tier3Session: {
+    surface: string;
+    actorId: string;
+    grantedAt: string;
+    expiresAt: string;
+    remainingMs: number;
+  } | null;
+  cognitive: {
+    mode: CognitiveMode;
+    name: string;
+    temperature: number;
+    style: string;
+    pattern: string;
+    description: string;
+  };
+  tools: Array<{
+    name: string;
+    tier: 0 | 1 | 2 | 3;
+    capabilities: string[];
+    description: string;
+    featureFlag: string | null;
+    available: boolean;
+  }>;
+  toolsAvailable: number;
+  toolsRegistered: number;
+  featureFlags: string[];
+  activeTier3SessionsAcrossSurfaces: Array<{
+    surface: string;
+    actorId: string;
+    grantedAt: string;
+    expiresAt: string;
+    remainingMs: number;
+  }>;
+  asOf: string;
+}
+
+export function runMemphisSelfDescribe(
+  input: MemphisSelfDescribeInput = {},
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): MemphisSelfDescribeOutput {
+  const surface = input.surface ?? 'mcp';
+  const actorId = input.actorId ?? 'local';
+  const policy = resolveSurfacePolicy(surface, rawEnv);
+
+  const tier3 = getActiveTier3Session(
+    surface as Parameters<typeof getActiveTier3Session>[0],
+    actorId,
+    rawEnv,
+  );
+  const now = Date.now();
+
+  const effectiveTier = (tier3 ? 3 : policy.maxToolTier) as 0 | 1 | 2 | 3;
+
+  const mode = (getCognitiveMode(rawEnv) ?? 'A') as CognitiveMode;
+  const modeConfig = getCognitiveModeConfig(mode);
+
+  const allRegistered = getToolNames(rawEnv);
+  const toolsRegistered = allRegistered.length;
+
+  const tools = allRegistered.map((name) => {
+    const meta = getToolMeta(name);
+    const available = meta ? isToolAllowedForSurface(name, policy) : false;
+    return {
+      name,
+      tier: (meta?.tier ?? 0) as 0 | 1 | 2 | 3,
+      capabilities: meta?.capabilities ?? [],
+      description: meta?.description ?? '',
+      featureFlag: meta?.featureFlag ?? null,
+      available,
+    };
+  });
+  const toolsAvailable = tools.filter((t) => t.available).length;
+
+  const tier3SessionView = tier3
+    ? {
+        surface: tier3.surface,
+        actorId: tier3.actorId,
+        grantedAt: new Date(tier3.grantedAt).toISOString(),
+        expiresAt: new Date(tier3.expiresAt).toISOString(),
+        remainingMs: Math.max(0, tier3.expiresAt - now),
+      }
+    : null;
+
+  const acrossSurfaces = listActiveTier3Sessions(rawEnv).map((s) => ({
+    surface: s.surface,
+    actorId: s.actorId,
+    grantedAt: new Date(s.grantedAt).toISOString(),
+    expiresAt: new Date(s.expiresAt).toISOString(),
+    remainingMs: Math.max(0, s.expiresAt - now),
+  }));
+
+  return {
+    surface,
+    surfacePolicy: policy,
+    effectiveTier,
+    tier3Session: tier3SessionView,
+    cognitive: {
+      mode,
+      name: modeConfig.name,
+      temperature: modeConfig.temperature,
+      style: modeConfig.style,
+      pattern: modeConfig.pattern,
+      description: modeConfig.description,
+    },
+    tools,
+    toolsAvailable,
+    toolsRegistered,
+    featureFlags: listEnabledFeatureFlags(rawEnv),
+    activeTier3SessionsAcrossSurfaces: acrossSurfaces,
+    asOf: new Date(now).toISOString(),
+  };
+}

--- a/tests/unit/cli.tier.handler.test.ts
+++ b/tests/unit/cli.tier.handler.test.ts
@@ -35,9 +35,10 @@ function buildContext(opts: {
   json?: boolean;
   subcommand?: string;
   token?: string;
+  argv?: string[];
 } = {}): CliContext {
   return {
-    argv: [],
+    argv: opts.argv ?? [],
     args: {
       command: 'tier',
       subcommand: opts.subcommand ?? 'status',
@@ -165,6 +166,117 @@ describe('memphis tier status', () => {
 
     const errOutput = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
     expect(errOutput).toContain('Unknown tier subcommand: bogus');
-    expect(errOutput).toContain('Usage: memphis tier <status>');
+    expect(errOutput).toContain('Usage: memphis tier <status|revoke>');
+  });
+});
+
+describe('memphis tier revoke', () => {
+  it('revokes all sessions when called bare', async () => {
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, revoked: 2, scope: 'all' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await tierCommandHandler.handle(buildContext({ subcommand: 'revoke' }));
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(out).toContain('Revoked 2 tier-3 sessions');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const callBody = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body ?? '{}'));
+    expect(callBody).toEqual({ all: true });
+  });
+
+  it('revokes a specific surface+actor pair via flags', async () => {
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ ok: true, revoked: 1, surface: 'telegram', actorId: '12345' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await tierCommandHandler.handle(
+      buildContext({
+        subcommand: 'revoke',
+        argv: ['--surface', 'telegram', '--actor', '12345'],
+      }),
+    );
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(out).toContain('surface=telegram actor=12345');
+
+    const callBody = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body ?? '{}'));
+    expect(callBody).toEqual({ surface: 'telegram', actorId: '12345' });
+  });
+
+  it('errors when only one of --surface/--actor is supplied', async () => {
+    await tierCommandHandler.handle(
+      buildContext({ subcommand: 'revoke', argv: ['--surface', 'telegram'] }),
+    );
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('--surface and --actor must be supplied together');
+  });
+
+  it('reports zero-revoked when no active sessions', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ ok: true, revoked: 0, scope: 'all' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      ),
+    );
+
+    await tierCommandHandler.handle(buildContext({ subcommand: 'revoke' }));
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(out).toContain('No active tier-3 sessions to revoke');
+  });
+
+  it('surfaces 404 when specific session is missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              ok: false,
+              error: 'no active tier-3 session for surface=tui actorId=ghost',
+            }),
+            { status: 404, headers: { 'content-type': 'application/json' } },
+          ),
+      ),
+    );
+
+    await tierCommandHandler.handle(
+      buildContext({
+        subcommand: 'revoke',
+        argv: ['--surface', 'tui', '--actor', 'ghost'],
+      }),
+    );
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('no active tier-3 session');
+  });
+
+  it('actionable error when daemon refuses connection', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Promise.reject(new Error('connect ECONNREFUSED 127.0.0.1:3100'))),
+    );
+
+    await tierCommandHandler.handle(buildContext({ subcommand: 'revoke' }));
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('Memphis daemon is not running');
   });
 });

--- a/tests/unit/cli.tools.handler.test.ts
+++ b/tests/unit/cli.tools.handler.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for `memphis tools list/describe` CLI handler (S3).
+ *
+ * Mirrors the shape of `cli.tier.handler.test.ts` (PR #282). Mocks global
+ * `fetch` to drive every code path without standing up a daemon.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CliContext } from '../../src/infra/cli/context.js';
+import { toolsCommandHandler } from '../../src/infra/cli/handlers/tools.handler.js';
+
+interface ConsoleSpy {
+  log: ReturnType<typeof vi.spyOn>;
+  error: ReturnType<typeof vi.spyOn>;
+}
+
+let consoleSpy: ConsoleSpy;
+
+beforeEach(() => {
+  consoleSpy = {
+    log: vi.spyOn(console, 'log').mockImplementation(() => undefined),
+    error: vi.spyOn(console, 'error').mockImplementation(() => undefined),
+  };
+});
+
+afterEach(() => {
+  consoleSpy.log.mockRestore();
+  consoleSpy.error.mockRestore();
+  vi.restoreAllMocks();
+});
+
+const samplePayload = {
+  surface: 'cli',
+  surfacePolicy: { maxToolTier: 2 },
+  effectiveTier: 2 as const,
+  cognitive: { mode: 'A', name: 'ConsciousCapture' },
+  tools: [
+    {
+      name: 'memphis_journal',
+      tier: 0 as const,
+      capabilities: ['write'],
+      description: 'Save entries to journal chain',
+      featureFlag: null,
+      available: true,
+    },
+    {
+      name: 'memphis_self_describe',
+      tier: 0 as const,
+      capabilities: ['read'],
+      description: 'Runtime self-introspection',
+      featureFlag: null,
+      available: true,
+    },
+    {
+      name: 'memphis_exec',
+      tier: 2 as const,
+      capabilities: ['execute'],
+      description: 'Run a command',
+      featureFlag: null,
+      available: true,
+    },
+  ],
+  toolsAvailable: 3,
+  toolsRegistered: 3,
+  featureFlags: [],
+  asOf: '2026-04-26T16:00:00.000Z',
+};
+
+function buildContext(opts: {
+  argv?: string[];
+  json?: boolean;
+  subcommand?: string;
+  target?: string;
+} = {}): CliContext {
+  return {
+    argv: opts.argv ?? [],
+    args: {
+      command: 'tools',
+      subcommand: opts.subcommand ?? 'list',
+      target: opts.target,
+      json: opts.json ?? false,
+    } as CliContext['args'],
+    getConfig: () =>
+      ({
+        HOST: '127.0.0.1',
+        PORT: 3100,
+        MEMPHIS_API_TOKEN: 'test-token',
+      }) as ReturnType<CliContext['getConfig']>,
+    getContainer: () => ({}) as ReturnType<CliContext['getContainer']>,
+  };
+}
+
+function mockFetchResolve(payload: unknown, status = 200): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify(payload), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+}
+
+function mockFetchReject(error: Error): void {
+  vi.stubGlobal('fetch', vi.fn(async () => Promise.reject(error)));
+}
+
+describe('memphis tools list', () => {
+  it('renders the surface header + tools by tier', async () => {
+    mockFetchResolve(samplePayload);
+    await toolsCommandHandler.handle(buildContext());
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(out).toContain('Surface: cli');
+    expect(out).toContain('cognitive mode: A (ConsciousCapture)');
+    expect(out).toContain('Tools: 3/3 available');
+    expect(out).toContain('tier 0:');
+    expect(out).toContain('memphis_journal');
+    expect(out).toContain('memphis_self_describe');
+    expect(out).toContain('tier 2:');
+    expect(out).toContain('memphis_exec');
+  });
+
+  it('respects --tier 0 filter via argv', async () => {
+    mockFetchResolve(samplePayload);
+    await toolsCommandHandler.handle(buildContext({ argv: ['--tier', '0'] }));
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(out).toContain('tier 0:');
+    expect(out).not.toContain('tier 2:');
+    expect(out).not.toContain('memphis_exec');
+  });
+
+  it('--json emits parseable shape', async () => {
+    mockFetchResolve(samplePayload);
+    await toolsCommandHandler.handle(buildContext({ json: true }));
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    const parsed = JSON.parse(out);
+    expect(parsed.surface).toBe('cli');
+    expect(parsed.tools).toHaveLength(3);
+  });
+
+  it('actionable error when daemon refuses connection', async () => {
+    mockFetchReject(new Error('fetch failed: connect ECONNREFUSED 127.0.0.1:3100'));
+    await toolsCommandHandler.handle(buildContext());
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('Memphis daemon is not running');
+    expect(err).toContain('systemctl --user start memphis');
+  });
+
+  it('maps 401 to MEMPHIS_API_TOKEN message', async () => {
+    mockFetchResolve({ ok: false }, 401);
+    await toolsCommandHandler.handle(buildContext());
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('Unauthorized (401)');
+    expect(err).toContain('MEMPHIS_API_TOKEN');
+  });
+});
+
+describe('memphis tools describe', () => {
+  it('prints structured detail for known tool', async () => {
+    mockFetchResolve(samplePayload);
+    await toolsCommandHandler.handle(
+      buildContext({ subcommand: 'describe', target: 'memphis_self_describe' }),
+    );
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(out).toContain('Tool:         memphis_self_describe');
+    expect(out).toContain('Tier:         0');
+    expect(out).toContain('Available:    yes');
+    expect(out).toContain('Runtime self-introspection');
+  });
+
+  it('--json emits a single tool object', async () => {
+    mockFetchResolve(samplePayload);
+    await toolsCommandHandler.handle(
+      buildContext({ subcommand: 'describe', target: 'memphis_journal', json: true }),
+    );
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    const parsed = JSON.parse(out);
+    expect(parsed.name).toBe('memphis_journal');
+  });
+
+  it('errors on unknown tool name', async () => {
+    mockFetchResolve(samplePayload);
+    await toolsCommandHandler.handle(
+      buildContext({ subcommand: 'describe', target: 'memphis_bogus' }),
+    );
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('Tool not found');
+    expect(err).toContain('memphis_bogus');
+  });
+
+  it('rejects missing target with usage hint', async () => {
+    await toolsCommandHandler.handle(buildContext({ subcommand: 'describe' }));
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('Usage: memphis tools describe');
+  });
+});
+
+describe('memphis tools subcommand dispatch', () => {
+  it('rejects unknown subcommand with usage hint', async () => {
+    await toolsCommandHandler.handle(buildContext({ subcommand: 'bogus' }));
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('Unknown tools subcommand: bogus');
+    expect(err).toContain('Usage: memphis tools <list|describe>');
+  });
+});

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -146,6 +146,32 @@ describe('gateway system prompt', () => {
     expect(prompt).toContain('no auto-push on the release');
   });
 
+  it('emits a <capabilities> block telling the LLM to use memphis_self_describe (S3)', () => {
+    // 2026-04-26 sprint S3: LLM was hallucinating its capabilities ("I have
+    // only tier 0 tools") while running with maxToolTier=2. The capabilities
+    // block points the LLM at memphis_self_describe (and the per-tool docs
+    // above it) instead of training-data guesses.
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_journal', 'memphis_recall', 'memphis_self_describe'],
+    });
+
+    expect(prompt).toContain('<capabilities>');
+    expect(prompt).toContain('CAPABILITIES');
+    expect(prompt).toContain('Available tools this turn: 3');
+    expect(prompt).toContain('memphis_self_describe');
+    expect(prompt).toContain('do NOT guess from training data');
+    expect(prompt).toContain('`memphis_self_describe` is in your available-tools list above.');
+  });
+
+  it('warns when memphis_self_describe is unavailable on the surface', () => {
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_journal'],
+    });
+    expect(prompt).toContain(
+      'NOTE: `memphis_self_describe` is NOT available on this surface.',
+    );
+  });
+
   it('emits a <tier_system> block clarifying tier 3 is a permissions flag, not a tool tier', () => {
     // 2026-04-26 operator session: bot answered "I see no tier-3 tools, so
     // tier 3 is not useful" — correct observation, wrong conclusion. Tier 3

--- a/tests/unit/self-describe.test.ts
+++ b/tests/unit/self-describe.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for `runMemphisSelfDescribe`.
+ *
+ * Pin the contract surfaced after the 2026-04-26 operator session: the bot
+ * stops hallucinating its capabilities by reading runtime state through this
+ * helper instead.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runMemphisSelfDescribe } from '../../src/mcp/tools/self-describe.js';
+import {
+  __resetTier3SessionsForTests,
+  __seedTier3SessionForTests,
+} from '../../src/security/tier3-session.js';
+
+afterEach(() => {
+  __resetTier3SessionsForTests();
+});
+
+describe('runMemphisSelfDescribe', () => {
+  it('returns surface, policy, cognitive mode, tools and registered count for default surface', () => {
+    const out = runMemphisSelfDescribe({}, { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv);
+
+    expect(out.surface).toBe('mcp');
+    expect(typeof out.surfacePolicy.maxToolTier).toBe('number');
+    expect(['A', 'B', 'C', 'D', 'E']).toContain(out.cognitive.mode);
+    expect(out.toolsRegistered).toBeGreaterThan(0);
+    expect(out.tools.length).toBe(out.toolsRegistered);
+    // memphis_self_describe is itself in the registry
+    expect(out.tools.some((t) => t.name === 'memphis_self_describe')).toBe(true);
+  });
+
+  it('marks tools as available iff their tier is <= surface policy maxToolTier', () => {
+    const out = runMemphisSelfDescribe(
+      { surface: 'telegram' },
+      {
+        MEMPHIS_DATA_DIR: '/tmp/memphis-test',
+        MEMPHIS_SURFACE_TELEGRAM_MAX_TOOL_TIER: '0',
+      } as NodeJS.ProcessEnv,
+    );
+    expect(out.surfacePolicy.maxToolTier).toBe(0);
+    const tier0Tools = out.tools.filter((t) => t.tier === 0);
+    const tier2Tools = out.tools.filter((t) => t.tier === 2);
+    // Tier 0 tools should be available; tier 2 should not.
+    expect(tier0Tools.every((t) => t.available)).toBe(true);
+    if (tier2Tools.length > 0) {
+      expect(tier2Tools.every((t) => !t.available)).toBe(true);
+    }
+  });
+
+  it('reports active tier-3 session for the resolved (surface, actorId) pair', () => {
+    __seedTier3SessionForTests('telegram', '1316033647');
+    const out = runMemphisSelfDescribe(
+      { surface: 'telegram', actorId: '1316033647' },
+      { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv,
+    );
+
+    expect(out.effectiveTier).toBe(3);
+    expect(out.tier3Session).not.toBeNull();
+    expect(out.tier3Session!.surface).toBe('telegram');
+    expect(out.tier3Session!.actorId).toBe('1316033647');
+    expect(out.tier3Session!.remainingMs).toBeGreaterThan(0);
+  });
+
+  it('lists tier-3 sessions across surfaces in activeTier3SessionsAcrossSurfaces', () => {
+    __seedTier3SessionForTests('tui', 'local');
+    __seedTier3SessionForTests('telegram', '42');
+    const out = runMemphisSelfDescribe({}, { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv);
+
+    expect(out.activeTier3SessionsAcrossSurfaces).toHaveLength(2);
+    const surfaces = out.activeTier3SessionsAcrossSurfaces.map((s) => s.surface).sort();
+    expect(surfaces).toEqual(['telegram', 'tui']);
+  });
+
+  it('reflects MEMPHIS_FEATURES env var in featureFlags', () => {
+    const out = runMemphisSelfDescribe(
+      {},
+      {
+        MEMPHIS_DATA_DIR: '/tmp/memphis-test',
+        MEMPHIS_FEATURES: 'experimental-tools',
+      } as NodeJS.ProcessEnv,
+    );
+    expect(out.featureFlags).toContain('experimental-tools');
+  });
+
+  it('emits ISO timestamps for asOf and tier3 session timestamps', () => {
+    __seedTier3SessionForTests('cli', 'local');
+    const out = runMemphisSelfDescribe(
+      { surface: 'cli', actorId: 'local' },
+      { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv,
+    );
+    expect(out.asOf).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(out.tier3Session!.grantedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(out.tier3Session!.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/tests/unit/tool-executor-runtime-coverage.test.ts
+++ b/tests/unit/tool-executor-runtime-coverage.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit test: runtime executor (in-process) exposes the same tools as the
+ * registry, modulo feature-flagged ones.
+ *
+ * Surfaced after a 2026-04-26 deep search (sprint S1): seven tools were
+ * declared in `tool-registry.ts` but had no runtime handler — the LLM
+ * could see them in auto-generated docs but tool calls would land
+ * "tool not found". This test pins the contract that for every
+ * registered, feature-flag-allowed tool there IS a runtime handler.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { createInProcessToolExecutor } from '../../src/gateway/tool-executor.js';
+import { getToolNames } from '../../src/gateway/tool-registry.js';
+
+describe('runtime tool executor coverage', () => {
+  it('exposes every registered (non-experimental) tool as a runtime handler', () => {
+    const executor = createInProcessToolExecutor();
+    const runtimeNames = new Set(executor.listTools().map((t) => t.name));
+    const registryNames = getToolNames();
+
+    const missing = registryNames.filter((n) => !runtimeNames.has(n));
+    expect(missing).toEqual([]);
+  });
+
+  it('exposes the seven tools wired in sprint S1', () => {
+    const executor = createInProcessToolExecutor();
+    const names = new Set(executor.listTools().map((t) => t.name));
+
+    // S1 (2026-04-26) deep-search finding: these were in registry but
+    // not in createRuntimeTools, which left them invisible to TUI/Telegram
+    // chat surfaces (only MCP could see them). Now thin-wrapped.
+    expect(names.has('memphis_config_show')).toBe(true);
+    expect(names.has('memphis_config_set')).toBe(true);
+    expect(names.has('memphis_config_reload')).toBe(true);
+    expect(names.has('memphis_cognitive_mode_set')).toBe(true);
+    expect(names.has('memphis_presence')).toBe(true);
+    expect(names.has('memphis_loop_step')).toBe(true);
+    expect(names.has('memphis_restart')).toBe(true);
+  });
+
+  it('exposes experimental-feature-gated tools when MEMPHIS_FEATURES flag is set', () => {
+    const executor = createInProcessToolExecutor({
+      rawEnv: { ...process.env, MEMPHIS_FEATURES: 'experimental-tools' },
+    });
+    const names = new Set(executor.listTools().map((t) => t.name));
+
+    const flagged = getToolNames({ MEMPHIS_FEATURES: 'experimental-tools' });
+    const missing = flagged.filter((n) => !names.has(n));
+    expect(missing).toEqual([]);
+  });
+});

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -14,7 +14,8 @@ describe('tool registry', () => {
   it('exports all registered tools', () => {
     // Codex Round 5 P1 fix (#107): added 2 tier-2 mutating tools to
     // TOOL_REGISTRY (memphis_config_set, memphis_cognitive_mode_set).
-    expect(getToolNames()).toHaveLength(34);
+    // S3 (sprint 2026-04-26): added memphis_self_describe (tier 0, read).
+    expect(getToolNames()).toHaveLength(35);
   });
 
   it('hides experimental preview tools by default', () => {
@@ -71,7 +72,8 @@ describe('tool registry', () => {
 
   it('getToolsByTier returns correct tools', () => {
     const tier0 = getToolsByTier(0);
-    expect(tier0.length).toBe(13);
+    // 14 = 13 base tier-0 + memphis_self_describe (S3, sprint 2026-04-26)
+    expect(tier0.length).toBe(14);
     expect(tier0.every((t) => t.tier === 0)).toBe(true);
 
     const tier1 = getToolsByTier(1);


### PR DESCRIPTION
## Summary

Two bundled S6 fixes — both operator-facing, both small and tested.

### 1. Chat error-limit diagnostics (Task #21)

The native rust chat loop aborted with the bare string \"native rust chat exceeded recoverable error limit\" — operator hit this in TUI on 2026-04-26 with no way to know which tools failed without digging through logs. Symptom from operator side: \"duplicate replies\" (the LLM was actually retrying the same tool with the same args, silently).

Changes (\`crates/memphis-operator/src/chat.rs\`):
- accumulate \`(tool_name, first_line_of_error)\` per failure into an \`error_trail: Vec\`
- on abort, format the trail into the error: \`\"... (9 errors). Trail: tool_a: timeout; tool_b: bad param; tool_a: timeout\"\`
- bump default \`CHAT_MAX_ERRORS_DEFAULT\` 4 → 8 (LLM tool-use loops occasionally need 5–6 to recover; still env-overridable via \`MEMPHIS_CHAT_MAX_ERRORS\`)

### 2. \`memphis tier revoke\` CLI (S6 backlog)

TUI (\`/tier 0|2\` after #284) and Telegram (post #285) could revoke tier-3 sessions; CLI was inspect-only. Closing the surface gap.

Changes:
- new \`POST /v1/ops/tier3/revoke\` endpoint (\`src/infra/http/server.ts\`); auth-token gated
- body shapes: \`{ all: true }\` revokes every active session; \`{ surface, actorId }\` revokes a specific pair (404 if missing); surface validated against the \`Tier3Surface\` union
- new CLI subcommand \`memphis tier revoke [--surface <name> --actor <id>] [--json]\` (\`src/infra/cli/handlers/tier.handler.ts\`)
- handles ECONNREFUSED / 401 / 404 / partial-flags with actionable messages

## Test plan

- [x] \`cargo test -p memphis-operator --lib\` — 56/56 green
- [x] \`npm run typecheck\` clean
- [x] \`npx vitest run tests/unit/cli.tier.handler.test.ts\` — 12/12 green (6 new for revoke)

## Rubric impact

- **Criterion #6 (open known bugs):** Task #21 → closed; revoke gap → closed.
- One operator hot-fix from S6 backlog (\`memphis vault migrate\` for legacy \`./data/vault-*.json\`) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)