### PR TITLE
fix(napi): pino flush before exit closes one SEGV-shutdown cause (sprint 2.3, partial #270)

### DIFF
--- a/src/infra/logging/pino.ts
+++ b/src/infra/logging/pino.ts
@@ -39,6 +39,20 @@ interface MultistreamEntry {
 const multistreamByLogger = new WeakMap<Logger, MultistreamEntry>();
 
 /**
+ * Sprint 2.3 — track every pino destination so the graceful-shutdown
+ * sequence can flushSync them before exitFn(). Without this, sonic-boom
+ * destinations created with `sync: false` (default for stderr in
+ * production) hold pending log lines in memory at SIGTERM and the
+ * post-exit V8 teardown lands them on an FD already invalidated —
+ * one of the SEGV-on-shutdown causes flagged in #270.
+ *
+ * Strong references intentionally: streams are process-lifetime
+ * resources; if the operator drops a logger we still want to flush
+ * any buffered lines on shutdown rather than lose audit data.
+ */
+const allDestinations = new Set<DestinationStream>();
+
+/**
  * Resolve the local log file path.
  * Set MEMPHIS_LOG_FILE to override (default: ~/.memphis/logs/memphis.log).
  * Set MEMPHIS_LOG_FILE=none to disable file logging.
@@ -85,6 +99,7 @@ function getFileStream(): DestinationStream | null {
     // the bigger problem because the lost log lines are exactly the
     // boot-time diagnostics operators need to debug crashes.
     sharedFileStream = pino.destination({ dest: logPath, sync: true, mkdir: true });
+    allDestinations.add(sharedFileStream);
     return sharedFileStream;
   } catch {
     sharedFileStream = null;
@@ -98,6 +113,7 @@ export function createPinoLogger(options?: LoggerOptions): Logger {
     dest: 2,
     sync: process.env.NODE_ENV === 'test',
   });
+  allDestinations.add(stderrStream);
 
   // If file logging is available, use multistream (stderr + file)
   let logger: Logger;
@@ -172,4 +188,34 @@ export function setAllPinoLoggerLevels(level: string): {
 export function __resetPinoRegistryForTests(): void {
   liveLoggers.clear();
   // multistreamByLogger is a WeakMap — entries auto-clear when loggers GC
+}
+
+/**
+ * Sprint 2.3 — synchronously flush every tracked pino destination.
+ * Called from graceful-shutdown.ts AFTER `embed_shutdown()` and BEFORE
+ * `exitFn()`, so any buffered log lines (sonic-boom async destinations,
+ * stderr in production) hit disk before V8 tears down the FDs.
+ *
+ * Failure-tolerant: a per-stream flush error is counted and skipped;
+ * the remaining streams still get drained. Returns counts so the
+ * shutdown sequence can audit the outcome ("flushed=3 errors=0").
+ *
+ * Pino destinations expose `flushSync()` (sonic-boom). Streams that
+ * don't (custom transports) are silently skipped — no-ops on the
+ * unrecognised shape.
+ */
+export function flushAllPinoStreamsSync(): { flushed: number; errors: number } {
+  let flushed = 0;
+  let errors = 0;
+  for (const stream of allDestinations) {
+    const flushFn = (stream as { flushSync?: () => void }).flushSync;
+    if (typeof flushFn !== 'function') continue;
+    try {
+      flushFn.call(stream);
+      flushed += 1;
+    } catch {
+      errors += 1;
+    }
+  }
+  return { flushed, errors };
 }

--- a/src/infra/runtime/graceful-shutdown.ts
+++ b/src/infra/runtime/graceful-shutdown.ts
@@ -27,6 +27,7 @@ import { writePulseEvent } from './heartbeat-watchdog.js';
 import { resolveRustBridgePath } from './install-root.js';
 import { activeTurnCount, signalDrain } from './self-restart.js';
 import type { AppLogger } from '../logging/logger.js';
+import { flushAllPinoStreamsSync } from '../logging/pino.js';
 import { writeSecurityAudit } from '../logging/security-audit.js';
 import { shutdownOtel } from '../observability/otel.js';
 
@@ -303,6 +304,40 @@ export async function performGracefulShutdown(
         error: err instanceof Error ? err.message : String(err),
       },
       'embed_shutdown() failed — proceeding to exit anyway',
+    );
+  }
+
+  // 5.6. Sprint 2.3 (#270): flush all pino destinations before exit.
+  // Sonic-boom destinations created with `sync: false` (default for
+  // stderr in production) hold pending log lines in memory at SIGTERM —
+  // post-exit V8 teardown then lands them on an FD already invalidated.
+  // This was one of the SEGV-on-shutdown causes flagged in the issue.
+  // Order matters: flush AFTER embed_shutdown (which itself emits log
+  // lines) and BEFORE exitFn (which triggers V8 teardown).
+  try {
+    const flushResult = flushAllPinoStreamsSync();
+    logLine(
+      options.logger,
+      'info',
+      {
+        event: 'shutdown.pino-flush',
+        flushed: flushResult.flushed,
+        errors: flushResult.errors,
+      },
+      `pino flush — flushed=${flushResult.flushed} errors=${flushResult.errors}`,
+    );
+  } catch (err) {
+    // Pino flush itself never throws (failure-tolerant by design),
+    // but defensively swallow anything that does so we always reach
+    // exitFn.
+    logLine(
+      options.logger,
+      'warn',
+      {
+        event: 'shutdown.pino-flush.failed',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      'pino flush failed — proceeding to exit anyway',
     );
   }
 

--- a/tests/unit/pino-flush-shutdown.test.ts
+++ b/tests/unit/pino-flush-shutdown.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Sprint 2.3 — verify flushAllPinoStreamsSync() drains tracked pino
+ * destinations without throwing on absent / shape-mismatched streams.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetPinoRegistryForTests,
+  createPinoLogger,
+  flushAllPinoStreamsSync,
+} from '../../src/infra/logging/pino.js';
+
+describe('flushAllPinoStreamsSync (sprint 2.3)', () => {
+  it('returns counts and never throws when called on a fresh registry', () => {
+    __resetPinoRegistryForTests();
+    const result = flushAllPinoStreamsSync();
+    expect(typeof result.flushed).toBe('number');
+    expect(typeof result.errors).toBe('number');
+    expect(result.errors).toBe(0);
+  });
+
+  it('flushes destinations after a logger is created', () => {
+    __resetPinoRegistryForTests();
+    const logger = createPinoLogger({ level: 'info' });
+    logger.info('seed line');
+    const result = flushAllPinoStreamsSync();
+    // At least the stderr destination should be tracked. Sonic-boom
+    // exposes flushSync; if the log file path is also active we get 2.
+    expect(result.flushed).toBeGreaterThanOrEqual(1);
+    expect(result.errors).toBe(0);
+  });
+
+  it('counts errors per stream without aborting the whole flush', () => {
+    // We can't easily inject a mock pino destination into the global
+    // Set without exporting more internals; instead, verify the helper
+    // is idempotent and survives multiple back-to-back calls (the
+    // shutdown sequence calls it once, but a flush retry shouldn't
+    // explode if the stream already drained).
+    __resetPinoRegistryForTests();
+    createPinoLogger({ level: 'info' });
+    const a = flushAllPinoStreamsSync();
+    const b = flushAllPinoStreamsSync();
+    expect(a.errors).toBe(0);
+    expect(b.errors).toBe(0);
+  });
+
+  it('is safe to spy on without breaking', () => {
+    __resetPinoRegistryForTests();
+    createPinoLogger();
+    const spy = vi.fn(flushAllPinoStreamsSync);
+    const result = spy();
+    expect(spy).toHaveBeenCalledOnce();
+    expect(result.errors).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 2.3 from the v1.7.2+ roadmap. **Partial fix for issue #270** — closes ONE of the four cleanup-gap causes the audit identified, the most operationally visible one (and the one most reachable without Rust touch).

## What's fixed

Pino sonic-boom destinations created with `sync: false` (default for stderr in production) hold pending log lines in memory at SIGTERM. The previous shutdown sequence ran `embed_shutdown()` and went straight to `exitFn()`, so post-exit V8 teardown landed those buffered writes on FDs already invalidated — one of the SEGV-on-shutdown signatures in #270.

Now every tracked destination gets `flushSync()` between `embed_shutdown` and `exit`. Pending lines hit disk before V8 unwinds.

## Implementation

**`src/infra/logging/pino.ts`**
- New `allDestinations: Set<DestinationStream>` registers every pino sink at creation (sharedFileStream + per-logger stderr). Strong refs so a dropped logger doesn't lose buffered audit data.
- New `flushAllPinoStreamsSync()` walks the set, calls `.flushSync()` on each (sonic-boom shape), counts flushed + errors, never throws. Streams without `flushSync` (custom transports) silently skipped.

**`src/infra/runtime/graceful-shutdown.ts`**
- New step 5.6 between `embed_shutdown` (5.5) and `exitFn` (6) calls `flushAllPinoStreamsSync()` and audits the outcome (`flushed=N errors=M`) so operators see post-merge in journalctl which streams drained.
- Defensive try/catch around the flush itself (the helper is failure-tolerant by design, but the shutdown sequence MUST always reach `exitFn`, so we double-belt with swallow + warn log).

## Tests

- `tests/unit/pino-flush-shutdown.test.ts` (4 cases): empty registry, post-logger creation, repeated calls (idempotent), spy compatibility — all green
- Existing `tests/unit/graceful-shutdown.test.ts` (7 cases): green; new pino-flush log line visible in test output

## What's NOT fixed in this sprint (issue #270 follow-up scope)

- **`vault_shutdown()` NAPI export** — needs Rust touch + `.node` rebuild + bindings update; warrants its own sprint with full `cargo build:rust` + test cycle.
- **Case-index SQLite explicit close** — `rusqlite::Connection` auto-drops; explicit drop only matters under the same Rust touch sprint.
- **TaskQueueWal global flush** — investigated and not applicable: WAL uses per-record `fdatasync + close` pattern already (no global buffer state to drain).

The pino flush alone closes the most-frequent SEGV signature seen in production logs ("post-graceful-shutdown SIGSEGV with pino write backtrace" per #270 reproduction notes). Remaining causes require the Rust-side scope and a dedicated sprint with the appropriate test budget.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/unit/graceful-shutdown.test.ts tests/unit/pino-flush-shutdown.test.ts` — 11/11 green
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] Production soak: 7 days without restart-storm pattern (cron `nightly-shutdown-stress` will report this once configured)

## Backwards compatibility

- Pure additive: `allDestinations` Set tracks new destinations; existing pino consumers unaffected.
- `flushAllPinoStreamsSync()` is a new export; no existing callers to update.
- Shutdown sequence gains one step (5.6); duration grows by ~tens of milliseconds on a typical production destination set.
- Test seam unchanged.

## Related

- #270 (SEGV on shutdown — pino flush + cleanup races after `embed_shutdown()`) — partial close
- Plan: `/home/memphis/.claude/plans/glowing-knitting-lobster.md` Phase 2 — P1 platform reliability

🤖 Generated with [Claude Code](https://claude.com/claude-code)