### PR TITLE
fix(operator): correct soul-manifest path lookup

### DIFF
--- a/crates/memphis-operator/src/runtime.rs
+++ b/crates/memphis-operator/src/runtime.rs
@@ -755,10 +755,12 @@ fn count_chain_blocks(data_dir: &Path) -> usize {
 }
 
 fn read_cognitive_mode_summary(data_dir: &Path) -> (String, Option<String>) {
-    // soul-manifest.json is in the parent of data_dir (project root .memphis/)
-    // or relative to the config path. Try common locations.
-    let config_dir = data_dir.parent().unwrap_or(data_dir).join(".memphis");
-    let manifest_path = config_dir.join("soul-manifest.json");
+    // soul-manifest.json lives at <data_dir>/config/soul-manifest.json
+    // (matches src/soul/manifest.ts which writes via getConfigPath()).
+    // The previous parent-walk computed ~/.memphis/soul-manifest.json
+    // (missing the "config" segment) and silently returned the default
+    // mode for every read.
+    let manifest_path = data_dir.join("config").join("soul-manifest.json");
     if let Ok(content) = fs::read_to_string(&manifest_path) {
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) {
             let mode = value


### PR DESCRIPTION
## Summary

Sprint 3 PR-C3 of the Karpathy refactor — small standalone bug fix.

\`crates/memphis-operator/src/runtime.rs:read_cognitive_mode_summary\` was looking up the soul-manifest at:

\`\`\`rust
let config_dir = data_dir.parent().unwrap_or(data_dir).join(".memphis");
let manifest_path = config_dir.join("soul-manifest.json");
\`\`\`

For a real install where \`data_dir = ~/.memphis\`, this resolves to \`~/.memphis/soul-manifest.json\` — a file that doesn't exist. The TS side (\`src/soul/manifest.ts\`) writes the file via \`getConfigPath()\` to \`~/.memphis/config/soul-manifest.json\`. The parent-walk path was a stale assumption from an earlier directory layout.

Result: \`read_cognitive_mode_summary\` silently returned the default mode on every read; the operator's actual cognitive mode never surfaced into Rust callsites that depend on this function.

## After

\`\`\`rust
let manifest_path = data_dir.join("config").join("soul-manifest.json");
\`\`\`

Matches the TS side. Verified file location:

\`\`\`bash
$ find ~/.memphis -name soul-manifest.json
/home/memphis/.memphis/config/soul-manifest.json
\`\`\`

## Test plan

- [x] \`cargo test -p memphis-operator --lib\` — 61/61 green
- [ ] CI green (quality-gate runs full TS suite + cargo test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)