### PR TITLE
fix(vault): enforce 0600 perms on entry/state files at write time (sprint 2.2, #275)

### DIFF
--- a/src/infra/storage/rust-vault-adapter.ts
+++ b/src/infra/storage/rust-vault-adapter.ts
@@ -287,7 +287,10 @@ function persistVaultState(vault: JsVault, rawEnv: NodeJS.ProcessEnv = process.e
 
   if (pepper.length >= 12) {
     const serialized = serializeVaultStateV2(vault, pepper);
-    writeFileSync(statePath, JSON.stringify(serialized, null, 2));
+    // Sprint 2.2 (#275): create with 0600 mode at write time so there's
+    // no umask-window where the file is world-readable. Previous logic
+    // used default mode + chmod-after — race-prone on multi-user hosts.
+    writeFileSync(statePath, JSON.stringify(serialized, null, 2), { mode: 0o600 });
   } else {
     // Fallback to v1 if pepper is too short (should not happen in normal flow)
     const normalized = normalizeVault(vault);
@@ -295,9 +298,11 @@ function persistVaultState(vault: JsVault, rawEnv: NodeJS.ProcessEnv = process.e
       salt: normalized.salt.toString('base64'),
       masterKey: getVaultMasterKey(normalized).toString('base64'),
     };
-    writeFileSync(statePath, JSON.stringify(serialized, null, 2));
+    writeFileSync(statePath, JSON.stringify(serialized, null, 2), { mode: 0o600 });
   }
 
+  // Belt-and-suspenders: tighten if the file existed before this write
+  // (writeFileSync `mode` only applies to file creation, not overwrite).
   try {
     chmodSync(statePath, 0o600);
   } catch {
@@ -861,7 +866,8 @@ export function rotateVaultMasterKey(
       throw new Error('MEMPHIS_VAULT_PEPPER must be at least 12 characters to write v2 state.');
     }
     const wrapped = serializeVaultStateV2(newVault, pepper);
-    writeFileSync(tmpState, JSON.stringify(wrapped, null, 2));
+    // Sprint 2.2 (#275): create with 0600 at write time (closes umask race).
+    writeFileSync(tmpState, JSON.stringify(wrapped, null, 2), { mode: 0o600 });
     try {
       chmodSync(tmpState, 0o600);
     } catch {

--- a/src/infra/storage/vault-entry-store.ts
+++ b/src/infra/storage/vault-entry-store.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import type { VaultEntry } from './rust-vault-adapter.js';
@@ -44,7 +44,22 @@ function readAll(path: string): StoredVaultEntry[] {
 function writeAll(path: string, entries: StoredVaultEntry[]): void {
   const dir = dirname(path);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(path, JSON.stringify(entries, null, 2));
+  // Sprint 2.2 (#275): enforce 0600 on vault entry metadata. Even though
+  // ciphertext lives in vault.bin, the LIST of secret keys (entry names,
+  // types, ages, tags) carries operationally significant info on its own
+  // — `stripe_live`, `anthropic_prod`, `telegram_bot_token` reveal
+  // integrations to any local user reading the file. POSIX 0600 closes
+  // that read by anyone but the runtime user; on Windows the mode arg
+  // is ignored which is fine (NTFS ACLs don't honor POSIX modes).
+  writeFileSync(path, JSON.stringify(entries, null, 2), { mode: 0o600 });
+  // Tighten existing files in case they were created before this fix
+  // (or restored from a backup with permissive perms).
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // Best-effort — Windows / non-POSIX filesystems may reject; don't
+    // fail the write because chmod is unavailable.
+  }
 }
 
 export function saveVaultEntry(


### PR DESCRIPTION
## Summary

Sprint 2.2 from the v1.7.2+ roadmap. Closes issue **#275** — vault metadata files were created with default umask (typically 0644 = world-readable) because `writeFileSync` omitted the optional `mode` parameter. `vault-state.json` already had `chmod`-after-write but that leaves a race window between creation and chmod; `vault-entries.json` had no perms enforcement at all.

## Why this matters

Even though ciphertext lives in `vault.bin`, the metadata files leak operationally significant info on their own:
- **entries.json**: list of secret KEY NAMES (`stripe_live`, `anthropic_prod`, `telegram_bot_token`) reveals integrations Memphis runs.
- **vault-state.json**: salt + encrypted master key. Encrypted, but the envelope structure leaks vault version + presence of recovery flow.

On a multi-user box (or after a backup-restore that didn't preserve modes), 0644 lets every local user enumerate Memphis's secret namespace. That's a sovereignty-first violation regardless of whether the ciphertext stays sealed.

## Changes

**`src/infra/storage/vault-entry-store.ts:44-58`** (`writeAll`):
- Add `{ mode: 0o600 }` to `writeFileSync` so file creation is 0600 directly (no umask window)
- Add `chmodSync(path, 0o600)` after to tighten existing files (`writeFileSync` mode only applies on CREATE, not OVERWRITE)
- chmod is best-effort: Windows / non-POSIX FS reject silently rather than failing the write
- `chmodSync` added to imports

**`src/infra/storage/rust-vault-adapter.ts:288-306, 868-871`** (`writeVaultState` + rotation tmp file):
- Add `{ mode: 0o600 }` to all three `writeFileSync` calls (v1, v2, rotation tmp) so creation goes straight to 0600
- Existing `chmodSync`-after-write retained as defense-in-depth for the overwrite case

## Sprint 2.2 scope note

Original roadmap mentioned ed25519 signing seed file perms (#272). Investigation showed Memphis stores all signing material **inside the vault** (encrypted, via `mp_v0_signing_seed` key in `src/federation/mp/operator-key.ts`) — there's no separate disk-resident seed file. So #272 doesn't apply as written; pivoted to #275 which IS reachable.

Per-command CLI auth (#278) was originally bundled in this sprint as an RFC. Splitting that out — RFC needs its own design pass and shouldn't block the perms hardening from shipping.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/unit/vault*.test.ts` — 59/59 green (existing suites unaffected)
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] Manual verification post-merge: `stat ~/.memphis/vault/entries.json` shows `-rw-------` (mode 600)

## Backwards compatibility

- Existing files with permissive perms get tightened on next write (chmod-after).
- Pure additive change to `fs` operations — no behavior difference for callers.
- Windows / non-POSIX: `mode` arg is silently ignored, chmod call no-ops; vault still works, just without POSIX file-perm protection (consistent with prior state).

## Related

- Closes #275 (vault-entries.json / vault-state.json missing 0600 chmod after write)
- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 2 — P1 platform reliability
- #272 (ed25519 seed perms) does NOT apply — Memphis stores signing material in-vault, not on disk; documenting here so the issue can close as not-applicable rather than lingering open

🤖 Generated with [Claude Code](https://claude.com/claude-code)