### PR TITLE
test(shutdown): SEGV stress for mcp serve + full daemon (Track B B1, #270)

### DIFF
--- a/tests/integration/shutdown-segv-stress.test.ts
+++ b/tests/integration/shutdown-segv-stress.test.ts
@@ -124,9 +124,9 @@ async function runMcpServeIteration(iteration: number): Promise<IterationResult>
 async function runFullDaemonIteration(iteration: number): Promise<IterationResult> {
   const isolatedRoot = mkdtempSync(join(tmpdir(), `memphis-segv-daemon-${iteration}-`));
   // OS-assigned ephemeral port, freed immediately before spawn so the child
-  // can bind. Brief TOCTOU race vs. another local process picking the same
-  // port, but eliminates the systemd-already-running EADDRINUSE class that
-  // a fixed-range scheme hit on Codex P2 #340.
+  // can bind. Brief race vs. another local process picking the same port,
+  // but eliminates EADDRINUSE collisions from any process already on a fixed
+  // range (e.g. operator's own systemd-managed memphis service).
   const port = await pickEphemeralPort();
   const envFile = join(isolatedRoot, '.env');
   writeFileSync(
@@ -168,17 +168,11 @@ async function runFullDaemonIteration(iteration: number): Promise<IterationResul
     stderr += chunk.toString('utf8');
   });
 
-  // Readiness is two-stage:
-  //   1. Wait for `Server listening at http://127.0.0.1:<port>` on stderr —
-  //      proves *our* child owns the port (Codex P2 #340 — pure TCP probe
-  //      against a fixed port could connect to a stale process).
-  //   2. Wait for installShutdownHandlers to run — bootstrap registers the
-  //      SIGTERM handler at bootstrap.ts:470, which is AFTER `app.listen()`
-  //      logs the "Server listening" line. Without this delay, SIGTERM
-  //      arrives before the handler exists and the child gets terminated
-  //      by Node's default behavior (signal=SIGTERM, code=null), bypassing
-  //      performGracefulShutdown — exactly what this test is meant to
-  //      exercise.
+  // Two-stage readiness: wait for bootstrap's "Server listening" line on
+  // stderr (proves OUR child owns the port), then sleep so
+  // installShutdownHandlers runs before SIGTERM. The handler is registered
+  // in bootstrap.ts AFTER app.listen, so without this gap SIGTERM hits
+  // Node's default terminate and skips performGracefulShutdown entirely.
   const stderrReady = await waitForStderrListening(child, port, DAEMON_READY_TIMEOUT_MS);
   if (!stderrReady) {
     try {
@@ -331,9 +325,9 @@ function assertCleanShutdown(
   const notReady = results.filter((r) => !r.ready);
   // SEGV: explicit signal or 128+11 exit code.
   const segvHits = results.filter((r) => r.exitCode === 139 || r.exitSignal === 'SIGSEGV');
-  // Hung shutdown: SIGKILL'd by waitForExit (Codex P1 #340 — without this a
-  // hang reads as passing, masking the exact regression class this test exists
-  // to catch).
+  // Hung shutdown: SIGKILL'd by waitForExit. Counted as failure — without
+  // this a hang reads as passing and masks the exact regression class this
+  // test exists to catch.
   const hungShutdowns = results.filter((r) => r.ready && r.shutdownTimedOut);
   expect(
     notReady,

--- a/tests/integration/shutdown-segv-stress.test.ts
+++ b/tests/integration/shutdown-segv-stress.test.ts
@@ -1,0 +1,323 @@
+// Issue #270 evidence-driven close: spawn the runtime, send SIGTERM, assert
+// the child exits without SEGV. Two stress paths, both env-gated by
+// MEMPHIS_SEGV_STRESS=1:
+//
+//   1. `mcp serve --transport http` (N=20) — exercises the lighter mcp-serve
+//      SIGTERM handler that just flips stopRequested. Regression guard
+//      against process-static state added without a paired shutdown export.
+//
+//   2. `memphis serve` (N=10) — exercises the full bootstrap → installShutdown-
+//      Handlers → performGracefulShutdown sequence (drain → embed_shutdown →
+//      pino flush → exit). This is the path #270 actually points at; clean
+//      runs here close the SEGV-on-shutdown hypothesis empirically.
+//
+// Phase 1 audit confirmed the only process-static state with a non-trivial
+// Drop is EMBED_PIPELINE in crates/memphis-napi, already covered by
+// embed_shutdown() in graceful-shutdown.ts. Vault and CaseIndex are per-call.
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { connect } from 'node:net';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const STRESS_ENABLED = process.env.MEMPHIS_SEGV_STRESS === '1';
+const MCP_ITERATIONS = 20;
+const DAEMON_ITERATIONS = 10;
+const MCP_READY_TIMEOUT_MS = 8_000;
+const MCP_STOP_TIMEOUT_MS = 6_000;
+const DAEMON_READY_TIMEOUT_MS = 12_000;
+const DAEMON_STOP_TIMEOUT_MS = 18_000;
+const DAEMON_BASE_PORT = 45_000;
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(thisDir, '..', '..');
+const MEMPHIS_BIN = join(REPO_ROOT, 'bin', 'memphis.js');
+
+interface IterationResult {
+  iteration: number;
+  ready: boolean;
+  exitCode: number | null;
+  exitSignal: NodeJS.Signals | null;
+  durationMs: number;
+  stderrTail: string;
+}
+
+async function runMcpServeIteration(iteration: number): Promise<IterationResult> {
+  const isolatedRoot = mkdtempSync(join(tmpdir(), `memphis-segv-mcp-${iteration}-`));
+  const env = {
+    ...process.env,
+    MEMPHIS_DATA_DIR: isolatedRoot,
+    MEMPHIS_VAULT_STATE_PATH: join(isolatedRoot, 'vault-state.json'),
+    MEMPHIS_VAULT_ENTRIES_PATH: join(isolatedRoot, 'vault-entries.json'),
+    DEFAULT_PROVIDER: 'local-fallback',
+    LOCAL_FALLBACK_ENABLED: 'true',
+  };
+
+  const startedAt = Date.now();
+  const child = spawn(
+    process.execPath,
+    [
+      MEMPHIS_BIN,
+      'mcp',
+      'serve',
+      '--transport',
+      'http',
+      '--port',
+      '0',
+      '--duration-ms',
+      '0',
+      '--json',
+    ],
+    { env, stdio: ['ignore', 'pipe', 'pipe'] },
+  ) as ChildProcessWithoutNullStreams;
+
+  let stderr = '';
+  child.stderr.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+
+  const ready = await waitForStdoutReady(child, MCP_READY_TIMEOUT_MS);
+  if (!ready) {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      /* already exited */
+    }
+    await waitForExit(child, MCP_STOP_TIMEOUT_MS);
+    rmSync(isolatedRoot, { recursive: true, force: true });
+    return {
+      iteration,
+      ready: false,
+      exitCode: null,
+      exitSignal: null,
+      durationMs: Date.now() - startedAt,
+      stderrTail: stderr.slice(-500),
+    };
+  }
+
+  child.kill('SIGTERM');
+  const { code, signal } = await waitForExit(child, MCP_STOP_TIMEOUT_MS);
+  rmSync(isolatedRoot, { recursive: true, force: true });
+
+  return {
+    iteration,
+    ready: true,
+    exitCode: code,
+    exitSignal: signal,
+    durationMs: Date.now() - startedAt,
+    stderrTail: stderr.slice(-500),
+  };
+}
+
+async function runFullDaemonIteration(iteration: number): Promise<IterationResult> {
+  const isolatedRoot = mkdtempSync(join(tmpdir(), `memphis-segv-daemon-${iteration}-`));
+  const port = DAEMON_BASE_PORT + iteration;
+  const envFile = join(isolatedRoot, '.env');
+  writeFileSync(
+    envFile,
+    [
+      'HOST=127.0.0.1',
+      `PORT=${port}`,
+      'DEFAULT_PROVIDER=local-fallback',
+      'LOCAL_FALLBACK_ENABLED=true',
+      'RUST_EMBED_MODE=local',
+      'RUST_CHAIN_ENABLED=true',
+      'MEMPHIS_VAULT_PEPPER=segv-stress-pepper-1234567890',
+      'MEMPHIS_API_TOKEN=',
+      'MEMPHIS_CHANNEL_GATEWAY_ENABLED=false',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+
+  const env = {
+    ...process.env,
+    MEMPHIS_ENV_FILE: envFile,
+    MEMPHIS_DATA_DIR: isolatedRoot,
+    MEMPHIS_SKIP_FIRST_RUN_CHECKS: '1',
+    MEMPHIS_SKIP_VAULT_INTEGRITY_PROBE: 'true',
+    MEMPHIS_VAULT_STATE_PATH: join(isolatedRoot, 'vault-state.json'),
+    MEMPHIS_VAULT_ENTRIES_PATH: join(isolatedRoot, 'vault-entries.json'),
+    PORT: String(port),
+  };
+
+  const startedAt = Date.now();
+  const child = spawn(process.execPath, [MEMPHIS_BIN, 'serve'], {
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }) as ChildProcessWithoutNullStreams;
+
+  let stderr = '';
+  child.stderr.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+
+  const ready = await waitForTcpReady(port, DAEMON_READY_TIMEOUT_MS, child);
+  if (!ready) {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      /* already exited */
+    }
+    await waitForExit(child, DAEMON_STOP_TIMEOUT_MS);
+    rmSync(isolatedRoot, { recursive: true, force: true });
+    return {
+      iteration,
+      ready: false,
+      exitCode: null,
+      exitSignal: null,
+      durationMs: Date.now() - startedAt,
+      stderrTail: stderr.slice(-800),
+    };
+  }
+
+  child.kill('SIGTERM');
+  const { code, signal } = await waitForExit(child, DAEMON_STOP_TIMEOUT_MS);
+  rmSync(isolatedRoot, { recursive: true, force: true });
+
+  return {
+    iteration,
+    ready: true,
+    exitCode: code,
+    exitSignal: signal,
+    durationMs: Date.now() - startedAt,
+    stderrTail: stderr.slice(-800),
+  };
+}
+
+function waitForStdoutReady(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise((resolveReady) => {
+    let buffer = '';
+    let settled = false;
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.stdout.off('data', onData);
+      resolveReady(value);
+    };
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      // print() emits pretty-printed JSON (multi-line) when --json is set;
+      // detect both fields together rather than parsing line-by-line.
+      if (buffer.includes('"mode": "mcp-serve"') && buffer.includes('"ok": true')) {
+        settle(true);
+      }
+    };
+    const timer = setTimeout(() => settle(false), timeoutMs);
+    child.stdout.on('data', onData);
+    child.once('exit', () => settle(false));
+  });
+}
+
+async function waitForTcpReady(
+  port: number,
+  timeoutMs: number,
+  child: ChildProcessWithoutNullStreams,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) return false;
+    if (await tryTcpConnect(port, 500)) return true;
+    await sleep(250);
+  }
+  return false;
+}
+
+function tryTcpConnect(port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolveTry) => {
+    const socket = connect({ host: '127.0.0.1', port });
+    let settled = false;
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolveTry(value);
+    };
+    socket.setTimeout(timeoutMs, () => settle(false));
+    socket.once('connect', () => settle(true));
+    socket.once('error', () => settle(false));
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function waitForExit(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs: number,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolveExit) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolveExit({ code: child.exitCode, signal: child.signalCode });
+      return;
+    }
+    const killTimer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already exited */
+      }
+    }, timeoutMs);
+    child.once('exit', (code, signal) => {
+      clearTimeout(killTimer);
+      resolveExit({ code, signal });
+    });
+  });
+}
+
+function summarize(label: string, results: IterationResult[]): void {
+  const lines = results.map(
+    (r) =>
+      `  #${String(r.iteration).padStart(2, '0')}: ready=${r.ready} code=${r.exitCode} signal=${r.exitSignal} ms=${r.durationMs}`,
+  );
+  process.stderr.write(`[${label}] ${results.length} iterations:\n${lines.join('\n')}\n`);
+}
+
+function assertNoSegv(results: IterationResult[]): void {
+  const segvHits = results.filter((r) => r.exitCode === 139 || r.exitSignal === 'SIGSEGV');
+  const notReady = results.filter((r) => !r.ready);
+  expect(
+    notReady,
+    `iterations failed to reach ready: ${JSON.stringify(notReady, null, 2)}`,
+  ).toEqual([]);
+  expect(
+    segvHits,
+    `iterations hit SEGV on shutdown: ${JSON.stringify(segvHits, null, 2)}`,
+  ).toEqual([]);
+}
+
+describe.runIf(STRESS_ENABLED)('shutdown SEGV stress (issue #270 evidence)', () => {
+  it(
+    `mcp serve: ${MCP_ITERATIONS} spawn-then-SIGTERM cycles without SEGV`,
+    async () => {
+      const results: IterationResult[] = [];
+      for (let i = 1; i <= MCP_ITERATIONS; i++) {
+        results.push(await runMcpServeIteration(i));
+      }
+      summarize('shutdown-segv-stress mcp', results);
+      assertNoSegv(results);
+    },
+    MCP_ITERATIONS * (MCP_READY_TIMEOUT_MS + MCP_STOP_TIMEOUT_MS) + 30_000,
+  );
+
+  it(
+    `memphis serve (full bootstrap): ${DAEMON_ITERATIONS} spawn-then-SIGTERM cycles without SEGV`,
+    async () => {
+      const results: IterationResult[] = [];
+      for (let i = 1; i <= DAEMON_ITERATIONS; i++) {
+        results.push(await runFullDaemonIteration(i));
+      }
+      summarize('shutdown-segv-stress daemon', results);
+      assertNoSegv(results);
+    },
+    DAEMON_ITERATIONS * (DAEMON_READY_TIMEOUT_MS + DAEMON_STOP_TIMEOUT_MS) + 60_000,
+  );
+});

