### PR TITLE
fix(tests): macOS-portable tmpdir — fixes 8 cross-arch failures from /private/var symlink

### DIFF
--- a/tests/helpers/tmpdir.ts
+++ b/tests/helpers/tmpdir.ts
@@ -1,0 +1,24 @@
+import { realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+/**
+ * macOS-portable tmpdir.
+ *
+ * On macOS `os.tmpdir()` returns `/var/folders/<…>/T/` but Memphis path
+ * resolvers — notably `resolveInstallRoot` in
+ * `src/infra/runtime/install-root.ts` — call `realpathSync()` to follow
+ * the `/var/folders/…` → `/private/var/folders/…` symlink that macOS
+ * inserts. Any test that builds a fixture path with `os.tmpdir()` and
+ * then compares it against a path produced through Memphis' resolution
+ * chain would otherwise fail on macOS with `expected '/private/var/…'
+ * to be '/var/…'`. The 2026-04-29 cross-arch CI run on PR #371 surfaced
+ * exactly this on 8 tests across cli.apps, install-root, managed-apps,
+ * self-modify-path-validation, and vault-paths.
+ *
+ * Calling `realpathSync(tmpdir())` once at module load means both sides
+ * of the comparison are dereferenced consistently. On Linux this is a
+ * no-op (no symlink to follow) so existing assertions stay green.
+ */
+export function realTmpdir(): string {
+  return realpathSync(tmpdir());
+}

--- a/tests/unit/cli.apps.test.ts
+++ b/tests/unit/cli.apps.test.ts
@@ -1,5 +1,4 @@
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
@@ -7,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { vaultEncrypt } from '../../src/infra/storage/rust-vault-adapter.js';
 import { saveVaultEntry } from '../../src/infra/storage/vault-entry-store.js';
 import { runCli, runCliResult } from '../helpers/cli.js';
+import { realTmpdir as tmpdir } from '../helpers/tmpdir.js';
 
 vi.mock('../../src/infra/auth/operator-gate.js', () => ({
   isOperatorConfigured: vi.fn(() => true),

--- a/tests/unit/install-root.test.ts
+++ b/tests/unit/install-root.test.ts
@@ -1,5 +1,4 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -8,6 +7,8 @@ import {
   resolveInstallRoot,
   resolveInstallRootWithSource,
 } from '../../src/infra/runtime/install-root.js';
+import { realTmpdir as tmpdir } from '../helpers/tmpdir.js';
+
 
 function makePackage(root: string, name: string): void {
   writeFileSync(join(root, 'package.json'), JSON.stringify({ name }, null, 2));

--- a/tests/unit/managed-apps.manifest.test.ts
+++ b/tests/unit/managed-apps.manifest.test.ts
@@ -1,8 +1,8 @@
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
+
 
 import {
   vaultEncrypt,
@@ -20,6 +20,7 @@ import {
   planManagedAppAction,
   validateManagedAppManifestFile,
 } from '../../src/modules/apps/manifest.js';
+import { realTmpdir as tmpdir } from '../helpers/tmpdir.js';
 
 vi.mock('../../src/infra/auth/operator-gate.js', () => ({
   isOperatorConfigured: vi.fn(() => true),

--- a/tests/unit/managed-apps.registry.test.ts
+++ b/tests/unit/managed-apps.registry.test.ts
@@ -1,5 +1,4 @@
 import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -9,6 +8,7 @@ import {
   getManagedAppRegistryRecord,
   recordManagedAppExecution,
 } from '../../src/modules/apps/registry.js';
+import { realTmpdir as tmpdir } from '../helpers/tmpdir.js';
 
 describe('managed app registry', () => {
   it('records successful applied actions as installed app state', () => {

--- a/tests/unit/self-modify-path-validation.test.ts
+++ b/tests/unit/self-modify-path-validation.test.ts
@@ -1,10 +1,10 @@
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { validateFilePath } from '../../src/mcp/tools/self-modify.js';
+import { realTmpdir } from '../helpers/tmpdir.js';
 
 /**
  * Regression net for #136: self-modify's validateFilePath used path.resolve
@@ -21,8 +21,8 @@ interface Env {
 }
 
 function setup(): Env {
-  const tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'memphis-selfmod-'));
-  const outsideDir = mkdtempSync(path.join(os.tmpdir(), 'memphis-selfmod-outside-'));
+  const tmpRoot = mkdtempSync(path.join(realTmpdir(), 'memphis-selfmod-'));
+  const outsideDir = mkdtempSync(path.join(realTmpdir(), 'memphis-selfmod-outside-'));
   mkdirSync(path.join(tmpRoot, 'src'), { recursive: true });
   return { tmpRoot, outsideDir };
 }

--- a/tests/unit/vault-paths.test.ts
+++ b/tests/unit/vault-paths.test.ts
@@ -22,7 +22,7 @@ import {
   writeFileSync,
   mkdirSync,
 } from 'node:fs';
-import { tmpdir, homedir } from 'node:os';
+import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -31,6 +31,7 @@ import {
   __resetVaultPathWarnings,
   resolveVaultPath,
 } from '../../src/infra/storage/vault-paths.js';
+import { realTmpdir as tmpdir } from '../helpers/tmpdir.js';
 
 interface Sandbox {
   dir: string;


### PR DESCRIPTION
## Summary

Cross-arch CI on \`macos-latest\` reported 8 test failures with the same shape:

\`\`\`
expected '/private/var/folders/tb/…'
   to be '/var/folders/tb/…'
\`\`\`

macOS' \`/var/folders/<…>/T/\` tmpdir lives behind a \`/private/var\` symlink. Memphis path resolvers (notably \`resolveInstallRoot\` in \`src/infra/runtime/install-root.ts\`) call \`realpathSync()\` to follow npm-link / homebrew install chains. Tests that built fixture paths with raw \`os.tmpdir()\` and then compared against paths produced through Memphis' resolution chain mismatched on macOS only — \`expected '/var/...'\` vs \`'/private/var/...'\`.

## Failing tests on macos-latest before this PR

- \`tests/unit/cli.apps.test.ts\` (3) — file-backed action with vault env/file bindings
- \`tests/unit/install-root.test.ts\` — walk-up from import URL
- \`tests/unit/managed-apps.manifest.test.ts\` (3) — file-backed managed app actions
- \`tests/unit/managed-apps.registry.test.ts\` (1) — applied-action registry
- \`tests/unit/self-modify-path-validation.test.ts\` — accepts a normal path inside project root
- \`tests/unit/vault-paths.test.ts\` — legacy \`\${installRoot}/data/<file>\`

## Fix

New \`tests/helpers/tmpdir.ts:realTmpdir()\` returns \`realpathSync(tmpdir())\`. Six failing test files migrated to use it.

On Linux: no-op (no symlink to follow) — existing 2440 unit tests stay green.
On macOS: both sides of the comparison are dereferenced consistently.

## Verification

- Linux: 50/50 of the affected tests green locally
- Lint clean
- macOS: verdict from cross-arch matrix on this PR's CI run

If macOS still red after this PR, the residual failures are NOT path-symlink-related and need separate diagnosis (NAPI chain lock semantics or vault file binding behaviour, per \`project_macos_compat_pending.md\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)