### PR TITLE
fix(security): vault file 0600 perms + secret-scan sk-/Stripe + monitorRuntime listener cleanup

### DIFF
--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -2,7 +2,22 @@
 set -euo pipefail
 
 # Lightweight grep-based baseline (can be replaced by gitleaks/trufflehog later)
-PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|ghp_[0-9A-Za-z]{36}|-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----|api[_-]?key\s*[:=]\s*["\x27][A-Za-z0-9_\-]{16,})'
+#
+# Coverage matrix (issue #274):
+#   - AKIA…       AWS access key id
+#   - AIza…       GCP API key
+#   - xox[baprs]- Slack tokens
+#   - ghp_…       GitHub personal access token
+#   - sk-ant-…    Anthropic API key
+#   - sk-proj-…   OpenAI project key (modern format)
+#   - sk-…        OpenAI / Mistral / generic sk-prefixed keys (lower-bound 32 chars
+#                 to avoid matching `sk-` in unrelated text like CSS selectors)
+#   - sk_live_…   Stripe live secret key
+#   - sk_test_…   Stripe test secret key
+#   - rk_live_…   Stripe live restricted key
+#   - PEM private keys
+#   - api_key="…" generic high-entropy assignment
+PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|ghp_[0-9A-Za-z]{36}|sk-ant-[A-Za-z0-9_\-]{20,}|sk-proj-[A-Za-z0-9_\-]{20,}|sk-[A-Za-z0-9_\-]{32,}|sk_live_[A-Za-z0-9]{20,}|sk_test_[A-Za-z0-9]{20,}|rk_live_[A-Za-z0-9]{20,}|-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----|api[_-]?key\s*[:=]\s*["\x27][A-Za-z0-9_\-]{16,})'
 
 # Exclude data directory (contains npm documentation embeddings, not real secrets)
 if grep -RInE --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=data --exclude='package-lock.json' "$PATTERN" .; then

--- a/src/infra/cli/commands/debug.ts
+++ b/src/infra/cli/commands/debug.ts
@@ -258,6 +258,11 @@ export async function monitorRuntime(
   await new Promise<void>((resolve) => {
     setTimeout(() => {
       clearInterval(timer);
+      // Defensive cleanup: emitter is local-scoped and gets GC'd when this
+      // function returns, but explicitly removing the listener satisfies
+      // resource-cleanup linters and makes the no-leak guarantee explicit.
+      // Issue #277.
+      emitter.removeAllListeners('tick');
       resolve();
     }, durationMs);
   });

--- a/src/infra/storage/rust-vault-adapter.ts
+++ b/src/infra/storage/rust-vault-adapter.ts
@@ -287,7 +287,11 @@ function persistVaultState(vault: JsVault, rawEnv: NodeJS.ProcessEnv = process.e
 
   if (pepper.length >= 12) {
     const serialized = serializeVaultStateV2(vault, pepper);
-    writeFileSync(statePath, JSON.stringify(serialized, null, 2));
+    // mode: 0o600 closes the read-by-others window between create and the
+    // chmodSync below — without this, a file freshly created with the
+    // default umask (0022 → 0644) is briefly readable to other local
+    // users. Issue #275 / #272 family.
+    writeFileSync(statePath, JSON.stringify(serialized, null, 2), { mode: 0o600 });
   } else {
     // Fallback to v1 if pepper is too short (should not happen in normal flow)
     const normalized = normalizeVault(vault);
@@ -295,7 +299,7 @@ function persistVaultState(vault: JsVault, rawEnv: NodeJS.ProcessEnv = process.e
       salt: normalized.salt.toString('base64'),
       masterKey: getVaultMasterKey(normalized).toString('base64'),
     };
-    writeFileSync(statePath, JSON.stringify(serialized, null, 2));
+    writeFileSync(statePath, JSON.stringify(serialized, null, 2), { mode: 0o600 });
   }
 
   try {
@@ -689,7 +693,10 @@ export function rotateVaultStatePepper(
 
   const wrapped = serializeVaultStateV2(vault, newPepper);
   const tmpPath = `${statePath}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmpPath, JSON.stringify(wrapped, null, 2));
+  // mode at create-time + chmod after = belt + suspenders. mode applies
+  // only to fresh creates; chmod handles overwrite of any pre-existing
+  // file at tmpPath with looser perms.
+  writeFileSync(tmpPath, JSON.stringify(wrapped, null, 2), { mode: 0o600 });
   try {
     chmodSync(tmpPath, 0o600);
   } catch {
@@ -861,7 +868,7 @@ export function rotateVaultMasterKey(
       throw new Error('MEMPHIS_VAULT_PEPPER must be at least 12 characters to write v2 state.');
     }
     const wrapped = serializeVaultStateV2(newVault, pepper);
-    writeFileSync(tmpState, JSON.stringify(wrapped, null, 2));
+    writeFileSync(tmpState, JSON.stringify(wrapped, null, 2), { mode: 0o600 });
     try {
       chmodSync(tmpState, 0o600);
     } catch {
@@ -869,7 +876,7 @@ export function rotateVaultMasterKey(
     }
 
     mkdirSync(dirname(entriesPath), { recursive: true });
-    writeFileSync(tmpEntries, JSON.stringify(reencryptedStored, null, 2));
+    writeFileSync(tmpEntries, JSON.stringify(reencryptedStored, null, 2), { mode: 0o600 });
     try {
       chmodSync(tmpEntries, 0o600);
     } catch {

--- a/src/infra/storage/vault-entry-store.ts
+++ b/src/infra/storage/vault-entry-store.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import type { VaultEntry } from './rust-vault-adapter.js';
@@ -44,7 +44,24 @@ function readAll(path: string): StoredVaultEntry[] {
 function writeAll(path: string, entries: StoredVaultEntry[]): void {
   const dir = dirname(path);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(path, JSON.stringify(entries, null, 2));
+  // Pre-create at 0600 so the file is never readable by other local users
+  // even for the milliseconds between create and chmod. writeFileSync's
+  // mode option only applies on creation; pass it explicitly so a fresh
+  // vault file lands at 0600 from the first byte.
+  writeFileSync(path, JSON.stringify(entries, null, 2), { mode: 0o600 });
+  // Defensive chmod for the case where the file already existed with
+  // a different mode (writeFileSync with mode= ignores it on overwrite).
+  // Issue #275: vault-entries.json was readable to other users on shared
+  // hosts because writeFileSync uses the umask default (typically 0022 →
+  // file ends at 0644). Operator's vault contents are AES-256-GCM
+  // encrypted but the metadata (entry keys, fingerprints, IVs, audit
+  // timestamps) leaks if anyone can read the file.
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // Best-effort — older Node on some platforms (Windows) may not
+    // support chmod. Vault encryption still protects the contents.
+  }
 }
 
 export function saveVaultEntry(

--- a/tools/training/kartograf-corpus.py
+++ b/tools/training/kartograf-corpus.py
@@ -120,6 +120,13 @@ SECRET_PATTERNS = [
     ("gcp-api-key", re.compile(rb"AIza[0-9A-Za-z\-_]{35}")),
     ("github-pat", re.compile(rb"ghp_[0-9A-Za-z]{36}")),
     ("anthropic-key", re.compile(rb"sk-ant-[A-Za-z0-9\-_]{20,}")),
+    ("openai-project-key", re.compile(rb"sk-proj-[A-Za-z0-9_\-]{20,}")),
+    # OpenAI / Mistral / generic sk-prefixed (lower bound 32 chars to skip
+    # false positives on `sk-` substrings in unrelated text). Issue #274.
+    ("openai-or-generic-sk", re.compile(rb"\bsk-[A-Za-z0-9_\-]{32,}")),
+    ("stripe-live-secret", re.compile(rb"sk_live_[A-Za-z0-9]{20,}")),
+    ("stripe-test-secret", re.compile(rb"sk_test_[A-Za-z0-9]{20,}")),
+    ("stripe-restricted-key", re.compile(rb"rk_live_[A-Za-z0-9]{20,}")),
     ("slack-token", re.compile(rb"xox[baprs]-[0-9A-Za-z\-]{10,}")),
     ("jwt", re.compile(rb"eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+")),
     ("pem-private-key", re.compile(rb"-----BEGIN (RSA |EC |OPENSSH |PGP )?PRIVATE KEY-----")),


### PR DESCRIPTION
Bundles four open security/bug issues from the tracker:

## Issue #275 (P2): vault file 0600 perms at write time

\`writeFileSync\` without an explicit mode used the default umask (typically 0022 → 0644). On shared/multi-tenant hosts that meant other local users could read the file in the milliseconds between create and the post-write \`chmodSync\`. Vault contents are AES-256-GCM encrypted but metadata (entry keys, fingerprints, IVs, audit timestamps) leaked.

Every \`writeFileSync\` to a vault file now passes \`{ mode: 0o600 }\`. Sites updated:
- \`src/infra/storage/vault-entry-store.ts\` (primary saveVaultEntry write)
- \`src/infra/storage/rust-vault-adapter.ts\` ×5 (state write v1+v2, rotation tmp, master-key-rotate tmps)

## Issue #272 (P1): ed25519 signing seed perms — covered by the vault fix

Issue body assumes the signing seed lives in a separate file at an env-resolved path. In current code the MP v0 signing seed is stored INSIDE the vault (\`src/federation/mp/operator-key.ts:79 → storeVaultSecret\`) — the vault 0600 fix above covers it. No standalone seed file exists. **Closes #272 by reference, not by code change.**

## Issue #274 (P2): secret-scan missing sk-/Stripe patterns

Added to \`scripts/secret-scan.sh\` and the Kartograf corpus mirror:
- \`sk-proj-*\` (OpenAI project key)
- \`sk-*\` (OpenAI/Mistral/generic, ≥32 chars to skip false positives)
- \`sk_live_*\`, \`sk_test_*\`, \`rk_live_*\` (Stripe)

Anthropic \`sk-ant-*\` was already covered.

## Issue #277 (P2): monitorRuntime listener cleanup

The \`EventEmitter\` at \`debug.ts:242\` is local-scoped so the \"leak\" is theoretical (GC reclaims on return). Added explicit \`emitter.removeAllListeners('tick')\` after \`clearInterval\` as defensive cleanup.

## Tests
- 59/59 vault unit tests pass
- TS typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)