### PR TITLE
fix(minimax): strip <think>…</think> reasoning blocks before surfacing content

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -479,8 +479,14 @@ export class MinimaxProvider implements Provider {
         ? inlineParse.calls
         : undefined;
 
+    // Strip <think>…</think> reasoning blocks before surfacing content
+    // to the gateway. The Rust chat path has a streaming stripper but
+    // the TS provider path didn't — operators saw paragraphs of model
+    // chain-of-thought leak into Telegram replies on 2026-04-29.
+    const finalContent = stripThinkBlocks(inlineParse.cleaned || msg?.content || '');
+
     return {
-      content: inlineParse.cleaned || msg?.content || '',
+      content: finalContent,
       model,
       provider: 'minimax',
       tokens: data.usage
@@ -493,6 +499,32 @@ export class MinimaxProvider implements Provider {
       tool_calls: toolCalls?.length ? toolCalls : undefined,
     };
   }
+}
+
+/**
+ * Strip `<think>…</think>` reasoning blocks from assistant content.
+ * MiniMax M2.7 (and several other models) emit chain-of-thought wrapped
+ * in `<think>` tags inline with the user-facing reply. Memphis' Rust
+ * chat path has a streaming ThinkStripper, but the TS provider path
+ * surfaces the raw content to surfaces like Telegram, where operators
+ * see paragraphs of "<think>The user just said…</think>" before the
+ * actual answer. Operator hit this on Telegram 2026-04-29.
+ *
+ * Strips both well-formed blocks and unclosed trailing `<think>` (drops
+ * everything from the open tag if no close tag follows — matches the
+ * Rust stripper's finalize-on-EOF behaviour for streaming).
+ */
+function stripThinkBlocks(content: string): string {
+  // Drop well-formed <think>…</think> blocks (lazy match across newlines).
+  let cleaned = content.replace(/<think>[\s\S]*?<\/think>/gi, '');
+  // If a stray opening <think> remains without a close (truncated
+  // response, model never closed it), drop everything from there on
+  // rather than leak the partial reasoning.
+  const orphanOpen = cleaned.search(/<think>/i);
+  if (orphanOpen !== -1) {
+    cleaned = cleaned.slice(0, orphanOpen);
+  }
+  return cleaned.trim();
 }
 
 /**

--- a/tests/unit/minimax-inline-tool-parser.test.ts
+++ b/tests/unit/minimax-inline-tool-parser.test.ts
@@ -174,3 +174,51 @@ describe('MinimaxProvider — system-role coalescing', () => {
     expect(captured!.messages.filter((m) => m.role === 'system')).toHaveLength(0);
   });
 });
+
+describe('MinimaxProvider — <think> block stripping', () => {
+  const originalFetch = globalThis.fetch;
+
+  it('strips well-formed <think>…</think> blocks from content', async () => {
+    globalThis.fetch = mockMinimaxResponse(
+      '<think>The user just said hi. I should reply briefly.</think>\n\nHello there!',
+    );
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    const res = await provider.chat([{ role: 'user', content: 'hi' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(res.content).toBe('Hello there!');
+    expect(res.content).not.toContain('<think>');
+  });
+
+  it('drops content from orphan <think> open with no close (truncated reply)', async () => {
+    globalThis.fetch = mockMinimaxResponse(
+      'Some preamble.\n<think>Reasoning that got cut off mid-stream …',
+    );
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    const res = await provider.chat([{ role: 'user', content: 'x' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(res.content).toBe('Some preamble.');
+    expect(res.content).not.toContain('<think>');
+  });
+
+  it('handles multiple <think> blocks across the response', async () => {
+    globalThis.fetch = mockMinimaxResponse(
+      '<think>First reasoning.</think>Step 1.\n<think>Second reasoning.</think>Step 2.',
+    );
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    const res = await provider.chat([{ role: 'user', content: 'go' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(res.content).toBe('Step 1.\nStep 2.');
+  });
+
+  it('preserves content with no <think> tags unchanged', async () => {
+    globalThis.fetch = mockMinimaxResponse('Plain reply with no reasoning markers.');
+    const provider = new MinimaxProvider({ apiKey: 'test', model: 'MiniMax-M2.7' });
+    const res = await provider.chat([{ role: 'user', content: 'hi' }]);
+    globalThis.fetch = originalFetch;
+
+    expect(res.content).toBe('Plain reply with no reasoning markers.');
+  });
+});


### PR DESCRIPTION
## Summary

Operator-visible bug on Telegram 2026-04-29:

\`\`\`
You: ?
Memphis Agent: <think>The user's message is just "?" - they seem to be
asking what happened or what's going on. Looking at the context, I see
that I was in the middle of writing a comprehensive test report …</think>

## ✅ STATUS — co robię
…
\`\`\`

The bot leaked its full chain-of-thought into the Telegram reply.

## Root cause

MiniMax M2.7 emits `<think>…</think>` reasoning inline with the user-facing reply. The Rust chat path has \`crates/memphis-operator/src/think_stripper.rs\` (streaming) but the TypeScript provider path didn't strip anything — the raw content went straight from \`MinimaxProvider.chat\` to the gateway to Telegram \`bot.api.sendMessage\`.

## Fix

Strip in \`MinimaxProvider.chat\` at the return boundary, after structured/inline tool-call extraction:

- Well-formed `<think>…</think>` blocks → dropped (lazy match across newlines, multiple blocks).
- Orphan `<think>` open with no close (truncated stream) → drop everything from the open tag onward, matches the Rust stripper's finalize-on-EOF behaviour.

## Tests

11/11 in this file:
- inline tool-call XML extraction (PR #366)
- multi-parameter invoke
- structured-vs-inline precedence
- plain content passthrough
- malformed-block drop
- multi-system coalescing (PR #367)
- no-system-pieces omission
- well-formed think strip
- orphan-open truncation
- multi-block strip
- plain-no-think passthrough

## Smoke check (operator)

\`\`\`bash
cd ~/memphis && git checkout -- AGENTS.md CLAUDE.md && git pull --rebase origin main && npm run build && memphis service restart
\`\`\`

Then on Telegram:
\`\`\`
You: hej
\`\`\`

Bot's reply should NOT contain `<think>` blocks anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)