### PR TITLE
fix(apps): default manifest platforms to linux+darwin+win32 (macOS CI)

### DIFF
--- a/src/modules/apps/manifest.ts
+++ b/src/modules/apps/manifest.ts
@@ -271,7 +271,14 @@ function normalizeManifest(input: unknown): ManagedAppManifest {
     description: parsed.description,
     homepage: parsed.homepage,
     capabilities: [...(parsed.capabilities ?? [])].sort(),
-    platforms: parsed.platforms ?? ['linux'],
+    // Default to all three supported platforms so a manifest without an
+    // explicit `platforms` list runs anywhere memphis itself runs.
+    // Restricting to linux-only out-of-box was an arbitrary cap that broke
+    // every managed-app integration test on macOS cross-arch CI without
+    // signalling intent in the manifest source. Operators who need a
+    // platform-locked manifest should pass `platforms: ["linux"]`
+    // explicitly — the default is permissive.
+    platforms: parsed.platforms ?? ['linux', 'darwin', 'win32'],
     runtime: {
       node: parsed.runtime?.node,
       commands: (parsed.runtime?.commands ?? []).map((command) => ({


### PR DESCRIPTION
## Summary

After PR #372 fixed the path-symlink class of macOS test failures, 5 tests still failed with the same shape:

\`\`\`
managed app action cannot run until requirements pass:
platform darwin not in supported set: linux
\`\`\`

## Root cause

\`ManagedAppManifestSchema\` (\`src/modules/apps/manifest.ts:274\`) defaulted \`platforms\` to \`['linux']\` when the field was omitted. Test fixtures construct minimal manifests without an explicit \`platforms\` list, so the linux-only default kicked in and the requirement gate refused to execute on macOS.

The schema-level cap was arbitrary: memphis itself runs on \`linux\`/\`darwin\`/\`win32\` (supported set is the union, see \`manifest.ts:201\`). A manifest with no explicit platform restriction has no reason to refuse darwin or win32.

## Fix

Default platforms to \`['linux', 'darwin', 'win32']\`. Operators who need a platform-locked manifest can still pass \`platforms: ["linux"]\` explicitly — the default is now permissive instead of restrictive.

## macOS CI status

After PR #372 + this PR: 8/8 of the originally-tracked macOS failures should be resolved. Verdict from cross-arch matrix on the post-merge push run.

## Tests

32/32 of the affected tests green on Linux. \`npm run lint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)