### PR TITLE
fix(config): production safety check accepts <PROVIDER>_VAULT_KEY alternative

### DIFF
--- a/src/infra/config/profiles.ts
+++ b/src/infra/config/profiles.ts
@@ -30,6 +30,35 @@ export function applyConfigProfile(config: AppConfig): AppConfig {
   };
 }
 
+/**
+ * Provider key requirement entry. A bare string means "this exact key
+ * must be set". An array means "any one of these alternatives is enough"
+ * — used so a vault-managed setup (`MINIMAX_VAULT_KEY=minimax_api_key`)
+ * is accepted in place of plaintext `MINIMAX_API_KEY`. Without this
+ * either-of shape the daemon would crashloop in production whenever
+ * the operator stored their provider key in vault and removed the
+ * plaintext from .env (the recommended hardening — observed downstream
+ * 2026-04-29 when an operator's MiniMax setup ran fine on every CLI
+ * command but `systemctl --user start memphis` died with
+ * "Production safety check failed: minimax requires MINIMAX_API_KEY"
+ * even though the vault-resolved value populated MINIMAX_API_KEY at
+ * runtime).
+ */
+type KeyRequirement = string | readonly string[];
+
+function isRequirementSatisfied(config: AppConfig, requirement: KeyRequirement): boolean {
+  if (typeof requirement === 'string') {
+    return Boolean(String(config[requirement as keyof AppConfig] ?? '').trim());
+  }
+  return requirement.some((alt) =>
+    Boolean(String(config[alt as keyof AppConfig] ?? '').trim()),
+  );
+}
+
+function describeRequirement(requirement: KeyRequirement): string {
+  return typeof requirement === 'string' ? requirement : requirement.join(' or ');
+}
+
 export function validateProductionSafety(config: AppConfig): void {
   if (config.NODE_ENV !== 'production') return;
 
@@ -37,15 +66,21 @@ export function validateProductionSafety(config: AppConfig): void {
     throw new Error('Production safety check failed: MEMPHIS_API_TOKEN is required in production');
   }
 
-  const providerRequirements = [
+  const providerRequirements: ReadonlyArray<{
+    provider: string;
+    keys: ReadonlyArray<KeyRequirement>;
+  }> = [
     { provider: 'shared-llm', keys: ['SHARED_LLM_API_BASE', 'SHARED_LLM_API_KEY'] },
     {
       provider: 'decentralized-llm',
       keys: ['DECENTRALIZED_LLM_API_BASE', 'DECENTRALIZED_LLM_API_KEY'],
     },
-    { provider: 'minimax', keys: ['MINIMAX_API_KEY'] },
-    { provider: 'deepseek', keys: ['DEEPSEEK_API_KEY'] },
-    { provider: 'glm', keys: ['GLM_API_KEY'] },
+    // Mirror src/infra/config/env.ts:resolveDefaultProvider — vault-key
+    // alternatives are equally valid because vault-resolve runs before
+    // the runtime opens any provider connection.
+    { provider: 'minimax', keys: [['MINIMAX_API_KEY', 'MINIMAX_VAULT_KEY']] },
+    { provider: 'deepseek', keys: [['DEEPSEEK_API_KEY', 'DEEPSEEK_VAULT_KEY']] },
+    { provider: 'glm', keys: [['GLM_API_KEY', 'GLM_VAULT_KEY']] },
   ] as const;
 
   for (const requirement of providerRequirements) {
@@ -53,15 +88,15 @@ export function validateProductionSafety(config: AppConfig): void {
       continue;
     }
 
-    const missing = requirement.keys.filter(
-      (key) => !String(config[key as keyof AppConfig] ?? '').trim(),
-    );
+    const missing = requirement.keys.filter((key) => !isRequirementSatisfied(config, key));
     if (missing.length === 0) {
       return;
     }
 
     throw new Error(
-      `Production safety check failed: ${requirement.provider} requires ${requirement.keys.join(' and ')}`,
+      `Production safety check failed: ${requirement.provider} requires ${missing
+        .map(describeRequirement)
+        .join(' and ')}`,
     );
   }
 }

--- a/tests/unit/config-profiles.test.ts
+++ b/tests/unit/config-profiles.test.ts
@@ -74,4 +74,41 @@ describe('config profiles', () => {
     const cfg = base();
     expect(() => validateProductionSafety(cfg)).not.toThrow();
   });
+
+  it('accepts MINIMAX_VAULT_KEY in place of plaintext MINIMAX_API_KEY in production', () => {
+    process.env.MEMPHIS_API_TOKEN = 'token-123';
+    const cfg = {
+      ...base(),
+      NODE_ENV: 'production' as const,
+      DEFAULT_PROVIDER: 'minimax' as const,
+      MINIMAX_VAULT_KEY: 'minimax_api_key',
+      // No MINIMAX_API_KEY — the vault reference is enough.
+    };
+    expect(() => validateProductionSafety(cfg)).not.toThrow();
+    delete process.env.MEMPHIS_API_TOKEN;
+  });
+
+  it('accepts DEEPSEEK_VAULT_KEY in place of plaintext DEEPSEEK_API_KEY in production', () => {
+    process.env.MEMPHIS_API_TOKEN = 'token-123';
+    const cfg = {
+      ...base(),
+      NODE_ENV: 'production' as const,
+      DEFAULT_PROVIDER: 'deepseek' as const,
+      DEEPSEEK_VAULT_KEY: 'deepseek_api_key',
+    };
+    expect(() => validateProductionSafety(cfg)).not.toThrow();
+    delete process.env.MEMPHIS_API_TOKEN;
+  });
+
+  it('still throws when neither plaintext nor vault key is present', () => {
+    process.env.MEMPHIS_API_TOKEN = 'token-123';
+    const cfg = {
+      ...base(),
+      NODE_ENV: 'production' as const,
+      DEFAULT_PROVIDER: 'minimax' as const,
+      // No MINIMAX_API_KEY, no MINIMAX_VAULT_KEY
+    };
+    expect(() => validateProductionSafety(cfg)).toThrow(/MINIMAX_API_KEY or MINIMAX_VAULT_KEY/);
+    delete process.env.MEMPHIS_API_TOKEN;
+  });
 });