--- a/tests/integration/shutdown-segv-stress.test.ts
+++ b/tests/integration/shutdown-segv-stress.test.ts
@@ -318,10 +318,7 @@ function summarize(label: string, results: IterationResult[]): void {
   process.stderr.write(`[${label}] ${results.length} iterations:\n${lines.join('\n')}\n`);
 }
 
-function assertCleanShutdown(
-  results: IterationResult[],
-  options: { requireGracefulHandler: boolean },
-): void {
+function assertCleanShutdown(results: IterationResult[]): void {
   const notReady = results.filter((r) => !r.ready);
   // SEGV: explicit signal or 128+11 exit code.
   const segvHits = results.filter((r) => r.exitCode === 139 || r.exitSignal === 'SIGSEGV');
@@ -329,6 +326,12 @@ function assertCleanShutdown(
   // this a hang reads as passing and masks the exact regression class this
   // test exists to catch.
   const hungShutdowns = results.filter((r) => r.ready && r.shutdownTimedOut);
+  // Every ready iteration must exit with code 0. Any other outcome fails
+  // the iteration: code=null (signal-killed including default-SIGTERM with
+  // no handler), code=75 (drain timeout — no in-flight turns in this test,
+  // so drain MUST succeed), or any other non-zero. The test sends SIGTERM
+  // and expects a clean handler-driven exit, period.
+  const dirtyExits = results.filter((r) => r.ready && r.exitCode !== 0);
   expect(
     notReady,
     `iterations failed to reach ready: ${JSON.stringify(notReady, null, 2)}`,
@@ -341,18 +344,10 @@ function assertCleanShutdown(
     hungShutdowns,
     `iterations exceeded shutdown timeout (SIGKILL'd): ${JSON.stringify(hungShutdowns, null, 2)}`,
   ).toEqual([]);
-  if (options.requireGracefulHandler) {
-    // signal=SIGTERM with code=null means Node's default terminate fired —
-    // performGracefulShutdown never ran. Either the handler isn't installed
-    // (real bug) or our post-listen delay raced the handler install.
-    const handlerBypass = results.filter(
-      (r) => r.ready && r.exitCode === null && r.exitSignal === 'SIGTERM',
-    );
-    expect(
-      handlerBypass,
-      `iterations bypassed performGracefulShutdown (default SIGTERM): ${JSON.stringify(handlerBypass, null, 2)}`,
-    ).toEqual([]);
-  }
+  expect(
+    dirtyExits,
+    `iterations did not exit cleanly with code 0: ${JSON.stringify(dirtyExits, null, 2)}`,
+  ).toEqual([]);
 }
 
 describe.runIf(STRESS_ENABLED)('shutdown SEGV stress (issue #270 evidence)', () => {
@@ -364,7 +359,7 @@ describe.runIf(STRESS_ENABLED)('shutdown SEGV stress (issue #270 evidence)', () 
         results.push(await runMcpServeIteration(i));
       }
       summarize('shutdown-segv-stress mcp', results);
-      assertCleanShutdown(results, { requireGracefulHandler: false });
+      assertCleanShutdown(results);
     },
     MCP_ITERATIONS * (MCP_READY_TIMEOUT_MS + MCP_STOP_TIMEOUT_MS) + 30_000,
   );
@@ -377,7 +372,7 @@ describe.runIf(STRESS_ENABLED)('shutdown SEGV stress (issue #270 evidence)', () 
         results.push(await runFullDaemonIteration(i));
       }
       summarize('shutdown-segv-stress daemon', results);
-      assertCleanShutdown(results, { requireGracefulHandler: true });
+      assertCleanShutdown(results);
     },
     DAEMON_ITERATIONS * (DAEMON_READY_TIMEOUT_MS + DAEMON_STOP_TIMEOUT_MS) + 60_000,
   );

--- a/tests/integration/shutdown-segv-stress.test.ts
+++ b/tests/integration/shutdown-segv-stress.test.ts
@@ -16,7 +16,7 @@
 // embed_shutdown() in graceful-shutdown.ts. Vault and CaseIndex are per-call.
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { connect } from 'node:net';
+import { createServer, type AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -30,7 +30,13 @@ const MCP_READY_TIMEOUT_MS = 8_000;
 const MCP_STOP_TIMEOUT_MS = 6_000;
 const DAEMON_READY_TIMEOUT_MS = 12_000;
 const DAEMON_STOP_TIMEOUT_MS = 18_000;
-const DAEMON_BASE_PORT = 45_000;
+// Post-listen window during which bootstrap finishes wiring background loops
+// (channel gateway, scheduler, OTel) and finally calls installShutdownHandlers
+// at bootstrap.ts:470. Without this delay SIGTERM races the handler install
+// and the child gets terminated by Node's default behaviour (signal=SIGTERM,
+// code=null), bypassing performGracefulShutdown — exactly what this test is
+// supposed to exercise. assertCleanShutdown catches that mode explicitly.
+const POST_LISTEN_HANDLER_INSTALL_MS = 2_000;
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(thisDir, '..', '..');
@@ -41,6 +47,7 @@ interface IterationResult {
   ready: boolean;
   exitCode: number | null;
   exitSignal: NodeJS.Signals | null;
+  shutdownTimedOut: boolean;
   durationMs: number;
   stderrTail: string;
 }
@@ -93,13 +100,14 @@ async function runMcpServeIteration(iteration: number): Promise<IterationResult>
       ready: false,
       exitCode: null,
       exitSignal: null,
+      shutdownTimedOut: false,
       durationMs: Date.now() - startedAt,
       stderrTail: stderr.slice(-500),
     };
   }
 
   child.kill('SIGTERM');
