### PR TITLE
feat(otel): adopt withSpan at turn/provider/tool boundaries (sprint 0.1)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -539,9 +539,11 @@ async function startChannelGateway(container?: {
   }
 
   const cognitiveMode = getCognitiveMode();
-  const llm = providerToLlmClient(provider, {
-    temperature: getCognitiveModeConfig(cognitiveMode).temperature,
-  });
+  const llm = providerToLlmClient(
+    provider,
+    { temperature: getCognitiveModeConfig(cognitiveMode).temperature },
+    { providerLabel: provider.name, modelLabel: provider.defaultModel() },
+  );
   const memory = createInProcessMemoryClient({ surface: 'telegram' });
   const toolExecutor = createInProcessToolExecutor({
     surface: 'telegram',

--- a/src/gateway/agent-runtime.ts
+++ b/src/gateway/agent-runtime.ts
@@ -10,6 +10,7 @@ import { getDataDir } from '../config/paths.js';
 import type { TokenUsage } from '../core/types.js';
 import { resolveAgentProfile } from '../infra/agent-profile.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
+import { classifyToolOutput, instrument } from '../infra/observability/instrument.js';
 import { resolveInstallRoot } from '../infra/runtime/install-root.js';
 import { appendBlock, getChainAdapterStatus } from '../infra/storage/chain-adapter.js';
 import {
@@ -310,7 +311,23 @@ export async function runAgentLoop(options: {
         if (!toolExecutor) {
           return JSON.stringify({ error: 'no tool executor configured' });
         }
-        return toolExecutor.execute(toolCall);
+        return instrument(
+          'tool.call',
+          {
+            'tool.name': toolCall.name,
+            'tool.id': toolCall.id,
+          },
+          () => toolExecutor.execute(toolCall),
+          {
+            postAttributes: (output) => {
+              const out = output as string;
+              return {
+                'tool.output.shape': classifyToolOutput(out),
+                'tool.output.length': out.length,
+              };
+            },
+          },
+        );
       },
       toolExecutor?.maxParallel ?? 4,
     );

--- a/src/gateway/provider-adapter.ts
+++ b/src/gateway/provider-adapter.ts
@@ -1,15 +1,29 @@
 /**
  * Wraps a Memphis Provider (chat interface) into the LlmClient
  * interface that the gateway loop expects.
+ *
+ * Sprint 0.1 (otel adoption): provider.completion span emitted around
+ * each provider.chat() call, with token + tool-call counts as
+ * post-attributes. Span name + attribute namespace stable so cron-driven
+ * `otel-coverage` task can grep JSONL deterministically.
  */
 
 import type { LlmClient, LlmResponse } from './chat-types.js';
+import { instrument } from '../infra/observability/instrument.js';
 import type { ChatMessage, ChatToolDefinition, ChatOptions } from '../providers/index.js';
 import type { RuntimeProvider } from '../providers/runtime.js';
+
+export interface ProviderAdapterMeta {
+  /** Provider label (e.g. "anthropic", "glm", "ollama"). */
+  providerLabel?: string;
+  /** Fallback model label when defaults.model is unset. */
+  modelLabel?: string;
+}
 
 export function providerToLlmClient(
   provider: Pick<RuntimeProvider, 'chat'>,
   defaults: Pick<ChatOptions, 'model' | 'temperature' | 'maxTokens'> = {},
+  meta: ProviderAdapterMeta = {},
 ): LlmClient {
   return {
     async complete(input: {
@@ -19,28 +33,53 @@ export function providerToLlmClient(
       temperature?: number;
       maxTokens?: number;
     }): Promise<LlmResponse> {
-      // Per-call overrides win over construction-time defaults so cognitive
-      // mode dispatch can re-tune temperature/maxTokens on each turn.
-      const response = await provider.chat(input.messages, {
-        model: defaults.model,
-        temperature: input.temperature ?? defaults.temperature,
-        maxTokens: input.maxTokens ?? defaults.maxTokens,
-        systemPrompt: input.system,
-        tools: input.tools,
-      });
+      const providerName = meta.providerLabel ?? 'unknown';
+      const modelName = defaults.model ?? meta.modelLabel ?? 'unknown';
 
-      return {
-        content: response.content,
-        tool_calls: response.tool_calls,
-        usage: response.tokens
-          ? {
-              inputTokens: response.tokens.prompt,
-              outputTokens: response.tokens.completion,
-              totalTokens: response.tokens.total,
-              estimated: response.tokens.estimated,
-            }
-          : undefined,
-      };
+      return instrument(
+        'provider.completion',
+        {
+          'provider.name': providerName,
+          'provider.model': modelName,
+          'provider.tools.count': input.tools?.length ?? 0,
+          'provider.messages.count': input.messages.length,
+        },
+        async () => {
+          // Per-call overrides win over construction-time defaults so cognitive
+          // mode dispatch can re-tune temperature/maxTokens on each turn.
+          const response = await provider.chat(input.messages, {
+            model: defaults.model,
+            temperature: input.temperature ?? defaults.temperature,
+            maxTokens: input.maxTokens ?? defaults.maxTokens,
+            systemPrompt: input.system,
+            tools: input.tools,
+          });
+
+          return {
+            content: response.content,
+            tool_calls: response.tool_calls,
+            usage: response.tokens
+              ? {
+                  inputTokens: response.tokens.prompt,
+                  outputTokens: response.tokens.completion,
+                  totalTokens: response.tokens.total,
+                  estimated: response.tokens.estimated,
+                }
+              : undefined,
+          };
+        },
+        {
+          postAttributes: (r) => {
+            const result = r as LlmResponse;
+            return {
+              'provider.tokens.input': result.usage?.inputTokens ?? 0,
+              'provider.tokens.output': result.usage?.outputTokens ?? 0,
+              'provider.tokens.total': result.usage?.totalTokens ?? 0,
+              'provider.tool_calls.count': result.tool_calls?.length ?? 0,
+            };
+          },
+        },
+      );
     },
   };
 }

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -43,6 +43,7 @@ import { AppError } from '../core/errors.js';
 import type { RuntimeTelemetry, TokenUsage } from '../core/types.js';
 import { metrics } from '../infra/logging/metrics.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
+import { instrument } from '../infra/observability/instrument.js';
 import { buildRuntimeTelemetry, recordTurnTelemetry } from '../infra/runtime/turn-telemetry.js';
 import type { ChatMessage, ChatToolCall, ChatToolDefinition } from '../providers/index.js';
 import type { RuntimeProvider } from '../providers/runtime.js';
@@ -717,11 +718,15 @@ function resolveLlm(
 } {
   if (options.provider) {
     return {
-      llm: providerToLlmClient(options.provider, {
-        model: options.model,
-        temperature: contribution?.temperature,
-        maxTokens: contribution?.maxTokens,
-      }),
+      llm: providerToLlmClient(
+        options.provider,
+        {
+          model: options.model,
+          temperature: contribution?.temperature,
+          maxTokens: contribution?.maxTokens,
+        },
+        { providerLabel: options.provider.name, modelLabel: options.provider.defaultModel() },
+      ),
       provider: options.provider.name,
       model: options.model ?? options.provider.defaultModel(),
     };
@@ -739,6 +744,31 @@ function resolveLlm(
 }
 
 export async function runTurnRuntime(options: TurnRuntimeInput): Promise<TurnRuntimeResult> {
+  return instrument(
+    'turn.dispatch',
+    {
+      surface: options.surface,
+      'audit.surface': options.auditSurface ?? options.surface,
+      'conversation.id': options.conversationId ?? 'none',
+      'actor.id': options.actorId ?? 'local',
+    },
+    () => runTurnRuntimeImpl(options),
+    {
+      postAttributes: (r) => {
+        const result = r as TurnRuntimeResult;
+        return {
+          provider: result.provider,
+          model: result.model,
+          'turn.timing_ms': result.timingMs,
+          'turn.halt_reason': result.haltReason ?? 'none',
+          'turn.persistence.degraded': result.persistence.degraded,
+        };
+      },
+    },
+  );
+}
+
+async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntimeResult> {
   const startedAt = Date.now();
   const turnId = generateTurnId();
   const classification = await resolveInputClassification(options);

--- a/src/infra/observability/console-exporter.ts
+++ b/src/infra/observability/console-exporter.ts
@@ -1,0 +1,91 @@
+/**
+ * Local JSONL span sink — sovereign-first telemetry fallback.
+ *
+ * Writes one line per span event to `<dataDir>/telemetry/spans-YYYY-MM-DD.jsonl`,
+ * regardless of whether the OpenTelemetry SDK is enabled. The OTel pipeline
+ * (otel.ts) only emits when MEMPHIS_OTEL_ENDPOINT is set; without that, spans
+ * vanish into the no-op proxy tracer. This module exists so operators can
+ * inspect runtime behavior locally without standing up an OTLP collector.
+ *
+ * Failure handling is fire-and-forget: any write error is reported once to
+ * stderr and the failure flag is set so subsequent calls go silent — telemetry
+ * must never break the hot path.
+ *
+ * Disable with MEMPHIS_TELEMETRY_LOCAL_SINK=false for operators who want pure
+ * OTel mode and don't want files growing on disk.
+ */
+
+import { appendFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { getDataDir, ensureDir } from '../../config/paths.js';
+
+export type SpanStatus = 'ok' | 'error';
+
+export interface LocalSpanRecord {
+  ts: string;
+  name: string;
+  attrs: Record<string, string | number | boolean | null>;
+  durationMs?: number;
+  status: SpanStatus;
+  errorMessage?: string;
+  events?: Array<{ name: string; attrs?: Record<string, unknown> }>;
+}
+
+let writeFailedOnce = false;
+
+function isEnabled(rawEnv: NodeJS.ProcessEnv = process.env): boolean {
+  const flag = rawEnv.MEMPHIS_TELEMETRY_LOCAL_SINK;
+  if (flag === undefined) return true;
+  const normalized = flag.trim().toLowerCase();
+  return !['0', 'false', 'no', 'off'].includes(normalized);
+}
+
+function todayStamp(now: Date = new Date()): string {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(now.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function getTelemetryDir(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  return path.join(getDataDir(rawEnv), 'telemetry');
+}
+
+export function getSpansFilePath(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): string {
+  return path.join(getTelemetryDir(rawEnv), `spans-${todayStamp(now)}.jsonl`);
+}
+
+export function recordLocalSpan(
+  record: Omit<LocalSpanRecord, 'ts'>,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!isEnabled(rawEnv)) return;
+  if (writeFailedOnce) return;
+
+  const fullRecord: LocalSpanRecord = {
+    ts: new Date().toISOString(),
+    ...record,
+  };
+
+  try {
+    const dir = ensureDir(getTelemetryDir(rawEnv));
+    const filePath = path.join(dir, `spans-${todayStamp()}.jsonl`);
+    appendFileSync(filePath, JSON.stringify(fullRecord) + '\n', 'utf8');
+  } catch (err) {
+    writeFailedOnce = true;
+    process.stderr.write(
+      `[memphis-telemetry] local span sink disabled after first failure: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
+}
+
+/** Test-only: re-enable writes after failure (test harness). */
+export function __resetLocalSinkForTests(): void {
+  writeFailedOnce = false;
+}

--- a/src/infra/observability/instrument.ts
+++ b/src/infra/observability/instrument.ts
@@ -1,0 +1,110 @@
+/**
+ * Unified instrumentation wrapper.
+ *
+ * `instrument(name, attrs, fn)` runs the supplied async fn while:
+ *   1. Creating an OpenTelemetry span via `withSpan` (no-op when OTel SDK is
+ *      not enabled — the API package returns a proxy tracer).
+ *   2. Emitting a parallel local JSONL record via `recordLocalSpan`, so spans
+ *      are observable on operator boxes without an OTLP collector.
+ *
+ * The local record captures duration and status; the OTel span captures the
+ * same plus parent context for distributed tracing. Either path can be
+ * disabled independently (MEMPHIS_OTEL_ENDPOINT for OTel,
+ * MEMPHIS_TELEMETRY_LOCAL_SINK for the JSONL sink).
+ *
+ * Use this from gateway/agent/provider boundaries (Sprint 0.1 adoption — see
+ * docs/roadmap and `feat(otel): adopt withSpan` PR).
+ */
+
+import { recordLocalSpan, type SpanStatus } from './console-exporter.js';
+import { withSpan } from './otel.js';
+
+export type SpanAttributes = Record<string, string | number | boolean>;
+
+/**
+ * Classify a tool's stringified JSON output as success / error / unknown.
+ *
+ * Foundation for Sprint 1.3 (anti-confabulation guard) — the agent loop will
+ * use the same classifier to decide whether to inject a "do not claim
+ * success" system message before the next LLM turn.
+ *
+ * Rules:
+ *  - parsed object with `error` key, or `blocked: true`, or `ok: false` → error
+ *  - any other parsed object/array → success
+ *  - parse failure → unknown (raw string output, e.g. plain text)
+ */
+export function classifyToolOutput(output: string): 'success' | 'error' | 'unknown' {
+  try {
+    const parsed: unknown = JSON.parse(output);
+    if (parsed !== null && typeof parsed === 'object') {
+      const obj = parsed as Record<string, unknown>;
+      if ('error' in obj) return 'error';
+      if (obj.blocked === true) return 'error';
+      if (obj.ok === false) return 'error';
+    }
+    return 'success';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export interface InstrumentOptions {
+  /** Attributes evaluated *after* fn runs (e.g. classifying the result). */
+  postAttributes?: (result: unknown) => SpanAttributes;
+}
+
+/**
+ * Wrap an async operation with both OTel span + local JSONL record.
+ *
+ * The local record is written even if the OTel SDK is not enabled — that's
+ * the whole point of this wrapper.
+ */
+export async function instrument<T>(
+  name: string,
+  attributes: SpanAttributes,
+  fn: () => Promise<T>,
+  options: InstrumentOptions = {},
+): Promise<T> {
+  const startedAt = Date.now();
+  let status: SpanStatus = 'ok';
+  let errorMessage: string | undefined;
+  let result: T | undefined;
+  let thrown: unknown;
+
+  try {
+    result = await withSpan(name, attributes, async (span) => {
+      const inner = await fn();
+      // Promote post-attributes to OTel span when caller supplies them.
+      if (options.postAttributes) {
+        const post = options.postAttributes(inner);
+        for (const [key, value] of Object.entries(post)) {
+          if (value !== null && value !== undefined) {
+            span.setAttribute(key, value as string | number | boolean);
+          }
+        }
+      }
+      return inner;
+    });
+  } catch (err) {
+    status = 'error';
+    errorMessage = err instanceof Error ? err.message : String(err);
+    thrown = err;
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const finalAttrs: SpanAttributes = { ...attributes };
+  if (status === 'ok' && options.postAttributes && result !== undefined) {
+    Object.assign(finalAttrs, options.postAttributes(result));
+  }
+
+  recordLocalSpan({
+    name,
+    attrs: finalAttrs,
+    durationMs,
+    status,
+    errorMessage,
+  });
+
+  if (thrown !== undefined) throw thrown;
+  return result as T;
+}

--- a/tests/unit/observability-instrument.test.ts
+++ b/tests/unit/observability-instrument.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Sprint 0.1 (otel adoption) — golden test for the unified instrument()
+ * wrapper + local JSONL sink.
+ *
+ * Verifies:
+ *  - classifyToolOutput handles all 5 shapes (success/error/blocked/ok-false/parse-fail)
+ *  - instrument() writes one JSONL line per call with duration + status
+ *  - post-attributes are merged into the recorded span attrs
+ *  - thrown errors are recorded with status=error and rethrown
+ *  - nested instrument calls produce ordered, independent records
+ *  - MEMPHIS_TELEMETRY_LOCAL_SINK=false disables the writer
+ */
+
+import { mkdtempSync, readFileSync, existsSync, rmSync, readdirSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetLocalSinkForTests,
+  getSpansFilePath,
+} from '../../src/infra/observability/console-exporter.js';
+import {
+  classifyToolOutput,
+  instrument,
+} from '../../src/infra/observability/instrument.js';
+
+interface SpanLine {
+  ts: string;
+  name: string;
+  attrs: Record<string, unknown>;
+  durationMs?: number;
+  status: 'ok' | 'error';
+  errorMessage?: string;
+}
+
+function readSpans(dataDir: string): SpanLine[] {
+  const dir = path.join(dataDir, 'telemetry');
+  if (!existsSync(dir)) return [];
+  const files = readdirSync(dir).filter((f) => f.startsWith('spans-') && f.endsWith('.jsonl'));
+  const out: SpanLine[] = [];
+  for (const f of files) {
+    const raw = readFileSync(path.join(dir, f), 'utf8').trim();
+    if (!raw) continue;
+    for (const line of raw.split('\n')) {
+      out.push(JSON.parse(line));
+    }
+  }
+  return out;
+}
+
+describe('classifyToolOutput', () => {
+  it.each([
+    ['{"foo":"bar"}', 'success'],
+    ['{"results":[1,2,3]}', 'success'],
+    ['[]', 'success'],
+    ['{"error":"permission denied"}', 'error'],
+    ['{"ok":false,"reason":"x"}', 'error'],
+    ['{"blocked":true,"tool":"x"}', 'error'],
+    ['not json text', 'unknown'],
+    ['', 'unknown'],
+  ])('classifies %s as %s', (input, expected) => {
+    expect(classifyToolOutput(input)).toBe(expected);
+  });
+
+  it('treats blocked:false as success', () => {
+    expect(classifyToolOutput('{"blocked":false}')).toBe('success');
+  });
+
+  it('treats ok:true as success', () => {
+    expect(classifyToolOutput('{"ok":true}')).toBe('success');
+  });
+});
+
+describe('instrument() + local JSONL sink', () => {
+  let tmpDir: string;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'memphis-otel-test-'));
+    process.env.MEMPHIS_DATA_DIR = tmpDir;
+    delete process.env.MEMPHIS_OTEL_ENDPOINT;
+    delete process.env.MEMPHIS_TELEMETRY_LOCAL_SINK;
+    __resetLocalSinkForTests();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) {
+      if (!(key in savedEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+    __resetLocalSinkForTests();
+  });
+
+  it('writes one JSONL line per successful instrument call', async () => {
+    const result = await instrument(
+      'test.span',
+      { 'test.id': 'abc', count: 1 },
+      async () => 42,
+    );
+    expect(result).toBe(42);
+
+    const spans = readSpans(tmpDir);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe('test.span');
+    expect(spans[0].status).toBe('ok');
+    expect(spans[0].attrs['test.id']).toBe('abc');
+    expect(spans[0].attrs.count).toBe(1);
+    expect(spans[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records error status and rethrows when fn throws', async () => {
+    const err = new Error('boom');
+    await expect(
+      instrument('failing.span', { tag: 'x' }, async () => {
+        throw err;
+      }),
+    ).rejects.toThrow('boom');
+
+    const spans = readSpans(tmpDir);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe('failing.span');
+    expect(spans[0].status).toBe('error');
+    expect(spans[0].errorMessage).toBe('boom');
+  });
+
+  it('merges post-attributes into the recorded span', async () => {
+    await instrument(
+      'tool.call',
+      { 'tool.name': 'memphis_journal' },
+      async () => '{"ok":true,"index":42}',
+      {
+        postAttributes: (output) => ({
+          'tool.output.shape': classifyToolOutput(output as string),
+          'tool.output.length': (output as string).length,
+        }),
+      },
+    );
+
+    const spans = readSpans(tmpDir);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].attrs['tool.name']).toBe('memphis_journal');
+    expect(spans[0].attrs['tool.output.shape']).toBe('success');
+    expect(spans[0].attrs['tool.output.length']).toBe(22);
+  });
+
+  it('captures output.shape=error when tool returns semantic error', async () => {
+    await instrument(
+      'tool.call',
+      { 'tool.name': 'memphis_exec' },
+      async () => '{"error":"PERMISSION_DENIED"}',
+      {
+        postAttributes: (output) => ({
+          'tool.output.shape': classifyToolOutput(output as string),
+        }),
+      },
+    );
+
+    const spans = readSpans(tmpDir);
+    expect(spans[0].attrs['tool.output.shape']).toBe('error');
+    expect(spans[0].status).toBe('ok'); // fn didn't throw — span itself is ok
+  });
+
+  it('records nested spans in completion order', async () => {
+    await instrument('outer.turn', { surface: 'test' }, async () => {
+      await instrument('inner.tool', { name: 'a' }, async () => 'ok-a');
+      await instrument('inner.tool', { name: 'b' }, async () => 'ok-b');
+      return 'done';
+    });
+
+    const spans = readSpans(tmpDir);
+    expect(spans).toHaveLength(3);
+    expect(spans[0].name).toBe('inner.tool');
+    expect(spans[0].attrs.name).toBe('a');
+    expect(spans[1].name).toBe('inner.tool');
+    expect(spans[1].attrs.name).toBe('b');
+    expect(spans[2].name).toBe('outer.turn');
+  });
+
+  it('writes to file at getSpansFilePath(rawEnv)', async () => {
+    await instrument('path.check', {}, async () => 1);
+    const expectedPath = getSpansFilePath(process.env);
+    expect(existsSync(expectedPath)).toBe(true);
+  });
+
+  it('respects MEMPHIS_TELEMETRY_LOCAL_SINK=false', async () => {
+    process.env.MEMPHIS_TELEMETRY_LOCAL_SINK = 'false';
+    await instrument('disabled.span', {}, async () => 1);
+    expect(readSpans(tmpDir)).toHaveLength(0);
+  });
+
+  it('respects MEMPHIS_TELEMETRY_LOCAL_SINK=0', async () => {
+    process.env.MEMPHIS_TELEMETRY_LOCAL_SINK = '0';
+    await instrument('disabled.span', {}, async () => 1);
+    expect(readSpans(tmpDir)).toHaveLength(0);
+  });
+
+  it('hierarchy golden test — turn → provider → tool.call', async () => {
+    await instrument('turn.dispatch', { surface: 'telegram' }, async () => {
+      await instrument(
+        'provider.completion',
+        { 'provider.name': 'anthropic', 'provider.model': 'claude-opus-4-7' },
+        async () => 'response',
+      );
+      await instrument(
+        'tool.call',
+        { 'tool.name': 'memphis_journal' },
+        async () => '{"ok":true}',
+        {
+          postAttributes: (o) => ({ 'tool.output.shape': classifyToolOutput(o as string) }),
+        },
+      );
+      await instrument(
+        'tool.call',
+        { 'tool.name': 'memphis_exec' },
+        async () => '{"error":"denied"}',
+        {
+          postAttributes: (o) => ({ 'tool.output.shape': classifyToolOutput(o as string) }),
+        },
+      );
+      return 'turn-result';
+    });
+
+    const spans = readSpans(tmpDir);
+    const counts = spans.reduce<Record<string, number>>((acc, s) => {
+      acc[s.name] = (acc[s.name] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(counts['turn.dispatch']).toBe(1);
+    expect(counts['provider.completion']).toBe(1);
+    expect(counts['tool.call']).toBe(2);
+
+    const toolSpans = spans.filter((s) => s.name === 'tool.call');
+    const shapes = toolSpans.map((s) => s.attrs['tool.output.shape']);
+    expect(shapes).toContain('success');
+    expect(shapes).toContain('error');
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 0.1 from the post-v1.7.2 roadmap (`/home/memphis/.claude/plans/glowing-knitting-lobster.md`): adopt OpenTelemetry `withSpan` at three boundaries that matter for the next sprints — turn dispatch, provider completion, tool call. Adds a sovereign-first local JSONL sink so spans land on disk even without `MEMPHIS_OTEL_ENDPOINT`.

This unblocks Sprint 0.2 (confabulation-event detector) and Sprint 1.3 (anti-confab guard) by giving them a measurable signal: every tool call now emits a `tool.output.shape` post-attribute classifying the JSON shape as `success` / `error` / `unknown`.

## Changes

**New modules:**
- `src/infra/observability/console-exporter.ts` — append-only JSONL writer at `<dataDir>/telemetry/spans-YYYY-MM-DD.jsonl`. Failsafe (first write error mutes the writer + reports to stderr; never blocks hot path). Disabled with `MEMPHIS_TELEMETRY_LOCAL_SINK=false`.
- `src/infra/observability/instrument.ts` — unified `instrument(name, attrs, fn, { postAttributes })` wrapper that runs `withSpan` (no-op when OTel SDK isn't enabled) + `recordLocalSpan` in parallel. Exports `classifyToolOutput(json) → 'success' | 'error' | 'unknown'`.

**Adopted in 3 hot paths:**
- `src/gateway/turn-runtime.ts:741` — `runTurnRuntime` body extracted to `runTurnRuntimeImpl`; public function wraps it in `instrument('turn.dispatch', …)` with surface / audit.surface / conversation.id / actor.id pre-attrs and provider / model / timing / halt-reason post-attrs.
- `src/gateway/provider-adapter.ts` — `providerToLlmClient` wraps each `provider.chat()` in `instrument('provider.completion', …)`. New optional 3rd parameter `meta: { providerLabel, modelLabel }` so the span attribute is filled (covers anthropic / glm / ollama / local-fallback via shared adapter).
- `src/gateway/agent-runtime.ts:306` — each accepted tool call passes through `instrument('tool.call', …)` with post-attribute `tool.output.shape` from `classifyToolOutput`. Errors propagate to `executeSingleCall` unchanged (it already wraps thrown errors as JSON output).

**Updated callers (passing providerLabel):**
- `src/gateway/turn-runtime.ts:721` (`resolveLlm`)
- `src/app/bootstrap.ts:542` (telegram channel boot)

**Tests:**
- `tests/unit/observability-instrument.test.ts` (19 cases) — classifier (8 shapes), single-span + post-attrs + error rethrow, env disable (`MEMPHIS_TELEMETRY_LOCAL_SINK=false`/`0`), nested span ordering, and the 3-tier hierarchy golden case (`turn → provider → tool.call` with mixed success/error tool shapes).

## Telemetry signal (sprint exit criterion)

After this PR, every successful turn produces ≥1 span in `~/.memphis/telemetry/spans-YYYY-MM-DD.jsonl`:
- 1× `turn.dispatch` (with `provider`, `model`, `turn.timing_ms` post-attrs)
- ≥1× `provider.completion` (with `provider.tokens.input`, `provider.tokens.output`, `provider.tool_calls.count`)
- N× `tool.call` per tool invoked (with `tool.name`, `tool.output.shape`, `tool.output.length`)

Inspect: `tail -f ~/.memphis/telemetry/spans-$(date -u +%F).jsonl | jq .`

## Backwards compatibility

- `providerToLlmClient` 3rd arg is optional (default `{}`) — existing call site in `provider-adapter-defaults.test.ts` continues to work without modification.
- OTel SDK still gated by `MEMPHIS_OTEL_ENDPOINT`. Without it, the OTel proxy tracer is a no-op and only the local JSONL sink emits — which can itself be turned off with `MEMPHIS_TELEMETRY_LOCAL_SINK=false`.
- No changes to existing public types (`TurnRuntimeInput`, `LlmClient`, `ChatToolCall`).

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green (auto-fix applied for import order)
- [x] `npm run test:ts` — 2409 / 2410 pass, 1 pre-existing `tests/e2e/full-workflow.e2e.test.ts:120` failure on dev box (vault re-init refusal: `Vault has 3 existing entries`). **Verified failure reproduces on `main` without these changes** — unrelated to sprint, similar shape to the dev-machine-only flakes addressed in PR #297. Adding to follow-up triage list separately.
- [ ] Manual smoke: run runtime, send 1 message via TUI/Telegram, inspect `~/.memphis/telemetry/spans-*.jsonl` for the 3-tier hierarchy
- [ ] Verify `MEMPHIS_TELEMETRY_LOCAL_SINK=false` truly suppresses writes

## Related

- Issue #114 — adoption progress (vault boundary deferred to Sprint 2.4 alongside silent-fail surface in `runtime-security-events.ts`)
- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 0 — Telemetry foundation

🤖 Generated with [Claude Code](https://claude.com/claude-code)