### PR TITLE
fix(mcp): register memphis_self_describe + memphis_repair + memphis_cron (wiring W1)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -18,6 +18,7 @@ import {
   runMemphisConfigSet,
   runMemphisConfigShow,
 } from './tools/config.js';
+import { runMemphisCron } from './tools/cron.js';
 import { runMemphisDb } from './tools/db.js';
 import { runMemphisDecide } from './tools/decide.js';
 import { runMemphisDeploy } from './tools/deploy.js';
@@ -35,8 +36,10 @@ import { runMemphisPackage } from './tools/package.js';
 import { runMemphisPresence } from './tools/presence.js';
 import { runMemphisProviders } from './tools/providers.js';
 import { runMemphisRecall } from './tools/recall.js';
+import { runMemphisRepair } from './tools/repair.js';
 import { runMemphisRestart } from './tools/restart.js';
 import { runMemphisSearch } from './tools/search.js';
+import { runMemphisSelfDescribe } from './tools/self-describe.js';
 import { runMemphisSelfModify } from './tools/self-modify.js';
 import { runMemphisSoulRead, runMemphisSoulWrite } from './tools/soul.js';
 import { runMemphisSystemInfo } from './tools/system-info.js';
@@ -360,6 +363,100 @@ export function createMemphisMcpServer(
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
           structuredContent: result as Record<string, unknown>,
+        };
+      }),
+    );
+  }
+
+  // Wiring W1 (sprint marathon follow-up): memphis_self_describe was added
+  // in PR #310 to close the "what can you do" confabulation gap, but the
+  // MCP server registration was missed — external MCP clients (Claude
+  // Desktop, MCP Inspector, etc.) couldn't see the tool that was
+  // designed precisely for them. The in-process executor + system prompt
+  // already register it; this block fills the third surface.
+  const selfDescribePolicy = getToolPolicy(permissions, 'memphis_self_describe', resolvedManifest);
+  if (shouldRegisterTool('memphis_self_describe', selfDescribePolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_self_describe',
+      {
+        description:
+          'Runtime self-introspection — active surface, effective tier, cognitive mode, full tool inventory with availability, feature flags, cross-surface tier-3 sessions. Call BEFORE answering "what can you do" questions instead of guessing from training data.',
+        inputSchema: {
+          surface: z.string().optional(),
+          actorId: z.string().optional(),
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate(
+        'memphis_self_describe',
+        selfDescribePolicy,
+        approvals,
+        async (args) => {
+          const result = runMemphisSelfDescribe(
+            { surface: args.surface, actorId: args.actorId },
+            rawEnv,
+          );
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+            structuredContent: toJsonRecord(result),
+          };
+        },
+      ),
+    );
+  }
+
+  // Wiring W1: memphis_repair — runtime state repair (chain integrity,
+  // SQLite, migrations, derived indexes). Tier 0 read-equivalent (it's
+  // safe to invoke), already wired in the in-process executor; was
+  // missing from MCP server.
+  const repairPolicy = getToolPolicy(permissions, 'memphis_repair', resolvedManifest);
+  if (shouldRegisterTool('memphis_repair', repairPolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_repair',
+      {
+        description:
+          'Repair Memphis runtime state — chain integrity, SQLite, migrations, derived indexes',
+        inputSchema: {
+          force: z.boolean().optional(),
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate('memphis_repair', repairPolicy, approvals, async (args) => {
+        const result = await runMemphisRepair({ force: args.force });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          structuredContent: toJsonRecord(result),
+        };
+      }),
+    );
+  }
+
+  // Wiring W1: memphis_cron — scheduled-task management (list/add/remove/
+  // enable/disable). Tier 2 — reachable from operator/telegram surfaces;
+  // already wired in the in-process executor; was missing from MCP server.
+  const cronPolicy = getToolPolicy(permissions, 'memphis_cron', resolvedManifest);
+  if (shouldRegisterTool('memphis_cron', cronPolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_cron',
+      {
+        description: 'Manage scheduled tasks (list, add, remove, enable, disable)',
+        inputSchema: {
+          action: z.enum(['list', 'add', 'remove', 'enable', 'disable']),
+          cron: z.string().optional(),
+          name: z.string().optional(),
+          taskType: z.enum(['shell', 'reflection', 'git-pull-build', 'http']).optional(),
+          script: z.string().optional(),
+          url: z.string().optional(),
+          method: z.string().optional(),
+          taskId: z.string().optional(),
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate('memphis_cron', cronPolicy, approvals, async (args) => {
+        const result = runMemphisCron(args);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          structuredContent: toJsonRecord(result),
         };
       }),
     );


### PR DESCRIPTION
## Summary

Wiring sweep follow-up after the post-v1.7.2 sprint marathon. **Closes the most ironic gap of the whole audit**: three tools were fully wired through the in-process executor, system prompt, and surface-policy filters, but never registered on the MCP server itself. External MCP clients (Claude Desktop, MCP Inspector, OpenClaw, future MCP-based operator tooling) couldn't see them.

## The big one — memphis_self_describe

PR #310 added `memphis_self_describe` specifically to close the "what can you do" confabulation gap. Sprint 1.3 (#327) wrote the system prompt rule that **REQUIRES** calling it before answering capability questions:

> When the user asks "what can you do" / "co potrafisz" / ..., you MUST call `memphis_self_describe` BEFORE answering. Do not enumerate from memory or training.

But the tool wasn't registered on the MCP surface where external model clients live. So an MCP client following the prompt rule would call `memphis_self_describe` and get **"tool not found"** — a fresh confabulation vector that defeats the whole point.

## Three tools fixed

1. **memphis_self_describe** (tier 0) — runtime self-introspection
2. **memphis_repair** (tier 0) — runtime state repair (chain integrity, SQLite, migrations)
3. **memphis_cron** (tier 2) — scheduled-task management

Each registration mirrors the `memphis_health` template:
- `getToolPolicy` + `shouldRegisterTool` gate
- `registerTool` with explicit Zod `inputSchema` (preserves gateway registry shape)
- `withApprovalGate` wrapping the handler for require-approval policy
- `toJsonRecord` helper from sprint 3.2 (#330) for `structuredContent` envelope

## How it was found

Internal wiring audit Explore agent cross-referenced TOOL_REGISTRY entries against `server.registerTool` call sites. Coverage matrix:

| Layer | Coverage |
|---|---|
| Tool registry (`tool-registry.ts`) | 38/38 ✓ |
| In-process executor (`tool-executor.ts`) | 38/38 ✓ |
| System prompt (`system-prompt.ts`) | 38/38 ✓ |
| Surface policy (`surface-policy.ts`) | 38/38 ✓ |
| Self-describe introspection (`self-describe.ts`) | 38/38 ✓ |
| **MCP server (`server.ts`)** | **35/38 → 38/38** ✓ |

PR #283 added 7 tools to the executor + system prompt; PR #310 added `memphis_self_describe`. Neither cycle propagated the registration to `server.ts`. Fix walks the same path the established tools follow.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green (import order auto-fix applied)
- [x] `npx vitest run tests/unit/mcp` — 99/99 green
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] Manual smoke: invoke `memphis_self_describe` via Claude Desktop / MCP Inspector against this branch — should return tool inventory instead of "unknown tool"

## Backwards compatibility

Pure additive — registers three tools that previously didn't exist on the MCP surface. Existing MCP consumers see new tools they can opt into; consumers that don't ask for them are unaffected.

## Related

- Closes the implicit dependency from sprint 1.3 (#327) on `memphis_self_describe` being reachable from MCP-driven prompt enforcement
- Continues from sprint 3.2 (#330) — uses the same `toJsonRecord` helper for `structuredContent`
- Internal audit memory: `/home/memphis/.claude/projects/-home-memphis/memory/project_sprint_marathon_2026_04_28.md` (this fix is the first in a series of W-numbered "wiring" sprints found post-marathon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)