### PR TITLE
fix(cli): eagerly resolve VAULT:<key> in every command (telegram status, etc.)

### DIFF
--- a/src/infra/cli/index.ts
+++ b/src/infra/cli/index.ts
@@ -7,6 +7,7 @@ import { parseCommand } from './parser.js';
 import { checkDependencies } from './utils/dependencies.js';
 import { ensureDir, getDataDir } from '../../config/paths.js';
 import { formatCliError, toAppError } from '../../core/errors.js';
+import { resolveVaultSecrets } from '../config/vault-resolve.js';
 import { resolveExitCode } from '../runtime/exit-codes.js';
 
 const FIRST_RUN_MARKER = resolve(getDataDir(), '.first-run-checks');
@@ -61,6 +62,26 @@ export async function runCli(argv: string[] = process.argv ?? []): Promise<void>
 
     if (args.verbose) {
       process.env.LOG_LEVEL = 'debug';
+    }
+
+    // Eagerly resolve VAULT:<key> references in process.env before any
+    // handler runs. Previously vault-resolve happened lazily via
+    // loadConfig() which only fired for handlers that touched
+    // context.getConfig() / getContainer(). Handlers like
+    // `memphis telegram status` read process.env directly and saw the
+    // unresolved literal `VAULT:telegram_bot_token` — telegram-readiness
+    // detected the literal and reported `Token: missing` even though the
+    // vault entry existed and other commands resolved it fine. The
+    // 2026-04-29 operator smoke session hit exactly this. Doing the
+    // resolution here once means every CLI handler sees the same
+    // resolved env regardless of which paths it touches downstream.
+    try {
+      resolveVaultSecrets(process.env);
+    } catch {
+      // Vault not initialized yet (e.g. fresh install before
+      // `memphis init`) — fall through silently. Subsequent handlers
+      // that actually need vault secrets will surface a more specific
+      // error than crashing the CLI on every command.
     }
 
     if (args.command !== 'doctor' && args.command !== 'repair') {


### PR DESCRIPTION
## Summary

Operator hit this on 2026-04-29 right after PR #364 merged:

\`\`\`
$ memphis vault list | grep telegram
  "key": "telegram_bot_token"            # vault has it
$ memphis telegram status
  Telegram: missing-token
  Token: missing                          # status doesn't see it
$ memphis doctor --post-install
  [memphis-config] Resolved 2 secret(s)…  # doctor does
\`\`\`

## Root cause

Vault-resolve fires inside \`loadConfig()\`. \`loadConfig\` was lazily called via \`context.getConfig()\` / \`getContainer()\`. Handlers like \`memphis telegram status\` call \`getTelegramReadinessStatus(process.env, …)\` directly — never touching context, never resolving vault. \`process.env.MEMPHIS_TELEGRAM_BOT_TOKEN\` stays at the literal \`VAULT:telegram_bot_token\`. \`isUnresolvedVaultRef\` (added 2026-04-20 to prevent the literal-token-to-getMe crashloop) correctly drops it → "Token: missing".

## Fix

Move \`resolveVaultSecrets(process.env)\` into \`runCli\` itself, immediately after arg parsing. Every command, every handler, sees the same resolved env. Wrapped in try/catch so a fresh install (no vault yet) doesn't break commands that don't need vault — empty resolve, proceed.

## Smoke check (operator)

\`\`\`bash
cd ~/memphis && git pull origin main && npm run build

memphis telegram status
# Expected: Token: present (memphis), Bot: @<your-bot>

memphis telegram smoke-test
# If still 404 → token revoked at BotFather; setup with new token:
memphis setup telegram --bot-token <NEW> --allowed-user-ids <YOUR_TG_ID>
\`\`\`

## Net impact

- 1 file, +21 -0
- Typecheck + lint green
- Risk: every CLI invocation now does vault-resolve. Wrapped in try/catch — failure modes (vault missing, decrypt errors) fall through silently and downstream handlers surface specific errors as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)