### PR TITLE
fix(soul): apply MEMPHIS_AUTONOMY_MODE env override on read (sprint 1.1, B1)

### DIFF
--- a/src/soul/manifest.ts
+++ b/src/soul/manifest.ts
@@ -85,12 +85,35 @@ export function loadSoulManifest(rawEnv: NodeJS.ProcessEnv = process.env): SoulM
   const manifestPath = getSoulManifestPath(rawEnv);
   if (!existsSync(manifestPath)) return null;
 
+  let parsed: SoulManifest;
   try {
     const raw = JSON.parse(readFileSync(manifestPath, 'utf8')) as unknown;
-    return soulManifestSchema.parse(raw);
+    parsed = soulManifestSchema.parse(raw);
   } catch {
     return null;
   }
+
+  // Sprint 1.1 fix: env override must be applied on every read, not only
+  // on write (ensureSoulManifest). Without this, tier-3 elevation flips
+  // MEMPHIS_AUTONOMY_MODE=full in process env but resolveToolPolicy still
+  // sees the on-disk mode (typically 'balanced') because tool-executor
+  // calls loadSoulManifest, not ensureSoulManifest. That gap rationalised
+  // the 2026-04-27 confabulation incident — the bot saw "tier 3 unlocks
+  // full" in the prompt but kept getting PERMISSION_DENIED at runtime.
+  //
+  // Read-side override matches write-side semantics in ensureSoulManifest
+  // (lines 127–134): same env var, same autonomyModeSchema validation,
+  // same precedence. Invalid env values are ignored — fall back to disk
+  // value rather than fail the whole load.
+  const envMode = rawEnv.MEMPHIS_AUTONOMY_MODE;
+  if (envMode) {
+    const overridden = autonomyModeSchema.safeParse(envMode);
+    if (overridden.success) {
+      parsed.mode = overridden.data as AutonomyMode;
+    }
+  }
+
+  return parsed;
 }
 
 export function writeSoulManifest(

--- a/tests/unit/soul-manifest-env-override.test.ts
+++ b/tests/unit/soul-manifest-env-override.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Sprint 1.1 — verify loadSoulManifest applies MEMPHIS_AUTONOMY_MODE env
+ * override on read, matching the existing write-side behaviour in
+ * ensureSoulManifest. Without this, tier-3 elevation flips the env var but
+ * resolveToolPolicy keeps reading the on-disk mode (typically 'balanced')
+ * because tool-executor reads via loadSoulManifest, not ensureSoulManifest.
+ *
+ * 4-variant matrix covering the cross-product of (disk mode, env override).
+ */
+
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ensureSoulManifest,
+  loadSoulManifest,
+  writeSoulManifest,
+} from '../../src/soul/manifest.js';
+import type { AutonomyMode } from '../../src/soul/types.js';
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `memphis-soul-env-override-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('loadSoulManifest — env override (sprint 1.1)', () => {
+  let dataDir: string;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    dataDir = makeTmpDir();
+    process.env.MEMPHIS_DATA_DIR = dataDir;
+    delete process.env.MEMPHIS_AUTONOMY_MODE;
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) {
+      if (!(key in savedEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+  });
+
+  function seedManifestOnDisk(diskMode: AutonomyMode): void {
+    const fresh = ensureSoulManifest(process.env);
+    fresh.mode = diskMode;
+    writeSoulManifest(fresh, process.env);
+  }
+
+  it('A. disk=balanced, env=full → load returns full', () => {
+    seedManifestOnDisk('balanced');
+    process.env.MEMPHIS_AUTONOMY_MODE = 'full';
+    const loaded = loadSoulManifest(process.env);
+    expect(loaded?.mode).toBe('full');
+  });
+
+  it('B. disk=full, env=balanced → load returns balanced', () => {
+    seedManifestOnDisk('full');
+    process.env.MEMPHIS_AUTONOMY_MODE = 'balanced';
+    const loaded = loadSoulManifest(process.env);
+    expect(loaded?.mode).toBe('balanced');
+  });
+
+  it('C. disk=quiet, env=paranoid → load returns paranoid', () => {
+    seedManifestOnDisk('quiet');
+    process.env.MEMPHIS_AUTONOMY_MODE = 'paranoid';
+    const loaded = loadSoulManifest(process.env);
+    expect(loaded?.mode).toBe('paranoid');
+  });
+
+  it('D. disk=balanced, env unset → load returns balanced (no override applied)', () => {
+    seedManifestOnDisk('balanced');
+    delete process.env.MEMPHIS_AUTONOMY_MODE;
+    const loaded = loadSoulManifest(process.env);
+    expect(loaded?.mode).toBe('balanced');
+  });
+
+  it('E. invalid env value falls back to disk mode (parse safe)', () => {
+    seedManifestOnDisk('balanced');
+    process.env.MEMPHIS_AUTONOMY_MODE = 'not-a-real-mode';
+    const loaded = loadSoulManifest(process.env);
+    expect(loaded?.mode).toBe('balanced');
+  });
+
+  it('F. empty string env value treated as unset', () => {
+    seedManifestOnDisk('full');
+    process.env.MEMPHIS_AUTONOMY_MODE = '';
+    const loaded = loadSoulManifest(process.env);
+    expect(loaded?.mode).toBe('full');
+  });
+
+  it('uses the explicit rawEnv argument over process.env', () => {
+    seedManifestOnDisk('balanced');
+    process.env.MEMPHIS_AUTONOMY_MODE = 'paranoid';
+    const explicit = { ...process.env, MEMPHIS_AUTONOMY_MODE: 'full' };
+    const loaded = loadSoulManifest(explicit);
+    expect(loaded?.mode).toBe('full');
+  });
+
+  it('returns null when no manifest file exists (regardless of env)', () => {
+    process.env.MEMPHIS_AUTONOMY_MODE = 'full';
+    const loaded = loadSoulManifest(process.env);
+    expect(loaded).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 1.1 from the v1.7.2+ roadmap. Closes the seed bug from the 2026-04-27 health audit: tier-3 elevation flips `MEMPHIS_AUTONOMY_MODE=full` in the per-turn `rawEnv`, but `loadSoulManifest` only read the on-disk JSON. Authorization stayed stuck at the disk mode across the entire tier-3 session window — directly rationalising the bot's confabulation incident on Telegram (it kept getting PERMISSION_DENIED while the system prompt promised tier 3 = full mode, so it invented `ALLOW_EXEC=true` and similar phantom keys to explain the contradiction).

## Why this matters

**Single-line architectural fix that closes 4 of 14 category-A env-override sites** identified in the health audit (tool-executor.ts:1238, self-modify.ts:234, storage.handler.ts:558, storage.handler.ts:592 — all four call `loadSoulManifest()` without `rawEnv`, so they all silently inherit the broken read-side behaviour). Remaining 10 sites use `getCognitiveMode` / `loadOperatorConfig` / `validateOperatorPassphrase` and land in sprint 1.2.

## Change

`src/soul/manifest.ts:84` `loadSoulManifest`: after `soulManifestSchema.parse(raw)` succeeds, apply the `MEMPHIS_AUTONOMY_MODE` env override using the **exact same** validation + precedence rules as the existing write-side code in `ensureSoulManifest:127–134`:
- Same env var
- Same `autonomyModeSchema.safeParse` validation (invalid values ignored)
- Env wins over disk
- Empty / missing / unparseable env values fall back to disk mode

## Tests

`tests/unit/soul-manifest-env-override.test.ts` (8 cases) covers the cross-product matrix:

| Case | Disk | Env | Expected |
|---|---|---|---|
| A (the seed scenario) | balanced | full | full |
| B (operator down-shift) | full | balanced | balanced |
| C | quiet | paranoid | paranoid |
| D | balanced | unset | balanced |
| E (invalid env) | balanced | "not-a-real-mode" | balanced |
| F (empty env) | full | "" | full |
| G | rawEnv argument wins over process.env | | |
| H | null when manifest file missing | | |

Verified existing suites still pass: `tests/unit/soul-manifest.test.ts`, `tests/unit/tier3-session.test.ts`, `tests/unit/gateway-exec-policy.test.ts` — 56/56 green together.

## Telemetry signal (sprint exit criterion)

After sprint 0.1 (#323) merges and this PR rolls out:
- `turn.dispatch` span with `MEMPHIS_AUTONOMY_MODE=full` in env now produces `tier.effective: full` consistently
- 7-day window: 0 mismatches between `tier.envOverride` and `tier.effective` (currently this attribute is implicit; explicit attribute is sprint 1.2 follow-up)

Quick smoke (after merge):
```bash
cat ~/.memphis/config/soul-manifest.json | jq .mode  # disk value
MEMPHIS_AUTONOMY_MODE=balanced node -e "
  import('./dist/soul/manifest.js').then(m => console.log(m.loadSoulManifest().mode))
