### PR TITLE
feat(backup): capture redacted .env in archive (Phase C)

### DIFF
--- a/src/infra/cli/commands/backup.ts
+++ b/src/infra/cli/commands/backup.ts
@@ -22,6 +22,8 @@ import chalk from 'chalk';
 import cliProgress from 'cli-progress';
 
 import { getDataDir } from '../../../config/paths.js';
+import { resolveDotEnvPath } from '../../config/dotenv-file.js';
+import { classifyField } from '../../config/mutability.js';
 import type { CliContext } from '../context.js';
 import { print } from '../utils/render.js';
 
@@ -366,7 +368,73 @@ function resolveBackupFile(input: string, backupRoot: string): string {
   return hit.path;
 }
 
+/**
+ * Filename used to capture a redacted snapshot of `installRoot/.env` inside
+ * the backup archive. Lives at `memphisRoot/.env-redacted` (a path the
+ * daemon never reads) only for the duration of the tar run; deleted
+ * post-archive. The double dash + name shape is intentional so it
+ * never collides with operator-managed files.
+ */
+const REDACTED_ENV_FILENAME = '.env-redacted';
+
+/**
+ * Read `installRoot/.env`, drop secret lines (per `classifyField`), and
+ * return the surviving body. Returns null when no `.env` exists or when
+ * resolveDotEnvPath cannot find the install root. The pepper, API tokens,
+ * and any other field classified as `secret` are stripped so the backup
+ * archive never carries them; provider URLs, vault refs, and runtime knobs
+ * stay so restore can re-create the operator's config without manual
+ * `vault add` re-runs for each provider.
+ */
+function buildRedactedDotEnv(): string | null {
+  const envPath = resolveDotEnvPath();
+  if (!existsSync(envPath)) return null;
+  const raw = readFileSync(envPath, 'utf8');
+  const out: string[] = [
+    '# memphis-backup: redacted .env snapshot — secrets stripped via classifyField',
+    `# source: ${envPath}`,
+    `# captured: ${new Date().toISOString()}`,
+    '',
+  ];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      out.push(line);
+      continue;
+    }
+    const eq = line.indexOf('=');
+    if (eq <= 0) {
+      out.push(line);
+      continue;
+    }
+    const key = line.slice(0, eq).trim();
+    if (classifyField(key) === 'secret') {
+      out.push(`# ${key}=<REDACTED — secret field, restore from external store>`);
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
 function createArchive(memphisRoot: string, backupPath: string): void {
+  // Phase C (2026-04-26): write a redacted .env into memphisRoot for the
+  // tar run so backup carries provider URLs + vault refs. Always cleaned
+  // up afterwards so the file doesn't linger in the data dir between
+  // backups.
+  const redactedEnvPath = join(memphisRoot, REDACTED_ENV_FILENAME);
+  let redactedEnvWritten = false;
+  try {
+    const redacted = buildRedactedDotEnv();
+    if (redacted !== null) {
+      writeFileSync(redactedEnvPath, redacted, 'utf8');
+      redactedEnvWritten = true;
+    }
+  } catch {
+    // Best-effort: if .env can't be read, just skip the redacted capture.
+    // The rest of the backup still completes.
+  }
+
   try {
     execFileSync('tar', [
       '-czf',
@@ -380,11 +448,84 @@ function createArchive(memphisRoot: string, backupPath: string): void {
       '.',
     ]);
   } catch (error) {
+    if (redactedEnvWritten) {
+      try {
+        unlinkSync(redactedEnvPath);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
     if (!isTarExecutionError(error)) {
       throw error;
     }
     createFallbackArchive(memphisRoot, backupPath);
+    return;
   }
+
+  if (redactedEnvWritten) {
+    try {
+      unlinkSync(redactedEnvPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+}
+
+/**
+ * Counterpart to `buildRedactedDotEnv`. After tar extracts the archive,
+ * if it contains `.env-redacted`, merge those (non-secret) values into
+ * `installRoot/.env` — additive: existing keys are preserved (operator may
+ * have edited them post-restore), new keys from the archive get appended.
+ * Returns the count of keys applied or 0 when there's nothing to do.
+ */
+function applyRedactedDotEnv(memphisRoot: string): number {
+  const stagedPath = join(memphisRoot, REDACTED_ENV_FILENAME);
+  if (!existsSync(stagedPath)) return 0;
+  const stagedRaw = readFileSync(stagedPath, 'utf8');
+  const installEnvPath = resolveDotEnvPath();
+  const existingRaw = existsSync(installEnvPath)
+    ? readFileSync(installEnvPath, 'utf8')
+    : '';
+  const existingKeys = new Set<string>();
+  for (const line of existingRaw.split(/\r?\n/)) {
+    const eq = line.indexOf('=');
+    if (eq > 0 && !line.trim().startsWith('#')) {
+      existingKeys.add(line.slice(0, eq).trim());
+    }
+  }
+
+  const additions: string[] = [];
+  for (const line of stagedRaw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (existingKeys.has(key)) continue;
+    additions.push(line);
+  }
+
+  if (additions.length === 0) {
+    // Nothing new to add — clean up the staged file and return.
+    try {
+      unlinkSync(stagedPath);
+    } catch {
+      /* best-effort */
+    }
+    return 0;
+  }
+
+  const merged = existingRaw.endsWith('\n') || existingRaw === ''
+    ? `${existingRaw}# memphis-backup: restored .env keys (Phase C, ${new Date().toISOString()})\n${additions.join('\n')}\n`
+    : `${existingRaw}\n# memphis-backup: restored .env keys (Phase C, ${new Date().toISOString()})\n${additions.join('\n')}\n`;
+  writeFileSync(installEnvPath, merged, 'utf8');
+
+  try {
+    unlinkSync(stagedPath);
+  } catch {
+    /* best-effort */
+  }
+  return additions.length;
 }
 
 function extractArchive(archivePath: string, targetRoot: string): void {
@@ -697,6 +838,12 @@ export async function restoreBackup(options: RestoreOptions): Promise<{
   if (options.pepperRestore) {
     applyRestoredVaultPepper(memphisRoot, options.pepperRestore);
   }
+
+  // Phase C: if the archive carried a redacted .env snapshot (provider URLs,
+  // vault refs, non-secret runtime knobs), merge those keys into
+  // installRoot/.env. Existing keys are preserved — operator may have
+  // edited .env post-restore; we only add missing ones.
+  applyRedactedDotEnv(memphisRoot);
 
   const post = await verifyBackup({
     file: backupPath,

--- a/tests/unit/backup-env-redacted.test.ts
+++ b/tests/unit/backup-env-redacted.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression: `memphis backup create` captures a redacted snapshot of
+ * `installRoot/.env`, and `memphis backup restore` re-applies the
+ * non-secret keys to `installRoot/.env` without overwriting existing
+ * values. Phase C of the v1.7.1 gap-fill plan.
+ *
+ * Threat model:
+ *   - secrets (MEMPHIS_VAULT_PEPPER, *_API_KEY, *_TOKEN) MUST stay out of
+ *     the archive (operator's external store is authoritative)
+ *   - non-secret config (provider URLs, vault refs, runtime knobs) is
+ *     captured so a fresh install with a restored archive doesn't need
+ *     manual `memphis vault add` re-runs for each provider
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createBackup, restoreBackup, listArchiveContents } from '../../src/infra/cli/commands/backup.js';
+
+interface DrillEnv {
+  memphisRoot: string;
+  backupRoot: string;
+  installRoot: string;
+  originalEnv: NodeJS.ProcessEnv;
+}
+
+function setup(): DrillEnv {
+  const memphisRoot = mkdtempSync(join(tmpdir(), 'memphis-env-redact-data-'));
+  const backupRoot = join(memphisRoot, 'backups');
+  mkdirSync(backupRoot, { recursive: true });
+  // Token fixture content for the data tree so tar has files to capture.
+  mkdirSync(join(memphisRoot, 'fixture'), { recursive: true });
+  writeFileSync(join(memphisRoot, 'fixture', 'sentinel.txt'), 'untouched', 'utf8');
+
+  const installRoot = mkdtempSync(join(tmpdir(), 'memphis-env-redact-install-'));
+  writeFileSync(
+    join(installRoot, 'package.json'),
+    JSON.stringify({ name: '@memphis-chains/memphis' }),
+  );
+
+  const originalEnv = { ...process.env };
+  process.env.MEMPHIS_RUNTIME_ROOT = installRoot;
+  delete process.env.MEMPHIS_ENV_FILE;
+  return { memphisRoot, backupRoot, installRoot, originalEnv };
+}
+
+function tearDown(env: DrillEnv): void {
+  rmSync(env.memphisRoot, { recursive: true, force: true });
+  rmSync(env.installRoot, { recursive: true, force: true });
+  process.env = env.originalEnv;
+}
+
+describe('backup .env-redacted capture (Phase C)', () => {
+  let env: DrillEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    tearDown(env);
+  });
+
+  it('omits secret fields and includes vault-ref + URL fields in archive', async () => {
+    const seedEnv = [
+      'MEMPHIS_VAULT_PEPPER=topSecretPepperShouldNotLeak',
+      'MEMPHIS_API_TOKEN=longLivedAuthToken123',
+      'MINIMAX_API_KEY=plaintext-api-key',
+      'MINIMAX_VAULT_KEY=minimax_api_key',
+      'MINIMAX_BASE_URL=https://api.minimax.io/v1',
+      'DEFAULT_PROVIDER=minimax',
+    ].join('\n');
+    writeFileSync(join(env.installRoot, '.env'), seedEnv, 'utf8');
+
+    const created = await createBackup({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      tag: 'env-redact',
+      showProgress: false,
+    });
+
+    const entries = listArchiveContents(created.backupPath);
+    const redactedInArchive = entries.find((e) => e.endsWith('.env-redacted') || e === './.env-redacted');
+    expect(redactedInArchive).toBeDefined();
+
+    // Read the archive's .env-redacted content via restore-then-inspect.
+    // We can't peek inside the tar without re-extracting, so we run a
+    // restore into a fresh memphisRoot and assert the merged installRoot
+    // .env carries the non-secrets but NOT the secrets.
+  });
+
+  it('round-trips: secrets stripped, non-secrets restored to fresh installRoot/.env', async () => {
+    const seedEnv = [
+      'MEMPHIS_VAULT_PEPPER=topSecretPepperShouldNotLeak',
+      'MEMPHIS_API_TOKEN=longLivedAuthToken123',
+      'MINIMAX_API_KEY=plaintext-api-key',
+      'MINIMAX_VAULT_KEY=minimax_api_key',
+      'MINIMAX_BASE_URL=https://api.minimax.io/v1',
+      'DEFAULT_PROVIDER=minimax',
+    ].join('\n');
+    writeFileSync(join(env.installRoot, '.env'), seedEnv, 'utf8');
+
+    const created = await createBackup({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      tag: 'roundtrip',
+      showProgress: false,
+    });
+
+    // Simulate a fresh install: blow away install .env, re-apply via restore.
+    rmSync(join(env.installRoot, '.env'));
+    expect(existsSync(join(env.installRoot, '.env'))).toBe(false);
+
+    await restoreBackup({
+      file: created.file,
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      confirm: true,
+      showProgress: false,
+    });
+
+    // installRoot/.env should now exist with non-secrets but no secrets.
+    expect(existsSync(join(env.installRoot, '.env'))).toBe(true);
+    const restoredEnv = readFileSync(join(env.installRoot, '.env'), 'utf8');
+
+    // Non-secret config preserved
+    expect(restoredEnv).toContain('MINIMAX_VAULT_KEY=minimax_api_key');
+    expect(restoredEnv).toContain('MINIMAX_BASE_URL=https://api.minimax.io/v1');
+    expect(restoredEnv).toContain('DEFAULT_PROVIDER=minimax');
+
+    // Secrets MUST be stripped
+    expect(restoredEnv).not.toContain('topSecretPepperShouldNotLeak');
+    expect(restoredEnv).not.toContain('longLivedAuthToken123');
+    expect(restoredEnv).not.toContain('plaintext-api-key');
+  });
+
+  it('does not overwrite existing keys in installRoot/.env on restore', async () => {
+    const seedEnv = [
+      'MINIMAX_VAULT_KEY=archived-key-pointer',
+      'DEFAULT_PROVIDER=minimax',
+    ].join('\n');
+    writeFileSync(join(env.installRoot, '.env'), seedEnv, 'utf8');
+
+    const created = await createBackup({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      tag: 'preserve',
+      showProgress: false,
+    });
+
+    // Operator-edits .env between backup and restore — different value
+    // for an existing key, plus a new key the archive doesn't know.
+    writeFileSync(
+      join(env.installRoot, '.env'),
+      [
+        'MINIMAX_VAULT_KEY=operator-edited-pointer',
+        'MEMPHIS_API_TOKEN=operator-set-token',
+      ].join('\n'),
+      'utf8',
+    );
+
+    await restoreBackup({
+      file: created.file,
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      confirm: true,
+      showProgress: false,
+    });
+
+    const restored = readFileSync(join(env.installRoot, '.env'), 'utf8');
+    // Operator's edit preserved, NOT clobbered by archive's older value
+    expect(restored).toContain('MINIMAX_VAULT_KEY=operator-edited-pointer');
+    expect(restored).not.toContain('MINIMAX_VAULT_KEY=archived-key-pointer');
+    // Operator's manual addition preserved
+    expect(restored).toContain('MEMPHIS_API_TOKEN=operator-set-token');
+    // Missing-from-existing key gets appended from the archive
+    expect(restored).toContain('DEFAULT_PROVIDER=minimax');
+  });
+
+  it('skips capture when no installRoot/.env exists', async () => {
+    // No .env at all in installRoot; backup still succeeds, archive
+    // lacks the .env-redacted entry.
+    const created = await createBackup({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      tag: 'no-env',
+      showProgress: false,
+    });
+
+    const entries = listArchiveContents(created.backupPath);
+    const redacted = entries.find(
+      (e) => e.endsWith('.env-redacted') || e === './.env-redacted',
+    );
+    expect(redacted).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2a found that \`memphis backup create\` excluded \`.env\` entirely. Cross-host restore therefore required operator to manually re-run \`memphis vault add\` for each provider just to re-write the auto-set vault refs (\`MINIMAX_VAULT_KEY=minimax_api_key\` etc.). Friction.

This PR captures a **redacted** snapshot of \`installRoot/.env\` inside the archive at \`.env-redacted\`. Secret fields (per existing \`classifyField\`) are stripped; provider URLs, vault refs, and runtime knobs survive.

## What's redacted vs preserved

| Field | Classification | Action |
|---|---|---|
| \`MEMPHIS_VAULT_PEPPER\` | secret | stripped |
| \`MEMPHIS_API_TOKEN\` | secret | stripped |
| \`MINIMAX_API_KEY\` (plaintext) | secret | stripped |
| \`MINIMAX_VAULT_KEY=minimax_api_key\` | warm (vault ref pointer) | preserved |
| \`MINIMAX_BASE_URL\` | hot | preserved |
| \`DEFAULT_PROVIDER\` | hot | preserved |

## Restore behaviour

\`restoreBackup\` calls \`applyRedactedDotEnv\` post-extract:
- existing keys in \`installRoot/.env\` are **preserved** (operator may have edited between backup and restore)
- only missing keys are **appended** with a timestamped marker comment

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npx vitest run tests/unit/backup-env-redacted.test.ts\` — **4/4 green**:
  1. Archive contains \`.env-redacted\` entry
  2. Round-trip: secrets stripped, non-secrets restored to fresh \`installRoot/.env\`
  3. Operator edits preserved (not clobbered) on restore
  4. Skip capture when no \`installRoot/.env\` exists

## Pairs with #294

Together with the pepper-path fix in #294, \`memphis backup restore --pepper-restore <pepper>\` now delivers a fully working install on a fresh host with no manual config re-creation: pepper supplied externally, everything else (encrypted vault, chains, sqlite, embed index, AND non-secret env config) round-trips through the archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)