### PR TITLE
feat(tui): /provider /model persist to .env across restarts (Phase A2)

### DIFF
--- a/crates/memphis-tui/src/app.rs
+++ b/crates/memphis-tui/src/app.rs
@@ -1060,26 +1060,16 @@ impl AppState {
                 self.start_vault_read_task(client.clone(), key.to_string());
             }
             [scope, action, name] if *scope == "provider" && *action == "set" => {
-                self.chat_provider = Some(name.to_string());
-                self.append_line(success(format!("active provider set to {name}")));
-                self.append_blank();
+                self.set_active_provider_and_persist(client, name);
             }
             [scope, action, model @ ..] if *scope == "model" && *action == "set" => {
-                let model = model.join(" ");
-                self.chat_model = Some(model.clone());
-                self.append_line(success(format!("active model set to {model}")));
-                self.append_blank();
+                self.set_active_model_and_persist(client, &model.join(" "));
             }
             [cmd, value] if *cmd == "provider" => {
-                self.chat_provider = Some(value.to_string());
-                self.append_line(success(format!("active provider set to {value}")));
-                self.append_blank();
+                self.set_active_provider_and_persist(client, value);
             }
             [cmd, value @ ..] if *cmd == "model" => {
-                let model = value.join(" ");
-                self.chat_model = Some(model.clone());
-                self.append_line(success(format!("active model set to {model}")));
-                self.append_blank();
+                self.set_active_model_and_persist(client, &value.join(" "));
             }
             [cmd, value] if *cmd == "session" => {
                 self.switch_session(client, value);
@@ -1142,6 +1132,75 @@ impl AppState {
                 }
             },
         );
