### PR TITLE
fix(ollama): default keep_alive to 24h (drop opt-in requirement)

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -212,14 +212,12 @@ export class OllamaProvider implements Provider {
 
     // OLLAMA_KEEP_ALIVE controls how long Ollama keeps the model loaded in
     // memory after this request. Default Ollama behaviour unloads after 5
-    // minutes idle, so the operator's first message after a coffee break
-    // pays a 30-60s cold-load tax — and on slower machines the cold load
-    // can exceed the request timeout entirely. Operator sets a longer
-    // window (e.g. "24h") to keep the model warm. "0" unloads immediately.
-    const keepAlive = this.rawEnv.OLLAMA_KEEP_ALIVE?.trim();
-    if (keepAlive) {
-      body.keep_alive = keepAlive;
-    }
+    // minutes idle, so the first message after a coffee break pays a
+    // 30-60s cold-load tax. Memphis defaults to "24h" so the model stays
+    // warm without operator intervention; operator can override (e.g. "0"
+    // to unload immediately, "5m" for stock Ollama behaviour).
+    const keepAlive = this.rawEnv.OLLAMA_KEEP_ALIVE?.trim() || '24h';
+    body.keep_alive = keepAlive;
 
     if (ollamaTools?.length) {
       body.tools = ollamaTools;


### PR DESCRIPTION
## Summary

PR #348 added \`OLLAMA_KEEP_ALIVE\` as opt-in env. Operator pushed back: Memphis should not require the operator to know Ollama's 5-minute default unload exists, let alone tune around it. Now Memphis defaults to \`24h\` so the model stays warm out-of-box.

## Why default 24h instead of explicit-only

- Memphis is a runtime built for solo-founder daily use, not a generic LLM proxy.
- Cold-load tax (30-60s on slower CPUs) blocks the very first message after a break — the operator opens TUI, sends "yo", waits, gets timeout. That's a product fail.
- "24h" is enough that the model stays warm across normal-day idle periods.
- Operators who prefer stock Ollama (5m) or instant unload (0) just set \`OLLAMA_KEEP_ALIVE\` — the override path stays.

## Test plan

- [x] Typecheck: green
- Lint: green (auto on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)