### PR TITLE
feat(cli): memphis vault migrate — move legacy data/vault-*.json (S6)

### DIFF
--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -231,7 +231,7 @@ workflow: Classify arbitrary text against Memphis taxonomy and emit tags. Use `-
 
 Encrypted secret storage with passphrase protection.
 
-syntax: `memphis vault <init|add|get|list> [--passphrase <secret>] [--recovery-question <q>] [--recovery-answer <a>] [--key <name>] [--value <text>] [--json]`
+syntax: `memphis vault <init|add|get|list|migrate|reset|pepper-rotate|master-key-rotate|entry-delete|recovery-unlock> [--passphrase <secret>] [--recovery-question <q>] [--recovery-answer <a>] [--key <name>] [--value <text>] [--yes] [--json]`
 
 workflow:
 
@@ -239,6 +239,7 @@ workflow:
 - `vault add --key <name> --value <text>`: Store an encrypted secret
 - `vault get --key <name>`: Retrieve and decrypt a secret
 - `vault list [--key <prefix>]`: List stored secret metadata (not values)
+- `vault migrate [--yes] [--json]`: Move legacy `${installRoot}/data/vault-{state,entries}.json` files into `${MEMPHIS_HOME ?? ~/.memphis}/`. Refuses to clobber if a target file already exists. Operators with installs predating PR #279 use this to opt-in to the new absolute-path defaults.
 
 ---
 

--- a/src/infra/cli/handlers/vault.handler.ts
+++ b/src/infra/cli/handlers/vault.handler.ts
@@ -709,6 +709,11 @@ async function handleVaultMigrate(context: CliContext): Promise<boolean> {
       '\nIf the new location is the active vault, delete the legacy files manually.\n' +
         'If the legacy location is the active vault, set MEMPHIS_VAULT_*_PATH to point to it.',
     );
+    // Codex P2 fix on PR #289: scripts that wrap `vault migrate` need
+    // a non-zero exit code to know the operation was refused. `return
+    // true` is "I handled it" — the failure signal goes through
+    // process.exitCode, mirroring the configure-retired pattern.
+    process.exitCode = 1;
     return true;
   }
 
@@ -716,6 +721,7 @@ async function handleVaultMigrate(context: CliContext): Promise<boolean> {
   if (!yes) {
     if (!process.stdin.isTTY) {
       console.error('vault migrate requires --yes when stdin is not a TTY.');
+      process.exitCode = 1;
       return true;
     }
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });

--- a/src/infra/cli/handlers/vault.handler.ts
+++ b/src/infra/cli/handlers/vault.handler.ts
@@ -3,6 +3,8 @@ import { dirname, join } from 'node:path';
 import { emitKeypressEvents } from 'node:readline';
 import { createInterface } from 'node:readline/promises';
 
+import type { CommandHandler } from './command-handler.js';
+import { getDataDir } from '../../../config/paths.js';
 import {
   recoverOperatorPassphrase,
   requireOperatorAuth,
@@ -16,11 +18,11 @@ import {
 } from '../../../security/vault-boundary.js';
 import { findVaultKeyReferences, upsertEnvVars } from '../../config/env-file.js';
 import { writeSecurityAudit } from '../../logging/security-audit.js';
+import { resolveInstallRoot } from '../../runtime/install-root.js';
 import { rotateVaultMasterKey, rotateVaultStatePepper } from '../../storage/rust-vault-adapter.js';
 import { deleteVaultEntriesByKey, listVaultEntries } from '../../storage/vault-entry-store.js';
 import { resolveVaultPath } from '../../storage/vault-paths.js';
 import type { CliContext } from '../context.js';
-import type { CommandHandler } from './command-handler.js';
 import { print } from '../utils/render.js';
 
 function resolveVaultStatePath(rawEnv: NodeJS.ProcessEnv): string {
@@ -106,6 +108,7 @@ export const vaultCommandHandler: CommandHandler = {
       'entry-delete': async () => handleVaultEntryDelete(context),
       'master-key-rotate': async () => handleVaultMasterKeyRotate(context),
       'recovery-unlock': () => handleVaultRecoveryUnlock(context),
+      migrate: async () => handleVaultMigrate(context),
     };
     const handler = subcommand ? handlers[subcommand] : undefined;
     if (!handler) throw new Error(`Unknown vault subcommand: ${String(subcommand)}`);
@@ -622,6 +625,166 @@ async function handleVaultMasterKeyRotate(context: CliContext): Promise<boolean>
     });
     throw err;
   }