### PR DESCRIPTION
## Summary

Operator-visible bug observed downstream 2026-04-29:

\`\`\`
[MISSING_ENV] Production safety check failed: minimax requires MINIMAX_API_KEY
\`\`\`

Daemon crashlooping every 5s under systemd because \`validateProductionSafety\` (\`src/infra/config/profiles.ts\`) had a hardcoded list demanding plaintext \`MINIMAX_API_KEY\`. Operator had hardened their setup the recommended way:

1. Stored the key in vault (\`memphis vault add minimax_api_key\`).
2. Set \`MINIMAX_VAULT_KEY=minimax_api_key\` in .env.
3. Removed plaintext \`MINIMAX_API_KEY\` from .env.

Every CLI command worked (vault-resolve populates the plaintext at runtime). But \`systemctl --user start memphis\` died — the production safety check runs before the runtime touches the vault.

## Inconsistency this fixed

\`requireConfiguredProvider\` in \`src/infra/config/env.ts:267\` already accepted the either-of shape:

\`\`\`ts
requireConfiguredProvider(config, 'minimax', [['MINIMAX_API_KEY', 'MINIMAX_VAULT_KEY']])
\`\`\`

\`validateProductionSafety\` did not. So warning-mode (cascade walk) saw the vault key as fine; throw-mode (production gate) didn't. Two checks, same logical question, different answers.

## Fix

Mirror the \`resolveDefaultProvider\` shape: \`KeyRequirement = string | string[]\`. Array means "any of these alternatives". \`minimax/deepseek/glm\` each accept \`<PROVIDER>_API_KEY OR <PROVIDER>_VAULT_KEY\`.

## Smoke check (operator)

\`\`\`bash
# After PR merges:
cd ~/memphis && git pull origin main && npm run build && memphis service restart
journalctl --user -u memphis -n 5 --no-pager
# Expected: no MISSING_ENV crash, daemon stays running
memphis service status   # active: yes (and stays yes)
\`\`\`

## Net impact

- 1 source file, 1 test file
- 10/10 config-profiles tests green (+3 new)
- Removes a real cause of operator-visible crashloop in vault-hardened production setups

🤖 Generated with [Claude Code](https://claude.com/claude-code)