### PR TITLE
fix(env): sweep env-override sites + harden rustLoopAdapter race (sprint 1.2)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -538,7 +538,7 @@ async function startChannelGateway(container?: {
     return null;
   }
 
-  const cognitiveMode = getCognitiveMode();
+  const cognitiveMode = getCognitiveMode(process.env);
   const llm = providerToLlmClient(
     provider,
     { temperature: getCognitiveModeConfig(cognitiveMode).temperature },
@@ -561,7 +561,7 @@ async function startChannelGateway(container?: {
         const allowlistCount = parseTelegramAllowedUserIds(process.env).length;
         const embedStatus = getRustEmbedAdapterStatus(process.env);
         const rustBridge = embedStatus.bridgeLoaded ? 'rust-napi' : 'ts-legacy';
-        const mode = getCognitiveMode();
+        const mode = getCognitiveMode(process.env);
         const modeConfig = getCognitiveModeConfig(mode);
         const surfaceLines = formatSurfaceStatusLines(getActiveSurfacesSnapshot());
         return [

--- a/src/gateway/agent-runtime.ts
+++ b/src/gateway/agent-runtime.ts
@@ -39,20 +39,26 @@ let rustLoopAdapter: NapiChainAdapter | null = null;
 let rustLoopChecked = false;
 
 function getRustLoopAdapter(): NapiChainAdapter | null {
-  if (!rustLoopChecked) {
-    rustLoopChecked = true;
-    try {
-      const adapter = new NapiChainAdapter();
-      adapter.soulLoopStep(
-        { steps: 0, tool_calls: 0, wait_ms: 0, errors: 0, completed: false, halt_reason: null },
-        { type: 'complete', data: { summary: 'probe' } },
-      );
-      rustLoopAdapter = adapter;
-      log.info('rust loop engine connected');
-    } catch {
-      log.info('rust loop engine unavailable — using TypeScript fallback');
-    }
+  if (rustLoopChecked) return rustLoopAdapter;
+
+  // Sprint 1.2 (D1) — flip the gate AFTER assigning the result so a
+  // future async-ified probe (NAPI load could become async) can't see
+  // checked=true while adapter is still null. Keeps the synchronous
+  // contract intact today; hardens against drift.
+  let adapter: NapiChainAdapter | null = null;
+  try {
+    adapter = new NapiChainAdapter();
+    adapter.soulLoopStep(
+      { steps: 0, tool_calls: 0, wait_ms: 0, errors: 0, completed: false, halt_reason: null },
+      { type: 'complete', data: { summary: 'probe' } },
+    );
+    log.info('rust loop engine connected');
+  } catch {
+    log.info('rust loop engine unavailable — using TypeScript fallback');
+    adapter = null;
   }
+  rustLoopAdapter = adapter;
+  rustLoopChecked = true;
   return rustLoopAdapter;
 }
 

--- a/src/gateway/channels/telegram.ts
+++ b/src/gateway/channels/telegram.ts
@@ -375,7 +375,7 @@ export function createTelegramAdapter(
           .trim()
           .toUpperCase();
         if (!arg) {
-          const current = getCognitiveMode();
+          const current = getCognitiveMode(process.env);
           const config = getCognitiveModeConfig(current);
           await ctx.reply(`Mode: ${current} — ${config.name}\n${config.description}`);
           return;
@@ -384,7 +384,7 @@ export function createTelegramAdapter(
           await ctx.reply('Usage: /mode [A|B|C|D|E]');
           return;
         }
-        const prev = getCognitiveMode();
+        const prev = getCognitiveMode(process.env);
         setCognitiveMode(arg as 'A' | 'B' | 'C' | 'D' | 'E');
         const config = getCognitiveModeConfig(arg as 'A' | 'B' | 'C' | 'D' | 'E');
         await ctx.reply(`Mode: ${prev} → ${arg} (${config.name})\n${config.description}`);

--- a/src/infra/cli/handlers/operator.handler.ts
+++ b/src/infra/cli/handlers/operator.handler.ts
@@ -19,7 +19,7 @@ function createRl(): readline.Interface {
 }
 
 async function handleOperatorStatus(context: CliContext): Promise<boolean> {
-  const config = loadOperatorConfig();
+  const config = loadOperatorConfig(process.env);
   const configured = config !== null;
 
   if (context.args.json) {

--- a/src/infra/cli/handlers/storage.handler.ts
+++ b/src/infra/cli/handlers/storage.handler.ts
@@ -555,7 +555,7 @@ async function handleSoulStep(context: CliContext): Promise<boolean> {
 
 async function handleSoulShow(context: CliContext): Promise<boolean> {
   const { json } = context.args;
-  const manifest = loadSoulManifest() ?? ensureSoulManifest();
+  const manifest = loadSoulManifest(process.env) ?? ensureSoulManifest(process.env);
   const memory = loadSoulMemory();
 
   const summary = {
@@ -589,7 +589,7 @@ async function handleSoulShow(context: CliContext): Promise<boolean> {
 
 async function handleSoulManifest(context: CliContext): Promise<boolean> {
   const { json } = context.args;
-  const manifest = loadSoulManifest() ?? ensureSoulManifest();
+  const manifest = loadSoulManifest(process.env) ?? ensureSoulManifest(process.env);
   print(manifest, json);
   return true;
 }

--- a/src/infra/cli/handlers/trust.handler.ts
+++ b/src/infra/cli/handlers/trust.handler.ts
@@ -42,14 +42,14 @@ async function handleTrustAdd(context: CliContext): Promise<boolean> {
   }
 
   // Validate tool name (allow '*' wildcard)
-  const knownTools = getToolNames();
+  const knownTools = getToolNames(process.env);
   if (toolName !== '*' && !knownTools.includes(toolName)) {
     console.error(`Unknown tool: ${toolName}`);
     console.error(`Known tools: ${knownTools.join(', ')}`);
     return true;
   }
 
-  const manifest = ensureSoulManifest();
+  const manifest = ensureSoulManifest(process.env);
   const rules = manifest.trustRules ?? [];
 
   // Remove existing rule for this tool if any

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -1345,7 +1345,7 @@ export function createHttpServer(
     const { loadPulseEntries } = await import('../runtime/heartbeat-watchdog.js');
     const { resolveProviderKeyResult } = await import('../../providers/index.js');
 
-    const mode = getCognitiveMode();
+    const mode = getCognitiveMode(process.env);
     const modeConfig = getCognitiveModeConfig(mode);
     const lastModified = getCognitiveModeLastModified();
     const pulseEntries = loadPulseEntries();

--- a/src/infra/runtime/lazy-singleton.ts
+++ b/src/infra/runtime/lazy-singleton.ts
@@ -1,0 +1,60 @@
+/**
+ * Promise-based lazy singleton — fixes the TOCTOU race in `if (!instance)
+ * instance = new X()` patterns.
+ *
+ * Sprint 1.2 (D1) closes the rustLoopAdapter race in
+ * `src/gateway/agent-runtime.ts:37-55` and is the canonical helper that
+ * sprint 2.1 (#271 scheduler/loop/vault) will reuse.
+ *
+ * The bug: Node.js single-threaded event loop does NOT prevent the race.
+ * If `getX()` reads `instance`, awaits something (or yields between two
+ * synchronous calls in the same tick of an async function), and writes
+ * after, two concurrent async paths can both pass the null check before
+ * either has finished initialization. The second instance silently
+ * overwrites the first; tasks attached to the first are lost.
+ *
+ * The fix: store `Promise<Instance>` instead of `Instance | null`. Both
+ * concurrent callers receive the same Promise; the factory runs exactly
+ * once. Failure mode: factory rejection clears the cache so the next
+ * caller can retry — without this, a transient init failure would
+ * permanently brick the singleton.
+ *
+ * Usage:
+ *   const getScheduler = lazySingleton(async () => createScheduler());
+ *   await getScheduler(); // first caller triggers factory
+ *   await getScheduler(); // second caller receives same instance
+ */
+
+export type LazySingleton<T> = {
+  /** Resolve the cached instance, initializing on first call. */
+  (): Promise<T>;
+  /** Test-only: clear the cached promise so the factory re-runs. */
+  reset: () => void;
+  /** Inspect whether init has been attempted (cache populated). */
+  isInitialized: () => boolean;
+};
+
+export function lazySingleton<T>(factory: () => Promise<T>): LazySingleton<T> {
+  let cached: Promise<T> | null = null;
+
+  const get = (): Promise<T> => {
+    if (cached === null) {
+      cached = factory().catch((err) => {
+        // Clear cache on rejection so the next caller can retry.
+        // Without this, a transient init failure (e.g. one-off NAPI
+        // load error during a flaky boot) would brick the singleton
+        // for the entire process lifetime.
+        cached = null;
+        throw err;
+      });
+    }
+    return cached;
+  };
+
+  return Object.assign(get, {
+    reset: (): void => {
+      cached = null;
+    },
+    isInitialized: (): boolean => cached !== null,
+  });
+}

--- a/src/infra/tui-host/commands.ts
+++ b/src/infra/tui-host/commands.ts
@@ -268,7 +268,7 @@ async function executeHealthStatus(context: TuiHostCommandContext): Promise<unkn
   context.emitLine('info', 'Loading Memphis runtime health...');
 
   // Get cognitive mode temperature
-  const cognitiveMode = getCognitiveMode();
+  const cognitiveMode = getCognitiveMode(process.env);
   const modeConfig = getCognitiveModeConfig(cognitiveMode);
 
   // Get chain block count
@@ -636,7 +636,7 @@ async function executeCognitiveMode(
 
 async function executeCognitiveModeGet(context: TuiHostCommandContext): Promise<unknown> {
   context.emitLine('info', 'Getting cognitive mode...');
-  const currentMode = getCognitiveMode();
+  const currentMode = getCognitiveMode(process.env);
   const config = getCognitiveModeConfig(currentMode);
   assertNotAborted(context.signal);
 
@@ -658,7 +658,7 @@ async function executeCognitiveModeSet(
   }
 
   context.emitLine('info', `Setting cognitive mode to ${newMode}...`);
-  const previousMode = getCognitiveMode();
+  const previousMode = getCognitiveMode(process.env);
   setCognitiveMode(newMode as CognitiveMode);
   assertNotAborted(context.signal);
 

--- a/tests/unit/lazy-singleton.test.ts
+++ b/tests/unit/lazy-singleton.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Sprint 1.2 — lazy-singleton helper unit tests.
+ *
+ * Verifies the Promise-based init guard pattern that callers (sprint 2.1
+ * scheduler/loop/vault, future async lazy initializers) will adopt.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { lazySingleton } from '../../src/infra/runtime/lazy-singleton.js';
+
+describe('lazySingleton', () => {
+  it('runs the factory exactly once across concurrent callers', async () => {
+    const factory = vi.fn(async () => ({ id: Math.random() }));
+    const get = lazySingleton(factory);
+
+    const results = await Promise.all(Array.from({ length: 100 }, () => get()));
+    expect(factory).toHaveBeenCalledTimes(1);
+    const ids = new Set(results.map((r) => r.id));
+    expect(ids.size).toBe(1);
+  });
+
+  it('caches the resolved value across sequential calls', async () => {
+    let count = 0;
+    const get = lazySingleton(async () => ({ count: ++count }));
+
+    const a = await get();
+    const b = await get();
+    const c = await get();
+
+    expect(count).toBe(1);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it('rejects the cached promise on factory failure but allows retry', async () => {
+    let attempts = 0;
+    const get = lazySingleton(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('first failure');
+      return { ok: true };
+    });
+
+    await expect(get()).rejects.toThrow('first failure');
+
+    // After failure the cache should be cleared so the next call retries.
+    const result = await get();
+    expect(result).toEqual({ ok: true });
+    expect(attempts).toBe(2);
+  });
+
+  it('reset() clears the cache so the factory re-runs', async () => {
+    const factory = vi.fn(async () => Math.random());
+    const get = lazySingleton(factory);
+
+    const a = await get();
+    const b = await get();
+    expect(a).toBe(b);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    get.reset();
+    const c = await get();
+    expect(c).not.toBe(a);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('isInitialized() reflects cache state correctly', async () => {
+    const get = lazySingleton(async () => 42);
+    expect(get.isInitialized()).toBe(false);
+
+    const promise = get();
+    expect(get.isInitialized()).toBe(true);
+    await promise;
+    expect(get.isInitialized()).toBe(true);
+
+    get.reset();
+    expect(get.isInitialized()).toBe(false);
+  });
+
+  it('concurrent calls during a slow factory share the same Promise', async () => {
+    let resolveFactory!: (value: { ready: true }) => void;
+    const factoryPromise = new Promise<{ ready: true }>((resolve) => {
+      resolveFactory = resolve;
+    });
+    const factory = vi.fn(() => factoryPromise);
+    const get = lazySingleton(factory);
+
+    const callA = get();
+    const callB = get();
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    resolveFactory({ ready: true });
+    const [a, b] = await Promise.all([callA, callB]);
+    expect(a).toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 1.2 from the v1.7.2+ roadmap. Closes the remaining category-A env-override sites that sprint 1.1 (#325) didn't reach, plus D1 race-pattern hardening on rustLoopAdapter lazy init. Together with #325 this addresses **11 of 14 category-A audit findings + the new D1 finding**.

## Sites swept

11 callers of `getCognitiveMode()` / `loadOperatorConfig()` / `getToolNames()` / `loadSoulManifest()` updated to pass `process.env` explicitly:

| File:Line | Function |
|---|---|
| src/app/bootstrap.ts:541,564 | getCognitiveMode |
| src/infra/http/server.ts:1348 | getCognitiveMode |
| src/infra/tui-host/commands.ts:271,639,661 | getCognitiveMode |
| src/gateway/channels/telegram.ts:378,387 | getCognitiveMode |
| src/infra/cli/handlers/operator.handler.ts:22 | loadOperatorConfig |
| src/infra/cli/handlers/trust.handler.ts:45 | getToolNames + ensureSoulManifest |
| src/infra/cli/handlers/storage.handler.ts:558,592 | loadSoulManifest + ensureSoulManifest |

After #325 these already see correct manifest mode by transitivity (because `loadSoulManifest` now applies envMode override on read). This sprint makes the contract **auditable** — grep `loadSoulManifest()` across src/ now returns zero hits outside tests.

## Sites deliberately NOT changed

- `src/infra/http/server.ts:926` (POST /v1/ops/restart)
- `src/mcp/tools/restart.ts:39`

Both pass `process.env` to `validateOperatorPassphrase`. **HTTP has no tier-3 session model** — passphrase comes from request body, validated against on-disk config in `process.env`. Threading `rawEnv` through these paths would be cargo-cult propagation without a downstream consumer. The HTTP code path is documented as such (`server.ts:894-899`).

## D1 race fix

`src/gateway/agent-runtime.ts:37-55` — `rustLoopAdapter` lazy init flips `rustLoopChecked = true` **after** assigning the adapter (or null on failure), not before. Today the probe is fully synchronous so the race isn't reachable in practice, but if NAPI load ever becomes async the old ordering would let one caller see `checked=true / adapter=null` mid-flight, returning null even when init would succeed. New ordering is failure-equivalent + race-resistant.

## New module: lazy-singleton

`src/infra/runtime/lazy-singleton.ts` — Promise-based init guard for the canonical `if (!instance) instance = new X()` pattern. Wraps a factory in a cached Promise so concurrent callers share the same in-flight init; resolved on success, **cleared on rejection** so the next caller can retry (without the clear-on-reject, a transient init failure would brick the singleton for the entire process lifetime).

Sprint 2.1 (`#271 — scheduler/loop/vault races`) will adopt this. Not retrofitting today because those three sites are async and need callers updated to await — keeping the diff focused.

## Tests

`tests/unit/lazy-singleton.test.ts` (6 cases):
- Single-execution under 100× concurrent callers
- Value caching across sequential calls
- Rejection clears cache + next call retries
- `reset()` clears cache
- `isInitialized()` reflects state correctly
- Concurrent calls during slow factory share same Promise

Existing suites pass (verified soul-manifest, cli.agent-runtime, tier3-session — green).

## Telemetry signal (sprint exit criterion)

After merge:
- `grep -rn "loadSoulManifest()\b" src/ | grep -v test` → zero hits
- `grep -rn "getCognitiveMode()\b" src/ | grep -v test` → zero hits
- `grep -rn "loadOperatorConfig()\b" src/ | grep -v test` → zero hits
- 7-day window: `tier.effective` span attribute matches `tier.envOverride` in 100% of turns where the override is set

## Backwards compatibility

- Pure additive change to existing function arguments (all functions already accepted `rawEnv` as optional with `process.env` default).
- Behavior change is **only** when `process.env.MEMPHIS_AUTONOMY_MODE` is set differently from the on-disk manifest mode — which is the bug fix from sprint 1.1.
- HTTP restart endpoint deliberately unchanged (see "Sites deliberately NOT changed" above).

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/unit/lazy-singleton.test.ts tests/unit/cli.agent-runtime.test.ts` — 8/8 green
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] Manual smoke: `/tier 3 <pin>` on Telegram → `/mode` → bot reports cognitive mode honoring env override
- [ ] Inspect `~/.memphis/telemetry/spans-*.jsonl` for `tier.effective` matching `tier.envOverride` post-merge

## Related

- Builds on #325 (sprint 1.1 — loadSoulManifest envMode read fix)
- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 1 — P0 bot reliability
- Sprint 1.3 follow-up will use sprint 0.2 detector to ship the anti-confab guard system message

🤖 Generated with [Claude Code](https://claude.com/claude-code)