### PR TITLE
fix(vault): anchor Rust bridge path to install root, not process.cwd (operator P0)

### DIFF
--- a/src/infra/storage/rust-vault-adapter.ts
+++ b/src/infra/storage/rust-vault-adapter.ts
@@ -13,7 +13,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, resolve as resolvePath } from 'node:path';
 
 import {
   hasRequiredBridgeExports,
@@ -26,6 +26,7 @@ import { resolveVaultPath } from './vault-paths.js';
 import { parseBool } from '../../core/env.js';
 import { errorTemplates } from '../../core/errors.js';
 import { writeSecurityAudit } from '../logging/security-audit.js';
+import { resolveInstallRoot } from '../runtime/install-root.js';
 
 /**
  * fsync a file so writes are durable on disk. Used between
@@ -356,7 +357,22 @@ function getVaultPepper(rawEnv: NodeJS.ProcessEnv): string {
 }
 
 function getBridgePath(rawEnv: NodeJS.ProcessEnv): string {
-  return rawEnv.RUST_CHAIN_BRIDGE_PATH ?? './crates/memphis-napi';
+  const override = rawEnv.RUST_CHAIN_BRIDGE_PATH?.trim();
+  if (override) return override;
+  // Anchor the default to the install root so the bridge resolves the same
+  // way regardless of `process.cwd()`. Operator memory note: `memphis` is
+  // on PATH and may be invoked from $HOME — without this, `loadBridgeModule`
+  // (createRequire(`${process.cwd()}/`)) looks at `~/crates/memphis-napi`
+  // and fails with "Rust vault bridge not found". See: operator log
+  // 2026-04-26 `memphis provider add minimax` from $HOME.
+  try {
+    return resolvePath(resolveInstallRoot({ rawEnv }), 'crates', 'memphis-napi');
+  } catch {
+    // resolveInstallRoot only throws when no override + no walkable
+    // package.json found; in that case the legacy relative path is the
+    // best we can do (preserves prior behaviour for embedded callers).
+    return './crates/memphis-napi';
+  }
 }
 
 function resolveVaultBridge(rawEnv: NodeJS.ProcessEnv = process.env): {

--- a/tests/unit/rust-vault-bridge-path.test.ts
+++ b/tests/unit/rust-vault-bridge-path.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Verifies the Rust vault bridge path is anchored to the Memphis install
+ * root, not `process.cwd()`.
+ *
+ * Why: operator hit `Vault secret write failed: Rust vault bridge not found
+ * at ./crates/memphis-napi` running `memphis provider add minimax` from
+ * $HOME on 2026-04-26. The bridge artifact existed at
+ * `<installRoot>/crates/memphis-napi/index.node`, but `getBridgePath`
+ * returned `'./crates/memphis-napi'` (relative), so `loadBridgeModule`'s
+ * `createRequire(\`${process.cwd()}/\`)` resolved against `~`, not the
+ * install tree. The CLI on PATH was effectively broken from any directory
+ * other than the source checkout.
+ *
+ * The fix anchors the default to `resolveInstallRoot(...)`. These tests
+ * pin the behaviour: env override wins, default is absolute path under
+ * the install root, and the fallback string is preserved when no install
+ * root can be resolved.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resetInstallRootMemoForTests } from '../../src/infra/runtime/install-root.js';
+import { getRustVaultAdapterStatus } from '../../src/infra/storage/rust-vault-adapter.js';
+
+afterEach(() => {
+  resetInstallRootMemoForTests();
+});
+
+describe('rust vault bridge path anchoring', () => {
+  it('respects RUST_CHAIN_BRIDGE_PATH override verbatim (no install-root prefix)', () => {
+    const out = getRustVaultAdapterStatus({
+      RUST_CHAIN_ENABLED: 'true',
+      RUST_CHAIN_BRIDGE_PATH: '/explicit/operator/override',
+    } as NodeJS.ProcessEnv);
+
+    // bridgePath must be the override, not relativised or rewritten.
+    expect(out.rustBridgePath).toBe('/explicit/operator/override');
+  });
+
+  it('default bridge path is absolute and anchored to the install root', () => {
+    // No override → resolved via resolveInstallRoot, which walks up from
+    // this file's location to the @memphis-chains/memphis package.json.
+    // We don't assert the exact path string (varies by checkout location),
+    // but it MUST be absolute (start with /) and end with the canonical
+    // crates/memphis-napi suffix.
+    const out = getRustVaultAdapterStatus({
+      RUST_CHAIN_ENABLED: 'true',
+    } as NodeJS.ProcessEnv);
+
+    expect(out.rustBridgePath.startsWith('/')).toBe(true);
+    expect(out.rustBridgePath.endsWith('crates/memphis-napi')).toBe(true);
+  });
+
+  it('default path is independent of process.cwd()', () => {
+    // Simulate the operator's broken-from-$HOME scenario: cwd is a
+    // directory that has no crates/memphis-napi underneath. Without the
+    // fix, the path would resolve relative to that cwd.
+    const original = process.cwd();
+    try {
+      process.chdir('/tmp');
+      const out = getRustVaultAdapterStatus({
+        RUST_CHAIN_ENABLED: 'true',
+      } as NodeJS.ProcessEnv);
+
+      expect(out.rustBridgePath.startsWith('/tmp/')).toBe(false);
+      expect(out.rustBridgePath.endsWith('crates/memphis-napi')).toBe(true);
+    } finally {
+      process.chdir(original);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Operator hit \`Vault secret write failed: Rust vault bridge not found at ./crates/memphis-napi\` from \`memphis provider add minimax\` run from \$HOME.
- The bridge artifact existed at \`<installRoot>/crates/memphis-napi/index.node\` (54 MB, built today).
- Root cause: \`getBridgePath()\` returned a relative \`'./crates/memphis-napi'\` and \`loadBridgeModule\` resolved via \`createRequire(\\\`\${process.cwd()}/\\\`)\` — so when cwd ≠ install root, the load failed.
- Effect: \`memphis\` on PATH was effectively broken from any directory other than the source checkout. Anything that touched the vault (provider add, vault add, init, even the boot-time integrity probe) failed with the \"bridge not found\" message that #305 just exposed to the operator.

## Fix
Route \`getBridgePath\` through the existing \`resolveInstallRoot()\` helper (the same one that fixed the \`.env\` resolution in #294/#176/etc.). The \`RUST_CHAIN_BRIDGE_PATH\` env override remains verbatim — only the default changed from relative to absolute.

## Tests
3 new tests in \`tests/unit/rust-vault-bridge-path.test.ts\`:
- \`RUST_CHAIN_BRIDGE_PATH\` override is preserved verbatim
- default bridge path is absolute and ends with \`crates/memphis-napi\`
- default is independent of \`process.cwd()\` (chdirs to /tmp to verify the operator's bug scenario)

\`npx vitest run tests/unit/rust-vault-bridge-path\` → 3/3 pass

## Verification on the operator's actual command
With this fix on PATH:
- \`cd ~ && memphis provider add minimax\` reaches the prompt and writes to vault (instead of bridge-not-found)
- \`cd /tmp && memphis vault list\` works (instead of silently degrading to no-vault mode)

## Operator-blocker context
This is the actual root cause behind the symptom #305 surfaced. With both #305 (cause-surfacing) and this PR (the actual fix) merged, \`memphis provider add\` works from any directory.

## Out of scope
- Other relative paths in adapters that may have the same bug — would need a targeted audit. Likely candidates: vault-state.json default location, log file default location. Filed mentally as v1.7.1 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)