"  # should print 'balanced' regardless of disk
```

## Backwards compatibility

- Pure read-side behaviour change: callers who don't set `MEMPHIS_AUTONOMY_MODE` see no difference.
- Callers who DO set the env (tier-3 sessions) now get the documented behaviour from the prompt — this is the bug fix, not a breaking change.
- `ensureSoulManifest` write-side unchanged (already applied env override correctly since 574943c).

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/unit/soul-manifest-env-override.test.ts` — 8/8 green
- [x] Existing suites: soul-manifest + tier3-session + gateway-exec-policy — 56/56 green
- [ ] Manual smoke: `/tier 3 <pin>` on Telegram → trigger a memphis_exec → observe `mode: full` actually applies in `resolveToolPolicy` (no PERMISSION_DENIED)
- [ ] Inspect `~/.memphis/telemetry/spans-*.jsonl` for clean tool.call hierarchy on tier-3 turns

## Related

- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 1 — P0 bot reliability
- Builds on the audit memory: `/home/memphis/.claude/projects/-home-memphis/memory/project_tier3_authorization_gap_2026_04_27.md`
- Sprint 1.2 follow-up will sweep the remaining 10 category-A sites + categories B/C/D/E/F (`getCognitiveMode`, `validateOperatorPassphrase`, `loadOperatorConfig` callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)