+    }
+
+    /// Phase A2 (v1.7.1): /provider X sets in-session value AND persists
+    /// `DEFAULT_PROVIDER=X` to installRoot/.env so next TUI start uses it.
+    /// Best-effort: in-session change always succeeds; persistence failure
+    /// (e.g. .env unwritable) is logged but doesn't abort.
+    fn set_active_provider_and_persist(&mut self, client: &mut MemphisClient, name: &str) {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            self.append_line(error_line("provider name must not be empty"));
+            self.append_blank();
+            return;
+        }
+        self.chat_provider = Some(trimmed.to_string());
+        match client.set_dotenv("DEFAULT_PROVIDER", trimmed) {
+            Ok(env_path) => {
+                self.append_line(success(format!(
+                    "active provider set to {trimmed} (persisted to {})",
+                    env_path.display()
+                )));
+            }
+            Err(error) => {
+                self.append_line(success(format!(
+                    "active provider set to {trimmed} (session-only)"
+                )));
+                self.append_line(dim(format!("could not persist to .env: {error}")));
+            }
+        }
+        self.append_blank();
+    }
+
+    /// Phase A2: /model X persists into `${PROVIDER}_MODEL` based on the
+    /// currently-active chat_provider. Without an active provider, just
+    /// sets the in-session value and warns (no env to write to).
+    fn set_active_model_and_persist(&mut self, client: &mut MemphisClient, model: &str) {
+        let trimmed = model.trim();
+        if trimmed.is_empty() {
+            self.append_line(error_line("model id must not be empty"));
+            self.append_blank();
+            return;
+        }
+        self.chat_model = Some(trimmed.to_string());
+        let provider = self.chat_provider.clone();
+        match provider.as_deref() {
+            Some(provider_name) => {
+                let env_key = crate::client::provider_model_env_key(provider_name);
+                match client.set_dotenv(&env_key, trimmed) {
+                    Ok(env_path) => {
+                        self.append_line(success(format!(
+                            "active model set to {trimmed} (persisted as {env_key} in {})",
+                            env_path.display()
+                        )));
+                    }
+                    Err(error) => {
+                        self.append_line(success(format!(
+                            "active model set to {trimmed} (session-only)"
+                        )));
+                        self.append_line(dim(format!("could not persist to .env: {error}")));
+                    }
+                }
+            }
+            None => {
+                self.append_line(success(format!("active model set to {trimmed} (session-only)")));
+                self.append_line(dim(
+                    "no active provider — run /provider <name> first to enable per-provider model persistence",
+                ));
+            }
+        }
+        self.append_blank();
     }
 
     fn switch_session(&mut self, client: &MemphisClient, session_id: &str) {

--- a/crates/memphis-tui/src/client.rs
+++ b/crates/memphis-tui/src/client.rs
@@ -117,6 +117,21 @@ impl MemphisClient {
         Ok(applied)
     }
 
+    /// Persist a single `KEY=VALUE` line into `installRoot/.env` and update
+    /// the in-process env so the next `OperatorRuntime::from_env()` reads
+    /// the new value. Used by `/provider` and `/model` slash commands to
+    /// make the operator's selection stick across TUI restarts (Phase A2).
+    ///
+    /// Idempotent: existing key gets overwritten in-place; missing key gets
+    /// appended. Returns the path that was written.
+    pub fn set_dotenv(&self, key: &str, value: &str) -> Result<PathBuf, String> {
+        let env_path = locate_dotenv_from_install_root()
+            .ok_or_else(|| "could not locate installRoot/.env".to_string())?;
+        write_dotenv_value(&env_path, key, value)?;
+        std::env::set_var(key, value);
+        Ok(env_path)
+    }
+
     pub fn fetch_snapshot(&self) -> AppSnapshot {
         self.runtime.snapshot()
     }
@@ -861,6 +876,50 @@ fn strip_dotenv_quotes(value: &str) -> &str {
     value
 }
 
+/// Phase A2: write a single KEY=VALUE pair into the .env at `path`. Idempotent
+/// — existing key gets overwritten in place, missing key gets appended. Used
+/// by `/provider` and `/model` slash commands to persist operator selection
+/// across TUI restarts.
+///
+/// Mirrors the TS-side `setDotEnvValues` shape so the two layers don't drift
+/// (we don't go through host RPC for this — slash commands need synchronous
+/// feedback, and a single key-value file write is < 1ms).
+fn write_dotenv_value(path: &Path, key: &str, value: &str) -> Result<(), String> {
+    let existing = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(format!("read {}: {error}", path.display())),
+    };
+    let prefix = format!("{key}=");
+    let mut lines: Vec<String> = existing.lines().map(String::from).collect();
+    let mut replaced = false;
+    for line in lines.iter_mut() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with(&prefix) && !trimmed.starts_with('#') {
+            *line = format!("{key}={value}");
+            replaced = true;
+            break;
+        }
+    }
+    if !replaced {
+        lines.push(format!("{key}={value}"));
+    }
+    let mut serialized = lines.join("\n");
+    if !serialized.ends_with('\n') {
+        serialized.push('\n');
+    }
+    std::fs::write(path, serialized)
+        .map_err(|error| format!("write {}: {error}", path.display()))
+}
+
+/// Map a provider name to the env key that holds its default model.
+/// `minimax` → `MINIMAX_MODEL`, `shared-llm` → `SHARED_LLM_MODEL` (matches
+/// the keys actually read by `crates/memphis-operator/src/provider.rs`'s
+/// `resolve_provider`).
+pub fn provider_model_env_key(provider: &str) -> String {
+    format!("{}_MODEL", provider.to_ascii_uppercase().replace('-', "_"))
+}
+
 #[cfg(test)]
 mod reload_tests {
     use super::{apply_dotenv_file, package_name_matches, strip_dotenv_quotes};
@@ -952,5 +1011,77 @@ mod reload_tests {
         assert!(!package_name_matches(&dir));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ─── Phase A2: persistence ────────────────────────────────────────
+
+    #[test]
+    fn write_dotenv_value_appends_when_key_is_missing() {
+        use super::write_dotenv_value;
+        let path = tmpfile("write-append.env", "EXISTING=keep\n");
+        write_dotenv_value(&path, "DEFAULT_PROVIDER", "minimax").expect("write");
+        let after = std::fs::read_to_string(&path).expect("read");
+        assert!(after.contains("EXISTING=keep"));
+        assert!(after.contains("DEFAULT_PROVIDER=minimax"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn write_dotenv_value_overwrites_in_place_when_key_exists() {
+        use super::write_dotenv_value;
+        let path = tmpfile(
+            "write-replace.env",
+            "DEFAULT_PROVIDER=ollama\nMINIMAX_BASE_URL=https://api.minimax.io/v1\n",
+        );
+        write_dotenv_value(&path, "DEFAULT_PROVIDER", "minimax").expect("write");
+        let after = std::fs::read_to_string(&path).expect("read");
+        // Old value gone, new value present, other keys preserved.
+        assert!(!after.contains("DEFAULT_PROVIDER=ollama"));
+        assert!(after.contains("DEFAULT_PROVIDER=minimax"));
+        assert!(after.contains("MINIMAX_BASE_URL=https://api.minimax.io/v1"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn write_dotenv_value_creates_file_when_missing() {
+        use super::write_dotenv_value;
+        let dir = tempdir_path(&format!("memphis-tui-write-create-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join(".env");
+        write_dotenv_value(&path, "DEFAULT_PROVIDER", "minimax").expect("write");
+        assert!(path.exists());
+        let after = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(after.trim(), "DEFAULT_PROVIDER=minimax");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn provider_model_env_key_uppercases_and_normalises_dashes() {
+        use super::provider_model_env_key;
+        assert_eq!(provider_model_env_key("minimax"), "MINIMAX_MODEL");
+        assert_eq!(provider_model_env_key("ollama"), "OLLAMA_MODEL");
+        assert_eq!(provider_model_env_key("shared-llm"), "SHARED_LLM_MODEL");
+        assert_eq!(
+            provider_model_env_key("decentralized-llm"),
+            "DECENTRALIZED_LLM_MODEL"
+        );
+        assert_eq!(provider_model_env_key("anthropic"), "ANTHROPIC_MODEL");
+    }
+
+    #[test]
+    fn write_dotenv_value_does_not_replace_commented_lines() {
+        use super::write_dotenv_value;
+        // A `# DEFAULT_PROVIDER=ollama` line MUST stay commented; the new
+        // KEY=VALUE goes appended, not in-place over the commented one.
+        let path = tmpfile(
+            "write-comment.env",
+            "# DEFAULT_PROVIDER=commented-out\nOTHER=keep\n",
+        );
+        write_dotenv_value(&path, "DEFAULT_PROVIDER", "minimax").expect("write");
+        let after = std::fs::read_to_string(&path).expect("read");
+        assert!(after.contains("# DEFAULT_PROVIDER=commented-out"));
+        assert!(after.contains("DEFAULT_PROVIDER=minimax"));
+        assert!(after.contains("OTHER=keep"));
+        let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## Summary

Operator's explicit ask: \"trzeba umieć ustawiać /provider i /model\". Pre-fix the slash commands set in-session values only — after TUI restart, forgotten. Operator had to re-issue both every session.

## Fix

Each slash now also writes the corresponding env var to \`installRoot/.env\`:

| Command | Persists |
|---|---|
| \`/provider X\` | \`DEFAULT_PROVIDER=X\` |
| \`/model X\` | \`\${PROVIDER_NAME}_MODEL=X\` (e.g. \`MINIMAX_MODEL=X\`) |

For \`/model\` the env key depends on the active \`chat_provider\`. Without one, operator gets a session-only set + warning (\"run \`/provider <name>\` first\").

## Mechanics

- \`MemphisClient::set_dotenv(key, value)\` — synchronous file write + \`std::env::set_var\` so the live process sees it. Idempotent: existing key gets overwritten in-place, missing appended. Comment lines (\`# KEY=...\`) are NEVER replaced — new pair appended below.
- \`provider_model_env_key\`: \`\"minimax\"\` → \`\"MINIMAX_MODEL\"\`, \`\"shared-llm\"\` → \`\"SHARED_LLM_MODEL\"\` (matches \`resolve_provider\`'s env reads).
- \`AppState::set_active_provider_and_persist\` / \`AppState::set_active_model_and_persist\`: 2 new helpers wrap both arm variants (with-\`set\` and bare-cmd) so all 4 slash variants share one code path.

## Operator flow

```
memphis vault add --key minimax_api_key
/reload                  # PR #296 — runtime sees vault key
/provider minimax        # this PR — persisted to .env
/model MiniMax-M2.7      # this PR — persisted as MINIMAX_MODEL
# chat works; survives restart
```

## Stacks on PR #296

Reuses \`locate_dotenv_from_install_root\` from Phase A1. **Base branch is \`feat/v171-tui-reload-and-provider-polish\`** so this needs to merge AFTER #296.

## Test plan

- [x] \`cargo build -p memphis-tui\` clean
- [x] \`cargo test -p memphis-tui\` — **93/93 green** (88 baseline + 5 new):
  - \`write_dotenv_value\` appends when key missing
  - \`write_dotenv_value\` overwrites in-place when key exists
  - \`write_dotenv_value\` creates file when missing
  - \`write_dotenv_value\` never replaces commented \`# KEY=\` lines
  - \`provider_model_env_key\` correctly handles all 5 provider name shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)