### PR TITLE
fix(providers): truth-model rollout — surface cause from 6 silent catches

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,7 +1,15 @@
+import { createContextualLogger } from '../infra/logging/contextual.js';
 import { sanitizeForJsonRequest } from '../infra/security/sanitizers.js';
 import { readVaultSecretByKey } from '../security/vault-boundary.js';
 import { AnthropicProvider } from './anthropic/adapter.js';
 import { GlmProvider } from './glm/adapter.js';
+
+// Module-scoped logger for silent-catch sites — provider-internal causes
+// are surfaced to logs without changing the caller-facing return shape.
+// Truth model: catch sites that previously discarded the error now feed
+// the cause into the audit trail so operators can diagnose flakes after
+// the fact.
+const log = createContextualLogger({ component: 'providers/index' });
 
 // Memphis LLM Provider System
 //
@@ -134,6 +142,9 @@ export class OllamaProvider implements Provider {
       const r = await fetch(`${this.baseUrl}/api/tags`, { signal: AbortSignal.timeout(3000) });
       return r.ok;
     } catch {
+      // Intentional silent catch — health probe is best-effort and runs
+      // on every provider-resolution call. Logging here would spam the
+      // operator's logs every time Ollama is offline (the common case).
       return false;
     }
   }
@@ -143,7 +154,12 @@ export class OllamaProvider implements Provider {
       const r = await fetch(`${this.baseUrl}/api/tags`);
       const d = (await r.json()) as { models?: Array<{ name: string }> };
       return d.models?.map((m) => m.name) || [];
-    } catch {
+    } catch (e) {
+      const cause = e instanceof Error ? e : new Error(String(e));
+      log.warn(
+        { provider: 'ollama', baseUrl: this.baseUrl, cause: cause.message },
+        'ollama listModels failed; returning empty list',
+      );
       return [];
     }
   }