-  const { code, signal } = await waitForExit(child, MCP_STOP_TIMEOUT_MS);
+  const { code, signal, timedOut } = await waitForExit(child, MCP_STOP_TIMEOUT_MS);
   rmSync(isolatedRoot, { recursive: true, force: true });
 
   return {
@@ -107,6 +115,7 @@ async function runMcpServeIteration(iteration: number): Promise<IterationResult>
     ready: true,
     exitCode: code,
     exitSignal: signal,
+    shutdownTimedOut: timedOut,
     durationMs: Date.now() - startedAt,
     stderrTail: stderr.slice(-500),
   };
@@ -114,7 +123,11 @@ async function runMcpServeIteration(iteration: number): Promise<IterationResult>
 
 async function runFullDaemonIteration(iteration: number): Promise<IterationResult> {
   const isolatedRoot = mkdtempSync(join(tmpdir(), `memphis-segv-daemon-${iteration}-`));
-  const port = DAEMON_BASE_PORT + iteration;
+  // OS-assigned ephemeral port, freed immediately before spawn so the child
+  // can bind. Brief TOCTOU race vs. another local process picking the same
+  // port, but eliminates the systemd-already-running EADDRINUSE class that
+  // a fixed-range scheme hit on Codex P2 #340.
+  const port = await pickEphemeralPort();
   const envFile = join(isolatedRoot, '.env');
   writeFileSync(
     envFile,
@@ -155,8 +168,19 @@ async function runFullDaemonIteration(iteration: number): Promise<IterationResul
     stderr += chunk.toString('utf8');
   });
 
