### PR TITLE
fix(vault): auto-resolve missing state path from sibling/legacy fallbacks

### DIFF
--- a/crates/memphis-operator/src/runtime.rs
+++ b/crates/memphis-operator/src/runtime.rs
@@ -1064,8 +1064,47 @@ fn read_vault_state_version(path: &Path) -> Option<u8> {
         .or(Some(1))
 }
 
+/// Auto-resolve the vault-state path with fallbacks. The configured path
+/// (from MEMPHIS_VAULT_STATE_PATH or default ./data/vault-state.json) wins
+/// when it exists. Otherwise, before failing, look in two well-known places:
+///   1. the directory containing vault_entries_path (operator probably moved
+///      entries via env override and the state moved with them)
+///   2. ~/.memphis/vault-state.json (the legacy / TS-side default)
+/// Returns the configured path unchanged if neither fallback exists, so the
+/// caller can produce the existing operator-actionable error message.
+fn resolve_vault_state_path(config: &OperatorConfig) -> std::path::PathBuf {
+    if config.vault_state_path.exists() {
+        return config.vault_state_path.clone();
+    }
+    if let Some(parent) = config.vault_entries_path.parent() {
+        let sibling = parent.join("vault-state.json");
+        if sibling.exists() {
+            eprintln!(
+                "[memphis-vault] using sibling vault-state at {} (configured path {} does not exist)",
+                sibling.display(),
+                config.vault_state_path.display(),
+            );
+            return sibling;
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let legacy = std::path::PathBuf::from(home)
+            .join(".memphis")
+            .join("vault-state.json");
+        if legacy.exists() {
+            eprintln!(
+                "[memphis-vault] using legacy ~/.memphis/vault-state.json (configured path {} does not exist); set MEMPHIS_VAULT_STATE_PATH to silence this notice",
+                config.vault_state_path.display(),
+            );
+            return legacy;
+        }
+    }
+    config.vault_state_path.clone()
+}
+
 fn load_vault(config: &OperatorConfig, optional: bool) -> Result<Option<Vault>, OperatorError> {
-    if optional && !config.vault_state_path.exists() {
+    let state_path = resolve_vault_state_path(config);
+    if optional && !state_path.exists() {
         // Silent-split detection: if the entries file exists at a different
         // path than the missing state file, the operator probably set
         // MEMPHIS_VAULT_ENTRIES_PATH but not MEMPHIS_VAULT_STATE_PATH (or
@@ -1074,10 +1113,9 @@ fn load_vault(config: &OperatorConfig, optional: bool) -> Result<Option<Vault>, 
         // diagnostic instead of silently returning None.
         if config.vault_entries_path.exists() {
             return Err(OperatorError::Vault(format!(
-                "vault path split: entries exist at {} but state is missing at {}. \
-                 Set MEMPHIS_VAULT_STATE_PATH to match the entries directory, or copy \
-                 the state file from ~/.memphis/vault-state.json (or wherever it lives) \
-                 so both files resolve to the same vault.",
+                "vault path split: entries exist at {} but state is missing at {} \
+                 (and no fallback found at ~/.memphis/vault-state.json or beside the \
+                 entries file). Set MEMPHIS_VAULT_STATE_PATH explicitly.",
                 config.vault_entries_path.display(),
                 config.vault_state_path.display(),
             )));
@@ -1085,7 +1123,7 @@ fn load_vault(config: &OperatorConfig, optional: bool) -> Result<Option<Vault>, 
         return Ok(None);
     }
 
-    let state = load_vault_state(&config.vault_state_path)?;
+    let state = load_vault_state(&state_path)?;
     let vault = match state {
         VaultState::V1 { salt, master_key } => Vault::from_parts(salt, master_key),
         VaultState::V2 {


### PR DESCRIPTION
## Summary

PR #350 surfaced the vault path split as a loud error (entries here, state missing there). This PR makes it self-healing — Memphis now finds the state file automatically when it's in a sensible nearby location.

## Resolution order

1. \`config.vault_state_path\` if it exists — unchanged.
2. \`<dir of vault_entries_path>/vault-state.json\` — operator moved entries via env, state moved with them just into the same dir.
3. \`~/.memphis/vault-state.json\` — legacy / TS-side default; this is where most splits actually have the state.
4. Otherwise: existing loud error from PR #350.

When fallback #2 or #3 resolves, log a one-line stderr notice naming the chosen path and instructing the operator to set \`MEMPHIS_VAULT_STATE_PATH\` explicitly to silence.

## Test plan

- [x] \`cargo test -p memphis-operator\` — 61/61 pass
- [x] \`npm run build\` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)