@@ -225,7 +241,21 @@ export class OllamaProvider implements Provider {
       if (typeof tc.function.arguments === 'string') {
         try {
           args = JSON.parse(tc.function.arguments);
-        } catch {
+        } catch (e) {
+          // Ollama returned non-JSON tool args. The caller can't recover
+          // (we set args = {} so the tool gets called with no params),
+          // but log the cause so it's visible if a model starts producing
+          // malformed tool calls in production.
+          const cause = e instanceof Error ? e : new Error(String(e));
+          log.warn(
+            {
+              provider: 'ollama',
+              tool: tc.function.name,
+              cause: cause.message,
+              rawArgs: tc.function.arguments,
+            },
+            'ollama tool_call arguments did not parse as JSON; falling back to empty args',
+          );
           args = {};
         }
       } else if (tc.function.arguments && typeof tc.function.arguments === 'object') {
@@ -379,7 +409,17 @@ export class MinimaxProvider implements Provider {
       if (typeof tc.function.arguments === 'string') {
         try {
           args = JSON.parse(tc.function.arguments);
-        } catch {
+        } catch (e) {
+          const cause = e instanceof Error ? e : new Error(String(e));
+          log.warn(
+            {
+              provider: 'minimax',
+              tool: tc.function.name,
+              cause: cause.message,
+              rawArgs: tc.function.arguments,
+            },
+            'minimax tool_call arguments did not parse as JSON; falling back to empty args',
+          );
           args = {};
         }
       } else if (tc.function.arguments && typeof tc.function.arguments === 'object') {
@@ -525,7 +565,17 @@ export class OpenAICompatibleProvider implements Provider {
       if (typeof tc.function.arguments === 'string') {
         try {
           args = JSON.parse(tc.function.arguments);
-        } catch {
+        } catch (e) {
+          const cause = e instanceof Error ? e : new Error(String(e));
+          log.warn(
+            {
+              provider: this.name,
+              tool: tc.function.name,
+              cause: cause.message,
+              rawArgs: tc.function.arguments,
+            },
+            'tool_call arguments did not parse as JSON; falling back to empty args',
+          );
           args = {};
         }
       } else if (tc.function.arguments && typeof tc.function.arguments === 'object') {
@@ -597,8 +647,22 @@ export function resolveProviderVaultKey(
     if (result.found && result.plaintext) {
       return result.plaintext;
     }
+    if (result.error) {
+      // Vault returned a non-throwing failure (e.g. decryption failed —
+      // see vault-boundary truth model). Surface for diagnostics; the
+      // caller still gets undefined and falls back to plaintext envs.
+      log.warn(
+        { vaultKey: mapping.vaultKey, cause: result.error },
+        'provider vault key lookup did not return plaintext',
+      );
+    }
     return undefined;
-  } catch {
+  } catch (e) {
+    const cause = e instanceof Error ? e : new Error(String(e));
+    log.warn(
+      { vaultKey: mapping.vaultKey, cause: cause.message },
+      'provider vault key lookup threw; falling back to plaintext env or undefined',
+    );
     return undefined;
   }
 }
@@ -762,7 +826,16 @@ export async function resolveProvider(config: ProviderConfig): Promise<Provider>
       if (provider.isConfigured() && (await provider.isAvailable())) {
         return provider;
       }
-    } catch {
+    } catch (e) {
+      const cause = e instanceof Error ? e : new Error(String(e));
+      // When NONE of the configured providers can be created/resolved,
+      // the operator sees the Ollama fallback at the bottom of this
+      // function and wonders "why didn't my MiniMax provider work?".
+      // Logging each skip names the per-provider cause.
+      log.warn(
+        { providerName: cfg.name, providerType: cfg.type, cause: cause.message },
+        'provider construction or availability check threw; skipping in fallback chain',
+      );
       continue;
     }
   }


### PR DESCRIPTION
## Summary
Apply the truth-model pattern (PR #305 vault-boundary methodology) to \`src/providers/index.ts\`. Previously 7 \`} catch {}\` sites discarded the underlying cause; operators saw \"no provider available\" or \"tool args empty\" with no diagnostic.

## Sites updated

| Line | Site | Treatment |
|---|---|---|
| 144 | \`OllamaProvider.isAvailable()\` health probe | **Intentional silent — annotated**. Runs every provider-resolution call; logging would spam logs every time Ollama is offline (the common case). |
| listModels() | Ollama \`/api/tags\` fetch | logs \`warn\` with cause; \`[]\` return preserved |
| 244 | Ollama tool_call args JSON.parse | logs \`warn\` with provider+tool+rawArgs; args default to \`{}\` |
| 411 | Minimax tool_call args JSON.parse | same pattern |
| 567 | Generic OpenAI-shape providers (DeepSeek/GLM/etc.) tool_call args JSON.parse | same pattern |
| 651 | \`resolveProviderVaultKey\` throw + result.error path | logs \`warn\` with vault key + cause; surfaces both throw-path AND \`result.error\` path (post-#305 vault-boundary returns errors instead of throwing in some cases) |
| 829 | \`resolveProvider\` fallback iteration | logs \`warn\` with provider name + type + cause when a provider fails to construct/resolve. **High operator value** — when MiniMax silently gets skipped and Ollama wins the fallback, operator now sees why. |

All caller-facing return shapes preserved. Added a module-scoped \`createContextualLogger\` with \`component: 'providers/index'\` so the warn lines are filterable.

## Why this matters

The operator's main daily-use bug yesterday was \`Vault secret write failed\` with no diagnostic — fixed in #305 by surfacing the cause. The provider chain has the SAME shape: silently swallowed failures producing operator-facing mystery (\"why isn't MiniMax responding?\"). This patch makes that visible.

## Tests
- \`tests/unit/providers*\` and \`tests/unit/provider*\` (4 files, 14 tests) all pass
- \`npx tsc --noEmit\` clean

## Out of scope
- Other provider files (\`src/providers/glm/adapter.ts:131\`, \`src/providers/anthropic/adapter.ts\` etc.) — separate sweep
- Provider HTTP error responses — already mapped through OperatorError in PR #302 ContextOverflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)