### PR TITLE
feat(slo): memphis_slo_status MCP tool + SLO evaluator (Track C3)

### DIFF
--- a/docs/operator/SLO.md
+++ b/docs/operator/SLO.md
@@ -1,0 +1,112 @@
+# Service Level Objectives (SLO)
+
+The runtime exposes a small set of SLOs computed from local telemetry spans (`<dataDir>/telemetry/spans-YYYY-MM-DD.jsonl`). These are not external SLAs — they are operator-facing health indicators that gate "is the runtime healthy" decisions.
+
+## Reading SLOs
+
+```bash
+# CLI / MCP / in-process — all wired to the same evaluator
+memphis_slo_status                  # default 7-day window
+memphis_slo_status windowDays=30    # custom window (1-90 days)
+```
+
+JSON envelope:
+
+```json
+{
+  "ok": true,
+  "windowDays": 7,
+  "windowStart": "2026-04-22T...",
+  "windowEnd": "2026-04-29T...",
+  "spanFilesScanned": 7,
+  "totalSamples": 1234,
+  "failingSlos": [],
+  "slos": [
+    {
+      "name": "p99_turn_latency_ms",
+      "description": "...",
+      "threshold": 3000,
+      "thresholdUnit": "ms",
+      "thresholdDirection": "below",
+      "value": 1450,
+      "status": "pass",
+      "samples": 200
+    },
+    ...
+  ]
+}
+```
+
+`status` is one of:
+- `pass` — value is on the right side of the threshold
+- `fail` — value crossed the threshold; investigate
+- `unavailable` — not enough samples in the window to compute (`reason` field explains why)
+
+## Current SLOs
+
+### p99_turn_latency_ms
+
+p99 of `turn.dispatch` span latency over the window. Latency is read from `attrs['turn.timing_ms']` first, falling back to `durationMs`.
+
+- **Threshold**: 3000 ms (3 seconds)
+- **Direction**: below (lower is better)
+- **Why this matters**: every user turn — TUI, CLI chat, Telegram, HTTP — emits this span. p99 above 3s means the slowest 1% of operator interactions are too laggy to trust. Persistent fails point at provider degradation, embedding storms, or chain-write contention.
+
+### confabulation_rate
+
+Ratio of `confabulation.event` spans to `turn.dispatch` spans.
+
+- **Threshold**: 0.001 (0.1%)
+- **Direction**: below (lower is better)
+- **Why this matters**: confabulation events are recorded by the rule-based detector when the bot's reply contradicts tool output, invents config keys, or claims success after a failure. Above 0.1% means the bot is degrading the operator's trust at scale.
+
+### provider_error_rate
+
+Ratio of `provider.completion` spans with `status=error`.
+
+- **Threshold**: 0.01 (1%)
+- **Direction**: below (lower is better)
+- **Why this matters**: provider failures cascade to `tool.call` retries and turn timeouts. Above 1% means the cascade is firing often enough to surface in user-visible latency.
+
+### tool_error_rate
+
+Ratio of `tool.call` spans with `status=error`.
+
+- **Threshold**: 0.05 (5%)
+- **Direction**: below (lower is better)
+- **Why this matters**: tools failing at >5% means either the LLM is calling the wrong tool, the tool is broken, or auth/policy is rejecting valid requests.
+
+## When an SLO fails
+
+1. Run `memphis_slo_status windowDays=1` to confirm the failure is fresh, not stale telemetry from days ago.
+2. Inspect the offending span class:
+   ```bash
+   # Recent turn.dispatch with >3s timing
+   grep '"name":"turn.dispatch"' ~/.memphis/telemetry/spans-$(date -u +%Y-%m-%d).jsonl | jq 'select(.attrs["turn.timing_ms"] > 3000)'
+   # Recent confabulation events
+   grep '"name":"confabulation.event"' ~/.memphis/telemetry/spans-$(date -u +%Y-%m-%d).jsonl
+   ```
+3. Check `memphis_health` for systemic issues (provider down, vault locked, chain integrity).
+4. Open an incident if the fail persists across two consecutive `slo_status` calls 15 minutes apart.
+
+## Recommended weekly cron
+
+```bash
+memphis cron add \
+  --type shell \
+  --cron "0 9 * * 1" \
+  --name weekly-slo-report \
+  --script "node bin/memphis.js mcp memphis_slo_status windowDays=7 --json | tee -a ~/.memphis/slo-history.log"
+```
+
+Runs every Monday 9 AM, appends snapshot to `slo-history.log`. Compare across weeks to spot drift before it crosses thresholds.
+
+## Adding new SLOs
+
+1. New SLO contributors emit spans through `recordLocalSpan({ name, attrs, durationMs, status })` in `src/infra/observability/console-exporter.ts`.
+2. Add a compute function in `src/observability/slo-evaluator.ts` that reads those spans from the window and returns `SloResult`.
+3. Push the new function into the `slos` array in `evaluateSlos()`.
+4. Cover with a unit test in `tests/unit/slo-evaluator.test.ts`.
+5. Document the new SLO in this file (threshold, direction, why it matters, how to remediate).
+
+The tool surface (`memphis_slo_status`) does not need updating — it returns whatever `evaluateSlos()` produces.

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -46,6 +46,7 @@ import { runMemphisRestart } from '../mcp/tools/restart.js';
 import { runMemphisSearch } from '../mcp/tools/search.js';
 import { runMemphisSelfDescribe } from '../mcp/tools/self-describe.js';
 import { runMemphisSelfModify } from '../mcp/tools/self-modify.js';
