### PR TITLE
fix(security): VAULT-ref leak filter applied to voice + HTTP API auth (Phase D1)

### DIFF
--- a/src/gateway/channels/telegram-readiness.ts
+++ b/src/gateway/channels/telegram-readiness.ts
@@ -14,19 +14,13 @@ export type TelegramReadinessStatus = {
   botName: string | null;
 };
 
-/**
- * Detects an unresolved vault reference like `VAULT:telegram_bot_token`.
- *
- * The memphis-config layer expands `VAULT:<key>` references into the actual
- * secret. If the vault entry is missing, the config layer logs a warning but
- * leaves the literal `VAULT:...` string in the env var. Treating that literal
- * as a valid bot token is what produced the 2026-04-20 crash loop where
- * Telegram API returned `getMe 404` on every service start, driving the
- * systemd restart counter past 3000 in under 3 hours.
- */
-function isUnresolvedVaultRef(token: string): boolean {
-  return /^VAULT:/i.test(token);
-}
+// `isUnresolvedVaultRef` was originally inlined here. Lifted to
+// `infra/config/vault-ref.ts` (Phase D1, v1.7.1) so other surfaces
+// (voice service, HTTP API auth, …) can reuse the same filter without
+// duplicating the regex. The 2026-04-20 Telegram crash loop (literal
+// `VAULT:telegram_bot_token` shipped to getMe → 404) was the
+// motivating incident.
+import { isUnresolvedVaultRef } from '../../infra/config/vault-ref.js';
 
 export function resolveTelegramBotToken(rawEnv: NodeJS.ProcessEnv = process.env): string | null {
   const candidates: Array<string | undefined> = [

--- a/src/gateway/voice/voice-service.ts
+++ b/src/gateway/voice/voice-service.ts
@@ -16,6 +16,7 @@
  *   GOOGLE_TTS_API_KEY     — required when TTS provider is "google"
  */
 
+import { readResolvedSecret } from '../../infra/config/vault-ref.js';
 import { createPinoLogger } from '../../infra/logging/pino.js';
 
 const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
@@ -48,8 +49,13 @@ const HF_INFERENCE_URL = 'https://api-inference.huggingface.co/models';
 const GOOGLE_TTS_URL = 'https://texttospeech.googleapis.com/v1/text:synthesize';
 
 export function resolveVoiceConfig(rawEnv: NodeJS.ProcessEnv = process.env): VoiceConfig | null {
-  const hfToken = rawEnv.HUGGINGFACE_API_TOKEN?.trim();
-  const googleKey = rawEnv.GOOGLE_TTS_API_KEY?.trim();
+  // Phase D1 (v1.7.1): same vault-ref filter as Telegram. If
+  // HUGGINGFACE_API_TOKEN was set in .env as `VAULT:huggingface_api_token`
+  // and the config layer couldn't expand it (vault locked, entry missing,
+  // expand-time race), we'd otherwise ship the literal "VAULT:..." string
+  // to api-inference.huggingface.co and get 401 on every voice request.
+  const hfToken = readResolvedSecret(rawEnv.HUGGINGFACE_API_TOKEN);
+  const googleKey = readResolvedSecret(rawEnv.GOOGLE_TTS_API_KEY);
   // Need at least HF token (for STT) to enable voice
   if (!hfToken) return null;
 
@@ -63,7 +69,7 @@ export function resolveVoiceConfig(rawEnv: NodeJS.ProcessEnv = process.env): Voi
     sttModel: rawEnv.MEMPHIS_STT_MODEL?.trim() || DEFAULT_STT_MODEL,
     ttsModel: rawEnv.MEMPHIS_TTS_MODEL?.trim() || defaultTtsModel,
     ttsProvider,
-    googleTtsApiKey: googleKey,
+    googleTtsApiKey: googleKey ?? undefined,
   };
 }
 

--- a/src/infra/config/vault-ref.ts
+++ b/src/infra/config/vault-ref.ts
@@ -1,0 +1,33 @@
+/**
+ * Detects an unresolved vault reference like `VAULT:huggingface_api_token`.
+ *
+ * The memphis-config layer expands `VAULT:<key>` strings into actual secret
+ * values at startup. If the vault entry is missing (or the vault is locked,
+ * or the env was loaded before vault was unlocked), the config layer logs
+ * a warning but leaves the literal `VAULT:...` string in the env var.
+ *
+ * Treating that literal as a real secret is what produced the 2026-04-20
+ * Telegram crash loop (PR #285 / S2.5): the bot's getMe() returned 404
+ * because the API token sent to Telegram was the literal "VAULT:telegram_bot_token"
+ * string. Same pattern reproduces wherever code reads a env var that might
+ * carry a vault ref (HUGGINGFACE_API_TOKEN, GOOGLE_TTS_API_KEY,
+ * MEMPHIS_API_TOKEN, etc.) — every such call site must filter before use.
+ *
+ * Originally lived as a private helper in `gateway/channels/telegram-readiness.ts`;
+ * lifted here so other surfaces can reuse without duplicating the regex.
+ */
+export function isUnresolvedVaultRef(value: string): boolean {
+  return /^VAULT:/i.test(value);
+}
+
+/**
+ * Returns the trimmed value if it's a real secret, or `null` if the slot is
+ * empty/whitespace OR carries an unresolved `VAULT:` literal. Useful as a
+ * drop-in replacement for `rawEnv.X?.trim()` at every secret-reading site.
+ */
+export function readResolvedSecret(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  if (isUnresolvedVaultRef(trimmed)) return null;
+  return trimmed;
+}

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -6,6 +6,7 @@ import { isAuthRequired } from './auth-policy.js';
 import { handleHttpError } from './error-handler.js';
 import { buildHealthPayload } from './health.js';
 import { globalLimiter, sensitiveLimiter } from './rate-limit.js';
+import { readResolvedSecret } from '../config/vault-ref.js';
 import { registerAnalyticsRoutes } from './routes/analytics.js';
 import { registerChatCompletionsRoutes } from './routes/chat-completions.js';
 import { registerChatRoutes } from './routes/chat.js';
@@ -175,7 +176,11 @@ export function createHttpServer(
 
   app.setErrorHandler((error, request, reply) => handleHttpError(error, request, reply));
 
-  const apiToken = process.env.MEMPHIS_API_TOKEN;
+  // Phase D1 (v1.7.1): same vault-ref filter as Telegram + voice. If
+  // MEMPHIS_API_TOKEN was set as `VAULT:memphis_api_token` and the config
+  // layer couldn't expand it, comparing the literal "VAULT:..." string to
+  // operator's real token would 401 every protected request.
+  const apiToken = readResolvedSecret(process.env.MEMPHIS_API_TOKEN) ?? undefined;
 
   app.addHook('onRequest', async (request, reply) => {
     const contextLogger = createContextualLogger({

--- a/tests/unit/vault-ref.test.ts
+++ b/tests/unit/vault-ref.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Phase D1: vault-ref leak filter — `VAULT:` literals must never reach
+ * downstream APIs as if they were real secrets. The 2026-04-20 Telegram
+ * crash loop was the motivating incident; same pattern applies to
+ * voice (HuggingFace token, Google TTS key) and HTTP API token auth.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { isUnresolvedVaultRef, readResolvedSecret } from '../../src/infra/config/vault-ref.js';
+
+describe('isUnresolvedVaultRef', () => {
+  it('flags VAULT:<name> literals (case-insensitive)', () => {
+    expect(isUnresolvedVaultRef('VAULT:huggingface_api_token')).toBe(true);
+    expect(isUnresolvedVaultRef('VAULT:foo')).toBe(true);
+    expect(isUnresolvedVaultRef('vault:bar')).toBe(true);
+    expect(isUnresolvedVaultRef('Vault:Baz')).toBe(true);
+  });
+
+  it('does not flag real secrets that happen to mention "vault"', () => {
+    expect(isUnresolvedVaultRef('hf_realToken123')).toBe(false);
+    expect(isUnresolvedVaultRef('mySecretWithVaultInside')).toBe(false);
+    expect(isUnresolvedVaultRef('keyVAULTtail')).toBe(false);
+    expect(isUnresolvedVaultRef('')).toBe(false);
+  });
+});
+
+describe('readResolvedSecret', () => {
+  it('returns the trimmed value for real secrets', () => {
+    expect(readResolvedSecret('  hf_realToken  ')).toBe('hf_realToken');
+    expect(readResolvedSecret('plain-token')).toBe('plain-token');
+  });
+
+  it('returns null for unresolved vault refs', () => {
+    expect(readResolvedSecret('VAULT:huggingface_api_token')).toBeNull();
+    expect(readResolvedSecret('vault:foo')).toBeNull();
+  });
+
+  it('returns null for empty / whitespace / undefined', () => {
+    expect(readResolvedSecret(undefined)).toBeNull();
+    expect(readResolvedSecret('')).toBeNull();
+    expect(readResolvedSecret('   ')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

S2.5 PR #285 fixed the Telegram allowlist parser to skip unresolved \`VAULT:<name>\` literals (the 2026-04-20 crash loop where literal \"VAULT:telegram_bot_token\" shipped to Telegram → getMe 404). Phase D1 audits whether the same vulnerability class exists elsewhere — **yes**, two more sites:

| Site | Vulnerability |
|---|---|
| \`src/gateway/voice/voice-service.ts::resolveVoiceConfig\` | reads \`HUGGINGFACE_API_TOKEN\` + \`GOOGLE_TTS_API_KEY\` raw → literal \"VAULT:...\" → 401 on every voice request |
| \`src/infra/http/server.ts:178\` | reads \`MEMPHIS_API_TOKEN\` raw → literal \"VAULT:...\" mismatches operator's actual token → 401 every protected route |

## Fix

Extract the helper into \`src/infra/config/vault-ref.ts\`:
- \`isUnresolvedVaultRef(value)\` — case-insensitive \`VAULT:\` prefix check
- \`readResolvedSecret(value)\` — drop-in for \`rawEnv.X?.trim()\` that returns \`null\` for empty / whitespace / unresolved-vault-ref values

Apply at the three sites (telegram, voice, HTTP API).

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npx eslint .\` clean (after auto-fix on import order)
- [x] \`vitest run tests/unit/vault-ref.test.ts\` — 5 new cases on the helper
- [x] \`vitest run tests/unit/telegram-readiness.test.ts\` — 8/8 existing tests still pass after the import refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)