### PR TITLE
fix(install): drop stale relative-path defaults from .env.example + onboarding wizard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,11 +70,20 @@ GEN_TIMEOUT_MS=90000
 GEN_MAX_TOKENS=4096
 GEN_TEMPERATURE=0.4
 
-DATABASE_URL=file:./data/memphis.db
+# DATABASE_URL=  # Optional override. Default resolves to
+# ~/.memphis/case-index.sqlite. Only set this if you intentionally
+# store the SQLite case-index outside the data dir. Use an ABSOLUTE
+# path: a relative `./data/...` resolves against installRoot, not cwd —
+# rarely what you want for runtime DB files.
+# Example: DATABASE_URL=file:/var/lib/memphis/case-index.sqlite
 
 # Rust/NAPI bridge runtime toggles
 RUST_CHAIN_ENABLED=true
-RUST_CHAIN_BRIDGE_PATH=./crates/memphis-napi
+# RUST_CHAIN_BRIDGE_PATH=  # Optional override. Default resolves to
+# <installRoot>/crates/memphis-napi automatically. Only set this if you
+# need to point at a non-default build artifact (e.g. release/ vs debug/).
+# If set, ABSOLUTE paths are used verbatim; relative paths anchor on the
+# install root (NOT cwd) — set absolute to avoid surprises.
 
 # Embedding configuration
 # Modes: local | ollama | openai-compatible | cohere | voyage | jina | mistral | together | nvidia | mixedbread
@@ -88,11 +97,17 @@ RUST_EMBED_PROVIDER_API_KEY=
 RUST_EMBED_PROVIDER_MODEL=nomic-embed-text
 RUST_EMBED_PROVIDER_TIMEOUT_MS=8000
 RUST_EMBED_PERSIST_ENABLED=true
-RUST_EMBED_PERSIST_PATH=./data/embed-index.json
+# RUST_EMBED_PERSIST_PATH=  # Optional override. Default is
+# ~/.memphis/embed/index-v1.json. As with the other path overrides,
+# use an ABSOLUTE path if you set this.
 
 # Vault runtime requirements (required when vault endpoints are used)
 MEMPHIS_VAULT_PEPPER=
-MEMPHIS_VAULT_ENTRIES_PATH=./data/vault-entries.json
+# MEMPHIS_VAULT_ENTRIES_PATH=  # Optional override. Default is
+# ~/.memphis/vault-entries.json. Only set if you intentionally store the
+# vault outside the user's home directory. If set, use an ABSOLUTE path —
+# relative paths anchor on installRoot (NOT cwd), which is rarely what
+# you want for vault data. Same applies to MEMPHIS_VAULT_STATE_PATH.
 
 # Gateway /exec hardening policy
 GATEWAY_EXEC_RESTRICTED_MODE=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## Unreleased
 
