### PR TITLE
fix(cli): operator-triage bundle — ask positional + dispatcher hint + bridge pre-flight + sonic-boom race

### DIFF
--- a/src/infra/cli/commands/provider.ts
+++ b/src/infra/cli/commands/provider.ts
@@ -4,8 +4,35 @@ import chalk from 'chalk';
 
 import { storeVaultSecret } from '../../../security/vault-boundary.js';
 import { upsertEnvVars } from '../../config/env-file.js';
+import { getRustVaultAdapterStatus } from '../../storage/rust-vault-adapter.js';
 import type { CliContext } from '../context.js';
 import { print } from '../utils/render.js';
+
+/**
+ * Refuse early if the Rust vault bridge isn't loadable. Without this check
+ * the operator types the API key, hits enter, and only THEN learns the
+ * write would have failed. Pre-flight before the prompt so secret entry
+ * can't happen unless we know the destination is reachable.
+ *
+ * Operator memory `feedback_interactive_secret_input`: never lose the
+ * secret to a downstream error the user couldn't predict.
+ */
+function preflightVaultBridge(): void {
+  const status = getRustVaultAdapterStatus(process.env);
+  if (!status.rustEnabled) {
+    throw new Error(
+      'Vault is disabled (RUST_CHAIN_ENABLED is not true). ' +
+        'Cannot store an API key without an active vault. ' +
+        'Set RUST_CHAIN_ENABLED=true and run: npm run build:rust',
+    );
+  }
+  if (!status.bridgeLoaded || !status.vaultApiAvailable) {
+    throw new Error(
+      `Rust vault bridge not available at ${status.rustBridgePath}. ` +
+        'Cannot store an API key. Run: npm run build:rust',
+    );
+  }
+}
 
 export async function promptHiddenSecret(label: string): Promise<string> {
   const stdin = process.stdin;
@@ -225,12 +252,19 @@ export async function handleProviderCommand(context: CliContext): Promise<boolea
           'provider add --json requires --api-key (no prompts in JSON mode). Omit --json to enter the key interactively.',
         );
       }
+      // Pre-flight before the prompt — refuse if vault can't accept the
+      // write, so the operator never types a secret that has nowhere to go.
+      preflightVaultBridge();
       process.stdout.write(`── Provider add: ${provider} ─────────────────────────\n`);
       process.stdout.write('The API key is prompted here instead of being passed on the\n');
       process.stdout.write('command line so it does not leak into your shell history.\n');
       process.stdout.write('It will be stored encrypted in the vault; only a reference\n');
       process.stdout.write('is written to .env.\n\n');
       apiKey = await promptHiddenSecret(`${provider} API key`);
+    } else {
+      // --api-key path also benefits from the pre-flight: same boundary,
+      // earlier failure (before any vault audit row gets written).
+      preflightVaultBridge();
     }
 
     const result = await enrollProviderKey(provider, apiKey, process.env);

--- a/src/infra/cli/dispatcher.ts
+++ b/src/infra/cli/dispatcher.ts
@@ -1,7 +1,79 @@
 import { createCliContext } from './context.js';
 import { dispatchCommand } from './handlers/command-handler.js';
-import { getCliCommandRegistrations } from './registry.js';
+import { CLI_COMPLETION_COMMANDS, getCliCommandRegistrations } from './registry.js';
 import type { CliArgs } from './types.js';
