### PR TITLE
fix(config): document 5 runtime env vars in envSchema (wiring W2)

### DIFF
--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -115,6 +115,18 @@ export const envSchema = z.object({
   RUST_CHAIN_BRIDGE_PATH: z.string().default('./crates/memphis-napi'),
   RUST_CHAIN_SIGNER_ALLOWLIST: z.string().optional(),
   MEMPHIS_API_TOKEN: z.string().optional(),
+  // Explicit override paths for vault state + entry metadata files. Default
+  // resolution lives in src/infra/storage/vault-paths.ts (data dir +
+  // canonical filename). Operators with non-standard layouts (legacy
+  // installs, multi-host federation, container mounts) set these. Both
+  // optional — fallback to dataDir-anchored default when unset.
+  MEMPHIS_VAULT_STATE_PATH: z.string().optional(),
+  MEMPHIS_VAULT_ENTRIES_PATH: z.string().optional(),
+  // Destructive override that lets `vault init` overwrite an existing vault
+  // (rust-vault-adapter.ts:558). Default = false; setting to true wipes
+  // existing entries irrecoverably. Schema entry exists so the operator
+  // sees it in `memphis config show` and so test seams type-check.
+  MEMPHIS_VAULT_FORCE_REINIT: boolFromString.optional(),
   MEMPHIS_VAULT_PEPPER: z
     .string()
     .optional()
@@ -132,6 +144,11 @@ export const envSchema = z.object({
     .enum(['trusted-pilot', 'public-deferred', 'public', 'untrusted'])
     .optional(),
   MEMPHIS_AUTONOMY_MODE: z.enum(['full', 'quiet', 'balanced', 'paranoid']).optional(),
+  // Set automatically by tier-3 elevation (src/security/tier3-session.ts) for
+  // the duration of the unrestricted session. Operators rarely set this by
+  // hand — included in schema for visibility in `memphis config show` and for
+  // typed validation of test seams.
+  MEMPHIS_TIER3_FS_UNRESTRICTED: boolFromString.optional(),
   MEMPHIS_SAFE_MODE: boolFromString.default(false),
   MEMPHIS_STRICT_MODE: boolFromString.default(false),
   MEMPHIS_FAULT_INJECT: z.string().optional(),
@@ -237,6 +254,10 @@ export const envSchema = z.object({
   // the documented graceful-fallback behavior.
   MEMPHIS_OTEL_SAMPLE_RATIO: z.coerce.number().optional(),
   MEMPHIS_OTEL_HEADERS: z.string().optional(),
+  // Sprint 0.1 (sovereign-first JSONL telemetry sink). Default = enabled
+  // (writes to <dataDir>/telemetry/spans-YYYY-MM-DD.jsonl). Set to false/0/no/off
+  // when running pure OTel mode and disk growth from local sink isn't wanted.
+  MEMPHIS_TELEMETRY_LOCAL_SINK: boolFromString.optional(),
   MEMPHIS_SNAPSHOT_MAX_AGE_MS: z.coerce.number().int().min(3600000).max(2592000000).optional(),
   MEMPHIS_SNAPSHOT_MIN_KEEP: z.coerce.number().int().min(1).max(1000).optional(),
   MEMPHIS_HEARTBEAT_INTERVAL_MS: z.coerce.number().int().min(5000).max(3600000).optional(),


### PR DESCRIPTION
## Summary

Wiring sweep follow-up. Internal audit found 121 env-var names referenced in `src/` but absent from `envSchema`. Most are dynamic prefixes (`MEMPHIS_SURFACE_*`, `MEMPHIS_BREAKER_*`, `MEMPHIS_PROVIDER_*`) or test seams that don't merit schema entries. **Five with concrete operator impact added** in this PR.

## What's added

| Var | Type | Why |
|---|---|---|
| `MEMPHIS_TIER3_FS_UNRESTRICTED` | bool optional | Set by tier-3 elevation; visibility in `config show` + test seam typing |
| `MEMPHIS_TELEMETRY_LOCAL_SINK` | bool optional | Sprint 0.1 (#323) sovereign JSONL sink toggle — schema entry was missed in the original PR |
| `MEMPHIS_VAULT_STATE_PATH` | string optional | Explicit vault-state.json override (legacy installs, container mounts) |
| `MEMPHIS_VAULT_ENTRIES_PATH` | string optional | Explicit vault-entries.json override (pair with STATE_PATH) |
| `MEMPHIS_VAULT_FORCE_REINIT` | bool optional | Destructive vault re-init flag — operators should discover this in `config show`, not in stack traces |

## What's deliberately NOT added

- `MEMPHIS_KARTOGRAF_REQUIRE_REAL_SESSION` — referenced only in a comment in `src/kartograf/session.ts:101` (sprint 4.2 stub). Earns a schema entry when the real ONNX session lands in Q2 N32.
- ~100 other env-var references — dynamic-prefixed (`MEMPHIS_SURFACE_<surface>_*`, `MEMPHIS_BREAKER_<provider>_*`) or internal test seams. Adding them inflates schema surface without operator value.

## How it was found

```bash
# All env vars in schema
grep -oE "[A-Z_]+:\s*z\." src/infra/config/schema.ts | sed 's/:.*//' | sort -u > schema-envs.txt
# All env vars in code
grep -rohE "MEMPHIS_[A-Z_]+|RUST_[A-Z_]+" src --include="*.ts" | sort -u > code-envs.txt
# Diff
comm -23 code-envs.txt schema-envs.txt | grep -vE "MEMPHIS_(SURFACE|BREAKER|PROVIDER|API|FEATURE|TEST)_"
```

121 results → triaged to 5 with concrete operator impact.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/unit/config` — 52/52 green
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] Manual smoke: `memphis config show` after merge — should list all 5 new keys

## Backwards compatibility

Pure additive — every new entry is `.optional()` so existing operators with these env vars unset see no change. Operators already setting them by hand now get type validation + visibility in `config show`.

## Related

- Sprint 0.1 (#323) introduced `MEMPHIS_TELEMETRY_LOCAL_SINK` without schema entry — this PR retrofits it
- Continues wiring sweep from W1 (#334)
- Future W3-W4 will close chain catalog orphans + dead module removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)