### PR TITLE
fix(operator): align Rust vault path defaults with TS layer

### DIFF
--- a/crates/memphis-operator/src/config.rs
+++ b/crates/memphis-operator/src/config.rs
@@ -46,18 +46,23 @@ impl OperatorConfig {
         let data_dir = resolve_data_dir(&env_map);
         let database_path = resolve_database_path(&env_map);
         let case_index_path = data_dir.join("case-index.sqlite");
-        let vault_state_path = PathBuf::from(
-            env_map
-                .get("MEMPHIS_VAULT_STATE_PATH")
-                .cloned()
-                .unwrap_or_else(|| "./data/vault-state.json".to_string()),
-        );
-        let vault_entries_path = PathBuf::from(
-            env_map
-                .get("MEMPHIS_VAULT_ENTRIES_PATH")
-                .cloned()
-                .unwrap_or_else(|| "./data/vault-entries.json".to_string()),
-        );
+        // Align with src/infra/storage/vault-paths.ts: vault files live under
+        // data_dir (i.e. ~/.memphis/) by default. The previous Rust defaults
+        // ./data/vault-state.json and ./data/vault-entries.json resolved
+        // against cwd — when memphis ran from anywhere outside the repo
+        // checkout, the Rust runtime pointed at non-existent files while the
+        // TS layer (and operator's actual files) lived under ~/.memphis/.
+        // Operator's 2026-04-29 vault-path-split incident traced to exactly
+        // this divergence; fix is to make the two layers agree at the
+        // default-resolution step.
+        let vault_state_path = env_map
+            .get("MEMPHIS_VAULT_STATE_PATH")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| data_dir.join("vault-state.json"));
+        let vault_entries_path = env_map
+            .get("MEMPHIS_VAULT_ENTRIES_PATH")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| data_dir.join("vault-entries.json"));
         let embed_persist_path = env_map
             .get("RUST_EMBED_PERSIST_PATH")
             .map(PathBuf::from)


### PR DESCRIPTION
## Summary

Sprint 3 PR-C1 of the Karpathy refactor — fixes the TS↔Rust vault path divergence at the **default-resolution step** rather than building a new shared crate.

## Root cause

\`crates/memphis-operator/src/config.rs:49-60\` defaulted vault paths to relative \`./data/vault-state.json\` / \`./data/vault-entries.json\`. When memphis runs from anywhere outside the repo checkout (= normal post-install case), these resolve against the process cwd → non-existent files. Meanwhile TS (\`src/infra/storage/vault-paths.ts\`) defaulted to \`\${data_dir}/vault-state.json\` = \`~/.memphis/vault-state.json\`.

The 2026-04-29 vault-path-split incident traced to exactly this: operator set \`MEMPHIS_VAULT_ENTRIES_PATH=./data/...\` without \`MEMPHIS_VAULT_STATE_PATH\`, Rust silently pointed at \`./data/vault-state.json\` (didn't exist), TS pointed at \`~/.memphis/vault-state.json\` (real). Chat path returned "vault entry could not be read"; \`vault list\` worked fine.

## Fix

When env override absent → derive from \`data_dir\` (absolute, matches TS).

\`\`\`rust
let vault_state_path = env_map
    .get("MEMPHIS_VAULT_STATE_PATH")
    .map(PathBuf::from)
    .unwrap_or_else(|| data_dir.join("vault-state.json"));
\`\`\`

Two layers now agree at the default-resolution step. The legacy fallback chain in \`resolve_vault_state_path\` (PR #350 + #351) stays as a safety net for operators upgrading from pre-fix layout.

## Smoke check (operator side)

After this PR merges and rebuild:

\`\`\`bash
# Verify vault paths point at ~/.memphis/ (no .env override needed)
memphis doctor --json | jq '.checks[] | select(.id == "vault") | .detail'

# Should NOT show "[memphis-vault] using legacy / sibling vault" notices any more
memphis tui   # tier 1 should be clean
\`\`\`

## Test plan

- [x] \`cargo test -p memphis-operator --lib\` — 61/61 green
- [ ] CI quality-gate
- [ ] Operator smoke: vault paths resolve to ~/.memphis/ without explicit env override

🤖 Generated with [Claude Code](https://claude.com/claude-code)