### PR TITLE
fix(backup): pepper-restore writes to installRoot/.env (Phase 2 bug)

### DIFF
--- a/src/infra/cli/commands/backup.ts
+++ b/src/infra/cli/commands/backup.ts
@@ -584,12 +584,19 @@ function verifyChecksum(archivePath: string): {
  * Write `MEMPHIS_VAULT_PEPPER=<pepper>` into the restored `.env` so the vault
  * (encrypted with the source host's pepper) stays decryptable after a
  * cross-host restore. The pepper itself is never logged or returned.
+ *
+ * Path bug fix (2026-04-26): originally wrote to `${memphisRoot}/.env`
+ * (i.e. `~/.memphis/.env`), but the daemon's dotenv loader anchors on
+ * `${installRoot}/.env` (the repo dir, e.g. `~/memphis/.env`). The pepper
+ * landed in a file the daemon never reads, so vault decryption failed
+ * silently after every cross-host restore. Now uses `resolveDotEnvPath`
+ * — the same helper `setDotEnvValues` uses everywhere else in Memphis.
  */
-function applyRestoredVaultPepper(memphisRoot: string, pepper: string): void {
+function applyRestoredVaultPepper(_memphisRoot: string, pepper: string): void {
   if (pepper.length < 12) {
     throw new Error('--pepper-restore: pepper must be at least 12 characters');
   }
-  const envPath = join(memphisRoot, '.env');
+  const envPath = resolveDotEnvPath();
   const existing = existsSync(envPath) ? readFileSync(envPath, 'utf8').split(/\r?\n/) : [];
   const next: string[] = [];
   let replaced = false;

--- a/tests/integration/backup-restore-drill.test.ts
+++ b/tests/integration/backup-restore-drill.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createBackup, restoreBackup } from '../../src/infra/cli/commands/backup.js';
+import { resetInstallRootMemoForTests } from '../../src/infra/runtime/install-root.js';
 
 interface DrillEnv {
   memphisRoot: string;
@@ -39,6 +40,16 @@ function setupDrillEnv(): DrillEnv {
     'MEMPHIS_VAULT_PEPPER=originalPepper123456\nGEN_MAX_TOKENS=1024\n',
     'utf8',
   );
+  // The pepper-restore path now anchors on `resolveInstallRoot()` (PR #294),
+  // which validates that the candidate dir has a `package.json` with name
+  // `@memphis-chains/memphis`. Drop a marker package.json into memphisRoot
+  // so the test's tmpdir is a valid install root, then point the resolver
+  // at it via MEMPHIS_RUNTIME_ROOT.
+  writeFileSync(
+    join(memphisRoot, 'package.json'),
+    JSON.stringify({ name: '@memphis-chains/memphis', version: '0.0.0-test' }),
+    'utf8',
+  );
   mkdirSync(backupRoot, { recursive: true });
   return { memphisRoot, backupRoot };
 }
@@ -50,11 +61,19 @@ function tearDown(env: DrillEnv): void {
 describe('backup → wipe → restore round trip', () => {
   let env: DrillEnv;
 
+  let savedRuntimeRoot: string | undefined;
+
   beforeEach(() => {
     env = setupDrillEnv();
+    savedRuntimeRoot = process.env.MEMPHIS_RUNTIME_ROOT;
+    process.env.MEMPHIS_RUNTIME_ROOT = env.memphisRoot;
+    resetInstallRootMemoForTests();
   });
 
   afterEach(() => {
+    if (savedRuntimeRoot === undefined) delete process.env.MEMPHIS_RUNTIME_ROOT;
+    else process.env.MEMPHIS_RUNTIME_ROOT = savedRuntimeRoot;
+    resetInstallRootMemoForTests();
     tearDown(env);
   });
 
@@ -122,11 +141,19 @@ describe('backup → wipe → restore round trip', () => {
 describe('--pepper-restore for cross-host vault recovery', () => {
   let env: DrillEnv;
 
+  let savedRuntimeRoot: string | undefined;
+
   beforeEach(() => {
     env = setupDrillEnv();
+    savedRuntimeRoot = process.env.MEMPHIS_RUNTIME_ROOT;
+    process.env.MEMPHIS_RUNTIME_ROOT = env.memphisRoot;
+    resetInstallRootMemoForTests();
   });
 
   afterEach(() => {
+    if (savedRuntimeRoot === undefined) delete process.env.MEMPHIS_RUNTIME_ROOT;
+    else process.env.MEMPHIS_RUNTIME_ROOT = savedRuntimeRoot;
+    resetInstallRootMemoForTests();
     tearDown(env);
   });
 

--- a/tests/unit/backup-pepper-restore-path.test.ts
+++ b/tests/unit/backup-pepper-restore-path.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression: --pepper-restore must write to ${installRoot}/.env, not
+ * ${memphisRoot}/.env. The original implementation
+ * (`applyRestoredVaultPepper`) targeted memphisRoot — i.e. ~/.memphis/.env —
+ * but the daemon's dotenv loader anchors on installRoot/.env (the repo dir,
+ * e.g. ~/memphis/.env). Result: the pepper landed in a file the daemon
+ * never reads, and vault decryption silently failed after every
+ * cross-host restore. Fix replaces the hardcoded path with
+ * `resolveDotEnvPath()` (the same helper `setDotEnvValues` uses).
+ *
+ * This test pins the fix by:
+ *   - building a synthetic install root in a tmpdir (with a `package.json`
+ *     so `resolveInstallRoot` accepts the override)
+ *   - pointing MEMPHIS_RUNTIME_ROOT at that tmpdir
+ *   - running create→restore with --pepper-restore
+ *   - asserting the new `MEMPHIS_VAULT_PEPPER=` line landed in the install
+ *     root's `.env`, NOT in memphisRoot/.env
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createBackup, restoreBackup } from '../../src/infra/cli/commands/backup.js';
+
+interface PathDrillEnv {
+  memphisRoot: string;
+  backupRoot: string;
+  installRoot: string;
+  originalEnv: NodeJS.ProcessEnv;
+}
+
+function setup(): PathDrillEnv {
+  const memphisRoot = mkdtempSync(join(tmpdir(), 'memphis-pepperpath-data-'));
+  const backupRoot = join(memphisRoot, 'backups');
+  mkdirSync(backupRoot, { recursive: true });
+
+  const installRoot = mkdtempSync(join(tmpdir(), 'memphis-pepperpath-install-'));
+  // resolveInstallRoot validates MEMPHIS_RUNTIME_ROOT against package.json
+  // name "@memphis-chains/memphis"; fake one so the override is accepted.
+  writeFileSync(
+    join(installRoot, 'package.json'),
+    JSON.stringify({ name: '@memphis-chains/memphis' }),
+  );
+
+  // Seed a fixture file in memphisRoot so backup has content to capture.
+  mkdirSync(join(memphisRoot, 'fixture'), { recursive: true });
+  writeFileSync(join(memphisRoot, 'fixture', 'sentinel.txt'), 'untouched', 'utf8');
+
+  const originalEnv = { ...process.env };
+  process.env.MEMPHIS_RUNTIME_ROOT = installRoot;
+  // Make sure no MEMPHIS_ENV_FILE override leaks in from the parent process.
+  delete process.env.MEMPHIS_ENV_FILE;
+  return { memphisRoot, backupRoot, installRoot, originalEnv };
+}
+
+function tearDown(env: PathDrillEnv): void {
+  rmSync(env.memphisRoot, { recursive: true, force: true });
+  rmSync(env.installRoot, { recursive: true, force: true });
+  process.env = env.originalEnv;
+}
+
+describe('--pepper-restore writes to installRoot/.env (not memphisRoot/.env)', () => {
+  let env: PathDrillEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('lands the pepper line in the install-root dotenv that the daemon actually reads', async () => {
+    const pepperValue = 'restoredPepper2026';
+    const created = await createBackup({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      tag: 'pepperpath',
+      showProgress: false,
+    });
+
+    // Pre-restore: install-root has no .env yet (no daemon was ever run).
+    const installEnvPath = join(env.installRoot, '.env');
+    const memphisEnvPath = join(env.memphisRoot, '.env');
+    expect(existsSync(installEnvPath)).toBe(false);
+
+    await restoreBackup({
+      file: created.file,
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      confirm: true,
+      showProgress: false,
+      pepperRestore: pepperValue,
+    });
+
+    // The pepper line MUST land at installRoot/.env — that's the path the
+    // daemon's dotenv loader reads. Anything else is the bug we're guarding.
+    expect(existsSync(installEnvPath)).toBe(true);
+    expect(readFileSync(installEnvPath, 'utf8')).toContain(`MEMPHIS_VAULT_PEPPER=${pepperValue}`);
+
+    // memphisRoot/.env may or may not exist depending on whether the
+    // archive contained a .env (this fixture didn't seed one), but if it
+    // does exist, it MUST NOT contain the new pepper — that path is dead.
+    if (existsSync(memphisEnvPath)) {
+      expect(readFileSync(memphisEnvPath, 'utf8')).not.toContain(
+        `MEMPHIS_VAULT_PEPPER=${pepperValue}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2a (fresh-install audit) found a silent bug in \`memphis backup restore --pepper-restore\`: the pepper writes to \`\${memphisRoot}/.env\` (~/.memphis/.env) but the daemon's dotenv loader reads from \`\${installRoot}/.env\` (the repo dir, e.g. ~/memphis/.env). Result: every cross-host restore landed the pepper in a file the daemon never reads, vault decryption silently failed.

## Repro evidence

- \`src/infra/config/dotenv-file.ts:14\` — daemon's \`resolveDotEnvPath\` returns \`join(resolveInstallRoot(), '.env')\`
- \`src/infra/cli/commands/backup.ts:451\` (pre-fix) — wrote to \`join(memphisRoot, '.env')\`
- \`getMemphisRoot()\` returns \`getDataDir()\` = ~/.memphis ≠ installRoot

## Changes

\`src/infra/cli/commands/backup.ts\`:
- Import \`resolveDotEnvPath\` (the same helper \`setDotEnvValues\` uses)
- \`applyRestoredVaultPepper\` now writes to \`resolveDotEnvPath()\` instead of the hardcoded \`memphisRoot\` path
- \`memphisRoot\` parameter renamed to \`_memphisRoot\` (unused but kept for API stability)

## Test plan

- [x] \`tests/unit/backup-pepper-restore-path.test.ts\` (NEW) — synthetic install root in tmpdir, create→restore→pepper, asserts pepper lands in \`installRoot/.env\`, NOT \`memphisRoot/.env\`. **1 test, passes.**
- [x] \`tests/unit/backup-pepper-restore-validation.test.ts\` (existing) — short-pepper rejection still works. **2 tests, both pass.**
- [x] \`npm run typecheck\` clean

## Phase 2 audit summary

This is the ONLY substantive code bug found in the backup→restore round-trip for the cross-host fresh-install workflow. \`memphis backup create\` correctly captures everything in \`~/.memphis/\` (vault state + entries, chains, sqlite, embeddings, operator config) but **NOT** \`.env\` itself — that's by design (separates pepper from data, layered security model). The operator-facing implication: when backing up, also save the pepper externally (KeePass / pendrive); the \`--pepper-restore\` flow then re-injects it into the right path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)