### PR TITLE
fix(ollama): expose OLLAMA_KEEP_ALIVE so the model stays warm

### DIFF
--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -85,6 +85,12 @@ export const envSchema = z.object({
   OLLAMA_REPEAT_PENALTY: z.coerce.number().min(0.5).max(5).optional(),
   OLLAMA_NUM_PREDICT_OFFLINE: z.coerce.number().int().min(64).max(32768).optional(),
   OLLAMA_REQUEST_TIMEOUT_MS: z.coerce.number().int().min(1000).max(3_600_000).optional(),
+  // Ollama keep-alive duration: how long the model stays loaded in RAM
+  // after a request. Accepts Ollama duration syntax (e.g. "5m", "24h",
+  // "0" to unload immediately). Default Ollama behaviour (env unset) is
+  // 5 minutes — the first message after idle pays a cold-load tax. Set
+  // to "24h" on a daily-use box to keep the model warm.
+  OLLAMA_KEEP_ALIVE: z.string().optional(),
   MINIMAX_API_KEY: z.string().optional(),
   MINIMAX_MODEL: z.string().optional(),
   MINIMAX_BASE_URL: z.string().optional(),

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -210,6 +210,17 @@ export class OllamaProvider implements Provider {
       options: optionsBody,
     };
 
+    // OLLAMA_KEEP_ALIVE controls how long Ollama keeps the model loaded in
+    // memory after this request. Default Ollama behaviour unloads after 5
+    // minutes idle, so the operator's first message after a coffee break
+    // pays a 30-60s cold-load tax — and on slower machines the cold load
+    // can exceed the request timeout entirely. Operator sets a longer
+    // window (e.g. "24h") to keep the model warm. "0" unloads immediately.
+    const keepAlive = this.rawEnv.OLLAMA_KEEP_ALIVE?.trim();
+    if (keepAlive) {
+      body.keep_alive = keepAlive;
+    }
+
     if (ollamaTools?.length) {
       body.tools = ollamaTools;
     }


### PR DESCRIPTION
## Symptom

Operator opens TUI after a break, sends a message via Ollama provider, gets:
\`\`\`
provider request failed: ... timed out reading response
\`\`\`

## Cause

Ollama unloads models from RAM after 5 minutes idle (default). Memphis didn't forward \`keep_alive\` in the request body, so it always inherited Ollama's 5-minute window. First message after idle = cold load (~30-60s on a CPU box) which often exceeded the request timeout.

## Fix

\`OllamaProvider.chat()\` now forwards \`OLLAMA_KEEP_ALIVE\` env into the request body when set. Ollama duration syntax: \`"5m"\` (default), \`"24h"\` (daily-use box), \`"0"\` (unload immediately). Empty/unset env preserves prior behaviour.

\`OLLAMA_KEEP_ALIVE\` added to envSchema with operator-facing comment.

## Operator action after merge

```
echo 'OLLAMA_KEEP_ALIVE=24h' >> .env
memphis service restart   # or just reopen TUI/Telegram
```

## Test plan

- [x] Typecheck: green
- [x] Lint: green
- Manual operator test (after merge): set \`OLLAMA_KEEP_ALIVE=24h\`, send message, then \`ollama ps\` — \`UNTIL\` column should show ~24h instead of ~5m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)