+
+/**
+ * Operators sometimes type a verb where Memphis expects a noun:
+ *   `memphis add provider minimax`  ← wrong
+ *   `memphis provider add minimax`  ← right (noun first, verb is the subcommand)
+ *
+ * When `add`/`remove`/`list`/etc. lands as the top-level command, the
+ * dispatcher fails with "Unknown command: add" — useless. This map names
+ * the actual `<noun> <verb>` shapes so the error tells the operator where
+ * the verb belongs.
+ */
+const VERB_FIRST_HINTS: Record<string, readonly string[]> = {
+  add: ['memphis vault add', 'memphis provider add', 'memphis trust add', 'memphis schedule add'],
+  remove: ['memphis vault remove', 'memphis trust remove', 'memphis schedule remove'],
+  rotate: ['memphis vault master-key-rotate', 'memphis vault pepper-rotate'],
+  recover: ['memphis vault recovery-unlock', 'memphis operator recover'],
+  set: ['memphis config set'],
+  get: ['memphis config get'],
+  show: ['memphis config show'],
+  status: ['memphis health', 'memphis tier status', 'memphis service status'],
+};
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  const m = a.length;
+  const n = b.length;
+  const prev: number[] = Array.from({ length: n + 1 }, (_, i) => i);
+  const curr: number[] = new Array(n + 1).fill(0);
+  for (let i = 1; i <= m; i += 1) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j += 1) {
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    for (let j = 0; j <= n; j += 1) prev[j] = curr[j];
+  }
+  return curr[n];
+}
+
+function suggestSimilarCommands(unknown: string): string[] {
+  const lower = unknown.toLowerCase();
+  const candidates: { name: string; distance: number }[] = [];
+  for (const command of CLI_COMPLETION_COMMANDS) {
+    const distance = levenshtein(lower, command.toLowerCase());
+    if (distance <= 2) candidates.push({ name: command, distance });
+  }
+  return candidates
+    .sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name))
+    .slice(0, 3)
+    .map((c) => c.name);
+}
+
+export function buildUnknownCommandMessage(unknown: string): string {
+  const lines = [`Unknown command: ${unknown}`];
+  const verbHint = VERB_FIRST_HINTS[unknown.toLowerCase()];
+  if (verbHint && verbHint.length > 0) {
+    lines.push('');
+    lines.push('Did you mean (the verb goes after the noun):');
+    for (const hint of verbHint) lines.push(`  ${hint}`);
+  } else {
+    const similar = suggestSimilarCommands(unknown);
+    if (similar.length > 0) {
+      lines.push('');
+      lines.push(`Did you mean: ${similar.join(', ')}?`);
+    }
+  }
+  lines.push('');
+  lines.push('Run `memphis help` for the full command list.');
+  return lines.join('\n');
+}
 
 export async function executeCommand(argv: string[], args: CliArgs): Promise<void> {
   const hasHelpFlag = argv.includes('--help');
@@ -19,6 +91,6 @@ export async function executeCommand(argv: string[], args: CliArgs): Promise<voi
   const handled = await dispatchCommand(context, handlers);
 
   if (!handled) {
-    throw new Error(`Unknown command: ${normalizedArgs.command}`);
+    throw new Error(buildUnknownCommandMessage(normalizedArgs.command ?? ''));
   }
 }

--- a/src/infra/cli/parser.ts
+++ b/src/infra/cli/parser.ts
@@ -14,6 +14,21 @@ function readNumberFlag(flags: Map<string, string | true>, name: string): number
   return value ? Number(value) : undefined;
 }
 
