### PR TITLE
refactor(sprint-2/b2): inline thin path-resolver wrappers

### DIFF
--- a/src/infra/cli/handlers/vault.handler.ts
+++ b/src/infra/cli/handlers/vault.handler.ts
@@ -25,14 +25,6 @@ import { resolveVaultPath } from '../../storage/vault-paths.js';
 import type { CliContext } from '../context.js';
 import { print } from '../utils/render.js';
 
-function resolveVaultStatePath(rawEnv: NodeJS.ProcessEnv): string {
-  return resolveVaultPath('vault-state.json', rawEnv);
-}
-
-function resolveVaultEntriesPath(rawEnv: NodeJS.ProcessEnv): string {
-  return resolveVaultPath('vault-entries.json', rawEnv);
-}
-
 async function promptHidden(label: string): Promise<string> {
   const stdin = process.stdin;
   const stdout = process.stdout;
@@ -825,8 +817,8 @@ async function handleVaultReset(context: CliContext): Promise<boolean> {
   }
 
   const rawEnv = process.env;
-  const statePath = resolveVaultStatePath(rawEnv);
-  const entriesPath = resolveVaultEntriesPath(rawEnv);
+  const statePath = resolveVaultPath('vault-state.json', rawEnv);
+  const entriesPath = resolveVaultPath('vault-entries.json', rawEnv);
   const stateExists = existsSync(statePath);
   const entriesExist = existsSync(entriesPath);
 

--- a/src/infra/storage/rust-vault-adapter.ts
+++ b/src/infra/storage/rust-vault-adapter.ts
@@ -166,10 +166,6 @@ function isV2State(state: PersistedVaultState): state is PersistedVaultStateV2 {
 
 let activeVault: JsVault | null = null;
 
-function getVaultStatePath(rawEnv: NodeJS.ProcessEnv): string {
-  return resolveVaultPath('vault-state.json', rawEnv);
-}
-
 function getVaultMasterKey(vault: JsVault): Buffer {
   const key = vault.master_key ?? vault.masterKey;
   if (!key) {
@@ -290,7 +286,7 @@ function snapshotVaultStateBeforeWrite(statePath: string): void {
 }
 
 function persistVaultState(vault: JsVault, rawEnv: NodeJS.ProcessEnv = process.env): void {
-  const statePath = getVaultStatePath(rawEnv);
+  const statePath = resolveVaultPath('vault-state.json', rawEnv);
   const pepper = getVaultPepper(rawEnv);
 
   mkdirSync(dirname(statePath), { recursive: true });
@@ -322,7 +318,7 @@ function persistVaultState(vault: JsVault, rawEnv: NodeJS.ProcessEnv = process.e
 }
 
 function loadPersistedVaultState(rawEnv: NodeJS.ProcessEnv = process.env): JsVault | null {
-  const statePath = getVaultStatePath(rawEnv);
+  const statePath = resolveVaultPath('vault-state.json', rawEnv);
   if (!existsSync(statePath)) return null;
 
   try {
@@ -556,7 +552,7 @@ export class VaultAlreadyInitializedError extends Error {
 
 function refuseIfVaultStateExists(rawEnv: NodeJS.ProcessEnv): void {
   if (parseBool(rawEnv.MEMPHIS_VAULT_FORCE_REINIT, false)) return;
-  const statePath = getVaultStatePath(rawEnv);
+  const statePath = resolveVaultPath('vault-state.json', rawEnv);
   if (!existsSync(statePath)) return;
   let raw: string;
   try {
@@ -679,7 +675,7 @@ export function rotateVaultStatePepper(
     throw new Error('New pepper must differ from old pepper.');
   }
 
-  const statePath = getVaultStatePath(rawEnv);
+  const statePath = resolveVaultPath('vault-state.json', rawEnv);
   if (!existsSync(statePath)) {
     throw new Error(`Vault state not found at ${statePath}. Run "memphis vault init" first.`);
   }
@@ -777,7 +773,7 @@ export function loadEntriesForRotationOrThrow(
 export function rotateVaultMasterKey(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): VaultMasterKeyRotateResult {
-  const statePath = getVaultStatePath(rawEnv);
+  const statePath = resolveVaultPath('vault-state.json', rawEnv);
   const entriesPath = getEntriesStorePath(rawEnv);
 
   if (!existsSync(statePath)) {

--- a/src/onboarding/first-run.ts
+++ b/src/onboarding/first-run.ts
@@ -129,10 +129,6 @@ function getFirstRunRecordPath(rawEnv: NodeJS.ProcessEnv = process.env): string 
   return join(getDataDir(rawEnv), 'config', FIRST_RUN_FILE);
 }
 
-function getVaultStatePath(rawEnv: NodeJS.ProcessEnv = process.env): string {
-  return resolveVaultPath('vault-state.json', rawEnv);
-}
-
 function getEnvFilePath(rawEnv: NodeJS.ProcessEnv = process.env): string {
   // Route through the shared `resolveDotEnvPath` so onboarding status
   // checks look at the same file the rest of the CLI writes to.
@@ -280,7 +276,7 @@ export function inspectFirstRunStatus(rawEnv: NodeJS.ProcessEnv = process.env): 
   const record = loadFirstRunRecord(rawEnv);
   const legacy = scanLegacyChainState(rawEnv);
   const envPresent = existsSync(resolve(getEnvFilePath(rawEnv)));
-  const vaultInitialized = existsSync(resolve(getVaultStatePath(rawEnv)));
+  const vaultInitialized = existsSync(resolve(resolveVaultPath('vault-state.json', rawEnv)));
   const operatorConfigured = isOperatorConfigured(rawEnv);
 
   if (legacy.state === 'legacy-manual') {


### PR DESCRIPTION
## Summary

Sprint 2 PR-B2 of the Karpathy refactor. Three thin local wrappers around \`resolveVaultPath()\` deleted; callsites now go directly to the canonical resolver.

## Before

Each of these files had a local helper that just forwarded to \`resolveVaultPath\`:
- \`src/onboarding/first-run.ts\` → \`getVaultStatePath\`
- \`src/infra/storage/rust-vault-adapter.ts\` → \`getVaultStatePath\` (5 callsites used it)
- \`src/infra/cli/handlers/vault.handler.ts\` → \`resolveVaultStatePath\` + \`resolveVaultEntriesPath\` (2 callsites)

## After

Direct \`resolveVaultPath('vault-state.json', rawEnv)\` / \`resolveVaultPath('vault-entries.json', rawEnv)\` calls. One canonical resolver in \`src/infra/storage/vault-paths.ts\`.

## Net impact

- 3 files, 8 insertions(+), 24 deletions(-)
- Typecheck green
- 2440/2442 tests pass
- Lint green

Sprint 3 (PR-C1/C2) will introduce a \`memphis-paths\` Rust crate and unify TS+Rust path resolution via NAPI exports — eliminating the TS↔Rust default split documented in \`project_vault_path_split.md\`.

## Test plan

- [x] \`npx tsc --noEmit -p tsconfig.json\` green
- [x] Targeted: \`tests/unit/cli.vault.test.ts\`, \`tests/unit/onboarding-first-run.test.ts\`, \`tests/unit/vault-paths.test.ts\` — green
- [x] \`npx vitest run\` — 2440 pass
- [x] \`npm run lint\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)