### PR TITLE
fix(silent-fail): surface vault fsync + security audit + Rust loop fallback (sprint 2.4)

### DIFF
--- a/src/gateway/agent-runtime.ts
+++ b/src/gateway/agent-runtime.ts
@@ -50,6 +50,9 @@ function getRustLoopAdapter(): NapiChainAdapter | null {
   // future async-ified probe (NAPI load could become async) can't see
   // checked=true while adapter is still null. Keeps the synchronous
   // contract intact today; hardens against drift.
+  // Sprint 2.4 — capture the probe error at warn level so triage can
+  // distinguish "Rust loop disabled by operator" from "Rust loop
+  // crashed during boot probe" without re-running the probe manually.
   let adapter: NapiChainAdapter | null = null;
   try {
     adapter = new NapiChainAdapter();
@@ -58,8 +61,11 @@ function getRustLoopAdapter(): NapiChainAdapter | null {
       { type: 'complete', data: { summary: 'probe' } },
     );
     log.info('rust loop engine connected');
-  } catch {
-    log.info('rust loop engine unavailable — using TypeScript fallback');
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'rust loop engine probe failed — using TypeScript fallback (perf regression possible)',
+    );
     adapter = null;
   }
   rustLoopAdapter = adapter;

--- a/src/infra/storage/rust-vault-adapter.ts
+++ b/src/infra/storage/rust-vault-adapter.ts
@@ -40,8 +40,19 @@ function fsyncFile(path: string): void {
   try {
     fd = openSync(path, 'r+');
     fsyncSync(fd);
-  } catch {
-    // Best-effort; proceed with the rename even if fsync isn't supported.
+  } catch (err) {
+    // Best-effort; proceed with the rename even if fsync isn't supported
+    // (e.g. tmpfs, network mount). Sprint 2.4: surface to stderr so the
+    // operator notices durability degradation — silent swallow used to
+    // mean nobody could tell whether vault writes were actually durable
+    // until a power-cut audit. Stderr instead of pino so this module
+    // stays free of logger dependencies (loaded during shutdown paths
+    // where pino transports may already be torn down).
+    process.stderr.write(
+      `[memphis-vault] fsync(${path}) failed — durability degraded for this write: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
   } finally {
     if (fd !== null) {
       try {

--- a/src/security/runtime-security-events.ts
+++ b/src/security/runtime-security-events.ts
@@ -53,7 +53,16 @@ export async function emitRuntimeSecurityEvent(
       },
       rawEnv,
     );
-  } catch {
-    // Security events must never fail closed on audit persistence.
+  } catch (err) {
+    // Security events must never fail closed on audit persistence —
+    // writeSecurityAudit (above) is the primary durability path; this
+    // appendBlock is the chain-replicated mirror. Sprint 2.4: surface
+    // the failure to stderr instead of total silence so operators can
+    // see chain-side audit drift in PULSE.md / journalctl.
+    process.stderr.write(
+      `[memphis-security] chain append failed for security event ${event.action}: ${
+        err instanceof Error ? err.message : String(err)
+      } — primary security-audit log unaffected\n`,
+    );
   }
 }


### PR DESCRIPTION
## Summary

Sprint 2.4 from the v1.7.2+ roadmap. Closes findings **C1, C2, C3** from the 2026-04-27 health audit — three places where genuine operational failures were swallowed silently, leaving operators no signal that anything had degraded.

All three changes are **observability-only**. Runtime behavior is identical: vault still rotates, security events still write to the primary audit log, agent loop still falls back to TS on Rust probe failure. What changes is that operators can SEE these conditions instead of guessing from secondary symptoms.

## C1 — vault fsync failure (rust-vault-adapter.ts:38)

`fsyncFile` swallowed every error with comment "Best-effort; proceed with the rename even if fsync isn't supported." Correct for the durability path (rename is the primary barrier), but operators had no signal when fsync was actually failing on their FS (tmpfs, network mount, read-only flake). Now surfaces to stderr with `[memphis-vault] fsync(...) failed — durability degraded` while keeping rename proceeding unchanged.

Stderr instead of pino because this module loads during shutdown paths where pino transports may already be torn down.

## C2 — chain-side security audit silent fail (runtime-security-events.ts:44)

Ironic — the chain append for security events caught with empty handler. The function ALSO writes to `writeSecurityAudit` upstream so the primary path was unaffected, but losing the chain-replicated mirror meant cross-process audit-trail consumers (PULSE.md, future federation) silently missed events. Now surfaces to stderr with `[memphis-security] chain append failed for security event ${action} — primary security-audit log unaffected`.

## C3 — Rust loop adapter fallback (agent-runtime.ts:51)

`getRustLoopAdapter` caught probe failure with `log.info('rust loop engine unavailable — using TypeScript fallback')` — no error captured. Operators running under Rust mode couldn't distinguish "Rust loop disabled intentionally" from "Rust loop crashed during boot probe (perf regression incoming)" without re-running the probe manually. Bumped from `log.info` → `log.warn` and added the error message to the log line.

## Why these were P2 not P0

The audit flagged these because **silence ≠ success**, but each failure has a working primary path:
- C1: rename still happens, vault still survives
- C2: writeSecurityAudit still persists the event upstream
- C3: TS fallback still works

P2 was the right tier — these were observability gaps, not correctness gaps. Sprint 2.4 closes the visibility cost without raising blast radius.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] Related suites pass (cli.agent-runtime + security/* — 6/6 green)
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] Manual verification: trigger a vault rotation on a tmpfs mount, observe stderr line; trigger a forced chain-append failure, observe stderr line

## Backwards compatibility

Pure additive logging. No public API changes. No behavioral changes to the protected primary paths (vault rotation, security audit log, TS loop fallback).

## Related

- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 2 — P1 platform reliability
- Audit memory: `/home/memphis/.claude/projects/-home-memphis/memory/project_health_check_2026_04_27.md` (category C: silent error swallowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)