+/**
+ * Commands that accept a free-text question as the bulk argument. For these,
+ * if --input is not given we join `positionals[1..]` into a single string so
+ * `memphis ask co jest` works the same as `memphis ask --input "co jest"`.
+ *
+ * Why: operator memory feedback — typing `--input X` for every chat is
+ * friction. The natural shell shape is `memphis ask <words>`. The current
+ * parser dropped that shape and threw "Missing required --input".
+ *
+ * `--input` still wins when given (operator can override a positional with
+ * an explicit flag). Subcommand-style commands (`ask-session`, `chat`
+ * subcommands) are not in this set; they still need explicit --input.
+ */
+const POSITIONAL_INPUT_COMMANDS = new Set(['ask', 'chat']);
+
 export function parseCommand(argv: string[]): CliArgs {
   const args = argv.slice(2);
   const positionals: string[] = [];
@@ -36,10 +51,21 @@ export function parseCommand(argv: string[]): CliArgs {
     i += 1;
   }
 
+  const inputFlag = readFlagValue(flags, '--input');
+  const positionalInput =
+    inputFlag === undefined &&
+    positionals[0] !== undefined &&
+    POSITIONAL_INPUT_COMMANDS.has(positionals[0])
+      ? positionals.slice(1).join(' ').trim() || undefined
+      : undefined;
+
   return {
     command: positionals[0],
-    subcommand: positionals[1],
-    target: positionals[2],
+    // For positional-input commands the words after the verb are the
+    // question, not a subcommand/target. Suppress sub/target so the
+    // handlers don't try to interpret them.
+    subcommand: positionalInput !== undefined ? undefined : positionals[1],
+    target: positionalInput !== undefined ? undefined : positionals[2],
     json: hasBooleanFlag(flags, '--json'),
     checkOnly: hasBooleanFlag(flags, '--check-only'),
     runCommand: readFlagValue(flags, '--run-command'),
@@ -47,7 +73,7 @@ export function parseCommand(argv: string[]): CliArgs {
     tui: hasBooleanFlag(flags, '--tui'),
     write: hasBooleanFlag(flags, '--write'),
     save: hasBooleanFlag(flags, '--save'),
-    input: readFlagValue(flags, '--input'),
+    input: inputFlag ?? positionalInput,
     session: readFlagValue(flags, '--session'),
     provider: readFlagValue(flags, '--provider') as CliArgs['provider'],
     model: readFlagValue(flags, '--model'),

--- a/src/infra/logging/pino.ts
+++ b/src/infra/logging/pino.ts
@@ -77,7 +77,14 @@ function getFileStream(): DestinationStream | null {
     // best-effort: rotation failure must never block logger startup
   }
   try {
-    sharedFileStream = pino.destination({ dest: logPath, sync: false, mkdir: true });
+    // sync: true uses sync open + sync writes, removing the
+    // "sonic boom is not ready yet" race that surfaces as
+    // `[memphis] uncaught exception` on rapid back-to-back service
+    // restarts. The throughput cost for a CLI/daemon writing a few
+    // hundred lines per second is negligible; the race-on-startup is
+    // the bigger problem because the lost log lines are exactly the
+    // boot-time diagnostics operators need to debug crashes.
+    sharedFileStream = pino.destination({ dest: logPath, sync: true, mkdir: true });
     return sharedFileStream;
   } catch {
     sharedFileStream = null;

--- a/tests/unit/cli.dispatcher-hint.test.ts
+++ b/tests/unit/cli.dispatcher-hint.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Verifies the "Unknown command" error includes actionable hints:
+ * - For a verb-first mistake (e.g. `memphis add provider`), name the
+ *   correct `<noun> <verb>` shapes so the operator can copy/paste
+ * - For a typo (e.g. `vualt`), name close matches via Levenshtein
+ *
+ * Operator log 2026-04-26: ran `memphis add provider minimax`, got
+ * just "Unknown command: add" with no path forward.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildUnknownCommandMessage } from '../../src/infra/cli/dispatcher.js';
+
+describe('Unknown-command hint builder', () => {
+  it('hints noun-first shape when operator types a verb (add)', () => {
+    const msg = buildUnknownCommandMessage('add');
+    expect(msg).toContain('Unknown command: add');
+    expect(msg).toContain('memphis vault add');
+    expect(msg).toContain('memphis provider add');
+    expect(msg).toContain('memphis help');
+  });
+
+  it('hints noun-first shape for `remove`', () => {
+    const msg = buildUnknownCommandMessage('remove');
+    expect(msg).toContain('memphis vault remove');
+  });
+
+  it('suggests close matches for typos (vualt → vault)', () => {
+    const msg = buildUnknownCommandMessage('vualt');
+    expect(msg).toContain('Did you mean');
+    expect(msg).toContain('vault');
+  });
+
+  it('suggests close matches for typos (asj → ask)', () => {
+    const msg = buildUnknownCommandMessage('asj');
+    expect(msg).toContain('ask');
+  });
+
+  it('falls through with just the help pointer when nothing matches', () => {
+    const msg = buildUnknownCommandMessage('xyzpdq-no-match');
+    expect(msg).toContain('Unknown command: xyzpdq-no-match');
+    expect(msg).toContain('memphis help');
+    // No "Did you mean" line when we have no candidates
+    expect(msg).not.toContain('Did you mean');
+  });
+});

--- a/tests/unit/cli.parser-positional-input.test.ts
+++ b/tests/unit/cli.parser-positional-input.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Verifies `memphis ask <words>` is accepted as the natural shape for a
+ * chat question — no `--input` flag required.
+ *
+ * Operator log 2026-04-26:
+ *   memphis ask co jest  →  Error: Missing required --input
+ *
+ * The fix: when command is in POSITIONAL_INPUT_COMMANDS and --input is
+ * absent, join positionals[1..] as the input. --input still wins when
+ * given so explicit operators can override.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseCommand } from '../../src/infra/cli/parser.js';
+
+describe('memphis ask — positional input fallback', () => {
+  it('joins multi-word positionals after `ask` into a single input', () => {
+    const args = parseCommand(['node', 'cli', 'ask', 'co', 'jest']);
+    expect(args.command).toBe('ask');
+    expect(args.input).toBe('co jest');
+    expect(args.subcommand).toBeUndefined();
+    expect(args.target).toBeUndefined();
+  });
+
+  it('accepts a single quoted positional as input', () => {
+    const args = parseCommand(['node', 'cli', 'ask', 'co jest']);
+    expect(args.input).toBe('co jest');
+  });
+
+  it('lets explicit --input override the positional fallback', () => {
+    const args = parseCommand([
+      'node',
+      'cli',
+      'ask',
+      '--input',
+      'X',
+      'ignored',
+      'positional',
+    ]);
+    expect(args.input).toBe('X');
+  });
+
+  it('also works for `chat`', () => {
+    const args = parseCommand(['node', 'cli', 'chat', 'hello', 'world']);
+    expect(args.command).toBe('chat');
+    expect(args.input).toBe('hello world');
+  });
+
+  it('does NOT consume positionals for non-chat commands', () => {
+    // `memphis vault add foo` — `add` is the subcommand, `foo` the target.
+    const args = parseCommand(['node', 'cli', 'vault', 'add', 'foo']);
+    expect(args.command).toBe('vault');
+    expect(args.subcommand).toBe('add');
+    expect(args.target).toBe('foo');
+    expect(args.input).toBeUndefined();
+  });
+
+  it('returns undefined input when ask has no positional and no --input', () => {
+    const args = parseCommand(['node', 'cli', 'ask']);
+    expect(args.command).toBe('ask');
+    expect(args.input).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Four operator-blocking UX bugs from the 2026-04-26 production log, each fixed with a focused minimal change. Each is independently useful; bundled because they all came from the same operator session and share the \"don't make the operator suffer for our internal mistakes\" theme.

## What broke

| # | Operator typed | Got | Should get |
|---|---|---|---|
| 1 | \`memphis ask co jest\` | Error: Missing required --input | A chat reply |
| 2 | \`memphis add provider minimax\` | Unknown command: add | Hint: \`memphis provider add minimax\` (verb after noun) |
| 3 | \`memphis provider add minimax\` (no Rust bridge built) | Types secret first, *then* learns it can't be saved | Pre-flight check refuses BEFORE the prompt |
| 4 | \`memphis service restart\` x10 | \`[memphis] uncaught exception: sonic boom is not ready yet\` | No exception |

## Fixes

**1. \`ask\`/\`chat\` positional input** — \`src/infra/cli/parser.ts\`
New \`POSITIONAL_INPUT_COMMANDS\` set. When command is \`ask\` or \`chat\` and \`--input\` is absent, join \`positionals[1..]\` as the input. \`--input\` still wins when given.

**2. Dispatcher \"Did you mean\"** — \`src/infra/cli/dispatcher.ts\`
New \`buildUnknownCommandMessage\` exports verb-first hints (\`add\` → \`memphis vault add\`, \`memphis provider add\`, ...) plus Levenshtein typo suggestions for unknown commands.

**3. Pre-flight Rust bridge before prompting** — \`src/infra/cli/commands/provider.ts\`
New \`preflightVaultBridge()\` runs \`getRustVaultAdapterStatus\` BEFORE \`promptHiddenSecret\`. If the bridge isn't loadable, refuse early with the \`npm run build:rust\` instruction. Operator memory rule \`feedback_interactive_secret_input\`: never make the operator type a secret that has nowhere to go.

**4. Sonic-boom race** — \`src/infra/logging/pino.ts\`
Switch \`pino.destination\` from \`sync: false\` to \`sync: true\`. The race-on-startup is the bigger problem because the lost log lines are exactly the boot-time diagnostics operators need to debug crashes. Throughput hit is negligible for a CLI/daemon writing a few hundred lines per second.

## Tests
- \`tests/unit/cli.dispatcher-hint.test.ts\` — 5 cases covering verb-first hints, Levenshtein typo matches, falls-through-clean
- \`tests/unit/cli.parser-positional-input.test.ts\` — 6 cases covering multi-word, single-quoted, --input override wins, chat command, vault-add unaffected, ask-with-no-args
- All 122 tests in \`tests/unit/cli/*\` pass

## Operator-blocker context
Even with #305 (cause-surfacing) and #306 (bridge path) merged, the operator's daily flow still hits these four UX bugs. This bundle clears the last layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)