### PR TITLE
refactor(sprint-2/b1): consolidate bool parsers into core/env.parseBool

### DIFF
--- a/src/cognitive/config-loader.ts
+++ b/src/cognitive/config-loader.ts
@@ -13,19 +13,11 @@ import type {
   ModelDConfig,
   ModelEConfig,
 } from './types.js';
+import { parseBool } from '../core/env.js';
+
 
 type CaptureLevel = 'minimal' | 'normal' | 'verbose';
 type ReflectionSchedule = 'daily' | 'weekly' | 'both';
-
-/**
- * Parses a string value to boolean.
- * Returns null if the value is not 'true' or 'false'.
- */
-function parseBool(value: string | undefined): boolean | null {
-  if (value === 'true') return true;
-  if (value === 'false') return false;
-  return null;
-}
 
 /**
  * Default configuration for Model A (Conscious Capture)
@@ -94,19 +86,25 @@ const DEFAULT_MODEL_E: ModelEConfig = {
 export function loadCognitiveConfig(env: NodeJS.ProcessEnv = process.env): CognitiveEngineConfig {
   // Model A config
   const modelA: ModelAConfig = {
-    autoCapture: parseBool(env.COGNITIVE_MODEL_A_AUTO_CAPTURE) ?? DEFAULT_MODEL_A.autoCapture,
+    autoCapture: parseBool(env.COGNITIVE_MODEL_A_AUTO_CAPTURE, DEFAULT_MODEL_A.autoCapture),
     captureLevel:
       (env.COGNITIVE_MODEL_A_CAPTURE_LEVEL as CaptureLevel) ?? DEFAULT_MODEL_A.captureLevel,
-    requireConfirmation:
-      parseBool(env.COGNITIVE_MODEL_A_REQUIRE_CONFIRMATION) ?? DEFAULT_MODEL_A.requireConfirmation,
+    requireConfirmation: parseBool(
+      env.COGNITIVE_MODEL_A_REQUIRE_CONFIRMATION,
+      DEFAULT_MODEL_A.requireConfirmation,
+    ),
   };
 
   // Model B config
   const modelB: ModelBConfig = {
-    gitWatchEnabled:
-      parseBool(env.COGNITIVE_MODEL_B_GIT_WATCH_ENABLED) ?? DEFAULT_MODEL_B.gitWatchEnabled,
-    fileWatchEnabled:
-      parseBool(env.COGNITIVE_MODEL_B_FILE_WATCH_ENABLED) ?? DEFAULT_MODEL_B.fileWatchEnabled,
+    gitWatchEnabled: parseBool(
+      env.COGNITIVE_MODEL_B_GIT_WATCH_ENABLED,
+      DEFAULT_MODEL_B.gitWatchEnabled,
+    ),
+    fileWatchEnabled: parseBool(
+      env.COGNITIVE_MODEL_B_FILE_WATCH_ENABLED,
+      DEFAULT_MODEL_B.fileWatchEnabled,
+    ),
     repoPath: env.COGNITIVE_MODEL_B_REPO_PATH ?? DEFAULT_MODEL_B.repoPath,
     sinceDays: env.COGNITIVE_MODEL_B_SINCE_DAYS
       ? Number(env.COGNITIVE_MODEL_B_SINCE_DAYS)
@@ -122,7 +120,10 @@ export function loadCognitiveConfig(env: NodeJS.ProcessEnv = process.env): Cogni
       ? Number(env.COGNITIVE_MODEL_B_CONFIDENCE_THRESHOLD)
       : DEFAULT_MODEL_B.confidenceThreshold,
     minConfidence: DEFAULT_MODEL_B.minConfidence,
-    includeMerges: parseBool(env.COGNITIVE_MODEL_B_INCLUDE_MERGES) ?? DEFAULT_MODEL_B.includeMerges,
+    includeMerges: parseBool(
+      env.COGNITIVE_MODEL_B_INCLUDE_MERGES,
+      DEFAULT_MODEL_B.includeMerges,
+    ),
   };
 
   // Model C config
@@ -164,11 +165,14 @@ export function loadCognitiveConfig(env: NodeJS.ProcessEnv = process.env): Cogni
     deepAnalysisDay: env.COGNITIVE_MODEL_E_DEEP_ANALYSIS_DAY
       ? Number(env.COGNITIVE_MODEL_E_DEEP_ANALYSIS_DAY)
       : DEFAULT_MODEL_E.deepAnalysisDay,
-    contradictionDetection:
-      parseBool(env.COGNITIVE_MODEL_E_CONTRADICTION_DETECTION) ??
+    contradictionDetection: parseBool(
+      env.COGNITIVE_MODEL_E_CONTRADICTION_DETECTION,
       DEFAULT_MODEL_E.contradictionDetection,
-    blindSpotAnalysis:
-      parseBool(env.COGNITIVE_MODEL_E_BLIND_SPOT_ANALYSIS) ?? DEFAULT_MODEL_E.blindSpotAnalysis,
+    ),
+    blindSpotAnalysis: parseBool(
+      env.COGNITIVE_MODEL_E_BLIND_SPOT_ANALYSIS,
+      DEFAULT_MODEL_E.blindSpotAnalysis,
+    ),
   };
 
   return {

--- a/src/gateway/exec-policy.ts
+++ b/src/gateway/exec-policy.ts
@@ -1,3 +1,4 @@
+import { parseBool } from '../core/env.js';
 import { AppError } from '../core/errors.js';
 import { secureCompare } from '../security/constant-time.js';
 
@@ -271,7 +272,7 @@ const DEFAULT_COMMAND_RULES: Record<string, CommandRule> = {
 
 export function loadGatewayExecPolicy(rawEnv: NodeJS.ProcessEnv = process.env): GatewayExecPolicy {
   const isFullAutonomy = (rawEnv.MEMPHIS_AUTONOMY_MODE ?? '').toLowerCase() === 'full';
-  const restrictedMode = isFullAutonomy ? false : toBool(rawEnv.GATEWAY_EXEC_RESTRICTED_MODE, true);
+  const restrictedMode = isFullAutonomy ? false : parseBool(rawEnv.GATEWAY_EXEC_RESTRICTED_MODE, true);
 
   const allowlist = new Map<string, CommandRule>();
   const allowlistNames = splitCsv(
@@ -417,7 +418,3 @@ function splitCsv(value: string | undefined, fallback: string[]): string[] {
     .filter(Boolean);
 }
 
-function toBool(value: string | undefined, fallback: boolean): boolean {
-  if (value == null) return fallback;
-  return value.toLowerCase() === 'true';
-}

--- a/src/gateway/surface-policy.ts
+++ b/src/gateway/surface-policy.ts
@@ -1,4 +1,6 @@
 import { getToolMeta, type ToolTier } from './tool-registry.js';
+import { parseBool } from '../core/env.js';
+
 
 export type SurfaceClass = 'operator' | 'chat' | 'service';
 
@@ -156,14 +158,6 @@ function surfaceEnvPrefix(surface: string): string {
   return `MEMPHIS_SURFACE_${slug}_`;
 }
 
-function parseBooleanEnv(value: string | undefined, fallback: boolean): boolean {
-  const normalized = value?.trim().toLowerCase();
-  if (!normalized) return fallback;
-  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-  return fallback;
-}
-
 function parseToolTierEnv(value: string | undefined, fallback: ToolTier): ToolTier {
   const normalized = value?.trim();
   if (normalized === '0' || normalized === '1' || normalized === '2' || normalized === '3') {
@@ -191,24 +185,24 @@ export function resolveSurfacePolicy(
     surface: normalizedSurface,
     surfaceClass,
     maxToolTier: parseToolTierEnv(rawEnv[`${prefix}MAX_TOOL_TIER`], defaults.maxToolTier),
-    allowUnknownTools: parseBooleanEnv(
+    allowUnknownTools: parseBool(
       rawEnv[`${prefix}ALLOW_UNKNOWN_TOOLS`],
       defaults.allowUnknownTools,
     ),
-    allowUrlFetch: parseBooleanEnv(rawEnv[`${prefix}ALLOW_URL_FETCH`], defaults.allowUrlFetch),
-    allowCognitivePrelude: parseBooleanEnv(
+    allowUrlFetch: parseBool(rawEnv[`${prefix}ALLOW_URL_FETCH`], defaults.allowUrlFetch),
+    allowCognitivePrelude: parseBool(
       rawEnv[`${prefix}ALLOW_COGNITIVE_PRELUDE`],
       defaults.allowCognitivePrelude,
     ),
-    allowMemoryRecall: parseBooleanEnv(
+    allowMemoryRecall: parseBool(
       rawEnv[`${prefix}ALLOW_MEMORY_RECALL`],
       defaults.allowMemoryRecall,
     ),
-    allowMemoryWrite: parseBooleanEnv(
+    allowMemoryWrite: parseBool(
       rawEnv[`${prefix}ALLOW_MEMORY_WRITE`],
       defaults.allowMemoryWrite,
     ),
-    allowOperatorOverride: parseBooleanEnv(
+    allowOperatorOverride: parseBool(
       rawEnv[`${prefix}ALLOW_OPERATOR_OVERRIDE`],
       defaults.allowOperatorOverride,
     ),


### PR DESCRIPTION
## Summary

Sprint 2 PR-B1 of the Karpathy refactor (`~/.claude/plans/glowing-knitting-lobster.md`). Three drift copies of bool parsing collapsed into the canonical \`core/env.parseBool\`.

**Before:**
- \`src/gateway/surface-policy.ts:parseBooleanEnv\` — accepted \`1/true/yes/on\` ✓
- \`src/gateway/exec-policy.ts:toBool\` — only \`"true"\` ✗ (silent drift bug)
- \`src/cognitive/config-loader.ts:parseBool\` — only \`"true"\`/\`"false"\` ✗
- \`src/core/env.ts:parseBool\` (canonical) — full set ✓

**After:** all callsites import \`parseBool\` from \`core/env\`. One canonical impl.

## Drive-by bug fix

\`GATEWAY_EXEC_RESTRICTED_MODE=1\` was silently ignored before this PR — only \`=true\` worked. Same shape as the vault-reinit guard bug fixed in PR #320; now consistent across the codebase.

## Net impact

- 3 files changed, 36 insertions(+), 41 deletions(-)
- Typecheck green
- 2440/2442 tests pass (2 pre-existing skips)
- Lint green

## Test plan

- [x] \`npx tsc --noEmit -p tsconfig.json\` green
- [x] \`npx vitest run\` — 2440 pass on retry (one worker-race flake on first run, known issue from sprint marathon)
- [x] \`npm run lint\` green
- [x] \`grep "function toBool\\|function parseBoolean\\|function parseBool" src/\` returns only the canonical \`core/env.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)