### PR TITLE
fix(vault): surface cause on secret-write failure (operator P0)

### DIFF
--- a/src/security/vault-boundary.ts
+++ b/src/security/vault-boundary.ts
@@ -164,12 +164,15 @@ function accessVaultSecretByKey(
       plaintext,
       createdAt: entry.createdAt,
     };
-  } catch {
+  } catch (e) {
+    const cause = e instanceof Error ? e : new Error(String(e));
     writeVaultAudit(ctx, operation, 'error', {
       key,
       found: true,
       entryId: entry.id,
       reason: 'vault_decrypt_failed',
+      causeMessage: cause.message,
+      causeCode: (e as NodeJS.ErrnoException)?.code,
     });
     return {
       found: true,
@@ -278,6 +281,7 @@ export function probeVaultStateEntriesIntegrity(
 
   const seenKeys = new Set<string>();
   const brokenKeys: string[] = [];
+  const brokenCauses: Record<string, string> = {};
 
   for (const entry of all) {
     if (seenKeys.has(entry.key)) continue;
@@ -286,12 +290,14 @@ export function probeVaultStateEntriesIntegrity(
     if (!latest) continue;
     if (!verifyVaultEntry(latest)) {
       brokenKeys.push(entry.key);
+      brokenCauses[entry.key] = 'integrity_verify_failed';
       continue;
     }
     try {
       vaultDecrypt(latest, rawEnv);
-    } catch {
+    } catch (e) {
       brokenKeys.push(entry.key);
+      brokenCauses[entry.key] = e instanceof Error ? e.message : String(e);
     }
   }
 
@@ -299,6 +305,7 @@ export function probeVaultStateEntriesIntegrity(
     writeVaultAudit(ctx, 'bounded-use', 'error', {
       probe: 'state-entries-integrity',
       brokenKeys,
+      brokenCauses,
       entriesChecked: seenKeys.size,
       reason: 'state_entries_mismatch',
     });
@@ -346,11 +353,14 @@ export function probeVaultCipherCycle(
       plaintextHash: fingerprintHash(plaintext),
     });
     return { ok: true };
-  } catch {
+  } catch (e) {
+    const cause = e instanceof Error ? e : new Error(String(e));
     writeVaultAudit(ctx, 'bounded-use', 'error', {
       key: '__vault_probe__',
       probe: 'cipher-cycle',
       reason: 'vault_probe_failed',
+      causeMessage: cause.message,
+      causeCode: (e as NodeJS.ErrnoException)?.code,
     });
     return { ok: false, error: 'Vault encryption cycle failed' };
   }
@@ -372,12 +382,16 @@ export function storeVaultSecret(
       plaintextHash: fingerprintHash(plaintext),
     });
     return stored;
-  } catch {
+  } catch (e) {
+    const cause = e instanceof Error ? e : new Error(String(e));
+    const causeCode = (e as NodeJS.ErrnoException)?.code;
     writeVaultAudit(ctx, 'secret-write', 'error', {
       key,
       reason: 'vault_secret_write_failed',
+      causeMessage: cause.message,
+      causeCode,
     });
-    throw new Error('Vault secret write failed');
+    throw new Error(`Vault secret write failed: ${cause.message}`, { cause });
   }
 }
 
@@ -395,12 +409,15 @@ export function decryptVaultEntryValue(
       source: 'raw-entry',
     });
     return { ok: true, plaintext };
-  } catch {
+  } catch (e) {
+    const cause = e instanceof Error ? e : new Error(String(e));
     writeVaultAudit(ctx, 'secret-read', 'error', {
       key: entry.key,
       entryId: entry.id,
       source: 'raw-entry',
       reason: 'vault_decrypt_failed',
+      causeMessage: cause.message,
+      causeCode: (e as NodeJS.ErrnoException)?.code,
     });
     return { ok: false, error: 'Vault entry decryption failed' };
   }


### PR DESCRIPTION
## Summary
- Operator hit \`Vault secret write failed\` from \`memphis provider add minimax\` with no diagnostic — the cause (pepper missing? state file unreadable? KDF mismatch?) was discarded by \`} catch {}\` blocks in vault-boundary.
- This PR captures the cause everywhere it was being thrown away and gets it to where it's useful, while preserving the security property that decrypt errors must NOT leak cause to attackers.

## Truth model

| Site | User-facing message | Audit log |
|---|---|---|
| \`storeVaultSecret\` (write) | inline cause + \`Error.cause\` chain | causeMessage + causeCode |
| \`probeVaultStateEntriesIntegrity\` | unchanged | per-key brokenCauses map |
| \`accessVaultSecretByKey\` (decrypt) | **stays generic** (oracle defense) | causeMessage + causeCode |
| \`probeVaultCipherCycle\` (decrypt) | **stays generic** | causeMessage + causeCode |
| \`decryptVaultEntryValue\` (decrypt) | **stays generic** | causeMessage + causeCode |

Why split: write-side errors are operational (paths, errno, missing pepper) — surfacing helps the operator. Decrypt-side errors against attacker-controlled ciphertext could become an oracle, so we keep the user-visible string flat. The existing test \`vault-boundary > returns generic decrypt errors and keeps audit metadata safe\` enforces this; that test continues to pass.

## What operator will see now
Before:
\`\`\`
[ERROR] Failed to load Memphis CLI: Vault secret write failed
\`\`\`
After (example with pepper missing):
\`\`\`
[ERROR] Failed to load Memphis CLI: Vault secret write failed: MEMPHIS_VAULT_PEPPER is required
[ERROR] Stack: Error: Vault secret write failed: MEMPHIS_VAULT_PEPPER is required
    at storeVaultSecret (.../vault-boundary.js:...)
    [cause]: Error: MEMPHIS_VAULT_PEPPER is required
\`\`\`

## Test plan
- [x] \`npx vitest run tests/unit/vault\` → 54/54 pass (9 files)
- [x] \`npx vitest run tests/unit/vault-boundary\` → 4/4 pass including the oracle-defense test
- [x] \`npx tsc --noEmit\` clean
- [ ] Operator reruns \`memphis provider add minimax\` after pulling — error message now names the cause

## Operator-blocker context
This unblocks the broader MiniMax flow (Phase A1 \`/reload\` + A2 \`/provider\`/\`/model\` already shipped in PRs #296 + #303). Without diagnosing why \`provider add\` fails, those features can't be reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)