### PR TITLE
fix(security): use valid system_event block type for audit chain mirror (wiring W6)

### DIFF
--- a/src/security/runtime-security-events.ts
+++ b/src/security/runtime-security-events.ts
@@ -45,10 +45,20 @@ export async function emitRuntimeSecurityEvent(
     await appendBlock(
       'system',
       {
-        type: 'security_event',
+        // Wiring W6 fix: was 'security_event', which is NOT in the Rust
+        // block_types enum (journal | ask | decision | system |
+        // system_event | insight | tool_call | tool_result | error |
+        // case | wallet_tx_*). Every emitRuntimeSecurityEvent call
+        // since this function landed has been failing the Rust schema
+        // validator silently. Sprint 2.4 (#328) surfaced the failures
+        // to stderr; THIS sprint fixes the underlying bug — switch to
+        // the valid `system_event` variant + tag with `security` so
+        // chain consumers can still filter to security-only events.
+        type: 'system_event',
         action: event.action,
         status: event.status,
         details,
+        tags: ['security', `status:${event.status}`],
         timestamp: new Date().toISOString(),
       },
       rawEnv,


### PR DESCRIPTION
## Summary

Sprint 2.4 (#328) silent-fail surfacing exposed a **long-standing bug** hidden by the previous empty-catch handler: every `emitRuntimeSecurityEvent` call has been failing the Rust block-type validator silently for as long as this function existed.

## Root cause

`appendBlock` was called with `type: 'security_event'`, but that's not a valid variant in the Rust `block_types` enum. Allowed variants are:

```
journal | ask | decision | system | system_event | insight |
tool_call | tool_result | error | case | wallet_tx_*
```

The Rust validator returns `unknown variant 'security_event'` and the chain append fails. Pre-#328 this was caught and ignored — `writeSecurityAudit` (the dedicated audit log) was unaffected, so operators never noticed. **Post-#328** the surface flag pushed the failure to stderr, which on CI's preflight gate gets captured as `gateError` — causing `testTs` to be reported as failed in the JSON summary even when no test ASSERTION failed (just noisy stderr looking like an error).

## Fix

Switch to the valid `system_event` variant + tag the block with `security` and `status:<status>` so chain consumers (`memphis_chain_query`, `PULSE.md` inspectors, future federation audit pollers) can still filter to security-only events with `where tags @> ['security']`. No information loss; the `action` and `status` fields stay where they were.

```diff
-        type: 'security_event',
+        // Wiring W6 fix: 'security_event' is NOT in the Rust enum.
+        type: 'system_event',
         action: event.action,
         status: event.status,
         details,
+        tags: ['security', `status:${event.status}`],
         timestamp: new Date().toISOString(),
```

## Why this kept hiding

Pre-#328 catch was empty. Post-#328 stderr was visible to operators but **not parsed** as a test failure — just noise. CI's preflight gate captures `stderr` as `gateError` text and propagates it through the JSON summary's `error` field, but the **subprocess exit code** is what determines `ok: false`. `vitest` itself was returning exit 1 for some other reason on CI (timezone-related test in confab-detector — fixed in W5/#337). The chain-append-failure stderr was a red herring that I followed deeper than needed, and discovered this real underlying bug along the way.

## Verification

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/unit/security` — 4/4 green
- [ ] Full `npm run test:ts` (will run on CI)
- [ ] After merge: stderr no longer carries `[memphis-security] chain append failed` lines; CI testTs gate stops being polluted with this noise.

## Behavior change

Pre-fix: every security event triggered a silent chain-append failure (or, post-#328, a noisy stderr write). Audit chain was effectively missing every security event since the function landed.

Post-fix: security events successfully append to the system chain as `system_event` blocks with `security` tag. Operators querying `system` chain with `tag = 'security'` now see actual audit data. Backwards-compatible at the chain layer (existing `system_event` consumers see new entries, identifiable by tag).

## Related

- Sprint 2.4 (#328) — silent-fail surfacing that exposed this bug
- W5 (#337) — fixes the two test flakes that were colliding with this issue
- Unblocks: W1 (#334), W2 (#335), W4 (#336)

🤖 Generated with [Claude Code](https://claude.com/claude-code)