### PR TITLE
fix(self-update): fall back to origin/main when branch has no upstream

### DIFF
--- a/src/infra/self-update/source-checkout.ts
+++ b/src/infra/self-update/source-checkout.ts
@@ -158,7 +158,7 @@ function hashFile(path: string): string | undefined {
 
 export type ResolvedBranchRef = {
   refName: string;
-  source: 'origin' | 'upstream';
+  source: 'origin' | 'upstream' | 'origin-main-fallback';
   warning?: string;
 };
 
@@ -192,8 +192,25 @@ function resolveBranchRef(
     }
   }
 
+  // Last resort: fall back to origin/main so operators stuck on a
+  // local-only branch (e.g. someone checked out a feature branch and
+  // never deleted it, or a stale `fix/*` from a past install) can still
+  // upgrade. Without this fallback, `memphis self-update install` would
+  // fail with a git-internals error message ("set upstream with …") that
+  // is intimidating for non-developers — observed on a downstream
+  // operator install 2026-04-29 stuck on `fix/high-loop-limits`.
+  const mainRef = 'origin/main';
+  const mainProbe = runGit(['rev-parse', '--verify', mainRef], runner, runtimeRoot);
+  if (mainProbe.status === 0) {
+    return {
+      refName: mainRef,
+      source: 'origin-main-fallback',
+      warning: `branch ${branch} has no remote tracking; falling back to origin/main. Run \`git checkout main\` to track main directly.`,
+    };
+  }
+
   return {
-    error: `branch ${branch} has no upstream (neither origin/${branch} nor @{upstream} resolved). Set one with \`git branch --set-upstream-to=<remote>/<branch>\` or push the branch to origin.`,
+    error: `branch ${branch} has no upstream and origin/main is unreachable. Run \`git fetch origin\` first, then \`git checkout main\` if you want to track main.`,
   };
 }
 

--- a/tests/unit/self-update.source-checkout.test.ts
+++ b/tests/unit/self-update.source-checkout.test.ts
@@ -140,7 +140,7 @@ describe('checkSourceUpdate', () => {
     expect(result.warnings?.some((w) => w.includes('upstream/dev-branch'))).toBe(true);
   });
 
-  it('reports a no-upstream error when neither origin nor @{upstream} resolve', () => {
+  it('falls back to origin/main when neither origin/<branch> nor @{upstream} resolve', () => {
     const root = makeFakeCheckout();
     const { runner } = makeRunner({
       'git rev-parse --abbrev-ref HEAD': { stdout: 'local-only\n' },
@@ -152,10 +152,34 @@ describe('checkSourceUpdate', () => {
         status: 128,
         stderr: 'fatal: no upstream configured for branch local-only',
       },
+      'git rev-parse --verify origin/main': { stdout: 'cccc333\n' },
+      'git rev-parse origin/main': { stdout: 'cccc333\n' },
+      'git log --pretty=%s aaaa111..cccc333': { stdout: 'fix: y\n' },
+    });
+    const result = checkSourceUpdate(root, runner);
+    expect(result.ok).toBe(true);
+    expect(result.updateAvailable).toBe(true);
+    // Operator gets a heads-up that we used main as fallback
+    expect(result.warnings?.some((w) => w.includes('origin/main'))).toBe(true);
+  });
+
+  it('only errors when origin/main is also missing (very degraded git state)', () => {
+    const root = makeFakeCheckout();
+    const { runner } = makeRunner({
+      'git rev-parse --abbrev-ref HEAD': { stdout: 'local-only\n' },
+      'git rev-parse HEAD': { stdout: 'aaaa111\n' },
+      'git config --get remote.origin.url': { stdout: 'origin\n' },
+      'git fetch --quiet origin': { stdout: '' },
+      'git rev-parse --verify origin/local-only': { status: 1, stderr: 'unknown revision' },
+      'git rev-parse --abbrev-ref local-only@{upstream}': {
+        status: 128,
+        stderr: 'fatal: no upstream configured for branch local-only',
+      },
+      'git rev-parse --verify origin/main': { status: 1, stderr: 'unknown revision' },
     });
     const result = checkSourceUpdate(root, runner);
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/no upstream/);
+    expect(result.error).toMatch(/origin\/main is unreachable/);
   });
 });
 


### PR DESCRIPTION
## Summary

Operator on a downstream install hit this 2026-04-29 trying to upgrade memphis to latest main:

\`\`\`
$ memphis self-update install
…
failedStage: fetch
error: branch fix/high-loop-limits has no upstream (neither origin/fix/high-loop-limits
       nor @{upstream} resolved). Set one with \`git branch --set-upstream-to=<remote>/<branch>\`
       or push the branch to origin.
\`\`\`

The operator was on a local-only branch (some old test/dev branch they hadn't deleted). \`memphis self-update\` errored with a git-internals message asking them to run \`git branch --set-upstream-to=…\` — incomprehensible for non-developers, and not the right answer (they wanted to upgrade memphis, not fix git tracking).

## Root cause

\`resolveBranchRef\` in \`source-checkout.ts\` checked \`origin/<branch>\` then \`@{upstream}\`, then bailed.

## Fix

Add \`origin/main\` as a third fallback. If neither the branch's matching origin ref nor its configured upstream resolves, fall back to \`origin/main\` with a warning so operators see they're being routed to main instead of their feature branch — they can run \`git checkout main\` if that's what they actually wanted.

Only errors now if even \`origin/main\` is unreachable (genuinely degraded git state).

## Smoke check

The downstream operator's manual recovery (after the failure):

\`\`\`bash
cd ~/.memphis/memphis
git fetch origin main
git reset --hard origin/main
npm install && npm run build && memphis service restart
\`\`\`

…now becomes a single \`memphis self-update install\` — works automatically with the fallback.

## Net impact

- 1 source file, 1 test file
- 17/17 source-checkout tests green
- Updated previous "no upstream errors" test for the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)