### PR TITLE
fix(tui): instrument silent-exit + warn on non-TTY stdin

### DIFF
--- a/src/infra/cli/commands/rust-tui.ts
+++ b/src/infra/cli/commands/rust-tui.ts
@@ -7,6 +7,20 @@ import type { CliContext } from '../context.js';
 
 const PROJECT_ROOT = resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
 
+/**
+ * If the Rust TUI exits cleanly (code 0) faster than this threshold, treat
+ * it as suspicious and warn the operator. The TUI's own boot path takes
+ * O(100ms) to load config + open terminal; an exit-0 in <SUSPICIOUS_FAST_EXIT_MS
+ * almost always means the TUI couldn't do its job and bailed (e.g. stdin
+ * not a TTY, missing terminal capabilities, panic during init that the
+ * Rust process printed-and-swallowed).
+ *
+ * Without this check, the operator's symptom is "I ran `memphis tui` and
+ * got my shell prompt back instantly with no error" — totally opaque.
+ * Captured 2026-04-26 in operator's production log.
+ */
+const SUSPICIOUS_FAST_EXIT_MS = 500;
+
 function resolveRustTuiBinary(): string | undefined {
   const suffix = process.platform === 'win32' ? '.exe' : '';
   const candidates = [
@@ -43,6 +57,29 @@ export async function runRustTui(context: CliContext): Promise<void> {
   }
   const args = binary ? runtimeArgs : ['run', '--quiet', '-p', 'memphis-tui', '--', ...runtimeArgs];
 
+  const verbose = process.env.MEMPHIS_DEBUG === '1' || context.args.verbose === true;
+  if (verbose) {
+    process.stderr.write(
+      `[memphis tui] launching ${binary ? 'binary' : 'cargo run'}: ${command} ${args.join(' ')}\n`,
+    );
+    process.stderr.write(
+      `[memphis tui] cwd=${PROJECT_ROOT} stdin.isTTY=${process.stdin.isTTY ? 'yes' : 'no'}\n`,
+    );
+  }
+
+  // Surface the most common silent-exit cause: stdin is not a TTY (e.g.
+  // operator piped output, ran in a non-interactive context, or the
+  // terminal lost its TTY status). The Rust TUI quits cleanly when it
+  // can't open raw mode, leaving the operator with no diagnostic.
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      '[memphis tui] WARNING: stdin is not a TTY. The Rust TUI requires an interactive terminal. ' +
+        'Run `memphis tui` directly from a shell, not piped/redirected.\n',
+    );
+  }
+
+  const startedAtMs = Date.now();
+
   await new Promise<void>((resolvePromise, reject) => {
     const child = spawn(command, args, {
       cwd: PROJECT_ROOT,
@@ -59,15 +96,28 @@ export async function runRustTui(context: CliContext): Promise<void> {
     });
 
     child.on('exit', (code, signal) => {
+      const elapsedMs = Date.now() - startedAtMs;
       if (signal) {
-        reject(new Error(`Rust TUI exited from signal ${signal}`));
+        reject(new Error(`Rust TUI exited from signal ${signal} (after ${elapsedMs}ms)`));
         return;
       }
       if (code === 0) {
+        // Detect the silent-fast-exit pattern that captured the operator
+        // off-guard on 2026-04-26. The exit was clean (code 0) but
+        // suspiciously fast — almost certainly the TUI noped out during
+        // init without printing a diagnostic.
+        if (elapsedMs < SUSPICIOUS_FAST_EXIT_MS) {
+          process.stderr.write(
+            `[memphis tui] WARNING: Rust TUI exited cleanly after only ${elapsedMs}ms. ` +
+              `This is faster than the TUI's own boot path; it likely bailed during init. ` +
+              `Common causes: stdin not a TTY (see warning above), missing terminal capabilities, ` +
+              `or the Rust binary panicked silently. Re-run with MEMPHIS_DEBUG=1 for more detail.\n`,
+          );
+        }
         resolvePromise();
         return;
       }
-      reject(new Error(`Rust TUI exited with code ${String(code)}`));
+      reject(new Error(`Rust TUI exited with code ${String(code)} (after ${elapsedMs}ms)`));
     });
   });
 }


### PR DESCRIPTION
## Summary
Operator hit \`memphis tui\` silently exiting on 2026-04-26: process returned to shell with no error, no output, no diagnostic.

The launcher's existing error paths (\`child.on('error')\`, non-zero exit, signal) all print via bin/memphis.js's \`[ERROR]\` catch, so the symptom must be a clean code-0 exit — almost certainly the Rust TUI bailing during init when stdin isn't a TTY or the terminal lacks capabilities.

## Three additions

1. **Pre-spawn TTY check** — if \`process.stdin.isTTY\` is false, print a prominent warning before launching. The Rust TUI requires raw mode on stdin and quits cleanly when it can't get one.

2. **Suspiciously-fast-exit detection** — if the child exits cleanly in <500ms (faster than the TUI's own boot path), warn the operator that it almost certainly bailed during init and point at \`MEMPHIS_DEBUG=1\` for more detail.

3. **MEMPHIS_DEBUG=1 / --verbose mode** — prints the resolved binary path (or \`cargo run\` fallback), arguments, cwd, and stdin TTY status. Lets operators capture launch-time state when filing bug reports.

## What this is and isn't

**Is**: instrumentation. With this in place, the next silent exit produces enough diagnostic output to identify the cause.

**Isn't**: a root-cause fix. The actual fix needs the operator's local repro logs to confirm what's bailing.

## After this lands

Operator next hits silent exit → re-runs as \`MEMPHIS_DEBUG=1 memphis tui\` → sees:
- \`[memphis tui] launching binary: ...\`
- \`[memphis tui] cwd=... stdin.isTTY=yes/no\`
- (if non-TTY): \`[memphis tui] WARNING: stdin is not a TTY...\`
- (if fast-exit): \`[memphis tui] WARNING: Rust TUI exited cleanly after Nms...\`

Three diagnostic outputs replace one mystery.

## Verification
- \`npx tsc --noEmit\` clean
- No test changes (no test currently covers the launcher; would need integration with Rust binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)