+}
+
+/**
+ * Move legacy `${installRoot}/data/vault-{state,entries}.json` files into the
+ * new home (`${MEMPHIS_HOME ?? ~/.memphis}/`).
+ *
+ * The 2026-04-25 silent re-init incident traced back to relative `./data/...`
+ * paths sharing the same vault between the daemon and any one-shot script
+ * launched from the repo root. PR #279 introduced absolute MEMPHIS_HOME paths
+ * with a deprecation warning when legacy files are detected. This subcommand
+ * is the operator-facing migration step.
+ *
+ * Behaviour:
+ *   - Detects legacy + new locations for both vault-state.json and
+ *     vault-entries.json
+ *   - If neither file exists in the legacy location → nothing to do
+ *   - If a new-location file already exists alongside a legacy one → refuses
+ *     (would clobber active state). Operator must resolve manually.
+ *   - Otherwise renames each file (atomic rename, falls back to copy+unlink
+ *     when crossing filesystems) and reports the result.
+ *   - Requires `--yes` for non-interactive confirmation, or prompts on TTY.
+ *
+ * Audit: every move emits a `vault-migrate` audit row.
+ */
+async function handleVaultMigrate(context: CliContext): Promise<boolean> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const readline = await import('node:readline/promises');
+
+  const rawEnv = process.env as NodeJS.ProcessEnv;
+  const newDir = getDataDir(rawEnv);
+  let installRoot: string | null = null;
+  try {
+    installRoot = resolveInstallRoot({ rawEnv });
+  } catch {
+    // ignore — handled below
+  }
+  if (!installRoot) {
+    console.error(
+      'vault migrate: could not discover install root; nothing to migrate.\n' +
+        'If your legacy vault lives somewhere unusual, set MEMPHIS_VAULT_STATE_PATH and ' +
+        'MEMPHIS_VAULT_ENTRIES_PATH instead and skip the migrate step.',
+    );
+    return true;
+  }
+
+  const files = ['vault-state.json', 'vault-entries.json'] as const;
+  const plan = await Promise.all(
+    files.map(async (file) => {
+      const legacy = path.join(installRoot, 'data', file);
+      const target = path.join(newDir, file);
+      const legacyExists = await fs
+        .access(legacy)
+        .then(() => true)
+        .catch(() => false);
+      const targetExists = await fs
+        .access(target)
+        .then(() => true)
+        .catch(() => false);
+      return { file, legacy, target, legacyExists, targetExists };
+    }),
+  );
+
+  const moves = plan.filter((p) => p.legacyExists);
+  if (moves.length === 0) {
+    if (context.args.json) {
+      console.log(JSON.stringify({ ok: true, migrated: 0, reason: 'no-legacy-vault' }, null, 2));
+    } else {
+      console.log(`No legacy vault files at ${path.join(installRoot, 'data')} — nothing to migrate.`);
+      console.log(`Active vault location: ${newDir}`);
+    }
+    return true;
+  }
+
+  const conflicts = moves.filter((p) => p.targetExists);
+  if (conflicts.length > 0) {
+    console.error('vault migrate refusing to clobber existing files:');
+    for (const c of conflicts) {
+      console.error(`  ${c.file}: legacy=${c.legacy} target=${c.target} (target exists)`);
+    }
+    console.error(
+      '\nIf the new location is the active vault, delete the legacy files manually.\n' +
+        'If the legacy location is the active vault, set MEMPHIS_VAULT_*_PATH to point to it.',
+    );
+    return true;
+  }
+
+  const yes = context.argv.includes('--yes');
+  if (!yes) {
+    if (!process.stdin.isTTY) {
+      console.error('vault migrate requires --yes when stdin is not a TTY.');
+      return true;
+    }
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      console.log('vault migrate plan:');
+      for (const m of moves) {
+        console.log(`  move ${m.legacy}`);
+        console.log(`    → ${m.target}`);
+      }
+      const answer = (await rl.question('Proceed? [y/N] ')).trim().toLowerCase();
+      if (answer !== 'y' && answer !== 'yes') {
+        console.log('Aborted.');
+        return true;
+      }
+    } finally {
+      rl.close();
+    }
+  }
+
+  await fs.mkdir(newDir, { recursive: true });
+  const moved: string[] = [];
+  for (const m of moves) {
+    try {
+      await fs.rename(m.legacy, m.target);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === 'EXDEV') {
+        // Cross-filesystem rename → fall back to copy+unlink.
+        await fs.copyFile(m.legacy, m.target);
+        await fs.unlink(m.legacy);
+      } else {
+        throw error;
+      }
+    }
+    moved.push(m.file);
+    try {
+      writeSecurityAudit({
+        action: 'vault-migrate',
+        status: 'allowed',
+        details: { actor: 'cli', file: m.file, legacy: m.legacy, target: m.target },
+      });
+    } catch {
+      /* audit best-effort */
+    }
+  }
+
+  if (context.args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          migrated: moved.length,
+          files: moved,
+          legacyDir: path.join(installRoot, 'data'),
+          targetDir: newDir,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(`Migrated ${moved.length} vault file${moved.length === 1 ? '' : 's'}:`);
+    for (const file of moved) {
+      console.log(`  ${file}`);
+    }
+    console.log(`From: ${path.join(installRoot, 'data')}`);
+    console.log(`To:   ${newDir}`);
+  }
+  return true;
 }
 
 async function handleVaultReset(context: CliContext): Promise<boolean> {

--- a/tests/unit/cli.vault-migrate.test.ts
+++ b/tests/unit/cli.vault-migrate.test.ts
@@ -43,6 +43,8 @@ beforeEach(() => {
   // getDataDir reads MEMPHIS_DATA_DIR / MEMPHIS_DIR (not MEMPHIS_HOME).
   process.env.MEMPHIS_DATA_DIR = memphisHome;
   delete process.env.MEMPHIS_DIR;
+  // Reset between tests so exit-code assertions don't leak across cases.
+  process.exitCode = 0;
 });
 
 afterEach(() => {
@@ -138,6 +140,9 @@ describe('memphis vault migrate', () => {
     expect(readFileSync(join(installRoot, 'data', 'vault-state.json'), 'utf8')).toBe(
       '{"legacy":true}',
     );
+    // Codex P2 fix: scripts wrapping `vault migrate` must see a non-zero
+    // exit code on conflict refusal, not a silent success.
+    expect(process.exitCode).toBe(1);
   });
 
   it('requires --yes when stdin is not a TTY', async () => {
@@ -154,5 +159,6 @@ describe('memphis vault migrate', () => {
     const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
     expect(err).toContain('requires --yes');
     expect(existsSync(join(installRoot, 'data', 'vault-state.json'))).toBe(true);
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/tests/unit/cli.vault-migrate.test.ts
+++ b/tests/unit/cli.vault-migrate.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for `memphis vault migrate` (S6).
+ *
+ * Drives the handler against a tmpdir filesystem so file moves are real but
+ * isolated. Exercises: no-legacy, both-files, partial, conflict-with-target,
+ * --yes acceptance, JSON output.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CliContext } from '../../src/infra/cli/context.js';
+import { vaultCommandHandler } from '../../src/infra/cli/handlers/vault.handler.js';
+
+interface ConsoleSpy {
+  log: ReturnType<typeof vi.spyOn>;
+  error: ReturnType<typeof vi.spyOn>;
+}
+
+let consoleSpy: ConsoleSpy;
+let installRoot: string;
+let memphisHome: string;
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  consoleSpy = {
+    log: vi.spyOn(console, 'log').mockImplementation(() => undefined),
+    error: vi.spyOn(console, 'error').mockImplementation(() => undefined),
+  };
+  installRoot = mkdtempSync(join(tmpdir(), 'memphis-vault-migrate-install-'));
+  memphisHome = mkdtempSync(join(tmpdir(), 'memphis-vault-migrate-home-'));
+  // resolveInstallRoot validates MEMPHIS_RUNTIME_ROOT against package.json
+  // name "@memphis-chains/memphis" — fake one so the override is accepted.
+  writeFileSync(
+    join(installRoot, 'package.json'),
+    JSON.stringify({ name: '@memphis-chains/memphis' }),
+  );
+  originalEnv = { ...process.env };
+  process.env.MEMPHIS_RUNTIME_ROOT = installRoot;
+  // getDataDir reads MEMPHIS_DATA_DIR / MEMPHIS_DIR (not MEMPHIS_HOME).
+  process.env.MEMPHIS_DATA_DIR = memphisHome;
+  delete process.env.MEMPHIS_DIR;
+});
+
+afterEach(() => {
+  consoleSpy.log.mockRestore();
+  consoleSpy.error.mockRestore();
+  vi.restoreAllMocks();
+  rmSync(installRoot, { recursive: true, force: true });
+  rmSync(memphisHome, { recursive: true, force: true });
+  process.env = originalEnv;
+});
+
+function buildContext(opts: {
+  argv?: string[];
+  json?: boolean;
+} = {}): CliContext {
+  return {
+    argv: opts.argv ?? ['--yes'],
+    args: {
+      command: 'vault',
+      subcommand: 'migrate',
+      json: opts.json ?? false,
+    } as CliContext['args'],
+    getConfig: () => ({}) as ReturnType<CliContext['getConfig']>,
+    getContainer: () => ({}) as ReturnType<CliContext['getContainer']>,
+  };
+}
+
+function writeLegacy(file: string, content: string): string {
+  const dir = join(installRoot, 'data');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, file);
+  writeFileSync(path, content);
+  return path;
+}
+
+function writeNew(file: string, content: string): string {
+  const path = join(memphisHome, file);
+  writeFileSync(path, content);
+  return path;
+}
+
+describe('memphis vault migrate', () => {
+  it('reports no-op when no legacy files exist', async () => {
+    await vaultCommandHandler.handle(buildContext({ json: true }));
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.migrated).toBe(0);
+    expect(parsed.reason).toBe('no-legacy-vault');
+  });
+
+  it('moves both vault files when only legacy exists', async () => {
+    writeLegacy('vault-state.json', '{"v":1}');
+    writeLegacy('vault-entries.json', '[{"k":"x"}]');
+
+    await vaultCommandHandler.handle(buildContext({ json: true }));
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.migrated).toBe(2);
+    expect(parsed.files).toEqual(
+      expect.arrayContaining(['vault-state.json', 'vault-entries.json']),
+    );
+
+    expect(existsSync(join(installRoot, 'data', 'vault-state.json'))).toBe(false);
+    expect(existsSync(join(installRoot, 'data', 'vault-entries.json'))).toBe(false);
+    expect(readFileSync(join(memphisHome, 'vault-state.json'), 'utf8')).toBe('{"v":1}');
+    expect(readFileSync(join(memphisHome, 'vault-entries.json'), 'utf8')).toBe('[{"k":"x"}]');
+  });
+
+  it('moves only the file that exists (partial legacy)', async () => {
+    writeLegacy('vault-state.json', '{"v":2}');
+
+    await vaultCommandHandler.handle(buildContext({ json: true }));
+
+    const parsed = JSON.parse(consoleSpy.log.mock.calls.map((c) => c[0]).join('\n'));
+    expect(parsed.migrated).toBe(1);
+    expect(parsed.files).toEqual(['vault-state.json']);
+  });
+
+  it('refuses to clobber when target file already exists', async () => {
+    writeLegacy('vault-state.json', '{"legacy":true}');
+    writeNew('vault-state.json', '{"new":true}');
+
+    await vaultCommandHandler.handle(buildContext({ json: true }));
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('refusing to clobber');
+    expect(err).toContain('vault-state.json');
+    expect(readFileSync(join(memphisHome, 'vault-state.json'), 'utf8')).toBe('{"new":true}');
+    expect(readFileSync(join(installRoot, 'data', 'vault-state.json'), 'utf8')).toBe(
+      '{"legacy":true}',
+    );
+  });
+
+  it('requires --yes when stdin is not a TTY', async () => {
+    writeLegacy('vault-state.json', '{"v":3}');
+    const wasIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+    try {
+      await vaultCommandHandler.handle(buildContext({ argv: [] }));
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: wasIsTTY, configurable: true });
+    }
+
+    const err = consoleSpy.error.mock.calls.map((c) => c[0]).join('\n');
+    expect(err).toContain('requires --yes');
+    expect(existsSync(join(installRoot, 'data', 'vault-state.json'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last S6 backlog item. PR #279 introduced absolute-path vault defaults under \`MEMPHIS_HOME\` (\`~/.memphis\`) to fix the 2026-04-25 silent re-init incident — relative \`./data/...\` paths let smoke scripts share the daemon's vault by accident. The resolver still honors the legacy path with a one-time deprecation warning, but operators had no clean way to migrate.

## Behaviour

\`memphis vault migrate [--yes] [--json]\`

| State | Action |
|---|---|
| No legacy files | reports no-op |
| Legacy only | renames into new location (atomic; falls back to copy+unlink across FS) |
| Legacy + new both populated | **refuses** to clobber, prints both paths so operator decides |
| Stdin not a TTY without \`--yes\` | refuses, asks for explicit \`--yes\` |
| Stdin is TTY | prompts \`Proceed? [y/N]\` |

Each successful move audits via \`writeSecurityAudit({ action: 'vault-migrate' })\`.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npx vitest run tests/unit/cli.vault-migrate.test.ts\` — **5/5 green** against a real tmpdir filesystem (no-op / both files / partial / conflict refusal / --yes-required-when-non-TTY)

## Rubric impact

S6 backlog items: 3/3 closed.
- Task #21 (chat error diagnostics) — PR #288
- \`memphis tier revoke\` CLI — PR #288
- \`memphis vault migrate\` CLI — **this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)