### PR TITLE
feat(channels): photo handler with honest fallback (sprint 3.1)

### DIFF
--- a/src/gateway/channels/telegram.ts
+++ b/src/gateway/channels/telegram.ts
@@ -808,6 +808,68 @@ export function createTelegramAdapter(
         });
       }
 
+      // Sprint 3.1 — photo handler with honest fallback. Vision pipeline
+      // (Anthropic image content blocks via multimodal IncomingMessage)
+      // is a follow-up sprint; today the bot acknowledges receipt,
+      // records an audit-trail entry with file_id + caption, and asks
+      // the user to describe the image OR wait for the vision sprint.
+      // This closes the confabulation gap from 2026-04-27 (bot claimed
+      // it could see photos when it could not) without shipping a
+      // half-wired pipeline.
+      bot.on('message:photo', async (ctx) => {
+        const msg = ctx.message;
+        if (!msg.photo || msg.from?.is_bot) return;
+
+        // User allowlist check (parity with text + voice handlers).
+        const allowedIds = parseTelegramAllowedUserIds(process.env);
+        const fromId = msg.from?.id;
+        if (
+          allowedIds.length > 0 &&
+          (fromId === undefined || !allowedIds.includes(String(fromId)))
+        ) {
+          await ctx.reply('Access denied.');
+          return;
+        }
+
+        // Pick the largest photo size (Telegram returns sorted list).
+        const largest = msg.photo[msg.photo.length - 1];
+        const caption = msg.caption?.trim() ?? '';
+        const fileId = largest.file_id;
+
+        const chatId = String(msg.chat.id);
+        const userId = `telegram:${String(msg.from?.id ?? 'unknown')}`;
+        const sessionTier = getSessionTier(chatId);
+
+        // Forward to the agent as a text turn that explicitly flags the
+        // attachment. The agent's TOOL_DISCIPLINE rule (sprint 1.3)
+        // means it MUST report "I cannot view images yet" rather than
+        // confabulate a description — the runtime never lies about
+        // its capabilities, and the operator chooses next steps.
+        const captionFragment = caption.length > 0 ? `caption: "${caption}"` : 'no caption';
+        const attachmentBrief =
+          `[Telegram attachment: photo (${captionFragment}, ` +
+          `width=${largest.width ?? '?'}, height=${largest.height ?? '?'}, ` +
+          `file_id=${fileId})] ` +
+          `Vision pipeline is not wired in this build — acknowledge the ` +
+          `attachment honestly, ask the user what they'd like described or ` +
+          `for a text summary, and do not invent image contents.`;
+
+        try {
+          await handler({
+            id: String(msg.message_id),
+            channel: 'telegram',
+            userId,
+            chatId,
+            text: attachmentBrief,
+            timestamp: new Date(msg.date * 1000),
+            rawEnvOverride: buildTierEnvOverride(chatId, sessionTier),
+          });
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          await ctx.reply(`Błąd obsługi zdjęcia: ${errMsg.slice(0, 200)}`);
+        }
+      });
+
       void bot.start({ drop_pending_updates: true });
       started = true;
     },


### PR DESCRIPTION
## Summary

Sprint 3.1 from the v1.7.2+ roadmap. Closes the capability gap from the 2026-04-27 audit: Memphis Agent had no `bot.on('message:photo')` handler at all, so photos were silently dropped. Any user follow-up ("co widzisz na zdjęciu?") got a confabulated answer.

**Pragmatic v1**: handler acknowledges receipt and forwards to the agent as a text turn explicitly flagging the attachment. Combined with sprint 1.3's TOOL_DISCIPLINE rule, the agent is now **forced to report "vision pipeline not wired" honestly** instead of inventing image contents.

## Why not full multimodal

Full Anthropic image content blocks + multimodal `IncomingMessage` + provider-adapter pass-through would touch 5+ files (`chat-types.ts`, `turn-runtime.ts`, `provider-adapter.ts`, `agent-runtime.ts`, plus all Anthropic/GLM/ollama dispatchers + tests). That's a separate sprint scope. v1 closes the **honesty gap** today; v2 (multimodal pipeline) lands when the IncomingMessage refactor warrants its own PR.

## Handler details

- `bot.on('message:photo')` with allowlist + tier-3 env propagation parity with the existing voice handler at `telegram.ts:743-808`
- Picks the largest photo size from `msg.photo` (Telegram returns sorted list)
- Forwards `file_id`, caption, dimensions to the agent via a structured text brief
- Brief text includes "do not invent image contents" so the LLM can't slip past sprint 1.3's TOOL_DISCIPLINE
- Errors caught with user-facing reply so a single bad photo doesn't leave the user staring at nothing

The brief lines up exactly with sprint 1.3's honesty-guard system message — the same machinery prevents confabulation on tool errors and on missing multimodal capability.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/unit/telegram*.test.ts` — 24/24 green
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] Manual smoke: send photo from real Telegram, observe honest acknowledgment + "describe what you want me to look at" prompt

## Backwards compatibility

Pure additive — no other surfaces, no public API changes. Telegram bot was previously silent on photos; now it acknowledges them. Voice + text handlers unchanged.

## Follow-up sprint candidate

**Sprint 3.1b — full multimodal pipeline**:
- Add `attachments?: ImageAttachment[]` to `IncomingMessage`
- `turn-runtime.ts` builds Anthropic-format `messages` with `content: [{type: 'image', source: {...}}]` blocks when attachments present
- Provider adapter passes through (Anthropic SDK already supports multimodal natively)
- Test with 1×1 PNG fixture
- Falls back to today's text-only honest acknowledgment when provider doesn't support vision

That's an honest 4-5 days of work and earns its own PR.

## Related

- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 3 — Capability completion
- Builds on sprint 1.3 TOOL_DISCIPLINE rule (forces honest "no vision yet" reply rather than confabulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)