### PR TITLE
fix(minimax): parse inline <toolcall>…</minimax:tool_call> XML in M2.7 responses

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -413,7 +413,7 @@ export class MinimaxProvider implements Provider {
     };
 
     const msg = data.choices?.[0]?.message;
-    const toolCalls: ChatToolCall[] | undefined = msg?.tool_calls?.map((tc) => {
+    const structuredToolCalls: ChatToolCall[] | undefined = msg?.tool_calls?.map((tc) => {
       let args: Record<string, unknown> = {};
       if (typeof tc.function.arguments === 'string') {
         try {
@@ -437,8 +437,30 @@ export class MinimaxProvider implements Provider {
       return { id: tc.id, name: tc.function.name, arguments: args };
     });
 
+    // MiniMax M2.7 sometimes ignores the structured tool_calls API and
+    // emits its native agent-mode XML in `content` instead — operator
+    // saw exactly this on Telegram 2026-04-29:
+    //   <toolcall>
+    //     <invoke name="memphis_exec">
+    //       <parameter name="command">echo …</parameter>
+    //     </invoke>
+    //   </minimax:tool_call>
+    // Bot rendered the XML as text, no tool ever ran. We parse the
+    // inline form here when structured tool_calls are absent and merge
+    // them into ChatToolCall[] so turn-runtime treats them like any
+    // other call. Only triggered when the structured channel is empty —
+    // a model that uses the proper API isn't affected.
+    const inlineParse = (msg?.content && (!structuredToolCalls || structuredToolCalls.length === 0))
+      ? parseMiniMaxInlineToolCalls(msg.content)
+      : { calls: [] as ChatToolCall[], cleaned: msg?.content ?? '' };
+    const toolCalls = structuredToolCalls?.length
+      ? structuredToolCalls
+      : inlineParse.calls.length > 0
+        ? inlineParse.calls
+        : undefined;
+
     return {
-      content: msg?.content || '',
+      content: inlineParse.cleaned || msg?.content || '',
       model,
       provider: 'minimax',
       tokens: data.usage
@@ -451,6 +473,49 @@ export class MinimaxProvider implements Provider {
       tool_calls: toolCalls?.length ? toolCalls : undefined,
     };
   }
+}
+
+/**
+ * Parse MiniMax M2.7 native agent-mode XML embedded in assistant content.
+ * Returns the structured tool calls plus content with the XML stripped.
+ *
+ * Format observed in production:
+ *   <toolcall>
+ *     <invoke name="<tool>">
+ *       <parameter name="<arg>">value</parameter>
+ *       …
+ *     </invoke>
+ *   </minimax:tool_call>
+ *
+ * The closing tag is `</minimax:tool_call>` (with the namespace prefix),
+ * the opening tag is `<toolcall>` without one — that asymmetry is part
+ * of MiniMax's training format, not a typo.
+ */
+function parseMiniMaxInlineToolCalls(content: string): {
+  calls: ChatToolCall[];
+  cleaned: string;
+} {
+  const calls: ChatToolCall[] = [];
+  const blockRe = /<toolcall>([\s\S]*?)<\/minimax:tool_call>/gi;
+  const cleaned = content.replace(blockRe, (_match, inner: string) => {
+    const invokeMatch = inner.match(/<invoke\s+name="([^"]+)">([\s\S]*?)<\/invoke>/);
+    if (!invokeMatch) return ''; // drop malformed block; better than echoing
+    const name = invokeMatch[1];
+    const paramsBlock = invokeMatch[2];
+    const args: Record<string, unknown> = {};
+    const paramRe = /<parameter\s+name="([^"]+)">([\s\S]*?)<\/parameter>/g;
+    let pm: RegExpExecArray | null;
+    while ((pm = paramRe.exec(paramsBlock)) !== null) {
+      args[pm[1]] = pm[2].trim();
+    }
+    calls.push({
+      id: `minimax_inline_${Date.now()}_${calls.length}`,
+      name,
+      arguments: args,
+    });
+    return '';
+  });
+  return { calls, cleaned: cleaned.trim() };
 }
 
 // ═══════════════════════════════════════════

--- a/tests/unit/minimax-inline-tool-parser.test.ts
+++ b/tests/unit/minimax-inline-tool-parser.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { MinimaxProvider } from '../../src/providers/index.js';
+
+/**
+ * MiniMax M2.7 sometimes emits agent-mode XML in `content` instead of
+ * using the structured tool_calls API. The provider adapter must parse
+ * that XML and surface it as ChatToolCall[] so turn-runtime executes
+ * the tool. Operator-observed regression on Telegram 2026-04-29.
+ */
+
+function mockMinimaxResponse(content: string, toolCalls?: unknown[]): typeof fetch {
+  return vi.fn(async () =>
+    new Response(
+      JSON.stringify({
+        choices: [
+          {
+            message: {
+              content,
+              ...(toolCalls ? { tool_calls: toolCalls } : {}),
+            },
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  ) as unknown as typeof fetch;
+}
+
+describe('MinimaxProvider — inline tool-call XML parser', () => {
+  const originalFetch = globalThis.fetch;
+
+  it('extracts <toolcall>…</minimax:tool_call> blocks into structured tool_calls', async () => {
+    globalThis.fetch = mockMinimaxResponse(
+      [
+        '<think>The user said test, run exec</think>',
+        '<toolcall>',
+        '<invoke name="memphis_exec">',
+        '<parameter name="command">echo "hello from exec"</parameter>',
+        '</invoke>',
+        '</minimax:tool_call>',
+      ].join('\n'),
+    );
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    const res = await provider.chat([{ role: 'user', content: 'test' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(res.tool_calls).toHaveLength(1);
+    expect(res.tool_calls?.[0].name).toBe('memphis_exec');
+    expect(res.tool_calls?.[0].arguments).toEqual({ command: 'echo "hello from exec"' });
+    // Block stripped from content
+    expect(res.content).not.toContain('<toolcall>');
+    expect(res.content).not.toContain('</minimax:tool_call>');
+  });
+
+  it('parses multiple parameters in one invoke', async () => {
+    globalThis.fetch = mockMinimaxResponse(
+      [
+        '<toolcall>',
+        '<invoke name="memphis_search">',
+        '<parameter name="query">test</parameter>',
+        '<parameter name="limit">5</parameter>',
+        '</invoke>',
+        '</minimax:tool_call>',
+      ].join('\n'),
+    );
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    const res = await provider.chat([{ role: 'user', content: 'search' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(res.tool_calls?.[0].arguments).toEqual({ query: 'test', limit: '5' });
+  });
+
+  it('prefers structured tool_calls over inline XML when both present', async () => {
+    globalThis.fetch = mockMinimaxResponse(
+      '<toolcall><invoke name="memphis_exec"><parameter name="command">x</parameter></invoke></minimax:tool_call>',
+      [
+        {
+          id: 'call_struct',
+          type: 'function',
+          function: { name: 'memphis_journal', arguments: '{"content":"y"}' },
+        },
+      ],
+    );
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    const res = await provider.chat([{ role: 'user', content: 'go' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(res.tool_calls).toHaveLength(1);
+    expect(res.tool_calls?.[0].name).toBe('memphis_journal');
+  });
+
+  it('passes through plain assistant content unchanged', async () => {
+    globalThis.fetch = mockMinimaxResponse('Hello world');
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    const res = await provider.chat([{ role: 'user', content: 'hi' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(res.content).toBe('Hello world');
+    expect(res.tool_calls).toBeUndefined();
+  });
+
+  it('drops malformed <toolcall> blocks rather than echoing them', async () => {
+    globalThis.fetch = mockMinimaxResponse(
+      'before <toolcall>not valid xml</minimax:tool_call> after',
+    );
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    const res = await provider.chat([{ role: 'user', content: 'x' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(res.content).toBe('before  after');
+    expect(res.tool_calls).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Operator-visible bug, observed live on Telegram 2026-04-29 right after PR #365 enabled the bot:

\`\`\`
[22:19] user: test
[22:19] bot: <think>The user just said "test". They probably want me to test memphis_exec again.
              </think>
              <toolcall>
                <invoke name="memphis_exec">
                  <parameter name="command">echo "hello from exec"</parameter>
                </invoke>
              </minimax:tool_call>
\`\`\`

No tool ran. Bot rendered the XML as plain text.

## Root cause

MiniMax M2.7 has a native agent-mode XML format (`<toolcall>` open / `</minimax:tool_call>` close — asymmetric tags from their training). Even when memphis sends \`tools\` in the structured OpenAI-compatible request, M2.7 sometimes emits the XML in \`content\` instead of populating \`tool_calls\`. \`MinimaxProvider\` only read \`tool_calls\`, so the XML reached the surface as text.

## Fix

In \`MinimaxProvider.chat\` — when structured \`tool_calls\` is empty, run the content through \`parseMiniMaxInlineToolCalls\` which:

- Extracts each \`<toolcall>…</minimax:tool_call>\` block.
- Parses the inner \`<invoke name="…">\` and \`<parameter name="…">value</parameter>\` pairs.
- Returns ChatToolCall[] in the same shape turn-runtime already handles.
- Strips the XML from the content before surfacing.

Structured \`tool_calls\` still wins when present (zero behavior change for properly-formatted responses).

## Tests

5/5 green:
- inline extraction with single parameter
- multi-parameter invoke
- structured-vs-inline precedence
- plain content passthrough
- malformed block drop (no echo)

## Smoke check (operator)

After merge:

\`\`\`bash
cd ~/memphis && git checkout -- AGENTS.md CLAUDE.md && git pull --rebase origin main && npm run build
memphis service restart
\`\`\`

Then on Telegram:
\`\`\`
You: yo
You: zrob ls -la
\`\`\`

Bot should run \`memphis_exec\` and return real output, not XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)