### PR TITLE
chore(tech-debt): consolidate MCP cast helper, scheduler HOME, backup progress (sprint 3.2)

### DIFF
--- a/src/infra/cli/commands/backup.ts
+++ b/src/infra/cli/commands/backup.ts
@@ -554,9 +554,14 @@ function withProgress<T>(label: string, enabled: boolean, fn: () => T): T {
   );
 
   bar.start(100, 10);
+  // Sprint 3.2: track current value locally so we don't reach into the
+  // bar's private state via `(bar as unknown as { value: number }).value`.
+  // cli-progress mutates internal state on `update()`; tracking it
+  // ourselves keeps the type contract honest and survives lib refactors.
+  let progress = 10;
   const timer = setInterval(() => {
-    const next = Math.min(90, (bar as unknown as { value: number }).value + 10);
-    bar.update(next);
+    progress = Math.min(90, progress + 10);
+    bar.update(progress);
   }, 120);
 
   try {

--- a/src/infra/runtime/scheduler.ts
+++ b/src/infra/runtime/scheduler.ts
@@ -377,10 +377,18 @@ export async function executeCommand(
 }
 
 function runShell(script: string, cwd: string): Promise<{ success: boolean; output: string }> {
+  // Sprint 3.2: HOME hardcoded to '/home/memphis' broke any operator
+  // running Memphis under a different user (snap install, fresh-install
+  // CLI on macOS, container with non-`memphis` user). Honor process.env
+  // HOME so the spawned shell sees the operator's actual $HOME — falls
+  // back to '/home/memphis' only when HOME is somehow unset (which
+  // shouldn't happen on POSIX, but the fallback keeps prior behavior
+  // for the dev-machine case).
+  const homeDir = process.env.HOME ?? '/home/memphis';
   return new Promise((resolve) => {
     const shell = spawn('/bin/bash', ['-c', script], {
       cwd,
-      env: { ...process.env, HOME: '/home/memphis' },
+      env: { ...process.env, HOME: homeDir },
     });
 
     let stdout = '';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -139,6 +139,26 @@ function pendingResult(data: Record<string, unknown>): ToolResult {
 }
 
 /**
+ * Coerce arbitrary JSON-serialisable tool output into the shape MCP's
+ * `structuredContent` requires (Record<string, unknown>). Sprint 3.2
+ * replaces 23 instances of inline `result as unknown as Record<string,
+ * unknown>` casts at tool registration sites — same outcome, single
+ * point of maintenance, and a runtime guard for primitive returns
+ * (which would otherwise silently violate the MCP type contract).
+ *
+ * Tool handlers in src/mcp/tools/ uniformly return objects today; this
+ * helper just removes the casting boilerplate. If a handler ever
+ * returns a primitive or array, we wrap it in `{ value: ... }` so the
+ * MCP envelope stays well-formed instead of crashing the SDK validator.
+ */
+function toJsonRecord(value: unknown): Record<string, unknown> {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return { value };
+}
+
+/**
  * Strip redacted fields from args before they're persisted to the approval
  * SQLite table. The original `args` passed to the handler are NOT modified
  * — the handler still receives the real values at execution time. Only
@@ -359,7 +379,7 @@ export function createMemphisMcpServer(
         const result = await runMemphisProviders();
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -379,7 +399,7 @@ export function createMemphisMcpServer(
         const result = runMemphisSystemInfo();
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -556,7 +576,7 @@ export function createMemphisMcpServer(
           const result = runMemphisLoopStep({ state, action, limits });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -633,7 +653,7 @@ export function createMemphisMcpServer(
           });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -732,7 +752,7 @@ export function createMemphisMcpServer(
         const result = await runMemphisCaseAppend({ entry });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -773,7 +793,7 @@ export function createMemphisMcpServer(
         const result = await runMemphisCaseQuery({ query });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -810,7 +830,7 @@ export function createMemphisMcpServer(
           });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -832,7 +852,7 @@ export function createMemphisMcpServer(
         const result = await runMemphisSoulRead({ section });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -877,7 +897,7 @@ export function createMemphisMcpServer(
         const result = await runMemphisSoulWrite({ updates });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -908,7 +928,7 @@ export function createMemphisMcpServer(
           );
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -941,7 +961,7 @@ export function createMemphisMcpServer(
           const result = runMemphisFsWrite({ path, content, mode, createDirs });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -972,7 +992,7 @@ export function createMemphisMcpServer(
           const result = runMemphisFsOps({ operation, source, destination, recursive });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -999,7 +1019,7 @@ export function createMemphisMcpServer(
           const result = await runMemphisWebSearch({ query, limit });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -1028,7 +1048,7 @@ export function createMemphisMcpServer(
           const result = runMemphisPackage({ manager, action, packages, global: isGlobal });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -1052,7 +1072,7 @@ export function createMemphisMcpServer(
         const result = runMemphisDb({ action, sql, database });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -1081,7 +1101,7 @@ export function createMemphisMcpServer(
           const result = runMemphisBuild({ project, command, profile });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -1113,7 +1133,7 @@ export function createMemphisMcpServer(
           const result = await runMemphisHealthCheck({ targets });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
       ),
@@ -1140,7 +1160,7 @@ export function createMemphisMcpServer(
         const result = runMemphisPresence();
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -1162,7 +1182,7 @@ export function createMemphisMcpServer(
         const result = runMemphisConfigShow({ key });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -1183,7 +1203,7 @@ export function createMemphisMcpServer(
         const result = await runMemphisConfigReload();
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
+          structuredContent: toJsonRecord(result),
         };
       }),
     );
@@ -1214,7 +1234,7 @@ export function createMemphisMcpServer(
           const result = runMemphisConfigSet({ key, value, passphrase });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
         // Both the operator credential AND the new config value (may itself
@@ -1256,7 +1276,7 @@ export function createMemphisMcpServer(
           const result = await runMemphisCognitiveModeSet({ mode, passphrase });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
         ['passphrase'],
@@ -1288,7 +1308,7 @@ export function createMemphisMcpServer(
           const result = await runMemphisRestart({ reason, actor_id, passphrase });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as unknown as Record<string, unknown>,
+            structuredContent: toJsonRecord(result),
           };
         },
         // Codex P1 (Round 4): `passphrase` must not be persisted to the


### PR DESCRIPTION
## Summary

Sprint 3.2 from the v1.7.2+ roadmap. Three independent P3 cleanups flagged in the 2026-04-27 health audit, each minimal-risk.

## 1. MCP cast consolidation (src/mcp/server.ts)

23× repetitive `result as unknown as Record<string, unknown>` casts at tool registration sites collapsed into a single `toJsonRecord(value)` helper that:

- Returns the object as-is when value is a non-array object
- Wraps primitives / arrays in `{ value }` so the MCP envelope stays well-formed instead of crashing the SDK validator if a handler ever returns something unusual

Tool handlers under `src/mcp/tools/` all return objects today, so the helper is functionally equivalent to the cast — just centralised for future drift resistance.

## 2. Scheduler HOME env (src/infra/runtime/scheduler.ts:383)

Hardcoded `HOME: '/home/memphis'` in the spawned shell env broke any operator running Memphis under a different user (snap install, fresh-install CLI on macOS, container with non-`memphis` user). Now honors `process.env.HOME` first; falls back to '/home/memphis' only when HOME is unset.

## 3. Backup progress shape (src/infra/cli/commands/backup.ts:558)

`(bar as unknown as { value: number }).value` reached into cli-progress private state. Replaced with a local `progress` counter we own, mutate, and pass through `bar.update()` — same visible behavior, honest type contract, survives a cli-progress refactor.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/unit/mcp` — 99/99 green
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] Manual smoke: backup CLI shows progress bar incrementing as before

## Backwards compatibility

- MCP cast → helper is functionally equivalent on every existing tool (all return objects). New handlers that accidentally return primitives now produce a valid `{ value }` envelope instead of a runtime SDK error.
- Scheduler HOME: `memphis` user on Linux still gets `HOME=/home/memphis` (operator's actual `$HOME`). Operators on other usernames now get THEIR `$HOME` (was previously masked).
- Backup progress: same visible behavior; `progress` value is local to the same closure.

## Related

- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 3 — Capability completion
- Audit memory category D (type casts) and E (hard-coded paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)