+import { runMemphisSloStatus } from '../mcp/tools/slo-status.js';
 import { runMemphisSoulRead, runMemphisSoulWrite } from '../mcp/tools/soul.js';
 import { runMemphisSystemInfo } from '../mcp/tools/system-info.js';
 import { runMemphisTest } from '../mcp/tools/test-run.js';
@@ -283,6 +284,25 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       isReadOnly: true,
       execute() {
         return runMemphisHealth();
+      },
+    }),
+    buildTool({
+      name: 'memphis_slo_status',
+      description:
+        'Runtime SLO snapshot — reads telemetry spans over a time window (default 7 days) and reports each SLO as pass/fail/unavailable',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          windowDays: {
+            type: 'number',
+            description: 'Number of days to scan back (1-90, default 7)',
+          },
+        },
+      },
+      isConcurrencySafe: true,
+      isReadOnly: true,
+      execute(args: { windowDays?: number }) {
+        return runMemphisSloStatus({ windowDays: args.windowDays }, deps.rawEnv);
       },
     }),
     buildTool({

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -115,6 +115,19 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
       })
       .strict(),
   },
+  memphis_slo_status: {
+    name: 'memphis_slo_status',
+    tier: 0,
+    capabilities: ['read'],
+    description:
+      'Runtime SLO snapshot — reads telemetry spans over a time window (default 7 days) and reports each SLO as pass/fail/unavailable with computed value, threshold, and sample count. Use to answer "is the runtime healthy" or to gate alerts.',
+    inputSchema: z
+      .object({
+        windowDays: z.number().int().min(1).max(90).optional(),
+        approval_request_id: z.string().optional(),
+      })
+      .strict(),
+  },
   memphis_repair: {
     name: 'memphis_repair',
     tier: 0,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -41,6 +41,7 @@ import { runMemphisRestart } from './tools/restart.js';
 import { runMemphisSearch } from './tools/search.js';
 import { runMemphisSelfDescribe } from './tools/self-describe.js';
 import { runMemphisSelfModify } from './tools/self-modify.js';
+import { runMemphisSloStatus } from './tools/slo-status.js';
 import { runMemphisSoulRead, runMemphisSoulWrite } from './tools/soul.js';
 import { runMemphisSystemInfo } from './tools/system-info.js';
 import { runMemphisTest } from './tools/test-run.js';
@@ -402,6 +403,28 @@ export function createMemphisMcpServer(
           };
         },
       ),
