### PR TITLE
feat(agent): anti-confabulation guard + self-describe enforcement (sprint 1.3)

### DIFF
--- a/src/gateway/agent-runtime.ts
+++ b/src/gateway/agent-runtime.ts
@@ -371,6 +371,47 @@ export async function runAgentLoop(options: {
       output: tr.output,
     }));
 
+    // Sprint 1.3: pre-emit a system-role hint summarising any tool
+    // failures so the LLM cannot fall back on "udało się"-style
+    // confabulation when the result message it just received is
+    // semantically `{ error: ... }` / `{ ok: false }` / `{ blocked: true }`.
+    // The hint is PUSHED BEFORE the tool messages below so the model
+    // sees explicit "do not claim success" framing alongside the raw
+    // outputs in its next turn. Belt-and-suspenders with the prompt
+    // rule in TOOL_DISCIPLINE_PREAMBLE; both target the same failure
+    // mode (rationalising 403/permission-denied as success).
+    const errorOutputs = toolResults.filter(
+      (tr) => classifyToolOutput(tr.output) === 'error',
+    );
+    if (errorOutputs.length > 0) {
+      const summary = errorOutputs
+        .map((tr) => {
+          let reason = '';
+          try {
+            const parsed = JSON.parse(tr.output) as Record<string, unknown>;
+            const errVal = parsed.error ?? parsed.reason ?? parsed.message;
+            if (typeof errVal === 'string') {
+              reason = errVal;
+            } else if (errVal !== undefined) {
+              reason = JSON.stringify(errVal);
+            } else {
+              reason = tr.output.slice(0, 200);
+            }
+          } catch {
+            reason = tr.output.slice(0, 200);
+          }
+          return `- ${tr.call.name}: ${(reason ?? 'unspecified error').slice(0, 200)}`;
+        })
+        .join('\n');
+      workingMessages.push({
+        role: 'system',
+        content:
+          `Tool execution surfaced errors (do NOT claim success in your reply):\n${summary}\n\n` +
+          `If the user asked for one of these actions, report the failure honestly with the error text. ` +
+          `Do not rationalise the denial by inventing config flags, env vars, or runtime modes that don't exist.`,
+      });
+    }
+
     for (const toolResult of toolResults) {
       if (toolResult.error) {
         log.error({ tool: toolResult.call.name, err: toolResult.error }, 'tool execution failed');

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -110,7 +110,30 @@ Tools save or retrieve state. They are NEVER how you reply to the user.
 After executing any tool call(s), you MUST produce a plain text response
 to the user. Do not package your reply as the argument to a tool.
 memphis_journal saves context for FUTURE sessions — it is not the channel
-for the response to the current message.`;
+for the response to the current message.
+
+### Honesty about tool results (sprint 1.3)
+
+If a tool result contains \`error\`, \`ok: false\`, or \`blocked: true\`,
+report failure HONESTLY with the error text. Do NOT claim success.
+Do NOT invent config flags or env vars to "explain" a denial — the
+operator gets a clearer path forward from a precise error message than
+from a confident-sounding fabrication. Phrases like "udało się",
+"zrobione", "skonfigurowane", "done", "enabled", "set up" are forbidden
+when the most recent tool batch returned an error.
+
+If the runtime injects a "Tool execution surfaced errors" system message
+after a tool batch, that message is authoritative — quote the failure
+to the user verbatim, then offer next steps if any apply.
+
+### Capability questions (sprint 1.3)
+
+When the user asks "what can you do" / "co potrafisz" / "jakie konfigi/
+flagi/tools są dostępne" / "what's available" / "show capabilities", you
+MUST call \`memphis_self_describe\` BEFORE answering. Do not enumerate
+your tools, tiers, or feature flags from memory or training data. The
+returned JSON is the source of truth for the current surface, effective
+tier, cognitive mode, and active feature flags.`;
 
 // ── Auto-generated tool docs (Sprint 0.5 G1) ─────────────────────────────────
 // Memphis has 37 registered tools (see src/gateway/tool-registry.ts). We hand-

--- a/tests/unit/honesty-guard.test.ts
+++ b/tests/unit/honesty-guard.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Sprint 1.3 — anti-confabulation guard end-to-end through runAgentLoop.
+ *
+ * Verifies the runtime injects a "Tool execution surfaced errors" system
+ * message after any tool batch where ≥1 result classifies as error
+ * (`{ error }` / `{ ok: false }` / `{ blocked: true }`). This message
+ * lands in the workingMessages stream BEFORE the tool messages so the
+ * LLM sees explicit "do not claim success" framing alongside the raw
+ * tool output in its next turn.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { runAgentLoop } from '../../src/gateway/agent-runtime.js';
+import type { LlmClient, ToolExecutor } from '../../src/gateway/chat-types.js';
+import type { ChatToolCall, ChatToolDefinition } from '../../src/providers/index.js';
+
+function makeLlm(turns: Array<{ content: string; tool_calls?: ChatToolCall[] }>): LlmClient {
+  let i = 0;
+  return {
+    async complete() {
+      const turn = turns[i] ?? turns[turns.length - 1];
+      i += 1;
+      return turn;
+    },
+  };
+}
+
+function makeExecutor(handlers: Record<string, () => string>): ToolExecutor {
+  const tools: ChatToolDefinition[] = Object.keys(handlers).map((name) => ({
+    name,
+    description: `${name} (test)`,
+    inputSchema: { type: 'object', properties: {} },
+  }));
+  return {
+    listTools: () => tools,
+    async execute(call) {
+      const handler = handlers[call.name];
+      if (!handler) return JSON.stringify({ error: `unknown tool: ${call.name}` });
+      return handler();
+    },
+    maxParallel: 4,
+  };
+}
+
+describe('sprint 1.3 — honesty guard injection', () => {
+  it('injects system message after tool returns { error }', async () => {
+    const toolCall: ChatToolCall = {
+      id: 'call-1',
+      name: 'memphis_exec',
+      arguments: {},
+    };
+    const llm = makeLlm([
+      { content: '', tool_calls: [toolCall] },
+      { content: 'I cannot run that — PERMISSION_DENIED.' },
+    ]);
+    const toolExecutor = makeExecutor({
+      memphis_exec: () => JSON.stringify({ error: 'PERMISSION_DENIED' }),
+    });
+
+    const result = await runAgentLoop({
+      systemPrompt: 'system',
+      messages: [{ role: 'user', content: 'run command' }],
+      llm,
+      toolExecutor,
+    });
+
+    const systemMessages = result.messages.filter((m) => m.role === 'system');
+    expect(systemMessages).toHaveLength(1);
+    expect(systemMessages[0].content).toContain('Tool execution surfaced errors');
+    expect(systemMessages[0].content).toContain('memphis_exec');
+    expect(systemMessages[0].content).toContain('PERMISSION_DENIED');
+  });
+
+  it('injects system message after tool returns { ok: false }', async () => {
+    const toolCall: ChatToolCall = { id: 'call-2', name: 'memphis_git', arguments: {} };
+    const llm = makeLlm([
+      { content: '', tool_calls: [toolCall] },
+      { content: 'Nothing to commit.' },
+    ]);
+    const toolExecutor = makeExecutor({
+      memphis_git: () => JSON.stringify({ ok: false, reason: 'nothing staged' }),
+    });
+
+    const result = await runAgentLoop({
+      systemPrompt: 'system',
+      messages: [{ role: 'user', content: 'commit' }],
+      llm,
+      toolExecutor,
+    });
+
+    const systemMessages = result.messages.filter((m) => m.role === 'system');
+    expect(systemMessages).toHaveLength(1);
+    expect(systemMessages[0].content).toContain('nothing staged');
+  });
+
+  it('injects system message after { blocked: true }', async () => {
+    const toolCall: ChatToolCall = { id: 'call-3', name: 'memphis_fs_write', arguments: {} };
+    const llm = makeLlm([
+      { content: '', tool_calls: [toolCall] },
+      { content: 'Refused.' },
+    ]);
+    const toolExecutor = makeExecutor({
+      memphis_fs_write: () => JSON.stringify({ blocked: true, tool: 'memphis_fs_write' }),
+    });
+
+    const result = await runAgentLoop({
+      systemPrompt: 'system',
+      messages: [{ role: 'user', content: 'write file' }],
+      llm,
+      toolExecutor,
+    });
+
+    const systemMessages = result.messages.filter((m) => m.role === 'system');
+    expect(systemMessages).toHaveLength(1);
+    expect(systemMessages[0].content).toContain('memphis_fs_write');
+  });
+
+  it('does NOT inject system message when tool returns success', async () => {
+    const toolCall: ChatToolCall = { id: 'call-4', name: 'memphis_journal', arguments: {} };
+    const llm = makeLlm([
+      { content: '', tool_calls: [toolCall] },
+      { content: 'Saved.' },
+    ]);
+    const toolExecutor = makeExecutor({
+      memphis_journal: () => JSON.stringify({ ok: true, index: 42 }),
+    });
+
+    const result = await runAgentLoop({
+      systemPrompt: 'system',
+      messages: [{ role: 'user', content: 'remember this' }],
+      llm,
+      toolExecutor,
+    });
+
+    const systemMessages = result.messages.filter((m) => m.role === 'system');
+    expect(systemMessages).toHaveLength(0);
+  });
+
+  it('summarises multiple tool errors in a single system message', async () => {
+    const tc1: ChatToolCall = { id: 'c1', name: 'memphis_exec', arguments: {} };
+    const tc2: ChatToolCall = { id: 'c2', name: 'memphis_git', arguments: {} };
+    const llm = makeLlm([
+      { content: '', tool_calls: [tc1, tc2] },
+      { content: 'Both failed.' },
+    ]);
+    const toolExecutor = makeExecutor({
+      memphis_exec: () => JSON.stringify({ error: 'PERMISSION_DENIED' }),
+      memphis_git: () => JSON.stringify({ ok: false, reason: 'detached HEAD' }),
+    });
+
+    const result = await runAgentLoop({
+      systemPrompt: 'system',
+      messages: [{ role: 'user', content: 'do stuff' }],
+      llm,
+      toolExecutor,
+    });
+
+    const systemMessages = result.messages.filter((m) => m.role === 'system');
+    expect(systemMessages).toHaveLength(1);
+    const content = systemMessages[0].content;
+    expect(content).toContain('memphis_exec');
+    expect(content).toContain('memphis_git');
+    expect(content).toContain('PERMISSION_DENIED');
+    expect(content).toContain('detached HEAD');
+  });
+
+  it('system message lands BEFORE the tool messages in the stream', async () => {
+    const toolCall: ChatToolCall = { id: 'c1', name: 'memphis_exec', arguments: {} };
+    const llm = makeLlm([
+      { content: '', tool_calls: [toolCall] },
+      { content: 'failed.' },
+    ]);
+    const toolExecutor = makeExecutor({
+      memphis_exec: () => JSON.stringify({ error: 'denied' }),
+    });
+
+    const result = await runAgentLoop({
+      systemPrompt: 'system',
+      messages: [{ role: 'user', content: 'x' }],
+      llm,
+      toolExecutor,
+    });
+
+    // Find positions in the message stream
+    const systemHintIdx = result.messages.findIndex(
+      (m) => m.role === 'system' && m.content.includes('Tool execution surfaced errors'),
+    );
+    const toolMsgIdx = result.messages.findIndex((m) => m.role === 'tool');
+    expect(systemHintIdx).toBeGreaterThan(-1);
+    expect(toolMsgIdx).toBeGreaterThan(-1);
+    expect(systemHintIdx).toBeLessThan(toolMsgIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 1.3 from the v1.7.2+ roadmap. Targets the central P0 finding from the 2026-04-27 audit: the agent loop pushed tool output to the LLM verbatim with no signal that a result was semantically a failure, leaving the model free to claim *"udało się"* / *"done"* anyway. Combined with #325 (env override fix), this addresses the dominant confabulation loop pattern observed in real Memphis Agent transcripts.

Two complementary changes — runtime guard + prompt rule.

## 1. Runtime guard (agent-runtime.ts)

After each tool batch, classify each result with `classifyToolOutput` from sprint 0.1. If ≥1 result is `error` shape (`{error}`, `{ok: false}`, `{blocked: true}`), inject a single `role: 'system'` message BEFORE the tool messages get pushed to `workingMessages`:

```
Tool execution surfaced errors (do NOT claim success in your reply):
- memphis_exec: PERMISSION_DENIED
- memphis_git: detached HEAD

If the user asked for one of these actions, report the failure honestly
with the error text. Do not rationalise the denial by inventing config
flags, env vars, or runtime modes that don't exist.
```

Defensive parsing: `errVal = parsed.error ?? parsed.reason ?? parsed.message`. Falls back to truncated raw output when parse fails or all three are missing. Hard-capped at 200 chars per tool so a verbose stack trace can't blow the prompt budget. Order matters — system message pushed **before** the `role: 'tool'` messages so the LLM sees the framing alongside the raw outputs in its next turn.

## 2. System prompt rule (system-prompt.ts)

Extended `TOOL_DISCIPLINE_PREAMBLE` with two enforcement blocks:

- **Honesty about tool results** — explicitly forbids "udało się", "zrobione", "done", "enabled", "set up" claims after error-shape tool results, names the runtime-injected system message as authoritative, tells the model to quote failures verbatim.

- **Capability questions** — when user asks "what can you do" / "co potrafisz" / "jakie konfigi/flagi/tools są dostępne" / "what's available", the model MUST call `memphis_self_describe` BEFORE answering. Closes the gap that landed `memphis_self_describe` in PR #310 but never enforced its use in the prompt.

## Belt-and-suspenders with sprint 0.2 detector

Sprint 0.2 (#324) measures `confabulationEvents7d`. This sprint flattens the curve. Together they validate the sprint 1.3 exit criterion: **≥70% reduction in `confabulationEvents7d` within a week of merge**. The detector keeps running and emitting `confabulation.event` spans regardless — this guard reduces the rate but doesn't replace the metric.

## Tests

`tests/unit/honesty-guard.test.ts` (6 cases) — verifies:

| Case | Tool result | Expected |
|---|---|---|
| 1 | `{error: "PERMISSION_DENIED"}` | system message with tool name + error |
| 2 | `{ok: false, reason: "nothing staged"}` | system message with reason |
| 3 | `{blocked: true, tool: "memphis_fs_write"}` | system message with tool name |
| 4 | `{ok: true, index: 42}` | NO system message |
| 5 | 2 errors in one batch | single system message summarising both |
| 6 | position invariant | system hint precedes role:'tool' messages |

Verified existing suites still pass: `cli.agent-runtime`, `gateway.system-prompt` — 26/26 green.

## Why this isn't a paranoid over-correction

The guard fires only when the tool output **already** indicates failure (matched 3 specific JSON shapes). The system message phrases failure neutrally — the LLM is told to report failure honestly, not to refuse the user. Successful tool results pass through unchanged. False-positive risk is bounded by the same `classifyToolOutput` heuristic the detector uses; if false positives accumulate in production telemetry, sprint 0.2's detector will flag them and we can retune the classifier in one place.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/unit/honesty-guard.test.ts` — 6/6 green
- [x] Related suites: `cli.agent-runtime` + `gateway.system-prompt` — 26/26 green
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] Manual smoke: trigger a `memphis_exec` denial via Telegram, observe bot reports failure honestly
- [ ] Manual smoke: ask "co potrafisz?" via Telegram, observe bot calls `memphis_self_describe` first
- [ ] 7-day soak: `confabulationEvents7d` drops ≥70% from baseline

## Backwards compatibility

- Pure additive change. Existing turns where all tools succeed see no behaviour difference.
- System prompt is longer by ~25 lines — measurable token-budget impact (~150 tokens) but well under any cognitive-mode `maxTokens` cap.
- No changes to public types or function signatures.

## Related

- Builds on #324 (sprint 0.2 — confabulation detector + 7d counter)
- Builds on #325 (sprint 1.1 — soul envMode read-side fix)
- Sprint 1.2 (#326) parallels this on env-sweep — independent, both can land in any order
- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 1 — P0 bot reliability

🤖 Generated with [Claude Code](https://claude.com/claude-code)