### PR TITLE
feat(observability): confabulation event detector + 7d health counter (sprint 0.2)

### DIFF
--- a/src/gateway/agent-runtime.ts
+++ b/src/gateway/agent-runtime.ts
@@ -10,6 +10,11 @@ import { getDataDir } from '../config/paths.js';
 import type { TokenUsage } from '../core/types.js';
 import { resolveAgentProfile } from '../infra/agent-profile.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
+import {
+  detectConfabulation,
+  recordConfabulationEvent,
+  type ToolResultSnapshot,
+} from '../infra/observability/confabulation-detector.js';
 import { classifyToolOutput, instrument } from '../infra/observability/instrument.js';
 import { resolveInstallRoot } from '../infra/runtime/install-root.js';
 import { appendBlock, getChainAdapterStatus } from '../infra/storage/chain-adapter.js';
@@ -261,6 +266,11 @@ export async function runAgentLoop(options: {
   let usage: TokenUsage | undefined;
 
   const workingMessages = [...options.messages];
+  // Sprint 0.2: snapshot of the most recent tool results, used by the
+  // confabulation detector to compare the model's eventual claim against
+  // tool reality. Reset on each new tool batch so we always check
+  // freshest evidence.
+  let lastToolResults: ToolResultSnapshot[] = [];
 
   for (;;) {
     const response = await options.llm.complete({
@@ -275,6 +285,28 @@ export async function runAgentLoop(options: {
     void auditLlmCall('provider', response.tool_calls?.length ?? 0);
 
     if (!response.tool_calls?.length) {
+      // Final reply path. If we have tool evidence from a prior iteration,
+      // run the confabulation detector against the model's claim. Detector
+      // is best-effort: any error here must NOT break the turn — record &
+      // continue.
+      if (lastToolResults.length > 0 && response.content) {
+        try {
+          const event = detectConfabulation(lastToolResults, response.content);
+          if (event) {
+            log.warn(
+              {
+                rule: event.rule,
+                tool: event.toolName,
+                evidence: event.evidence.slice(0, 100),
+              },
+              'confabulation detected',
+            );
+            recordConfabulationEvent(event);
+          }
+        } catch (err) {
+          log.warn({ err }, 'confabulation detector error — continuing');
+        }
+      }
       workingMessages.push({ role: 'assistant', content: response.content });
       return { reply: response.content, messages: workingMessages, usage };
     }
@@ -331,6 +363,13 @@ export async function runAgentLoop(options: {
       },
       toolExecutor?.maxParallel ?? 4,
     );
+
+    // Sprint 0.2: capture this batch's tool outputs for the
+    // confabulation detector to inspect on the next assistant claim.
+    lastToolResults = toolResults.map((tr) => ({
+      name: tr.call.name,
+      output: tr.output,
+    }));
 
     for (const toolResult of toolResults) {
       if (toolResult.error) {

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -9,6 +9,7 @@ import {
 } from '../../core/surface-presence.js';
 import { buildSurfacePolicySnapshot, type SurfacePolicy } from '../../gateway/surface-policy.js';
 import type { AppConfig } from '../config/schema.js';
+import { countConfabulationEventsInWindow } from '../observability/confabulation-detector.js';
 import {
   getLocalWorkerRuntimeStatus,
   type LocalWorkerRuntimeStatus,
@@ -50,6 +51,13 @@ export type HealthPayload = {
   localWorker?: LocalWorkerRuntimeStatus | null;
   scheduler?: SchedulerRuntimeStatus | null;
   latestTurnTelemetry: TurnTelemetrySnapshot[];
+  /**
+   * Sprint 0.2: rolling 7-day count of confabulation events recorded by
+   * the agent loop. Baseline metric for Sprint 1.3 anti-confab guard —
+   * exit criterion is ≥70% reduction within a week of the guard merging.
+   * Always returned (zero when telemetry sink is empty / disabled).
+   */
+  confabulationEvents7d: number;
   version: string;
   uptime_seconds: number;
   /**
@@ -325,6 +333,7 @@ export async function buildHealthPayload(
       workPollingTokenReady: options?.workPolling?.tokenReady ?? null,
     }),
     latestTurnTelemetry: snapshotTurnTelemetry(),
+    confabulationEvents7d: countConfabulationEventsInWindow(undefined, rawEnv),
     version: appVersion(),
     uptime_seconds: Math.floor(process.uptime()),
     shutdown: shutdown.shuttingDown ? shutdown : undefined,

--- a/src/infra/observability/confabulation-detector.ts
+++ b/src/infra/observability/confabulation-detector.ts
@@ -1,0 +1,336 @@
+/**
+ * Confabulation event detector — Sprint 0.2.
+ *
+ * Defines a measurable definition of bot confabulation across three rules
+ * and emits structured events to the same JSONL sink that Sprint 0.1
+ * established. Subsequent sprints (1.3 anti-confab guard) consume these
+ * events to validate that mitigations actually move the counter down over
+ * a 7-day rolling window.
+ *
+ * Rules (v1):
+ *   A. Tool returned semantic error (output.shape === 'error') OR threw,
+ *      but the model's next assistant message claims success
+ *      (PL + EN success phrases + checkmark glyphs).
+ *   B. Model references a phantom config key — a `MEMPHIS_*` env var or
+ *      `ALLOW_*=true` flag that does not exist in the runtime config
+ *      schema. Hardcoded blocklist of known fabrications observed in
+ *      Memphis Agent transcripts (2026-04-27 confab incident); future
+ *      iterations may cross-reference `memphis_self_describe` output.
+ *   C. Tool returned an empty list / zero count, but the model enumerates
+ *      concrete items in its reply (numbered list, bullets, dashes).
+ *
+ * Output: ConfabulationEvent | null. Caller (agent-runtime) decides
+ * whether to record the event via `recordConfabulationEvent`, which writes
+ * to the local JSONL sink with name `confabulation.event` so cron-driven
+ * `confabulation-watch` task (Sprint 0.2 follow-up) can grep deterministic
+ * line shape.
+ *
+ * v1 is regex-based — deterministic, cheap, no recursive LLM-as-judge
+ * surface. If false-positive rate exceeds 10% in the first week's
+ * production data, v2 may add an LLM-as-judge tier (rule D) gated on
+ * v1 detection so we don't pay model cost on every turn.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { recordLocalSpan } from './console-exporter.js';
+import { classifyToolOutput } from './instrument.js';
+import { getDataDir } from '../../config/paths.js';
+
+export type ConfabulationRule = 'A' | 'B' | 'C';
+
+export interface ConfabulationEvent {
+  rule: ConfabulationRule;
+  /** Short snippet of evidence (the matched phrase or phantom key). */
+  evidence: string;
+  /** Name of the tool whose output triggered the rule (A and C). */
+  toolName?: string;
+}
+
+export interface ToolResultSnapshot {
+  name: string;
+  output: string;
+}
+
+// ── Rule A: error → success claim ───────────────────────────────────────────
+
+/**
+ * PL + EN success phrases. Boundary-anchored where word-shape matters,
+ * loose otherwise (e.g. emoji checkmarks). Order matters only for which
+ * snippet we surface as evidence — first match wins.
+ */
+// Polish letters (ą ć ę ł ń ó ś ź ż) are not part of \w in JS regex without
+// the `u` flag + Unicode property escapes, which we don't want to bring in
+// for a v1 deterministic matcher. Use Unicode-aware boundaries via
+// negative lookbehind/lookahead with explicit letter classes for PL phrases;
+// English phrases stay on classic \b boundaries (ASCII letters only).
+const PL_LETTER = '[A-Za-zĄąĆćĘęŁłŃńÓóŚśŹźŻż]';
+function pl(phrase: string): RegExp {
+  // Match `phrase` only when not flanked by a Polish/ASCII letter on either
+  // side. Matches whole-word semantics across PL diacritics.
+  return new RegExp(`(?<!${PL_LETTER})${phrase}(?!${PL_LETTER})`, 'iu');
+}
+
+const SUCCESS_PHRASES: RegExp[] = [
+  // Polish
+  pl('udało się'),
+  pl('zrobione'),
+  pl('skonfigurowan[eya]'),
+  pl('włączon[eya]'),
+  pl('ustawion[eya]'),
+  pl('wykonane'),
+  pl('zapisane'),
+  pl('wczytane'),
+  pl('naprawione'),
+  pl('gotowe'),
+  pl('działa'),
+  // English
+  /\bdone\b/i,
+  /\benabled\b/i,
+  /\bset up\b/i,
+  /\bconfigured\b/i,
+  /\bsuccessful(?:ly)?\b/i,
+  /\bworking\b/i,
+  /\bready\b/i,
+  /\bfixed\b/i,
+  /\bloaded\b/i,
+  /\bsaved\b/i,
+  /\ball good\b/i,
+  /\bok ✅/i,
+  /✅\s*(?:ok|done|all good|gotowe|zrobione)/i,
+  // Bare checkmark in a "this worked" context — restricted to status-line shapes
+  // to limit false positives (the bot uses ✅ in tables that aren't claims).
+  /^\s*✅/m,
+];
+
+function claimContainsSuccess(modelClaim: string): RegExpMatchArray | null {
+  for (const re of SUCCESS_PHRASES) {
+    const match = modelClaim.match(re);
+    if (match) return match;
+  }
+  return null;
+}
+
+function toolOutputIsError(output: string): boolean {
+  return classifyToolOutput(output) === 'error';
+}
+
+// ── Rule B: phantom config keys ─────────────────────────────────────────────
+
+/**
+ * Hardcoded blocklist of fabricated runtime keys observed in real
+ * Memphis Agent transcripts. New entries appended as future incidents
+ * surface them — keeps detector deterministic without runtime config
+ * cross-reference.
+ *
+ * Pattern: literal env-var-shape strings the model has invented.
+ */
+const PHANTOM_CONFIG_KEYS: RegExp[] = [
+  // From 2026-04-27 incident — bot suggested ALLOW_EXEC=true to "unblock" exec
+  /\bALLOW_EXEC\s*=\s*true\b/i,
+  /\bALLOW_GIT\s*=\s*true\b/i,
+  /\bALLOW_CODE_READ\s*=\s*true\b/i,
+  // Generic "I'd unblock with X" pattern that's almost always fabricated
+  /\bMEMPHIS_(?:ALLOW|UNLOCK|BYPASS)_[A-Z_]+\s*=\s*true\b/i,
+  // Fabricated "permission flag" the runtime never exposes
+  /\bENABLE_TIER_[0-9]_BYPASS\b/i,
+];
+
+function findPhantomConfigKey(modelClaim: string): string | null {
+  for (const re of PHANTOM_CONFIG_KEYS) {
+    const match = modelClaim.match(re);
+    if (match) return match[0];
+  }
+  return null;
+}
+
+// ── Rule C: empty result → enumeration ──────────────────────────────────────
+
+/**
+ * Tool output represents an empty list (no items returned). Covers the
+ * common shapes Memphis tools use:
+ *   - bare `[]`
+ *   - `{ "items": [] }` / `{ "results": [] }` / `{ "matches": [] }` etc.
+ *   - `{ "count": 0 }` / `{ "total": 0 }`
+ */
+function toolOutputIsEmptyList(output: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(output);
+    if (Array.isArray(parsed)) return parsed.length === 0;
+    if (parsed === null || typeof parsed !== 'object') return false;
+    const obj = parsed as Record<string, unknown>;
+    for (const key of ['items', 'results', 'matches', 'entries', 'records', 'data']) {
+      const value = obj[key];
+      if (Array.isArray(value)) return value.length === 0;
+    }
+    if (typeof obj.count === 'number' && obj.count === 0) return true;
+    if (typeof obj.total === 'number' && obj.total === 0) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Model reply enumerates concrete items — numbered, bulleted, or dashed
+ * list with at least 2 entries on consecutive lines.
+ */
+const ENUMERATION_PATTERN = /(?:^|\n)\s*(?:[-•*]|\d+\.)\s+\S/g;
+
+function claimEnumeratesItems(modelClaim: string): boolean {
+  const matches = modelClaim.match(ENUMERATION_PATTERN);
+  return matches !== null && matches.length >= 2;
+}
+
+// ── Main entry ──────────────────────────────────────────────────────────────
+
+export function detectConfabulation(
+  toolResults: ToolResultSnapshot[],
+  modelClaim: string,
+): ConfabulationEvent | null {
+  if (!modelClaim || modelClaim.length === 0) return null;
+
+  // Rule A — error tool → success claim
+  for (const tr of toolResults) {
+    if (toolOutputIsError(tr.output)) {
+      const successMatch = claimContainsSuccess(modelClaim);
+      if (successMatch) {
+        return {
+          rule: 'A',
+          evidence: successMatch[0],
+          toolName: tr.name,
+        };
+      }
+    }
+  }
+
+  // Rule B — phantom config key
+  const phantom = findPhantomConfigKey(modelClaim);
+  if (phantom !== null) {
+    return { rule: 'B', evidence: phantom };
+  }
+
+  // Rule C — empty result enumerated
+  for (const tr of toolResults) {
+    if (toolOutputIsEmptyList(tr.output) && claimEnumeratesItems(modelClaim)) {
+      return {
+        rule: 'C',
+        evidence: 'enumeration after empty tool output',
+        toolName: tr.name,
+      };
+    }
+  }
+
+  return null;
+}
+
+// ── Recording ───────────────────────────────────────────────────────────────
+
+/**
+ * Record a detected confabulation event to the local JSONL sink. Uses
+ * `recordLocalSpan` so the event lands alongside other observability
+ * spans, keyed by the stable name `confabulation.event`. Cron-driven
+ * watch tasks can grep deterministically.
+ */
+export function recordConfabulationEvent(
+  event: ConfabulationEvent,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): void {
+  recordLocalSpan(
+    {
+      name: 'confabulation.event',
+      attrs: {
+        'confabulation.rule': event.rule,
+        'confabulation.tool': event.toolName ?? 'none',
+        'confabulation.evidence_length': event.evidence.length,
+        // Truncate evidence for storage (full text would balloon JSONL on
+        // long claims). 200 chars is enough for human triage in PULSE.md.
+        'confabulation.evidence_snippet': event.evidence.slice(0, 200),
+      },
+      status: 'ok',
+    },
+    rawEnv,
+  );
+}
+
+// ── 7-day rolling counter ───────────────────────────────────────────────────
+
+/**
+ * Scan local JSONL telemetry files for `confabulation.event` records
+ * emitted within the last `windowMs` milliseconds (default 7 days) and
+ * return the count.
+ *
+ * Used by `memphis_health.confabulationEvents7d` so operators (and the
+ * cron-driven `confabulation-watch` task) see baseline / regression at
+ * a glance without bespoke log-grepping.
+ *
+ * Failure modes: missing telemetry dir, unreadable files, malformed JSONL
+ * lines — all swallowed and treated as "no events". Health endpoint must
+ * never error because telemetry inspection failed.
+ */
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const SPANS_FILE_PATTERN = /^spans-(\d{4}-\d{2}-\d{2})\.jsonl$/;
+
+export function countConfabulationEventsInWindow(
+  windowMs: number = SEVEN_DAYS_MS,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): number {
+  const telemetryDir = path.join(getDataDir(rawEnv), 'telemetry');
+  if (!existsSync(telemetryDir)) return 0;
+
+  const cutoffMs = now.getTime() - windowMs;
+
+  let files: string[];
+  try {
+    files = readdirSync(telemetryDir);
+  } catch {
+    return 0;
+  }
+
+  // Limit to JSONL files whose date stamp is within the window. We compare
+  // the DAY of the file to the cutoff DAY so we don't open files that
+  // can't possibly contain in-window records — keeps health calls cheap.
+  const cutoffDay = new Date(cutoffMs);
+  const cutoffStamp = `${cutoffDay.getUTCFullYear()}-${String(
+    cutoffDay.getUTCMonth() + 1,
+  ).padStart(2, '0')}-${String(cutoffDay.getUTCDate()).padStart(2, '0')}`;
+
+  const candidates = files.filter((f) => {
+    const match = f.match(SPANS_FILE_PATTERN);
+    if (!match) return false;
+    return match[1] >= cutoffStamp;
+  });
+
+  let count = 0;
+  for (const f of candidates) {
+    let raw: string;
+    try {
+      raw = readFileSync(path.join(telemetryDir, f), 'utf8');
+    } catch {
+      continue;
+    }
+    for (const line of raw.split('\n')) {
+      if (!line) continue;
+      // Quick reject on the most common case (non-confab spans). Avoids
+      // JSON.parse cost on every line — health is called frequently.
+      if (!line.includes('"confabulation.event"')) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (parsed === null || typeof parsed !== 'object') continue;
+      const obj = parsed as { name?: unknown; ts?: unknown };
+      if (obj.name !== 'confabulation.event') continue;
+      if (typeof obj.ts !== 'string') continue;
+      const tsMs = Date.parse(obj.ts);
+      if (Number.isFinite(tsMs) && tsMs >= cutoffMs) {
+        count += 1;
+      }
+    }
+  }
+  return count;
+}

--- a/tests/unit/confabulation-detector.test.ts
+++ b/tests/unit/confabulation-detector.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Sprint 0.2 — confabulation detector unit tests.
+ *
+ * Three rules covered with positive + negative fixtures:
+ *   A. error tool → success-claim
+ *   B. phantom config key (ALLOW_EXEC=true and friends)
+ *   C. empty list → enumeration
+ *
+ * Plus 7-day rolling counter integration: writes events through
+ * recordConfabulationEvent → countConfabulationEventsInWindow returns
+ * the expected count.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  countConfabulationEventsInWindow,
+  detectConfabulation,
+  recordConfabulationEvent,
+  type ToolResultSnapshot,
+} from '../../src/infra/observability/confabulation-detector.js';
+import {
+  __resetLocalSinkForTests,
+  recordLocalSpan,
+} from '../../src/infra/observability/console-exporter.js';
+
+describe('detectConfabulation — Rule A (error → success claim)', () => {
+  it('flags PL "udało się" claim after a tool error', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_exec', output: '{"error":"PERMISSION_DENIED"}' },
+    ];
+    const event = detectConfabulation(tools, 'OK, udało się odblokować exec.');
+    expect(event).not.toBeNull();
+    expect(event!.rule).toBe('A');
+    expect(event!.toolName).toBe('memphis_exec');
+    expect(event!.evidence.toLowerCase()).toContain('udało się');
+  });
+
+  it('flags EN "done" claim after a tool error', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_git', output: '{"ok":false,"reason":"nothing staged"}' },
+    ];
+    const event = detectConfabulation(tools, 'Pushed the change. Done!');
+    expect(event!.rule).toBe('A');
+  });
+
+  it('flags blocked tool + ✅ checkmark claim', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_fs_write', output: '{"blocked":true,"tool":"memphis_fs_write"}' },
+    ];
+    const event = detectConfabulation(tools, '✅ OK, file saved.');
+    expect(event!.rule).toBe('A');
+  });
+
+  it('does NOT flag when tool succeeds and claim is success', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_journal', output: '{"ok":true,"index":42}' },
+    ];
+    const event = detectConfabulation(tools, 'Saved successfully.');
+    expect(event).toBeNull();
+  });
+
+  it('does NOT flag when tool errors but claim is honest', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_exec', output: '{"error":"PERMISSION_DENIED"}' },
+    ];
+    const event = detectConfabulation(
+      tools,
+      'I could not run that — runtime returned PERMISSION_DENIED.',
+    );
+    expect(event).toBeNull();
+  });
+});
+
+describe('detectConfabulation — Rule B (phantom config keys)', () => {
+  it('flags ALLOW_EXEC=true (the 2026-04-27 transcript fabrication)', () => {
+    const event = detectConfabulation(
+      [],
+      'To unblock exec, set ALLOW_EXEC=true in your env.',
+    );
+    expect(event!.rule).toBe('B');
+    expect(event!.evidence).toMatch(/ALLOW_EXEC\s*=\s*true/i);
+  });
+
+  it('flags ALLOW_GIT=true and ALLOW_CODE_READ=true', () => {
+    expect(detectConfabulation([], 'Try ALLOW_GIT=true.')!.rule).toBe('B');
+    expect(detectConfabulation([], 'Set ALLOW_CODE_READ=true.')!.rule).toBe('B');
+  });
+
+  it('flags MEMPHIS_BYPASS_AUTH=true generic pattern', () => {
+    const event = detectConfabulation(
+      [],
+      'Use MEMPHIS_BYPASS_AUTH=true if you really need to skip the gate.',
+    );
+    expect(event!.rule).toBe('B');
+  });
+
+  it('does NOT flag legitimate references to MEMPHIS_OTEL_ENDPOINT', () => {
+    const event = detectConfabulation(
+      [],
+      'Set MEMPHIS_OTEL_ENDPOINT=http://localhost:4318/v1/traces to enable tracing.',
+    );
+    expect(event).toBeNull();
+  });
+});
+
+describe('detectConfabulation — Rule C (empty list → enumeration)', () => {
+  it('flags enumeration after empty array tool output', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_recall', output: '[]' },
+    ];
+    const claim =
+      'Found relevant memories:\n1. Note about Watra\n2. Decision from April\n3. Reflection on Q1';
+    const event = detectConfabulation(tools, claim);
+    expect(event!.rule).toBe('C');
+    expect(event!.toolName).toBe('memphis_recall');
+  });
+
+  it('flags bullet enumeration after empty {results:[]} tool output', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_search', output: '{"results":[]}' },
+    ];
+    const claim = 'Top hits:\n- alpha\n- beta\n- gamma';
+    const event = detectConfabulation(tools, claim);
+    expect(event!.rule).toBe('C');
+  });
+
+  it('flags enumeration after {count:0}', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_chain_query', output: '{"count":0,"matches":[]}' },
+    ];
+    const claim = 'Matches:\n- one\n- two\n- three';
+    expect(detectConfabulation(tools, claim)!.rule).toBe('C');
+  });
+
+  it('does NOT flag when empty list and claim mentions no items', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_recall', output: '[]' },
+    ];
+    const event = detectConfabulation(tools, 'No memories found for that query.');
+    expect(event).toBeNull();
+  });
+
+  it('does NOT flag enumeration when tool returned a non-empty list', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_recall', output: '[{"content":"x","score":1}]' },
+    ];
+    const claim = 'Found:\n1. x\n2. (nothing else)';
+    expect(detectConfabulation(tools, claim)).toBeNull();
+  });
+});
+
+describe('detectConfabulation — composition', () => {
+  it('returns null on empty model claim', () => {
+    expect(detectConfabulation([], '')).toBeNull();
+  });
+
+  it('returns first-rule match (A wins over C when both apply)', () => {
+    const tools: ToolResultSnapshot[] = [
+      { name: 'memphis_recall', output: '{"error":"db unreachable"}' },
+    ];
+    const claim = 'Done. Found:\n1. a\n2. b';
+    expect(detectConfabulation(tools, claim)!.rule).toBe('A');
+  });
+});
+
+describe('countConfabulationEventsInWindow — 7d rolling counter', () => {
+  let tmpDir: string;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'memphis-confab-test-'));
+    process.env.MEMPHIS_DATA_DIR = tmpDir;
+    delete process.env.MEMPHIS_OTEL_ENDPOINT;
+    delete process.env.MEMPHIS_TELEMETRY_LOCAL_SINK;
+    __resetLocalSinkForTests();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) {
+      if (!(key in savedEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+    __resetLocalSinkForTests();
+  });
+
+  it('returns 0 when no telemetry dir', () => {
+    expect(countConfabulationEventsInWindow()).toBe(0);
+  });
+
+  it('returns count of recorded events', () => {
+    recordConfabulationEvent({ rule: 'A', evidence: 'udało się', toolName: 'memphis_exec' });
+    recordConfabulationEvent({ rule: 'B', evidence: 'ALLOW_EXEC=true' });
+    recordConfabulationEvent({ rule: 'C', evidence: 'enum after empty', toolName: 'memphis_recall' });
+
+    expect(countConfabulationEventsInWindow()).toBe(3);
+  });
+
+  it('does not count regular spans (only confabulation.event)', () => {
+    recordConfabulationEvent({ rule: 'A', evidence: 'x', toolName: 't' });
+    // Append non-confab spans to verify the counter filters by name.
+    recordLocalSpan({ name: 'turn.dispatch', attrs: { surface: 'test' }, status: 'ok' });
+    recordLocalSpan({ name: 'tool.call', attrs: { 'tool.name': 'x' }, status: 'ok' });
+    expect(countConfabulationEventsInWindow()).toBe(1);
+  });
+
+  it('respects the window — events older than windowMs excluded', () => {
+    const fixedNow = new Date('2026-04-28T12:00:00Z');
+    // Real recorded event has now() timestamp — too recent to test
+    // boundary directly. Use an empty window to assert filtering.
+    recordConfabulationEvent({ rule: 'A', evidence: 'x', toolName: 't' });
+    expect(countConfabulationEventsInWindow(0, process.env, fixedNow)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 0.2 from the v1.7.2+ roadmap. Builds on Sprint 0.1 telemetry foundation (#323) with a measurable definition of "bot confabulation" that future sprints can validate against.

This unblocks Sprint 1.3 (anti-confab guard): without a counter, the "≥70% reduction in confabulation events" exit criterion is unmeasurable. Now baseline accumulates over the next week.

## Three v1 detection rules

**A. Error tool → success claim.** Tool returned semantic error (output.shape === 'error' from Sprint 0.1 classifier) AND the next assistant message contains a success phrase. PL + EN word boundaries with Unicode-aware lookarounds for Polish diacritics (`\b` breaks on `ł/ą/ę` in JS without `/u` + property escapes — helper `pl(phrase)` emits negative lookbehind/lookahead instead). Phrase list seeded from the 2026-04-27 incident transcript.

**B. Phantom config key.** Hardcoded blocklist of fabricated runtime keys the bot has invented in real transcripts: `ALLOW_EXEC=true`, `ALLOW_GIT=true`, `ALLOW_CODE_READ=true`, generic `MEMPHIS_(ALLOW|UNLOCK|BYPASS)_*=true`, `ENABLE_TIER_N_BYPASS`.

**C. Empty list → enumeration.** Tool returned empty (covers `[]`, `{items:[]}`, `{results:[]}`, `{matches:[]}`, `{count:0}`, `{total:0}`) but reply enumerates ≥2 concrete items (numbered, bullet, dash).

## Changes

**New module:**
- `src/infra/observability/confabulation-detector.ts` — `detectConfabulation(toolResults, modelClaim)` returns `ConfabulationEvent | null`. `recordConfabulationEvent` writes to JSONL via Sprint 0.1's `recordLocalSpan` with name `confabulation.event`. `countConfabulationEventsInWindow` is a failure-tolerant 7d rolling counter (missing dir / unreadable files / malformed lines all → 0).

**Hook:**
- `src/gateway/agent-runtime.ts` — snapshot freshest tool batch into `lastToolResults`; on final assistant reply (no more tool_calls), run detector against model claim. Errors caught + logged; never break the turn.

**Health surface:**
- `src/infra/http/health.ts` — new field `confabulationEvents7d: number` on `HealthPayload`. Always returned (zero when telemetry sink empty).

**Tests:**
- `tests/unit/confabulation-detector.test.ts` (20 cases) — positive + negative per rule (PL + EN), composition (A wins over C when both fire), counter with non-confab spans intermixed to verify name-filtering precision.

## Telemetry signal

After this PR, `memphis_health` exposes `confabulationEvents7d`. Inspect:
```bash
curl -s -H "Authorization: Bearer $MEMPHIS_API_TOKEN" http://localhost:3000/v1/providers/health | jq .confabulationEvents7d
```

Or grep raw events:
```bash
jq -r 'select(.name=="confabulation.event") | "\(.ts) rule=\(.attrs["confabulation.rule"]) tool=\(.attrs["confabulation.tool"]) evidence=\(.attrs["confabulation.evidence_snippet"])"' \
  ~/.memphis/telemetry/spans-*.jsonl
```

## Backwards compatibility

- `confabulationEvents7d` is a new always-zero-when-empty field. Existing health consumers ignoring extra fields continue working.
- Detector failures caught at hook site — if the regex blows up on some pathological input, the turn still completes.
- No changes to existing public types beyond the additive `HealthPayload` field.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green (auto-fix applied)
- [x] `npx vitest run tests/unit/confabulation-detector.test.ts` — 20/20 green
- [x] `npm run test:ts` full — 2428/2430 (2 pre-existing flakes unrelated to this PR: `tests/e2e/full-workflow.e2e.test.ts:120` vault re-init refusal — verified pre-existing on main; `tests/unit/cli.ask-doctor.test.ts:123` parallelism timeout — passes when isolated, also reproduces on main)
- [ ] Manual smoke: send Telegram message that triggers a deny tool path, observe `confabulation.event` line in `~/.memphis/telemetry/spans-$(date -u +%F).jsonl` if model claims success despite the error
- [ ] Verify `memphis_health` returns `confabulationEvents7d` field

## Related

- Builds on #323 (Sprint 0.1 OTel adoption)
- Foundation for Sprint 1.3 (`feat(agent): anti-confabulation guard in tool-result feedback loop`) — will use the same detector + threshold
- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 0 — Telemetry foundation, Sprint 0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)