-  const ready = await waitForTcpReady(port, DAEMON_READY_TIMEOUT_MS, child);
-  if (!ready) {
+  // Readiness is two-stage:
+  //   1. Wait for `Server listening at http://127.0.0.1:<port>` on stderr —
+  //      proves *our* child owns the port (Codex P2 #340 — pure TCP probe
+  //      against a fixed port could connect to a stale process).
+  //   2. Wait for installShutdownHandlers to run — bootstrap registers the
+  //      SIGTERM handler at bootstrap.ts:470, which is AFTER `app.listen()`
+  //      logs the "Server listening" line. Without this delay, SIGTERM
+  //      arrives before the handler exists and the child gets terminated
+  //      by Node's default behavior (signal=SIGTERM, code=null), bypassing
+  //      performGracefulShutdown — exactly what this test is meant to
+  //      exercise.
+  const stderrReady = await waitForStderrListening(child, port, DAEMON_READY_TIMEOUT_MS);
+  if (!stderrReady) {
     try {
       child.kill('SIGKILL');
     } catch {
@@ -169,13 +193,15 @@ async function runFullDaemonIteration(iteration: number): Promise<IterationResul
       ready: false,
       exitCode: null,
       exitSignal: null,
+      shutdownTimedOut: false,
       durationMs: Date.now() - startedAt,
       stderrTail: stderr.slice(-800),
     };
   }
+  await sleep(POST_LISTEN_HANDLER_INSTALL_MS);
 
   child.kill('SIGTERM');
-  const { code, signal } = await waitForExit(child, DAEMON_STOP_TIMEOUT_MS);
+  const { code, signal, timedOut } = await waitForExit(child, DAEMON_STOP_TIMEOUT_MS);
   rmSync(isolatedRoot, { recursive: true, force: true });
 
   return {
@@ -183,6 +209,7 @@ async function runFullDaemonIteration(iteration: number): Promise<IterationResul
     ready: true,
     exitCode: code,
     exitSignal: signal,
+    shutdownTimedOut: timedOut,
     durationMs: Date.now() - startedAt,
     stderrTail: stderr.slice(-800),
   };
@@ -216,33 +243,29 @@ function waitForStdoutReady(
   });
 }
 
