### PR TITLE
fix(cli): vault add/get/entry-delete accept positional key (operator UX)

### DIFF
--- a/src/infra/cli/handlers/vault.handler.ts
+++ b/src/infra/cli/handlers/vault.handler.ts
@@ -175,10 +175,20 @@ async function handleVaultInit(context: CliContext): Promise<boolean> {
 
 async function handleVaultAdd(context: CliContext): Promise<boolean> {
   if (!(await requireOperatorAuth())) throw new Error('Operator authentication failed.');
-  const { json, key } = context.args;
+  const { json } = context.args;
   let { value } = context.args;
 
-  if (!key) throw new Error('vault add requires --key <name>');
+  // Accept the key either as `--key <name>` or as a positional argument
+  // (`memphis vault add <name>`). Operator's natural shape is the
+  // positional form — same UX gap that PR #307 fixed for `memphis ask`,
+  // applied here to the vault handler.
+  const key = context.args.key ?? context.args.target;
+
+  if (!key) {
+    throw new Error(
+      'vault add requires a key name. Pass it as `memphis vault add <name>` or `memphis vault add --key <name>`.',
+    );
+  }
 
   if (value === undefined) {
     if (json) {
@@ -264,8 +274,12 @@ const PROVIDER_VAULT_ENV_MAP: Record<string, string> = {
 
 async function handleVaultGet(context: CliContext): Promise<boolean> {
   if (!(await requireOperatorAuth())) throw new Error('Operator authentication failed.');
-  const { json, key } = context.args;
-  if (!key) throw new Error('vault get requires --key');
+  const { json } = context.args;
+  // Accept --key <name> or positional `vault get <name>`.
+  const key = context.args.key ?? context.args.target;
+  if (!key) {
+    throw new Error('vault get requires a key: `memphis vault get <name>` or `--key <name>`.');
+  }
   const result = readVaultSecretByKey(key, { surface: 'cli', command: 'vault get' }, process.env);
   if (!result.found) throw new Error(`vault key not found: ${key}`);
   if (result.error) throw new Error(result.error);
@@ -291,10 +305,14 @@ async function handleVaultList(context: CliContext): Promise<boolean> {
 
 async function handleVaultEntryDelete(context: CliContext): Promise<boolean> {
   if (!(await requireOperatorAuth())) throw new Error('Operator authentication failed.');
-  const { json, key, force, confirm } = context.args;
+  const { json, force, confirm } = context.args;
+  // Accept --key <name> or positional `vault entry-delete <name>`.
+  const key = context.args.key ?? context.args.target;
 
   if (!key) {
-    throw new Error('vault entry-delete requires --key <name>');
+    throw new Error(
+      'vault entry-delete requires a key: `memphis vault entry-delete <name>` or `--key <name>`.',
+    );
   }
   if (!confirm) {
     throw new Error(


### PR DESCRIPTION
Operator hit \`vault add requires --key <name>\` running:

\`\`\`bash
memphis vault add minimax_api_key
\`\`\`

Natural shell shape (positional) rejected — handler only looked at \`args.key\`. Same UX gap PR #307 fixed for \`memphis ask\`. Operator's muscle memory from \`memphis vault list\` / \`provider add minimax\` naturally uses positional.

## Three handlers updated

- \`vault add\` — accepts \`memphis vault add <key>\` or \`--key <key>\`
- \`vault get\` — same
- \`vault entry-delete\` — same

\`--key\` still works (no breaking change). Both forms documented in error message when neither is supplied.

## Operator-blocker context

Operator at client trying to populate vault, hit this immediately after the parseBool fix unblocked vault init. Each layer of the install path keeps surfacing one more UX gap; this is the next one.