### PR TITLE
fix(vault): detect path split + meaningful local-fallback output

### DIFF
--- a/crates/memphis-operator/src/chat.rs
+++ b/crates/memphis-operator/src/chat.rs
@@ -3494,7 +3494,7 @@ mod tests {
         let exchange = runtime
             .chat(None, "hello rust memphis", None, None)
             .expect("chat exchange");
-        assert!(exchange.reply.contains("Fallback response"));
+        assert!(exchange.reply.contains("[local-fallback]"));
         assert_eq!(exchange.provider, "local-fallback");
 
         let session = runtime.chat_session(None, 10).expect("chat session");
@@ -3502,7 +3502,7 @@ mod tests {
         assert_eq!(session.messages[0].role, "user");
         assert_eq!(session.messages[0].content, "hello rust memphis");
         assert_eq!(session.messages[1].role, "assistant");
-        assert!(session.messages[1].content.contains("Fallback response"));
+        assert!(session.messages[1].content.contains("[local-fallback]"));
     }
 
     #[test]

--- a/crates/memphis-operator/src/provider.rs
+++ b/crates/memphis-operator/src/provider.rs
@@ -361,15 +361,17 @@ impl ProviderRuntime {
             ProviderKind::LocalFallback => {
                 ensure_not_cancelled(cancel_flag)?;
                 let input = build_generate_input_from_chat(messages, opts, tools);
-                let content = format!("Fallback response: {input}");
+                // Local-fallback is the always-respond provider for when no
+                // LLM is reachable. Echoing the full prompt back was debug
+                // noise (made operator wait through 14KB of soul context
+                // streamed at 50ms/word). Now: short, honest acknowledgement
+                // that the runtime is alive but no real LLM is wired.
+                let content = "[local-fallback] No LLM configured — runtime is alive but cannot answer substantively. Configure a provider (memphis vault add --key <provider>_api_key) and re-select with /provider <name>.".to_string();
                 let token_usage = estimated_text_usage(input.as_str(), content.as_str());
                 on_event(ChatStreamEvent::Usage(token_usage.clone()));
-                emit_text_chunks(
-                    content.as_str(),
-                    cancel_flag,
-                    Some(Duration::from_millis(50)),
-                    &mut on_event,
-                )?;
+                // No artificial delay — local-fallback has no real LLM
+                // latency to simulate; instant emit is the right UX.
+                emit_text_chunks(content.as_str(), cancel_flag, None, &mut on_event)?;
                 Ok(ChatCompletion {
                     content,
                     model: model.to_string(),

--- a/crates/memphis-operator/src/runtime.rs
+++ b/crates/memphis-operator/src/runtime.rs
@@ -1066,6 +1066,22 @@ fn read_vault_state_version(path: &Path) -> Option<u8> {
 
 fn load_vault(config: &OperatorConfig, optional: bool) -> Result<Option<Vault>, OperatorError> {
     if optional && !config.vault_state_path.exists() {
+        // Silent-split detection: if the entries file exists at a different
+        // path than the missing state file, the operator probably set
+        // MEMPHIS_VAULT_ENTRIES_PATH but not MEMPHIS_VAULT_STATE_PATH (or
+        // vice versa) — the runtime then cannot decrypt the entries even
+        // though `vault list` (TS path) reads them fine. Surface a loud
+        // diagnostic instead of silently returning None.
+        if config.vault_entries_path.exists() {
+            return Err(OperatorError::Vault(format!(
+                "vault path split: entries exist at {} but state is missing at {}. \
+                 Set MEMPHIS_VAULT_STATE_PATH to match the entries directory, or copy \
+                 the state file from ~/.memphis/vault-state.json (or wherever it lives) \
+                 so both files resolve to the same vault.",
+                config.vault_entries_path.display(),
+                config.vault_state_path.display(),
+            )));
+        }
         return Ok(None);
     }
 


### PR DESCRIPTION
## Summary

Two related TUI bugs observed in operator session today.

## Bug 1: silent vault path split

Operator's \`.env\` had \`MEMPHIS_VAULT_ENTRIES_PATH=./data/vault-entries.json\` but **no** \`MEMPHIS_VAULT_STATE_PATH\`. Rust default for state is \`./data/vault-state.json\`. The actual state file lived at \`~/.memphis/vault-state.json\` (TS code uses a different default).

Result: \`memphis vault list\` (TS path) showed all entries with \`integrityOk: true\`, but every chat turn returned \`vault entry could not be read\` because the Rust runtime found entries but couldn't load the missing state file. Two loaders silently disagreed on where the vault lived.

**Fix**: \`load_vault\` (Rust) now detects the split — if entries file exists but state file doesn't, returns a loud \`OperatorError\` naming both paths and the actionable fix. Operator gets an immediately useful error instead of "vault entry could not be read" 5 turns in a row.

## Bug 2: useless local-fallback streaming

Local-fallback echoed the full prompt back (\`Fallback response: <14KB soul context>\`) and streamed it at 50ms-per-word. Operator selecting local-fallback (or hitting it via cascade from PR #349) waited ~100s for an echo that wasn't useful.

**Fix**: short honest message — \`[local-fallback] No LLM configured — runtime is alive but cannot answer substantively. Configure a provider...\`. Instant emit, no artificial delay.

## Operator immediate action (separate from this PR)

If you hit "vault entry could not be read" in TUI today, run:
\`\`\`bash
cp ~/.memphis/vault-state.json /home/memphis/memphis/data/vault-state.json
chmod 600 /home/memphis/memphis/data/vault-state.json
\`\`\`

After this PR merges + rebuild, the diagnostic above will surface automatically next time the split happens.

## Test plan

- [x] \`cargo test -p memphis-operator\` — 61/61 pass (test assertion updated for new local-fallback message)
- [x] \`cargo check -p memphis-operator\` — green
- [x] \`npm run build\` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)