-async function waitForTcpReady(
+function waitForStderrListening(
+  child: ChildProcessWithoutNullStreams,
   port: number,
   timeoutMs: number,
-  child: ChildProcessWithoutNullStreams,
 ): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null || child.signalCode !== null) return false;
-    if (await tryTcpConnect(port, 500)) return true;
-    await sleep(250);
-  }
-  return false;
-}
-
-function tryTcpConnect(port: number, timeoutMs: number): Promise<boolean> {
-  return new Promise((resolveTry) => {
-    const socket = connect({ host: '127.0.0.1', port });
+  return new Promise((resolveReady) => {
+    let buffer = '';
     let settled = false;
+    const needle = `Server listening at http://127.0.0.1:${port}`;
     const settle = (value: boolean) => {
       if (settled) return;
       settled = true;
-      socket.destroy();
-      resolveTry(value);
+      clearTimeout(timer);
+      child.stderr.off('data', onData);
+      resolveReady(value);
     };
-    socket.setTimeout(timeoutMs, () => settle(false));
-    socket.once('connect', () => settle(true));
-    socket.once('error', () => settle(false));
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      if (buffer.includes(needle)) settle(true);
+    };
+    const timer = setTimeout(() => settle(false), timeoutMs);
+    child.stderr.on('data', onData);
+    child.once('exit', () => settle(false));
   });
 }
 
@@ -250,16 +273,36 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+function pickEphemeralPort(): Promise<number> {
+  return new Promise((resolvePort, rejectPort) => {
+    const server = createServer();
+    server.unref();
+    server.once('error', rejectPort);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as AddressInfo | null;
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        rejectPort(new Error('failed to obtain ephemeral port'));
+        return;
+      }
+      const port = addr.port;
+      server.close(() => resolvePort(port));
+    });
+  });
+}
+
 function waitForExit(
   child: ChildProcessWithoutNullStreams,
   timeoutMs: number,
-): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; timedOut: boolean }> {
   return new Promise((resolveExit) => {
     if (child.exitCode !== null || child.signalCode !== null) {
-      resolveExit({ code: child.exitCode, signal: child.signalCode });
+      resolveExit({ code: child.exitCode, signal: child.signalCode, timedOut: false });
       return;
     }
+    let timedOut = false;
     const killTimer = setTimeout(() => {
+      timedOut = true;
       try {
         child.kill('SIGKILL');
       } catch {
@@ -268,7 +311,7 @@ function waitForExit(
     }, timeoutMs);
     child.once('exit', (code, signal) => {
       clearTimeout(killTimer);
-      resolveExit({ code, signal });
+      resolveExit({ code, signal, timedOut });
     });
   });
 }
@@ -276,14 +319,22 @@ function waitForExit(
 function summarize(label: string, results: IterationResult[]): void {
   const lines = results.map(
     (r) =>
-      `  #${String(r.iteration).padStart(2, '0')}: ready=${r.ready} code=${r.exitCode} signal=${r.exitSignal} ms=${r.durationMs}`,
+      `  #${String(r.iteration).padStart(2, '0')}: ready=${r.ready} code=${r.exitCode} signal=${r.exitSignal} timedOut=${r.shutdownTimedOut} ms=${r.durationMs}`,
   );
   process.stderr.write(`[${label}] ${results.length} iterations:\n${lines.join('\n')}\n`);
 }
 
-function assertNoSegv(results: IterationResult[]): void {
-  const segvHits = results.filter((r) => r.exitCode === 139 || r.exitSignal === 'SIGSEGV');
+function assertCleanShutdown(
+  results: IterationResult[],
+  options: { requireGracefulHandler: boolean },
+): void {
   const notReady = results.filter((r) => !r.ready);
+  // SEGV: explicit signal or 128+11 exit code.
+  const segvHits = results.filter((r) => r.exitCode === 139 || r.exitSignal === 'SIGSEGV');
+  // Hung shutdown: SIGKILL'd by waitForExit (Codex P1 #340 — without this a
+  // hang reads as passing, masking the exact regression class this test exists
+  // to catch).
+  const hungShutdowns = results.filter((r) => r.ready && r.shutdownTimedOut);
   expect(
     notReady,
     `iterations failed to reach ready: ${JSON.stringify(notReady, null, 2)}`,
@@ -292,6 +343,22 @@ function assertNoSegv(results: IterationResult[]): void {
     segvHits,
     `iterations hit SEGV on shutdown: ${JSON.stringify(segvHits, null, 2)}`,
   ).toEqual([]);
+  expect(
+    hungShutdowns,
+    `iterations exceeded shutdown timeout (SIGKILL'd): ${JSON.stringify(hungShutdowns, null, 2)}`,
+  ).toEqual([]);
+  if (options.requireGracefulHandler) {
+    // signal=SIGTERM with code=null means Node's default terminate fired —
+    // performGracefulShutdown never ran. Either the handler isn't installed
+    // (real bug) or our post-listen delay raced the handler install.
+    const handlerBypass = results.filter(
+      (r) => r.ready && r.exitCode === null && r.exitSignal === 'SIGTERM',
+    );
+    expect(
+      handlerBypass,
+      `iterations bypassed performGracefulShutdown (default SIGTERM): ${JSON.stringify(handlerBypass, null, 2)}`,
+    ).toEqual([]);
+  }
 }
 
 describe.runIf(STRESS_ENABLED)('shutdown SEGV stress (issue #270 evidence)', () => {
@@ -303,7 +370,7 @@ describe.runIf(STRESS_ENABLED)('shutdown SEGV stress (issue #270 evidence)', () 
         results.push(await runMcpServeIteration(i));
       }
       summarize('shutdown-segv-stress mcp', results);
-      assertNoSegv(results);
+      assertCleanShutdown(results, { requireGracefulHandler: false });
     },
     MCP_ITERATIONS * (MCP_READY_TIMEOUT_MS + MCP_STOP_TIMEOUT_MS) + 30_000,
   );
@@ -316,7 +383,7 @@ describe.runIf(STRESS_ENABLED)('shutdown SEGV stress (issue #270 evidence)', () 
         results.push(await runFullDaemonIteration(i));
       }
       summarize('shutdown-segv-stress daemon', results);
-      assertNoSegv(results);
+      assertCleanShutdown(results, { requireGracefulHandler: true });
     },
     DAEMON_ITERATIONS * (DAEMON_READY_TIMEOUT_MS + DAEMON_STOP_TIMEOUT_MS) + 60_000,
   );


### PR DESCRIPTION
## Summary
- Adds `tests/integration/shutdown-segv-stress.test.ts` with two env-gated stress paths (`MEMPHIS_SEGV_STRESS=1`) for issue #270.
- **mcp serve × 20**: regression guard against process-static state added without paired shutdown export.
- **memphis serve × 10 (full bootstrap)**: exercises full `performGracefulShutdown` (drain → embed_shutdown → pino flush → exit).
- Default-skipped — does not affect normal CI run time.

## Why

Issue #270 hypothesis (vault_shutdown / case_index_close NAPI exports needed) was based on stale code analysis. Phase 1 audit confirmed only `EMBED_PIPELINE` in `crates/memphis-napi` has non-trivial Drop process-static state, already covered by `embed_shutdown()` in `src/infra/runtime/graceful-shutdown.ts`. Vault and CaseIndex are per-call.

This PR provides the empirical evidence layer to back the audit before closing #270.

## B2 baseline (after Codex P1+P2 fixes)

```
[shutdown-segv-stress mcp] 20 iterations: 20/20 ready=true code=0 signal=null timedOut=false  ~1.1s avg
[shutdown-segv-stress daemon] 10 iterations: 10/10 ready=true code=0 signal=null timedOut=false  ~3.3s avg
Tests  2 passed (2)  Duration  56.65s
```

Zero exit 139, zero SIGSEGV, zero handler bypass, zero hangs. Daemon path emits `pino flush — flushed=11 errors=0` per iteration.

## Codex review log

- **Round 1** (commit `fa1224a`): 1 P1 + 1 P2.
  - **P1 (line 285) — hung shutdown reported as pass.** `waitForExit` SIGKILL'd hangs but `assertNoSegv` only failed on SEGV/139. Hangs counted as success.  Fixed in `bcc4d4c`: `waitForExit` returns `timedOut` flag; `assertCleanShutdown` rejects timed-out iterations. Daemon path also rejects `signal=SIGTERM+code=null` (handler bypass — `performGracefulShutdown` never ran).
  - **P2 (line 227) — daemon readiness probe could connect to a stale process.** Fixed-range port (45001..45010) on a multi-tenant box risks false-positive ready when something else is bound. *Not theoretical*: my own re-run hit EADDRINUSE on 45004. Fixed in `bcc4d4c`: OS-assigned ephemeral port via `pickEphemeralPort()`, plus stderr line match (`"Server listening at http://127.0.0.1:<port>"`) confirms our child owns the port.

## Scope honesty

- mcp serve path uses the lighter `stopRequested` handler in `src/infra/cli/commands/mcp.ts` — does NOT exercise `performGracefulShutdown`. Regression guard, not the SEGV closer.
- memphis serve path goes through full bootstrap → `installShutdownHandlers` → `performGracefulShutdown`. This is the path #270 actually points at.
- Neither path actively engages `EMBED_PIPELINE` queries before shutdown — `embed_shutdown` runs but on uninitialized state. This matches Phase 1 audit (no other static state to engage).
- Follow-up doc PR will codify the lifecycle invariant in `docs/dev/SHUTDOWN-LIFECYCLE.md` and close #270 with this evidence + audit.

## Test plan

- [x] Typecheck: `npx tsc --noEmit -p tsconfig.json` — green
- [x] Lint: `npm run lint` — green (auto-run on `git commit`)
- [x] Default test run (no env flag): `npx vitest run tests/integration/shutdown-segv-stress.test.ts` → 1 file skipped, 1 test skipped (gated)
- [x] Stress run: `MEMPHIS_SEGV_STRESS=1 npx vitest run tests/integration/shutdown-segv-stress.test.ts` → 2 passed in 56.65s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
