### PR TITLE
feat(tui): /reload slash command — refresh runtime from .env (Phase A1)

### DIFF
--- a/crates/memphis-tui/src/app.rs
+++ b/crates/memphis-tui/src/app.rs
@@ -391,6 +391,15 @@ const HELP_ENTRIES: &[HelpEntry] = &[
         example: "/refresh",
         route: CommandRoute::Native,
     },
+    HelpEntry {
+        // Phase A1 (Q2 2026): re-reads installRoot/.env into the in-process
+        // OperatorRuntime so post-startup `memphis vault add` is visible
+        // without restarting the TUI. Use after adding/changing provider
+        // keys mid-session.
+        display: "/reload",
+        example: "/reload",
+        route: CommandRoute::Native,
+    },
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -803,7 +812,7 @@ impl AppState {
         }
     }
 
-    pub fn execute_input(&mut self, client: &MemphisClient) {
+    pub fn execute_input(&mut self, client: &mut MemphisClient) {
         if self.active_command.is_some() {
             if !self.input_buffer.trim().is_empty() {
                 self.append_line(warning(
@@ -933,7 +942,7 @@ impl AppState {
         );
     }
 
-    fn execute_command(&mut self, command_line: &str, client: &MemphisClient) {
+    fn execute_command(&mut self, command_line: &str, client: &mut MemphisClient) {
         let tokens = match split_command_tokens(command_line) {
             Ok(tokens) => tokens,
             Err(error) => {
@@ -955,6 +964,26 @@ impl AppState {
                 self.append_blank();
             }
             [cmd] if *cmd == "clear" => self.clear_output(),
+            [cmd] if *cmd == "reload" => {
+                // Phase A1: drop in-process env-snapshot so post-startup
+                // .env writes (e.g. `memphis vault add` auto-setting
+                // MINIMAX_VAULT_KEY) become visible without restarting
+                // the whole TUI. Refresh the snapshot too so the next
+                // status-bar render reflects the new provider state.
+                match client.reload_env_from_disk() {
+                    Ok(applied) => {
+                        self.append_line(success(format!(
+                            "env reloaded ({applied} variables applied from .env); providers re-resolved"
+                        )));
+                        self.refresh(client);
+                        self.append_blank();
+                    }
+                    Err(error) => {
+                        self.append_line(error_line(format!("/reload failed: {error}")));
+                        self.append_blank();
+                    }
+                }
+            }
             [cmd] if *cmd == "refresh" => {
                 self.refresh(client);
                 self.append_line(success("snapshot refreshed"));
@@ -3764,6 +3793,7 @@ fn is_native_command_tokens(tokens: &[String]) -> bool {
                 cmd.as_str(),
                 "help"
                     | "clear"
+                    | "reload"
                     | "refresh"
                     | "overview"
                     | "memory"
@@ -5175,10 +5205,10 @@ mod tests {
             }),
             ..AppSnapshot::default()
         };
-        let client = MemphisClient::new();
+        let mut client = MemphisClient::new();
         let mut short = AppState::new(config());
         short.snapshot = snapshot.clone();
-        short.execute_command("telegram", &client);
+        short.execute_command("telegram", &mut client);
         let short_lines = short
             .output_buffer
             .iter()
@@ -5187,7 +5217,7 @@ mod tests {
 
         let mut explicit = AppState::new(config());
         explicit.snapshot = snapshot;
-        explicit.execute_command("telegram status", &client);
+        explicit.execute_command("telegram status", &mut client);
         let explicit_lines = explicit
             .output_buffer
             .iter()
@@ -5359,9 +5389,9 @@ mod tests {
     #[test]
     fn unknown_commands_fail_closed_instead_of_auto_fallback() {
         let mut app = AppState::new(config());
-        let client = MemphisClient::new();
+        let mut client = MemphisClient::new();
 
-        app.execute_command("banana", &client);
+        app.execute_command("banana", &mut client);
 
         assert!(app.active_command.is_none());
         let contents = app
@@ -5381,9 +5411,9 @@ mod tests {
     #[test]
     fn legacy_prefix_requires_explicit_subcommand() {
         let mut app = AppState::new(config());
-        let client = MemphisClient::new();
+        let mut client = MemphisClient::new();
 
-        app.execute_command("legacy", &client);
+        app.execute_command("legacy", &mut client);
 
         assert!(app.active_command.is_none());
         let contents = app

--- a/crates/memphis-tui/src/client.rs
+++ b/crates/memphis-tui/src/client.rs
@@ -88,6 +88,35 @@ impl MemphisClient {
         }
     }
 
+    /// Drop the cached env-snapshot OperatorRuntime and rebuild from the
+    /// current .env on disk. Use after `memphis vault add` or any other
+    /// out-of-process .env mutation so the next chat call sees the new
+    /// MINIMAX_VAULT_KEY (or whatever was just written) without bouncing
+    /// the whole TUI process.
+    ///
+    /// Returns the count of env vars actually applied from the file
+    /// (`Ok(n)`) or an error if the .env was unreadable.
+    ///
+    /// Mechanics:
+    ///   1. Walk up from `cwd` to find the install root (a directory
+    ///      whose `package.json` carries `name == "@memphis-chains/memphis"`).
+    ///   2. Parse `${installRoot}/.env` line-by-line.
+    ///   3. For every `KEY=VALUE` pair, call `std::env::set_var` so the
+    ///      next `env::vars()` snapshot sees it.
+    ///   4. Rebuild `self.runtime` via `OperatorRuntime::from_env()`.
+    ///
+    /// Note: this does NOT update OTHER MemphisClient clones held by
+    /// already-spawned tasks — they keep using their captured runtime.
+    /// That's intentional; in-flight requests should not have their
+    /// provider config yanked mid-stream.
+    pub fn reload_env_from_disk(&mut self) -> Result<usize, String> {
+        let env_path = locate_dotenv_from_install_root()
+            .ok_or_else(|| "could not locate installRoot/.env".to_string())?;
+        let applied = apply_dotenv_file(&env_path)?;
+        self.runtime = OperatorRuntime::from_env();
+        Ok(applied)
+    }
+
     pub fn fetch_snapshot(&self) -> AppSnapshot {
         self.runtime.snapshot()
     }
@@ -744,5 +773,184 @@ fn client_command_error(error: OperatorError) -> ClientCommandError {
     match error {
         OperatorError::Cancelled => ClientCommandError::Cancelled,
         other => ClientCommandError::Message(other.to_string()),
+    }
+}
+
+// ─── /reload helpers (Phase A1) ──────────────────────────────────────────
+//
+// Used by MemphisClient::reload_env_from_disk to pick up post-startup
+// .env changes (e.g. `memphis vault add` writes a new MINIMAX_VAULT_KEY)
+// without restarting the TUI process. Same install-root resolution logic
+// as the TS-side `resolveInstallRoot`: walk up from cwd looking for a
+// `package.json` whose name field is `@memphis-chains/memphis`.
+
+const MEMPHIS_PACKAGE_NAME: &str = "@memphis-chains/memphis";
+
+fn locate_dotenv_from_install_root() -> Option<PathBuf> {
+    let env_override = std::env::var("MEMPHIS_ENV_FILE").ok();
+    if let Some(path) = env_override {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+
+    let runtime_root = std::env::var("MEMPHIS_RUNTIME_ROOT").ok();
+    if let Some(root) = runtime_root {
+        let candidate = PathBuf::from(root.trim());
+        if package_name_matches(&candidate) {
+            return Some(candidate.join(".env"));
+        }
+    }
+
+    let cwd = std::env::current_dir().ok()?;
+    let mut current: Option<&Path> = Some(cwd.as_path());
+    while let Some(dir) = current {
+        if package_name_matches(dir) {
+            return Some(dir.join(".env"));
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+fn package_name_matches(dir: &Path) -> bool {
+    let pkg = dir.join("package.json");
+    let Ok(raw) = std::fs::read_to_string(&pkg) else {
+        return false;
+    };
+    // Cheap parse — full serde_json would pull in features we don't
+    // need just for one string lookup. Memphis's package.json is
+    // deterministic enough that a substring check is fine.
+    raw.contains(&format!("\"name\": \"{MEMPHIS_PACKAGE_NAME}\""))
+        || raw.contains(&format!("\"name\":\"{MEMPHIS_PACKAGE_NAME}\""))
+}
+
+fn apply_dotenv_file(path: &Path) -> Result<usize, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed reading {}: {error}", path.display()))?;
+    let mut applied = 0usize;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        // Strip surrounding quotes — common `KEY="value"` shape.
+        let value = strip_dotenv_quotes(value.trim());
+        std::env::set_var(key, value);
+        applied += 1;
+    }
+    Ok(applied)
+}
+
+fn strip_dotenv_quotes(value: &str) -> &str {
+    if value.len() >= 2 {
+        let first = value.chars().next().unwrap();
+        let last = value.chars().last().unwrap();
+        if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
+}
+
+#[cfg(test)]
+mod reload_tests {
+    use super::{apply_dotenv_file, package_name_matches, strip_dotenv_quotes};
+    use std::fs::write;
+    use std::path::PathBuf;
+
+    fn tmpfile(name: &str, content: &str) -> PathBuf {
+        let dir =
+            tempdir_path(&format!("memphis-tui-reload-{name}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir tmp");
+        let path = dir.join(name);
+        write(&path, content).expect("write fixture");
+        path
+    }
+
+    fn tempdir_path(suffix: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(suffix);
+        p
+    }
+
+    #[test]
+    fn strip_dotenv_quotes_handles_double_single_and_unquoted() {
+        assert_eq!(strip_dotenv_quotes(r#""hello""#), "hello");
+        assert_eq!(strip_dotenv_quotes(r#"'world'"#), "world");
+        assert_eq!(strip_dotenv_quotes("bare"), "bare");
+        assert_eq!(strip_dotenv_quotes(r#"""#), r#"""#); // single-char passthrough
+    }
+
+    #[test]
+    fn apply_dotenv_file_sets_keys_and_returns_count() {
+        // Use a unique env-key prefix so we don't trample real env state.
+        let path = tmpfile(
+            "set-keys.env",
+            "TUI_RELOAD_TEST_FOO=1\n\
+             # comment\n\
+             \n\
+             TUI_RELOAD_TEST_BAR=\"with spaces\"\n\
+             TUI_RELOAD_TEST_BAZ='quoted-single'\n",
+        );
+        // Pre-clean
+        std::env::remove_var("TUI_RELOAD_TEST_FOO");
+        std::env::remove_var("TUI_RELOAD_TEST_BAR");
+        std::env::remove_var("TUI_RELOAD_TEST_BAZ");
+
+        let applied = apply_dotenv_file(&path).expect("apply");
+        assert_eq!(applied, 3);
+        assert_eq!(std::env::var("TUI_RELOAD_TEST_FOO").unwrap(), "1");
+        assert_eq!(std::env::var("TUI_RELOAD_TEST_BAR").unwrap(), "with spaces");
+        assert_eq!(std::env::var("TUI_RELOAD_TEST_BAZ").unwrap(), "quoted-single");
+
+        // cleanup
+        std::env::remove_var("TUI_RELOAD_TEST_FOO");
+        std::env::remove_var("TUI_RELOAD_TEST_BAR");
+        std::env::remove_var("TUI_RELOAD_TEST_BAZ");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn apply_dotenv_file_errors_on_missing_path() {
+        let bogus = std::env::temp_dir().join("memphis-tui-reload-nope.env");
+        let _ = std::fs::remove_file(&bogus);
+        let result = apply_dotenv_file(&bogus);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn package_name_matches_recognises_memphis_package_json() {
+        let dir = tempdir_path(&format!(
+            "memphis-tui-reload-pkg-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        write(
+            dir.join("package.json"),
+            r#"{ "name": "@memphis-chains/memphis", "version": "1.0.0" }"#,
+        )
+        .expect("write pkg");
+        assert!(package_name_matches(&dir));
+
+        write(
+            dir.join("package.json"),
+            r#"{"name":"@memphis-chains/memphis"}"#,
+        )
+        .expect("rewrite");
+        assert!(package_name_matches(&dir));
+
+        write(dir.join("package.json"), r#"{ "name": "other" }"#).expect("other");
+        assert!(!package_name_matches(&dir));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/memphis-tui/src/main.rs
+++ b/crates/memphis-tui/src/main.rs
@@ -175,7 +175,7 @@ fn main() -> ExitCode {
     };
 
     let config = TuiConfig::from_env();
-    let client = MemphisClient::new();
+    let mut client = MemphisClient::new();
     let mut app = AppState::new(config.clone());
     app.refresh(&client);
 
@@ -184,7 +184,7 @@ fn main() -> ExitCode {
     }
 
     if let Some(command) = args.run_command {
-        return run_command(&mut app, &client, &command, args.json);
+        return run_command(&mut app, &mut client, &command, args.json);
     }
 
     let _terminal = match TerminalGuard::enter() {
@@ -251,7 +251,7 @@ fn main() -> ExitCode {
                         last_refresh = Instant::now();
                     }
                     AppAction::SubmitInput => {
-                        app.execute_input(&client);
+                        app.execute_input(&mut client);
                     }
                     AppAction::ClearOutput => {
                         app.clear_output();
@@ -347,7 +347,7 @@ fn build_check_only_report_from_parts(
     }
 }
 
-fn run_command(app: &mut AppState, client: &MemphisClient, command: &str, json: bool) -> ExitCode {
+fn run_command(app: &mut AppState, client: &mut MemphisClient, command: &str, json: bool) -> ExitCode {
     let report = execute_run_command(app, client, command, Duration::from_secs(30));
 
     if json {
@@ -380,7 +380,7 @@ fn run_command(app: &mut AppState, client: &MemphisClient, command: &str, json: 
 
 fn execute_run_command(
     app: &mut AppState,
-    client: &MemphisClient,
+    client: &mut MemphisClient,
     command: &str,
     timeout: Duration,
 ) -> RunCommandReport {
@@ -597,11 +597,11 @@ mod tests {
             data_dir: PathBuf::from("/tmp/memphis"),
             refresh_interval: Duration::from_millis(750),
         };
-        let client = MemphisClient::new();
+        let mut client = MemphisClient::new();
         let mut app = AppState::new(config);
         app.refresh(&client);
 
-        let report = execute_run_command(&mut app, &client, "/overview", Duration::from_millis(10));
+        let report = execute_run_command(&mut app, &mut client, "/overview", Duration::from_millis(10));
 
         assert!(report.ok);
         assert_eq!(report.mode, "run-command");
@@ -618,11 +618,11 @@ mod tests {
             data_dir: PathBuf::from("/tmp/memphis"),
             refresh_interval: Duration::from_millis(750),
         };
-        let client = MemphisClient::new();
+        let mut client = MemphisClient::new();
         let mut app = AppState::new(config);
         app.refresh(&client);
 
-        let report = execute_run_command(&mut app, &client, "/banana", Duration::from_millis(10));
+        let report = execute_run_command(&mut app, &mut client, "/banana", Duration::from_millis(10));
 
         assert!(!report.ok);
         assert_eq!(report.route, "unsupported");


### PR DESCRIPTION
## Summary

Closes operator's daily friction: \`memphis vault add\` writes new vault refs to \`.env\` but TUI's in-process \`OperatorRuntime\` captured \`env::vars()\` ONCE at \`MemphisClient::new()\`. Post-startup .env changes were invisible — operator had to bounce the entire TUI process every time they added a key.

## What it does

\`/reload\` (native, no host round-trip) — picks up \`.env\` mutations live:
1. Walks up from cwd to find install root (\`package.json\` with name \`@memphis-chains/memphis\`); honors \`MEMPHIS_RUNTIME_ROOT\` and \`MEMPHIS_ENV_FILE\` for tests/headless
2. Parses \`installRoot/.env\` (KEY=VALUE, #comments, blank lines, single+double quotes)
3. \`std::env::set_var\` for each pair
4. Rebuilds \`self.runtime\` via \`OperatorRuntime::from_env()\`
5. Calls \`self.refresh(client)\` — status bar reflects new provider state

After \`/reload\`, \`/provider minimax\` + \`/model MiniMax-M2.7\` (already in \`HELP_ENTRIES\`) actually hit a provider that resolves with the freshly-added vault key.

## Plumbing

\`reload_env_from_disk\` needs \`&mut MemphisClient\` so the chain widens:
- \`MemphisClient::reload_env_from_disk(&mut self) -> Result<usize, String>\`
- \`AppState::execute_input(&mut self, client: &mut MemphisClient)\`
- \`AppState::execute_command(&mut self, ..., client: &mut MemphisClient)\`
- \`main.rs\`: \`let mut client\`, \`&mut client\` at 4 call sites (3 in tests)

In-flight tasks unaffected — they hold their own \`MemphisClient::clone()\` from before \`/reload\`.

## Test plan

- [x] \`cargo build -p memphis-tui\` clean
- [x] \`cargo test -p memphis-tui\` — **88/88 green** (84 baseline + 4 new in \`client.rs::reload_tests\`)
- [x] \`HELP_ENTRIES\` route assertion auto-covers \`/reload\` Native classification

## Out of scope

- **Persistence of \`/provider\`/\`/model\` across TUI restarts**. Needs \`setDotEnvValues\` through the host (TS-side). Operator's specific request was reload-after-vault-add, which is what this delivers; persistence is a follow-up.
- **Daemon-side reload**. Daemon (separate process from TUI) has its own env snapshot via \`memphis serve\`. After \`/reload\`, TUI sees new keys but the running daemon doesn't until it gets a SIGHUP / restart. Operator can use \`memphis_restart\` (S1 wired) for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)