+    );
+  }
+
+  const sloStatusPolicy = getToolPolicy(permissions, 'memphis_slo_status', resolvedManifest);
+  if (shouldRegisterTool('memphis_slo_status', sloStatusPolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_slo_status',
+      {
+        description:
+          'Runtime SLO snapshot — reads telemetry spans over a time window (default 7 days) and reports each SLO as pass/fail/unavailable with computed value, threshold, and sample count.',
+        inputSchema: {
+          windowDays: z.number().int().min(1).max(90).optional(),
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate('memphis_slo_status', sloStatusPolicy, approvals, async (args) => {
+        const result = runMemphisSloStatus({ windowDays: args.windowDays }, rawEnv);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          structuredContent: toJsonRecord(result),
+        };
+      }),
     );
   }
 

--- a/src/mcp/tools/slo-status.ts
+++ b/src/mcp/tools/slo-status.ts
@@ -1,0 +1,26 @@
+import { evaluateSlos, type SloReport } from '../../observability/slo-evaluator.js';
+
+export interface MemphisSloStatusInput {
+  windowDays?: number;
+}
+
+export type MemphisSloStatusOutput = SloReport & {
+  ok: boolean;
+  failingSlos: string[];
+};
+
+export function runMemphisSloStatus(
+  input: MemphisSloStatusInput = {},
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): MemphisSloStatusOutput {
+  const report = evaluateSlos({
+    windowDays: input.windowDays,
+    rawEnv,
+  });
+  const failingSlos = report.slos.filter((s) => s.status === 'fail').map((s) => s.name);
+  return {
+    ...report,
+    ok: failingSlos.length === 0,
+    failingSlos,
+  };
+}

--- a/src/observability/slo-evaluator.ts
+++ b/src/observability/slo-evaluator.ts
@@ -1,0 +1,224 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getDataDir } from '../config/paths.js';
+
+export type SloStatus = 'pass' | 'fail' | 'unavailable';
+
+export interface SloResult {
+  name: string;
+  description: string;
+  threshold: number;
+  thresholdUnit: string;
+  thresholdDirection: 'below' | 'above';
+  value: number | null;
+  status: SloStatus;
+  samples: number;
+  reason?: string;
+}
+
+export interface SloReport {
+  windowDays: number;
+  windowStart: string;
+  windowEnd: string;
+  spanFilesScanned: number;
+  totalSamples: number;
+  slos: SloResult[];
+}
+
+interface SpanRecord {
+  ts: string;
+  name: string;
+  attrs?: Record<string, unknown>;
+  durationMs?: number;
+  status?: 'ok' | 'error';
+}
+
+const SPANS_FILE_RE = /^spans-(\d{4}-\d{2}-\d{2})\.jsonl$/;
+
+function readSpansInWindow(
+  rawEnv: NodeJS.ProcessEnv,
+  windowStart: Date,
+): { spans: SpanRecord[]; filesScanned: number } {
+  const dir = join(getDataDir(rawEnv), 'telemetry');
+  if (!existsSync(dir)) return { spans: [], filesScanned: 0 };
+  let filesScanned = 0;
+  const spans: SpanRecord[] = [];
+  const startMs = windowStart.getTime();
+  for (const entry of readdirSync(dir)) {
+    if (!SPANS_FILE_RE.test(entry)) continue;
+    const fullPath = join(dir, entry);
+    if (!statSync(fullPath).isFile()) continue;
+    filesScanned += 1;
+    const content = readFileSync(fullPath, 'utf8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: SpanRecord;
+      try {
+        parsed = JSON.parse(trimmed) as SpanRecord;
+      } catch {
+        continue;
+      }
+      if (typeof parsed.ts !== 'string') continue;
+      const tsMs = Date.parse(parsed.ts);
+      if (Number.isNaN(tsMs) || tsMs < startMs) continue;
+      spans.push(parsed);
+    }
+  }
+  return { spans, filesScanned };
+}
+
+function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx] ?? null;
+}
+
+function computeP99TurnLatency(spans: SpanRecord[]): SloResult {
+  const turnSpans = spans.filter((s) => s.name === 'turn.dispatch');
+  const latencies: number[] = [];
+  for (const s of turnSpans) {
+    const fromAttr = s.attrs?.['turn.timing_ms'];
+    const fromDuration = s.durationMs;
+    const v =
+      typeof fromAttr === 'number' ? fromAttr : typeof fromDuration === 'number' ? fromDuration : null;
+    if (typeof v === 'number' && Number.isFinite(v) && v >= 0) latencies.push(v);
+  }
+  const p99 = percentile(latencies, 99);
+  const threshold = 3000;
+  const status: SloStatus =
+    p99 === null ? 'unavailable' : p99 <= threshold ? 'pass' : 'fail';
+  return {
+    name: 'p99_turn_latency_ms',
+    description: 'p99 of turn.dispatch latency over the window',
+    threshold,
+    thresholdUnit: 'ms',
+    thresholdDirection: 'below',
+    value: p99,
+    status,
+    samples: latencies.length,
+    reason: p99 === null ? 'no turn.dispatch spans with latency in window' : undefined,
+  };
+}
+
+function computeConfabulationRate(spans: SpanRecord[]): SloResult {
+  const turnCount = spans.filter((s) => s.name === 'turn.dispatch').length;
+  const confabCount = spans.filter((s) => s.name === 'confabulation.event').length;
+  const threshold = 0.001; // 0.1%
+  if (turnCount === 0) {
+    return {
+      name: 'confabulation_rate',
+      description: 'Ratio of confabulation.event to turn.dispatch over the window',
+      threshold,
+      thresholdUnit: 'ratio',
+      thresholdDirection: 'below',
+      value: null,
+      status: 'unavailable',
+      samples: 0,
+      reason: 'no turn.dispatch spans in window',
+    };
+  }
+  const rate = confabCount / turnCount;
+  return {
+    name: 'confabulation_rate',
+    description: 'Ratio of confabulation.event to turn.dispatch over the window',
+    threshold,
+    thresholdUnit: 'ratio',
+    thresholdDirection: 'below',
+    value: rate,
+    status: rate <= threshold ? 'pass' : 'fail',
+    samples: turnCount,
+  };
+}
+
+function computeProviderErrorRate(spans: SpanRecord[]): SloResult {
+  const providerSpans = spans.filter((s) => s.name === 'provider.completion');
+  const errorSpans = providerSpans.filter((s) => s.status === 'error');
+  const threshold = 0.01; // 1%
+  if (providerSpans.length === 0) {
+    return {
+      name: 'provider_error_rate',
+      description: 'Ratio of provider.completion spans with status=error',
+      threshold,
+      thresholdUnit: 'ratio',
+      thresholdDirection: 'below',
+      value: null,
+      status: 'unavailable',
+      samples: 0,
+      reason: 'no provider.completion spans in window',
+    };
+  }
+  const rate = errorSpans.length / providerSpans.length;
+  return {
+    name: 'provider_error_rate',
+    description: 'Ratio of provider.completion spans with status=error',
+    threshold,
+    thresholdUnit: 'ratio',
+    thresholdDirection: 'below',
+    value: rate,
+    status: rate <= threshold ? 'pass' : 'fail',
+    samples: providerSpans.length,
+  };
+}
+
+function computeToolErrorRate(spans: SpanRecord[]): SloResult {
+  const toolSpans = spans.filter((s) => s.name === 'tool.call');
+  const errorSpans = toolSpans.filter((s) => s.status === 'error');
+  const threshold = 0.05; // 5%
+  if (toolSpans.length === 0) {
+    return {
+      name: 'tool_error_rate',
+      description: 'Ratio of tool.call spans with status=error',
+      threshold,
+      thresholdUnit: 'ratio',
+      thresholdDirection: 'below',
+      value: null,
+      status: 'unavailable',
+      samples: 0,
+      reason: 'no tool.call spans in window',
+    };
+  }
+  const rate = errorSpans.length / toolSpans.length;
+  return {
+    name: 'tool_error_rate',
+    description: 'Ratio of tool.call spans with status=error',
+    threshold,
+    thresholdUnit: 'ratio',
+    thresholdDirection: 'below',
+    value: rate,
+    status: rate <= threshold ? 'pass' : 'fail',
+    samples: toolSpans.length,
+  };
+}
+
+export interface EvaluateSlosOptions {
+  windowDays?: number;
+  rawEnv?: NodeJS.ProcessEnv;
+  now?: Date;
+}
+
+export function evaluateSlos(options: EvaluateSlosOptions = {}): SloReport {
+  const rawEnv = options.rawEnv ?? process.env;
+  const now = options.now ?? new Date();
+  const windowDays = Math.max(1, Math.floor(options.windowDays ?? 7));
+  const windowStart = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+
+  const { spans, filesScanned } = readSpansInWindow(rawEnv, windowStart);
+  const slos: SloResult[] = [
+    computeP99TurnLatency(spans),
+    computeConfabulationRate(spans),
+    computeProviderErrorRate(spans),
+    computeToolErrorRate(spans),
+  ];
+
+  return {
+    windowDays,
+    windowStart: windowStart.toISOString(),
+    windowEnd: now.toISOString(),
+    spanFilesScanned: filesScanned,
+    totalSamples: spans.length,
+    slos,
+  };
+}

