### PR TITLE
chore(s7): zero lint warnings — strip dead eslint-disable directives

### DIFF
--- a/tests/unit/consent-mark.test.ts
+++ b/tests/unit/consent-mark.test.ts
@@ -32,7 +32,6 @@ function mkCtx(args: Record<string, unknown>): {
 describe('consent mark CLI', () => {
   it('rejects unknown consent level', async () => {
     await expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       consentCommandHandler.handle(
         mkCtx({ subcommand: 'mark', chain: 'journal', fromIndex: 0, level: 'bogus', json: true }) as any,
       ),
@@ -41,7 +40,6 @@ describe('consent mark CLI', () => {
 
   it('rejects missing --chain', async () => {
     await expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       consentCommandHandler.handle(
         mkCtx({ subcommand: 'mark', fromIndex: 0, level: 'exportable', json: true }) as any,
       ),
@@ -51,7 +49,6 @@ describe('consent mark CLI', () => {
   it('rejects non-integer --from-index (no silent Math.floor coercion)', async () => {
     await expect(
       consentCommandHandler.handle(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         mkCtx({ subcommand: 'mark', chain: 'journal', fromIndex: 1.9, level: 'exportable', json: true }) as any,
       ),
     ).rejects.toThrow(/non-negative integer/);
@@ -59,7 +56,6 @@ describe('consent mark CLI', () => {
 
   it('rejects --from-index past chain tip', async () => {
     await expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       consentCommandHandler.handle(
         mkCtx({ subcommand: 'mark', chain: 'journal', fromIndex: 99, level: 'exportable', json: true }) as any,
       ),
@@ -69,7 +65,6 @@ describe('consent mark CLI', () => {
   it('canonicalizes chain aliases so target_chain matches the inspected chain', async () => {
     appendBlockMock.mockClear();
     await consentCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({
         subcommand: 'mark',
         chain: 'decision',
@@ -88,7 +83,6 @@ describe('consent mark CLI', () => {
     appendBlockMock.mockClear();
     // Dry run
     await consentCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({
         subcommand: 'mark',
         chain: 'journal',
@@ -101,7 +95,6 @@ describe('consent mark CLI', () => {
     expect(appendBlockMock).not.toHaveBeenCalled();
     // Real run
     await consentCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({
         subcommand: 'mark',
         chain: 'journal',

--- a/tests/unit/kartograf-cli.test.ts
+++ b/tests/unit/kartograf-cli.test.ts
@@ -57,7 +57,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
     // Capture stdout via console spy
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     await kartografCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({ subcommand: 'verify', file: envelopePath, json: true }) as any,
     );
     const out = JSON.parse(spy.mock.calls[0][0] as string);
@@ -78,7 +77,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
 
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     await kartografCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({ subcommand: 'verify', file: envelopePath, json: true }) as any,
     );
     const out = JSON.parse(spy.mock.calls[0][0] as string);
@@ -99,7 +97,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
 
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     await kartografCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({ subcommand: 'install', file: envelopePath, source: 'file', json: true }) as any,
     );
     const out = JSON.parse(spy.mock.calls[0][0] as string);
@@ -126,7 +123,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
     writeFileSync(join(dir, 'checkpoint.json'), JSON.stringify(env1));
     const log1 = vi.spyOn(console, 'log').mockImplementation(() => {});
     await kartografCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({ subcommand: 'install', file: join(dir, 'checkpoint.json'), source: 'file', json: true }) as any,
     );
     const out1 = JSON.parse(log1.mock.calls[0][0] as string);
@@ -147,7 +143,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
     writeFileSync(join(dir, 'checkpoint.json'), JSON.stringify(env2));
     const log2 = vi.spyOn(console, 'log').mockImplementation(() => {});
     await kartografCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({ subcommand: 'install', file: join(dir, 'checkpoint.json'), source: 'file', json: true }) as any,
     );
     const out2 = JSON.parse(log2.mock.calls[0][0] as string);
@@ -168,7 +163,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
     writeFileSync(join(dir, 'placeholder.json'), '{}');
     await expect(
       kartografCommandHandler.handle(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         mkCtx({
           subcommand: 'install',
           file: join(dir, 'placeholder.json'),
@@ -198,7 +192,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
 
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     await kartografCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({
         subcommand: 'install',
         file: envelopePath,
@@ -240,7 +233,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
 
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     await kartografCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({ subcommand: 'install', file: envelopePath, source: 'file', json: true }) as any,
     );
     const out = JSON.parse(spy.mock.calls[0][0] as string);
@@ -258,7 +250,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
     writeFileSync(join(dir, 'placeholder.json'), '{}');
     await expect(
       kartografCommandHandler.handle(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         mkCtx({
           subcommand: 'install',
           file: join(dir, 'placeholder.json'),
@@ -291,7 +282,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
 
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     await kartografCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({ subcommand: 'install', file: envelopePath, source: 'file', json: true }) as any,
     );
     const out = JSON.parse(spy.mock.calls[0][0] as string);
@@ -326,7 +316,6 @@ describe('memphis kartograf CLI (N40.2)', () => {
     process.env.MEMPHIS_DATA_DIR = dataDir;
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     await kartografCommandHandler.handle(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mkCtx({ subcommand: 'install', file: envelopePath, source: 'file', json: true }) as any,
     );
     const out = JSON.parse(spy.mock.calls[0][0] as string);


### PR DESCRIPTION
## Summary

S7 quality gate. \`tests/**\` files override \`@typescript-eslint/no-explicit-any\` to \`'off'\` (\`eslint.config.mjs:67\`), so 18 \`eslint-disable-next-line @typescript-eslint/no-explicit-any\` directives in two test files were dead — ESLint had been emitting warnings for each.

## Changes

- \`tests/unit/consent-mark.test.ts\`: 7 directives removed
- \`tests/unit/kartograf-cli.test.ts\`: 11 directives removed

(\`eslint --fix\` peeled them to whitespace-only lines; a follow-up sed strip removed those stranded blanks.)

## Test plan

- [x] \`npx eslint .\` → **0 errors / 0 warnings**
- [x] \`npm run typecheck\` clean
- [x] \`npx vitest run tests/unit/consent-mark.test.ts tests/unit/kartograf-cli.test.ts\` → 16/16 green

## Rubric impact

Criterion #7 (typecheck/lint warnings): ~18 → **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)