### PR TITLE
fix(ci): mark cross-arch matrix informational (continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,16 @@ jobs:
   # Cross-arch matrix runs on push to main only — catches regressions that
   # only fire on arm64 or macOS hardware before someone hits them in dev.
   # Uses GitHub-hosted free runners (ubuntu-24.04-arm + macos-latest M-chip).
+  #
+  # `continue-on-error: true` — Memphis was Linux-only by accident until this
+  # matrix landed; the first push surfaced real macOS path/vault/napi lock
+  # issues. Fixing them is its own sprint. Matrix stays informational so it
+  # signals regressions without blocking merges. See `project_macos_compat_pending`
+  # memory + GitHub issue for the macOS work.
   cross-arch:
     if: github.event_name == 'push'
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

PR #347 added cross-arch CI matrix and immediately surfaced ~7 real macOS test failures (apps file-backed actions, vault env/file bindings, install root resolution, napi chain append lock). Memphis has been Linux-only by accident; fixing macOS is its own sprint.

This PR keeps the matrix as a **regression signal** (continue-on-error: true) so it doesn't block future merges while the macOS work is pending.

## Memory captured

\`project_macos_compat_pending\` — failure list + suspected root causes (tmpdir hardcoded paths, fcntl-vs-cross-platform fs2 lock, vault binding semantics, pattern parser path) — ready for the macOS sprint to consume.

## Test plan

- [x] No code change beyond \`.github/workflows/ci.yml\`
- Future merges no longer blocked by macOS test failures from cross-arch matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)