--- a/tests/unit/slo-evaluator.test.ts
+++ b/tests/unit/slo-evaluator.test.ts
@@ -1,0 +1,173 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { evaluateSlos } from '../../src/observability/slo-evaluator.js';
+
+interface SpanLine {
+  ts: string;
+  name: string;
+  attrs?: Record<string, unknown>;
+  durationMs?: number;
+  status?: 'ok' | 'error';
+}
+
+function writeSpans(dir: string, dateStamp: string, spans: SpanLine[]): void {
+  const filePath = join(dir, `spans-${dateStamp}.jsonl`);
+  writeFileSync(filePath, spans.map((s) => JSON.stringify(s)).join('\n') + '\n', 'utf8');
+}
+
+describe('evaluateSlos', () => {
+  let dataDir: string;
+  let telemetryDir: string;
+  let prevDataDir: string | undefined;
+  const fixedNow = new Date('2026-04-29T12:00:00Z');
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'memphis-slo-test-'));
+    telemetryDir = join(dataDir, 'telemetry');
+    mkdirSync(telemetryDir, { recursive: true });
+    prevDataDir = process.env.MEMPHIS_DATA_DIR;
+    process.env.MEMPHIS_DATA_DIR = dataDir;
+  });
+
+  afterEach(() => {
+    if (prevDataDir !== undefined) process.env.MEMPHIS_DATA_DIR = prevDataDir;
+    else delete process.env.MEMPHIS_DATA_DIR;
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('reports unavailable for every SLO when telemetry dir is empty', () => {
+    const report = evaluateSlos({ now: fixedNow });
+    expect(report.totalSamples).toBe(0);
+    expect(report.spanFilesScanned).toBe(0);
+    for (const slo of report.slos) {
+      expect(slo.status).toBe('unavailable');
+      expect(slo.value).toBeNull();
+    }
+  });
+
+  it('computes p99 turn latency from turn.dispatch spans (high p99 → fail)', () => {
+    const today = '2026-04-29';
+    const spans: SpanLine[] = [];
+    // 50 fast + 50 slow → nearest-rank p99 lands in the slow half
+    for (let i = 0; i < 50; i++) {
+      spans.push({
+        ts: '2026-04-29T10:00:00Z',
+        name: 'turn.dispatch',
+        attrs: { 'turn.timing_ms': 500 },
+        durationMs: 500,
+        status: 'ok',
+      });
+    }
+    for (let i = 0; i < 50; i++) {
+      spans.push({
+        ts: '2026-04-29T10:00:01Z',
+        name: 'turn.dispatch',
+        attrs: { 'turn.timing_ms': 9999 },
+        durationMs: 9999,
+        status: 'ok',
+      });
+    }
+    writeSpans(telemetryDir, today, spans);
+
+    const report = evaluateSlos({ now: fixedNow });
+    const p99 = report.slos.find((s) => s.name === 'p99_turn_latency_ms');
+    expect(p99).toBeDefined();
+    expect(p99?.samples).toBe(100);
+    expect(p99?.value).toBe(9999);
+    expect(p99?.status).toBe('fail');
+  });
+
+  it('computes confabulation rate as ratio to turn.dispatch', () => {
+    const today = '2026-04-29';
+    const spans: SpanLine[] = [];
+    for (let i = 0; i < 1000; i++) {
+      spans.push({
+        ts: '2026-04-29T10:00:00Z',
+        name: 'turn.dispatch',
+        attrs: {},
+        durationMs: 500,
+        status: 'ok',
+      });
+    }
+    spans.push({
+      ts: '2026-04-29T10:00:00Z',
+      name: 'confabulation.event',
+      attrs: { 'confabulation.rule': 'a' },
+      status: 'ok',
+    });
+    writeSpans(telemetryDir, today, spans);
+
+    const report = evaluateSlos({ now: fixedNow });
+    const confab = report.slos.find((s) => s.name === 'confabulation_rate');
+    expect(confab?.value).toBe(1 / 1000);
+    expect(confab?.status).toBe('pass');
+  });
+
+  it('skips spans outside the window', () => {
+    writeSpans(telemetryDir, '2026-01-01', [
+      {
+        ts: '2026-01-01T10:00:00Z',
+        name: 'turn.dispatch',
+        durationMs: 99999,
+        status: 'ok',
+      },
+    ]);
+    writeSpans(telemetryDir, '2026-04-28', [
+      {
+        ts: '2026-04-28T10:00:00Z',
+        name: 'turn.dispatch',
+        attrs: { 'turn.timing_ms': 500 },
+        durationMs: 500,
+        status: 'ok',
+      },
+    ]);
+
+    const report = evaluateSlos({ now: fixedNow, windowDays: 7 });
+    const p99 = report.slos.find((s) => s.name === 'p99_turn_latency_ms');
+    expect(p99?.samples).toBe(1);
+    expect(p99?.value).toBe(500);
+    expect(p99?.status).toBe('pass');
+  });
+
+  it('reports failingSlos via the wrapped tool', () => {
+    const today = '2026-04-29';
+    const spans: SpanLine[] = [];
+    for (let i = 0; i < 100; i++) {
+      spans.push({
+        ts: '2026-04-29T10:00:00Z',
+        name: 'turn.dispatch',
+        durationMs: 5000,
+        status: 'ok',
+      });
+    }
+    writeSpans(telemetryDir, today, spans);
+
+    const report = evaluateSlos({ now: fixedNow });
+    const p99 = report.slos.find((s) => s.name === 'p99_turn_latency_ms');
+    expect(p99?.status).toBe('fail');
+    expect(p99?.value).toBe(5000);
+  });
+
+  it('returns empty samples and unavailable when window has no spans', () => {
+    writeSpans(telemetryDir, '2026-04-29', [
+      {
+        ts: '2026-04-29T10:00:00Z',
+        name: 'tool.call',
+        durationMs: 100,
+        status: 'ok',
+      },
+    ]);
+
+    const report = evaluateSlos({ now: fixedNow });
+    const confab = report.slos.find((s) => s.name === 'confabulation_rate');
+    expect(confab?.status).toBe('unavailable');
+    expect(confab?.reason).toContain('no turn.dispatch');
+    const tool = report.slos.find((s) => s.name === 'tool_error_rate');
+    expect(tool?.status).toBe('pass');
+    expect(tool?.value).toBe(0);
+  });
+});

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -15,7 +15,8 @@ describe('tool registry', () => {
     // Codex Round 5 P1 fix (#107): added 2 tier-2 mutating tools to
     // TOOL_REGISTRY (memphis_config_set, memphis_cognitive_mode_set).
     // S3 (sprint 2026-04-26): added memphis_self_describe (tier 0, read).
-    expect(getToolNames()).toHaveLength(35);
+    // Track C3 (2026-04-29): added memphis_slo_status (tier 0, read).
+    expect(getToolNames()).toHaveLength(36);
   });
 
   it('hides experimental preview tools by default', () => {
@@ -72,8 +73,9 @@ describe('tool registry', () => {
 
   it('getToolsByTier returns correct tools', () => {
     const tier0 = getToolsByTier(0);
-    // 14 = 13 base tier-0 + memphis_self_describe (S3, sprint 2026-04-26)
-    expect(tier0.length).toBe(14);
+    // 15 = 13 base tier-0 + memphis_self_describe (S3, sprint 2026-04-26)
+    //      + memphis_slo_status (Track C3, 2026-04-29)
+    expect(tier0.length).toBe(15);
     expect(tier0.every((t) => t.tier === 0)).toBe(true);
 
     const tier1 = getToolsByTier(1);


### PR DESCRIPTION
## Summary

New tool **\`memphis_slo_status\`** (tier 0, capability=read) reads telemetry spans from \`<dataDir>/telemetry/spans-*.jsonl\` over a configurable window (default 7 days) and computes a fixed set of operator-facing SLOs.

Bumps registered tool count from 35 to 36.

## SLOs implemented

| Name | Threshold | Direction | Reads |
|---|---|---|---|
| p99_turn_latency_ms | 3000 ms | below | turn.dispatch latency |
| confabulation_rate | 0.001 | below | confabulation.event / turn.dispatch |
| provider_error_rate | 0.01 | below | provider.completion status=error ratio |
| tool_error_rate | 0.05 | below | tool.call status=error ratio |

Each returns pass/fail/unavailable with computed value, threshold, sample count.

## Files

- \`src/observability/slo-evaluator.ts\` (NEW) — pure compute
- \`src/mcp/tools/slo-status.ts\` (NEW) — tool wrapper, derives \`ok\` + \`failingSlos\`
- \`src/gateway/tool-registry.ts\` — entry added
- \`src/mcp/server.ts\` — MCP registration
- \`src/gateway/tool-executor.ts\` — in-process executor
- \`tests/unit/slo-evaluator.test.ts\` (NEW) — 6 cases
- \`tests/unit/tool-registry.test.ts\` — counts bumped 35→36, tier-0 14→15
- \`docs/operator/SLO.md\` (NEW) — operator runbook + recommended weekly cron + contributor guide for adding SLOs

## Test plan

- [x] Typecheck: green
- [x] Lint: green
- [x] \`tests/unit/slo-evaluator.test.ts\` — 6/6 pass
- [x] \`tests/unit/tool-registry.test.ts\` — 12/12 pass with bumped counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)