+## v1.7.1 - 2026-04-27
+
+Fresh-install hotfix release. v1.7.0's vault-bridge fix (#306) only addressed one of six places
+the cwd-vs-installRoot bug hid in. Operators on legacy `.env` files (shipped from `.env.example`
+with relative path overrides) hit "Rust vault bridge not available at ./crates/memphis-napi"
+even after pulling v1.7.0. This release closes the gap end-to-end so the curl-installer
+one-liner produces a working install on a fresh PC.
+
+### Fixed
+
+- **Install-root anchoring sweep across 6 sibling files** (#314) — chain-adapter, rust-chain-adapter, rust-embed-adapter, graceful-shutdown, doctor's bridge probe, and rust-vault-adapter all now share `resolveRustBridgePath()`. Previously each had its own `?? './crates/memphis-napi'` fallback so vault, chain, embed, doctor, and graceful-shutdown all silently broke when `memphis` ran from any directory other than the source checkout. Sister fix in startup-guards.ts: trust-root path defaults to `<installRoot>/config/trust_root.json` instead of `./config/trust_root.json` (security-critical asset must not depend on cwd).
+- **Relative env overrides resolve against installRoot, not cwd** (#314) — `RUST_CHAIN_BRIDGE_PATH=./crates/memphis-napi` and `MEMPHIS_VAULT_ENTRIES_PATH=./data/...` style overrides shipped in legacy `.env` files now resolve against installRoot when relative. Absolute overrides remain verbatim. Without this, post-#306 operators with old `.env` files re-hit the same bridge-not-found break that v1.7.0 was supposed to close.
+- **Drop stale relative-path defaults from .env.example + onboarding wizard** (#315) — `RUST_CHAIN_BRIDGE_PATH`, `MEMPHIS_VAULT_ENTRIES_PATH`, `RUST_EMBED_PERSIST_PATH`, `DATABASE_URL` were templated as `./...` defaults that shadowed the correct in-code defaults. Fresh installs and `memphis init`'s wizard templates now omit these — defaults kick in cleanly (`~/.memphis/...` for vault/embed/sqlite, `<installRoot>/crates/memphis-napi` for the bridge). Documented when to set them explicitly (always with absolute paths).
+- **Backup pepper-restore writes to installRoot/.env** (#294) — `applyRestoredVaultPepper` now resolves `.env` via `resolveDotEnvPath()` instead of `${memphisRoot}/.env`. Pepper landed in a file the daemon never reads, silently breaking vault decryption after every cross-host restore. Integration test fixed to align with the install-root resolution path.
+
+### Added
+
+- **Provider-failure cause surfacing — truth-model rollout to providers/index.ts** (#312) — six silent `} catch {}` sites now log the cause via `logger.warn` (Ollama health/listModels, tool_call args parse for Ollama/Minimax/generic-OpenAI providers, vault-key resolution, fallback-chain provider construction). Caller-facing return shapes preserved. Operators now see WHY MiniMax was skipped before Ollama won the fallback.
+- **TUI silent-exit instrumentation** (#313) — pre-spawn TTY check + suspiciously-fast-exit warning + `MEMPHIS_DEBUG=1` verbose mode. The launcher's existing error paths handle non-zero exits and signals; this captures the silent code-0-exit case that lets the Rust TUI bail during init without printing anything.
+- **CLI operator-triage UX bundle** (#307) — `memphis ask "co jest"` now accepts positional input (no `--input` required); dispatcher prints "did you mean: memphis vault add" when operator types verb-first (`memphis add provider X`); `memphis provider add` pre-flights the Rust bridge BEFORE prompting for the API key (so operators don't type a secret into a doomed write); pino sonic-boom race fixed via `sync: true`. **Bundles 4 fixes from the operator's 2026-04-26 production log.**
+
 ## v1.7.0 - 2026-04-26
 
 The 2026-04-26 sprint cycle — 22 merged PRs covering the gap-fill plan (Phases A-G) plus an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memphis-chains/memphis",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memphis-chains/memphis",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memphis-chains/memphis",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Memphis sovereign AI runtime with chain-backed memory, encrypted vault, and a native operator console",
   "main": "dist/index.js",
   "type": "module",

--- a/src/infra/cli/onboarding-wizard.ts
+++ b/src/infra/cli/onboarding-wizard.ts
@@ -68,7 +68,10 @@ function buildProfileEnv(
       'RUST_EMBED_DIM=32',
       'RUST_EMBED_MAX_TEXT_BYTES=4096',
       'RUST_EMBED_PERSIST_ENABLED=true',
-      'RUST_EMBED_PERSIST_PATH=./data/embed-index.json',
+      // RUST_EMBED_PERSIST_PATH unset → defaults to ~/.memphis/embed/index-v1.json
+      // (anchored on user data dir, independent of cwd). Setting an explicit
+      // ./data/... path here would shadow that default with a cwd-relative path
+      // that breaks `memphis` invocations from any dir other than the checkout.
       `MEMPHIS_VAULT_PEPPER=${vaultPepper}`,
       '',
     ].join('\n'),
@@ -90,7 +93,10 @@ function buildProfileEnv(
       'RUST_EMBED_PROVIDER_MODEL=text-embedding-3-small',
       'RUST_EMBED_PROVIDER_API_KEY=',
       'RUST_EMBED_PERSIST_ENABLED=true',
-      'RUST_EMBED_PERSIST_PATH=./data/embed-index.json',
+      // RUST_EMBED_PERSIST_PATH unset → defaults to ~/.memphis/embed/index-v1.json
+      // (anchored on user data dir, independent of cwd). Setting an explicit
+      // ./data/... path here would shadow that default with a cwd-relative path
+      // that breaks `memphis` invocations from any dir other than the checkout.
       `MEMPHIS_VAULT_PEPPER=${vaultPepper}`,
       '',
     ].join('\n'),
@@ -112,7 +118,10 @@ function buildProfileEnv(
       'RUST_EMBED_PROVIDER_MODEL=text-embedding-3-small',
       'RUST_EMBED_PROVIDER_API_KEY=',
       'RUST_EMBED_PERSIST_ENABLED=true',
-      'RUST_EMBED_PERSIST_PATH=./data/embed-index.json',
+      // RUST_EMBED_PERSIST_PATH unset → defaults to ~/.memphis/embed/index-v1.json
+      // (anchored on user data dir, independent of cwd). Setting an explicit
+      // ./data/... path here would shadow that default with a cwd-relative path
+      // that breaks `memphis` invocations from any dir other than the checkout.
       `MEMPHIS_VAULT_PEPPER=${vaultPepper}`,
       '',
     ].join('\n'),
@@ -131,7 +140,10 @@ function buildProfileEnv(
       'RUST_EMBED_PROVIDER_URL=http://127.0.0.1:11434/api/embeddings',
       'RUST_EMBED_PROVIDER_MODEL=nomic-embed-text',
       'RUST_EMBED_PERSIST_ENABLED=true',
-      'RUST_EMBED_PERSIST_PATH=./data/embed-index.json',
+      // RUST_EMBED_PERSIST_PATH unset → defaults to ~/.memphis/embed/index-v1.json
+      // (anchored on user data dir, independent of cwd). Setting an explicit
+      // ./data/... path here would shadow that default with a cwd-relative path
+      // that breaks `memphis` invocations from any dir other than the checkout.
       `MEMPHIS_VAULT_PEPPER=${vaultPepper}`,
       '',
     ].join('\n'),


### PR DESCRIPTION
## Summary
Operator hit \"Rust vault bridge not available at ./crates/memphis-napi\" post-v1.7.0 because their .env shipped from .env.example with three legacy relative-path overrides:

- \`RUST_CHAIN_BRIDGE_PATH=./crates/memphis-napi\`
- \`MEMPHIS_VAULT_ENTRIES_PATH=./data/vault-entries.json\`
- \`RUST_EMBED_PERSIST_PATH=./data/embed-index.json\`
- \`DATABASE_URL=file:./data/memphis.db\`

Even with #314's relative-anchors-on-installRoot fix, these defaults are footguns: the vault entries path points at \`<installRoot>/data/...\` while the actual vault lives at \`~/.memphis/...\`.

## Fix
Comment out all four in \`.env.example\` + the four template strings in \`src/infra/cli/onboarding-wizard.ts\` (which generates fresh .env files at \`memphis init\` time). Defaults kick in cleanly. Documented when to set them explicitly (always with ABSOLUTE paths).

A fresh install from this version produces a .env without legacy overrides — vault, chain, embed, sqlite all resolve to \`~/.memphis/*\` defaults and stay working when \`memphis\` is run from any directory.

## Verification
- TS typecheck clean
- 5/5 env-related unit tests pass
- Operator can confirm by deleting their two stale lines from \`~/memphis/.env\` (the workaround is the same as this fix's effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)