### PR TITLE
refactor(env): drop MEMPHIS_DIR alias — single canonical MEMPHIS_DATA_DIR (Sprint 6 F1)

### DIFF
--- a/crates/memphis-operator/src/config.rs
+++ b/crates/memphis-operator/src/config.rs
@@ -150,7 +150,6 @@ fn expand_home(input: &str) -> PathBuf {
 fn resolve_data_dir(env_map: &HashMap<String, String>) -> PathBuf {
     let configured = env_map
         .get("MEMPHIS_DATA_DIR")
-        .or_else(|| env_map.get("MEMPHIS_DIR"))
         .map(String::as_str)
         .unwrap_or(DEFAULT_MEMPHIS_DATA_DIR);
 

--- a/src/cognitive/model-c.ts
+++ b/src/cognitive/model-c.ts
@@ -98,7 +98,7 @@ function resolvePatternRuntimeDir(memphisDir?: string): string | null {
   if (typeof memphisDir === 'string' && memphisDir.trim().length > 0) {
     return path.resolve(memphisDir);
   }
-  const explicit = process.env.MEMPHIS_DATA_DIR ?? process.env.MEMPHIS_DIR;
+  const explicit = process.env.MEMPHIS_DATA_DIR;
   if (typeof explicit === 'string' && explicit.trim().length > 0) {
     return path.resolve(explicit);
   }

--- a/src/cognitive/runtime-support.ts
+++ b/src/cognitive/runtime-support.ts
@@ -13,9 +13,7 @@ export const DEFAULT_COGNITIVE_CHAIN_LIMITS = {
 export function shouldUseTestIsolatedCognitiveState(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return (
-    rawEnv.NODE_ENV === 'test' && !rawEnv.MEMPHIS_DATA_DIR?.trim() && !rawEnv.MEMPHIS_DIR?.trim()
-  );
+  return rawEnv.NODE_ENV === 'test' && !rawEnv.MEMPHIS_DATA_DIR?.trim();
 }
 
 export function normalizeCognitiveBlock(block: Block): Block {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -20,7 +20,7 @@ function expandHome(input: string): string {
 }
 
 export function getDataDir(rawEnv: NodeJS.ProcessEnv = process.env): string {
-  const configured = rawEnv.MEMPHIS_DATA_DIR ?? rawEnv.MEMPHIS_DIR ?? DEFAULT_MEMPHIS_DATA_DIR;
+  const configured = rawEnv.MEMPHIS_DATA_DIR ?? DEFAULT_MEMPHIS_DATA_DIR;
   return path.resolve(expandHome(configured));
 }
 

--- a/src/gateway/memory-client.ts
+++ b/src/gateway/memory-client.ts
@@ -7,9 +7,7 @@ import { runMemphisJournal } from '../mcp/tools/journal.js';
 import { runMemphisRecall } from '../mcp/tools/recall.js';
 
 function shouldUseIsolatedTestMemory(rawEnv: NodeJS.ProcessEnv): boolean {
-  return (
-    rawEnv.NODE_ENV === 'test' && !rawEnv.MEMPHIS_DATA_DIR?.trim() && !rawEnv.MEMPHIS_DIR?.trim()
-  );
+  return rawEnv.NODE_ENV === 'test' && !rawEnv.MEMPHIS_DATA_DIR?.trim();
 }
 
 export type InProcessMemoryClientOptions = {

--- a/tests/cognitive/cognitive-integration.test.ts
+++ b/tests/cognitive/cognitive-integration.test.ts
@@ -11,19 +11,19 @@ import { ModelE_MetaCognitiveReflection } from '../../src/cognitive/model-e.js';
 import type { Block } from '../../src/memory/chain.js';
 
 let tmpMemphisDir = '';
-let oldMemphisDir: string | undefined;
+let oldMemphisDataDir: string | undefined;
 let tmpHome = '';
 
 beforeEach(() => {
-  oldMemphisDir = process.env.MEMPHIS_DIR;
+  oldMemphisDataDir = process.env.MEMPHIS_DATA_DIR;
   tmpMemphisDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cognitive-integration-'));
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cognitive-integration-home-'));
-  process.env.MEMPHIS_DIR = tmpMemphisDir;
+  process.env.MEMPHIS_DATA_DIR = tmpMemphisDir;
   process.env.HOME = tmpHome;
 });
 
 afterEach(() => {
-  process.env.MEMPHIS_DIR = oldMemphisDir;
+  process.env.MEMPHIS_DATA_DIR = oldMemphisDataDir;
   if (tmpMemphisDir && fs.existsSync(tmpMemphisDir)) {
     fs.rmSync(tmpMemphisDir, { recursive: true, force: true });
   }

--- a/tests/cognitive/empty-blocks-handling.test.ts
+++ b/tests/cognitive/empty-blocks-handling.test.ts
@@ -10,16 +10,16 @@ import { ModelC_PredictivePatterns } from '../../src/cognitive/model-c.js';
 import { ModelE_MetaCognitiveReflection } from '../../src/cognitive/model-e.js';
 
 let tmpMemphisDir = '';
-let oldMemphisDir: string | undefined;
+let oldMemphisDataDir: string | undefined;
 let oldHome: string | undefined;
 let tmpHome = '';
 
 beforeEach(() => {
-  oldMemphisDir = process.env.MEMPHIS_DIR;
+  oldMemphisDataDir = process.env.MEMPHIS_DATA_DIR;
   oldHome = process.env.HOME;
   tmpMemphisDir = fs.mkdtempSync(path.join(os.tmpdir(), 'empty-cognitive-'));
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'empty-cognitive-home-'));
-  process.env.MEMPHIS_DIR = tmpMemphisDir;
+  process.env.MEMPHIS_DATA_DIR = tmpMemphisDir;
   process.env.HOME = tmpHome;
 });
 
@@ -42,7 +42,7 @@ function rmWithRetry(dir: string): void {
 }
 
 afterEach(() => {
-  process.env.MEMPHIS_DIR = oldMemphisDir;
+  process.env.MEMPHIS_DATA_DIR = oldMemphisDataDir;
   if (oldHome === undefined) {
     delete process.env.HOME;
   } else {

--- a/tests/cognitive/malformed-data.test.ts
+++ b/tests/cognitive/malformed-data.test.ts
@@ -10,7 +10,7 @@ import { ModelE_MetaCognitiveReflection } from '../../src/cognitive/model-e.js';
 import type { Block } from '../../src/memory/chain.js';
 
 let tmpMemphisDir = '';
-let oldMemphisDir: string | undefined;
+let oldMemphisDataDir: string | undefined;
 
 beforeAll(() => {
   (
@@ -21,13 +21,13 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  oldMemphisDir = process.env.MEMPHIS_DIR;
+  oldMemphisDataDir = process.env.MEMPHIS_DATA_DIR;
   tmpMemphisDir = fs.mkdtempSync(path.join(os.tmpdir(), 'malformed-cognitive-'));
-  process.env.MEMPHIS_DIR = tmpMemphisDir;
+  process.env.MEMPHIS_DATA_DIR = tmpMemphisDir;
 });
 
 afterEach(() => {
-  process.env.MEMPHIS_DIR = oldMemphisDir;
+  process.env.MEMPHIS_DATA_DIR = oldMemphisDataDir;
   if (tmpMemphisDir && fs.existsSync(tmpMemphisDir)) {
     fs.rmSync(tmpMemphisDir, { recursive: true, force: true });
   }

--- a/tests/cognitive/model-c-comprehensive.test.ts
+++ b/tests/cognitive/model-c-comprehensive.test.ts
@@ -9,7 +9,7 @@ import type { IStore } from '../../src/cognitive/store.js';
 import type { Block } from '../../src/memory/chain.js';
 
 let tmpMemphisDir = '';
-let oldMemphisDir: string | undefined;
+let oldMemphisDataDir: string | undefined;
 let tmpHome = '';
 const chainCounters = new Map<string, number>();
 
@@ -56,17 +56,17 @@ const makeBlock = (
 });
 
 beforeEach(() => {
-  oldMemphisDir = process.env.MEMPHIS_DIR;
+  oldMemphisDataDir = process.env.MEMPHIS_DATA_DIR;
   tmpMemphisDir = fs.mkdtempSync(path.join(os.tmpdir(), 'model-c-'));
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'model-c-home-'));
   fs.mkdirSync(tmpMemphisDir, { recursive: true });
-  process.env.MEMPHIS_DIR = tmpMemphisDir;
+  process.env.MEMPHIS_DATA_DIR = tmpMemphisDir;
   process.env.HOME = tmpHome;
   chainCounters.clear();
 });
 
 afterEach(() => {
-  process.env.MEMPHIS_DIR = oldMemphisDir;
+  process.env.MEMPHIS_DATA_DIR = oldMemphisDataDir;
   if (tmpMemphisDir && fs.existsSync(tmpMemphisDir)) {
     fs.rmSync(tmpMemphisDir, { recursive: true, force: true });
   }

--- a/tests/helpers/cli.ts
+++ b/tests/helpers/cli.ts
@@ -43,7 +43,6 @@ function applyEnv(env?: NodeJS.ProcessEnv): () => void {
   const previous = { ...process.env };
   const memphisDataDir =
     env?.MEMPHIS_DATA_DIR ??
-    env?.MEMPHIS_DIR ??
     (env?.HOME ? resolve(env.HOME, '.memphis') : undefined);
 
   process.env = {

--- a/tests/unit/cli.vault-migrate.test.ts
+++ b/tests/unit/cli.vault-migrate.test.ts
@@ -40,9 +40,8 @@ beforeEach(() => {
   );
   originalEnv = { ...process.env };
   process.env.MEMPHIS_RUNTIME_ROOT = installRoot;
-  // getDataDir reads MEMPHIS_DATA_DIR / MEMPHIS_DIR (not MEMPHIS_HOME).
+  // getDataDir reads MEMPHIS_DATA_DIR (MEMPHIS_DIR alias dropped 2026-04-30).
   process.env.MEMPHIS_DATA_DIR = memphisHome;
-  delete process.env.MEMPHIS_DIR;
   // Reset between tests so exit-code assertions don't leak across cases.
   process.exitCode = 0;
 });

--- a/tests/unit/reflection-loop.test.ts
+++ b/tests/unit/reflection-loop.test.ts
@@ -45,7 +45,7 @@ describe('reflection loop runtime', () => {
 
   afterEach(() => {
     delete process.env.MEMPHIS_DATA_DIR;
-    delete process.env.MEMPHIS_DIR;
+    delete process.env.MEMPHIS_DATA_DIR;
     delete process.env.RUST_CHAIN_ENABLED;
     delete process.env.COGNITIVE_MODEL_E_REFLECTION_SCHEDULE;
     delete process.env.COGNITIVE_MODEL_E_DEEP_ANALYSIS_DAY;


### PR DESCRIPTION
## Summary

Sprint 6 PR-F1 from the Karpathy refactor plan. \`MEMPHIS_DATA_DIR\` was the canonical name; \`MEMPHIS_DIR\` was a backward-compat alias used as fallback. Two readable names for the same setting let drift sneak in:

- some test fixtures wrote \`process.env.MEMPHIS_DIR=…\`
- runtime code did \`MEMPHIS_DATA_DIR ?? MEMPHIS_DIR\`
- operators occasionally wrote one in .env while runtime expected the other

This PR collapses to \`MEMPHIS_DATA_DIR\` only.

## Changes

**Source migration (5 callsites)**:
- \`src/config/paths.ts:23\` — drop fallback
- \`src/cognitive/runtime-support.ts\` — drop secondary check
- \`src/cognitive/model-c.ts\` — drop secondary fallback
- \`src/gateway/memory-client.ts\` — drop secondary check
- \`tests/helpers/cli.ts\` — drop secondary fallback in CLI test runner

**Test fixture migration (6 files)**: \`process.env.MEMPHIS_DIR=…\` → \`process.env.MEMPHIS_DATA_DIR=…\`:
- \`tests/cognitive/{cognitive-integration,empty-blocks-handling,malformed-data,model-c-comprehensive}.test.ts\`
- \`tests/unit/cli.vault-migrate.test.ts\`
- \`tests/unit/reflection-loop.test.ts\`

**Rust side**: \`crates/memphis-operator/src/config.rs:148-153\` — drop \`or_else(|| env_map.get("MEMPHIS_DIR"))\` so operator runtime mirrors TypeScript canonical-only behaviour.

## Operator-facing impact

Operators with the old name in \`.env\` need a one-line rename:

\`\`\`bash
sed -i 's/^MEMPHIS_DIR=/MEMPHIS_DATA_DIR=/' ~/memphis/.env
\`\`\`

The fallback won't carry them silently any more — runtime will resolve to the default \`~/.memphis\` if the canonical name is absent.

## Tests

- 90/90 of the affected suites green on Linux
- \`cargo test -p memphis-operator\`: 61/61 green
- \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)