### PR TITLE
fix(minimax): coalesce system-role messages — fixes 400 'invalid message role: system'

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -333,8 +333,28 @@ export class MinimaxProvider implements Provider {
   async chat(messages: ChatMessage[], opts?: ChatOptions): Promise<ChatResponse> {
     const model = opts?.model || this.model;
 
-    // Convert ChatMessage union to MiniMax format with tool calling support
-    const mmMessages = messages.map((m) => {
+    // MiniMax (M2.7+ chat/completions) rejects requests that contain a
+    // `system` role anywhere except the very first message — operator hit
+    // `Minimax error: 400 invalid message role: system (2013)` on
+    // 2026-04-29 when conversation history (rebuilt from journal/cases)
+    // included a system note mid-stream. We collect every `system`
+    // content (history + opts.systemPrompt), merge into a single leading
+    // system message, and drop the rest. Tool/assistant/user roles are
+    // preserved as-is.
+    const systemPieces: string[] = [];
+    const nonSystemMessages: ChatMessage[] = [];
+    for (const m of messages) {
+      if (m.role === 'system') {
+        if (m.content) systemPieces.push(m.content);
+      } else {
+        nonSystemMessages.push(m);
+      }
+    }
+    if (opts?.systemPrompt) systemPieces.unshift(opts.systemPrompt);
+    const mergedSystem = systemPieces.join('\n\n').trim();
+
+    // Convert non-system ChatMessage union to MiniMax format with tool calling support
+    const mmMessages = nonSystemMessages.map((m) => {
       if (m.role === 'tool') {
         return {
           role: 'tool' as const,
@@ -356,9 +376,9 @@ export class MinimaxProvider implements Provider {
       return { role: m.role, content: sanitizeForJsonRequest(m.content) };
     });
 
-    const allMessages = opts?.systemPrompt
+    const allMessages = mergedSystem
       ? [
-          { role: 'system' as const, content: sanitizeForJsonRequest(opts.systemPrompt) },
+          { role: 'system' as const, content: sanitizeForJsonRequest(mergedSystem) },
           ...mmMessages,
         ]
       : mmMessages;

--- a/tests/unit/minimax-inline-tool-parser.test.ts
+++ b/tests/unit/minimax-inline-tool-parser.test.ts
@@ -113,3 +113,64 @@ describe('MinimaxProvider — inline tool-call XML parser', () => {
     expect(res.tool_calls).toBeUndefined();
   });
 });
+
+describe('MinimaxProvider — system-role coalescing', () => {
+  const originalFetch = globalThis.fetch;
+
+  it('merges multiple system messages into a single leading system', async () => {
+    let captured: { messages: Array<{ role: string; content: string }> } | undefined;
+    globalThis.fetch = (vi.fn(async (_url, init) => {
+      captured = JSON.parse((init as RequestInit).body as string);
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: 'ok' } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as unknown) as typeof fetch;
+
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    await provider.chat(
+      [
+        { role: 'system', content: 'history-system-1' },
+        { role: 'user', content: 'hi' },
+        { role: 'system', content: 'history-system-2' },
+        { role: 'user', content: 'hey' },
+      ],
+      { systemPrompt: 'opts-system' },
+    );
+    globalThis.fetch = originalFetch;
+
+    const sysMessages = captured!.messages.filter((m) => m.role === 'system');
+    expect(sysMessages).toHaveLength(1);
+    expect(sysMessages[0].content).toContain('opts-system');
+    expect(sysMessages[0].content).toContain('history-system-1');
+    expect(sysMessages[0].content).toContain('history-system-2');
+    // First message MUST be system
+    expect(captured!.messages[0].role).toBe('system');
+    // No system role in trailing messages
+    const trailingSystem = captured!.messages.slice(1).filter((m) => m.role === 'system');
+    expect(trailingSystem).toHaveLength(0);
+  });
+
+  it('omits system message entirely when no system pieces present', async () => {
+    let captured: { messages: Array<{ role: string }> } | undefined;
+    globalThis.fetch = (vi.fn(async (_url, init) => {
+      captured = JSON.parse((init as RequestInit).body as string);
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: 'ok' } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as unknown) as typeof fetch;
+
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    await provider.chat([{ role: 'user', content: 'hi' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(captured!.messages.filter((m) => m.role === 'system')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Operator hit a hard 400 on Telegram 2026-04-29 right after PR #366:

\`\`\`
[22:36] You: zrob ls -la
[22:36] Memphis Agent: Wystąpił błąd: Minimax error: 400 {"type":"error","error":
                       {"message":"invalid params, chat content has invalid
                       message role: system (2013)"}}
\`\`\`

## Root cause

MiniMax M2.7 \`chat/completions\` rejects requests where \`role: system\` appears anywhere except as the very first message. Memphis was emitting:

\`\`\`json
[
  { "role": "system", "content": "<system prompt>" },
  { "role": "user", "content": "..." },
  { "role": "system", "content": "<context note from journal>" },   ← rejected
  { "role": "user", "content": "zrob ls -la" }
]
\`\`\`

Conversation history (rebuilt from journal/cases) sometimes injects mid-stream system notes. OpenAI/Anthropic/GLM accept that shape; MiniMax 400's.

## Fix

In \`MinimaxProvider.chat\`, partition messages: collect every system content (history + \`opts.systemPrompt\`), merge into one leading system message, drop the rest. Tool/assistant/user roles preserved. No system at all → emit no system message (some MiniMax test models reject empty-content system role).

## Tests

7/7 green:
- inline tool-call XML extraction (PR #366 carry-over)
- multi-parameter invoke
- structured-vs-inline precedence
- plain content passthrough
- malformed-block drop
- **multi-system coalescing into one leading**
- **no-system-pieces omission**

## Smoke check (operator)

\`\`\`bash
cd ~/memphis && git checkout -- AGENTS.md CLAUDE.md && git pull --rebase origin main && npm run build && memphis service restart
\`\`\`

Then on Telegram retry:
\`\`\`
You: zrob ls -la
\`\`\`

Should now actually run \`memphis_exec\` and return the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)