### PR TITLE
fix(tui): refresh runs on background thread; main loop never blocks on it

### DIFF
--- a/crates/memphis-tui/src/app.rs
+++ b/crates/memphis-tui/src/app.rs
@@ -583,8 +583,24 @@ impl AppState {
     }
 
     pub fn refresh(&mut self, client: &MemphisClient) {
-        self.snapshot = client.fetch_snapshot();
-        self.provider_statuses = client.provider_statuses();
+        let snapshot = client.fetch_snapshot();
+        let provider_statuses = client.provider_statuses();
+        self.apply_refresh_snapshot(snapshot, provider_statuses);
+    }
+
+    /// Apply a snapshot/provider-statuses pair fetched on a background
+    /// thread without touching the client. Split out from `refresh` so
+    /// the TUI main loop can dispatch the slow MemphisClient calls to a
+    /// worker and merge the result here when it arrives. Behaviour
+    /// matches `refresh` exactly — same output-buffer initialization,
+    /// same field assignments — only the timing changes.
+    pub fn apply_refresh_snapshot(
+        &mut self,
+        snapshot: AppSnapshot,
+        provider_statuses: Vec<ProviderStatus>,
+    ) {
+        self.snapshot = snapshot;
+        self.provider_statuses = provider_statuses;
         if self.output_buffer.is_empty() {
             self.append_line(title("Memphis operator cockpit ready."));
             self.append_line(dim(

--- a/crates/memphis-tui/src/client.rs
+++ b/crates/memphis-tui/src/client.rs
@@ -13,8 +13,9 @@ use std::{
 
 use memphis_operator::{
     ChatExchange, ChatSessionView, ChatStreamEvent, MemoryQueryResult, OperatorError,
-    OperatorRuntime, OperatorSnapshot, ProviderStatus, VaultSecretView,
+    OperatorRuntime, OperatorSnapshot, VaultSecretView,
 };
+pub use memphis_operator::ProviderStatus;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/crates/memphis-tui/src/main.rs
+++ b/crates/memphis-tui/src/main.rs
@@ -8,6 +8,7 @@ mod widgets;
 use std::{
     env,
     process::ExitCode,
+    sync::mpsc,
     thread,
     time::{Duration, Instant},
 };
@@ -203,6 +204,20 @@ fn main() -> ExitCode {
         }
     };
 
+    // Refresh used to run inline on the main loop — `app.refresh(&client)`
+    // does vault decrypt + provider HTTP pings + memory snapshot, totalling
+    // 5–15s on a populated runtime. Every keystroke had to wait for the
+    // refresh cadence to clear before crossterm could read the input.
+    // Operator hit visible 15s lag on every keystroke 2026-04-29.
+    //
+    // We now spawn refresh on a background thread when the cadence elapses
+    // and read the result via a non-blocking try_recv. Only one refresh is
+    // in flight at a time (skip the next tick if the previous hasn't
+    // finished). Each background task creates its own MemphisClient — vault
+    // entry reads are file-open + AES-GCM decrypt, safe to do concurrently
+    // with the main thread (no shared mutable state, no locking required).
+    let mut pending_refresh: Option<mpsc::Receiver<RefreshResult>> = None;
+
     loop {
         app.poll_active_command();
 
@@ -211,8 +226,32 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
 
-        if last_refresh.elapsed() >= config.refresh_interval {
-            app.refresh(&client);
+        // Drain any background refresh that finished since the last tick.
+        if let Some(rx) = pending_refresh.as_ref() {
+            match rx.try_recv() {
+                Ok(result) => {
+                    app.apply_refresh_snapshot(result.snapshot, result.provider_statuses);
+                    pending_refresh = None;
+                }
+                Err(mpsc::TryRecvError::Empty) => {
+                    // Worker still running; leave the receiver in place,
+                    // try again next tick. Main loop continues.
+                }
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    // Worker thread crashed/exited without sending. Drop
+                    // the receiver and let the next cadence kick a fresh
+                    // attempt. We don't surface this to the operator —
+                    // the previous snapshot stays on screen, which is
+                    // strictly better than blocking the UI on the failure.
+                    pending_refresh = None;
+                }
+            }
+        }
+
+        // Kick a new background refresh when the cadence elapses AND no
+        // previous refresh is still running.
+        if pending_refresh.is_none() && last_refresh.elapsed() >= config.refresh_interval {
+            pending_refresh = Some(spawn_refresh());
             last_refresh = Instant::now();
         }
 
@@ -247,7 +286,10 @@ fn main() -> ExitCode {
                         }
                     }
                     AppAction::Refresh => {
-                        app.refresh(&client);
+                        // Operator pressed F5 / Ctrl-R — force an immediate
+                        // background refresh even if cadence hasn't elapsed.
+                        // Replaces any previously-in-flight refresh.
+                        pending_refresh = Some(spawn_refresh());
                         last_refresh = Instant::now();
                     }
                     AppAction::SubmitInput => {
@@ -269,6 +311,31 @@ fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
+}
+
+struct RefreshResult {
+    snapshot: client::AppSnapshot,
+    provider_statuses: Vec<client::ProviderStatus>,
+}
+
+/// Spawn a background thread that builds a fresh MemphisClient (so the
+/// main thread's client stays untouched), does the slow snapshot +
+/// provider-statuses calls, and returns the result through a channel.
+/// The receiver is non-blocking — the main loop polls it via try_recv.
+fn spawn_refresh() -> mpsc::Receiver<RefreshResult> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let bg_client = MemphisClient::new();
+        let snapshot = bg_client.fetch_snapshot();
+        let provider_statuses = bg_client.provider_statuses();
+        // Receiver may already be dropped if the operator quit between
+        // spawn and finish — ignore the send error in that case.
+        let _ = tx.send(RefreshResult {
+            snapshot,
+            provider_statuses,
+        });
+    });
+    rx
 }
 
 fn print_usage() {


### PR DESCRIPTION
## Summary

Operator-visible bug observed 2026-04-29: TUI keystrokes lagged ~15s. Every typed character had to wait for the in-progress refresh cycle to clear before crossterm's \`event::poll\` could read the input.

## Root cause

\`app.refresh(&client)\` in the main loop did:
- vault decrypt (Argon2 derive ~500ms + AES-GCM)
- provider HTTP pings (4 providers × ~1s remote, anthropic/glm/codex/ollama)
- memory snapshot (chains scan)

Total 5–15s on populated runtime. Inline on the event loop every \`refresh_interval\` (default 3s). Operator's keystroke wait = entire refresh duration.

## Fix

Refresh now runs on a background thread kicked off when cadence elapses if no previous refresh is still in flight. Result returns through \`std::sync::mpsc::channel\`. Main loop polls via \`try_recv\` (non-blocking) — apply on present, leave alone on empty, drop receiver on disconnected (previous snapshot stays visible, strictly better than blocking on a dead worker).

Force-refresh (F5 / Ctrl-R via \`AppAction::Refresh\`) replaces any in-flight worker with a new spawn.

## Concurrency model

Worker creates its own \`MemphisClient\` — vault entry reads are file-open + AES-GCM decrypt, safe for concurrent readers; no shared mutable state, no locking. Two file descriptors against \`vault-entries.json\` is fine (POSIX read concurrency).

## Smoke check (operator)

\`\`\`bash
cd ~/memphis && git pull origin main && npm run build:rust
memphis tui
# Type continuously — characters appear instantly, not after a 15s wait
# Refresh still happens; the overview tile updates in the background
# every refresh_interval without freezing input
\`\`\`

If still slow after this, it's not the refresh blocking — likely terminal emulator latency or runtime CPU starvation.

## Tests

- \`cargo build -p memphis-tui\` green
- \`cargo test -p memphis-tui\` 97/97 green
- Refactor split: \`AppState::refresh\` → \`apply_refresh_snapshot\` for the worker path; CLI \`run_command\` keeps the sync shape (no event loop, no benefit from async).

🤖 Generated with [Claude Code](https://claude.com/claude-code)