### PR TITLE
fix(security): enforce 0600 on sensitive config files + heal-on-load (#272)

### DIFF
--- a/src/infra/agent-profile.ts
+++ b/src/infra/agent-profile.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { z } from 'zod';
 
+import { healSensitiveFilePerms, writeSensitiveFile } from './storage/secure-file.js';
 import { getDataDir } from '../config/paths.js';
 
 export const DEFAULT_AGENT_NAME = 'Memphis Agent';
@@ -49,6 +50,8 @@ export function defaultAgentProfile(
 export function loadAgentProfile(rawEnv: NodeJS.ProcessEnv = process.env): AgentProfile | null {
   const profilePath = getAgentProfilePath(rawEnv);
   if (!existsSync(profilePath)) return null;
+  // Heal-on-load: tighten 0600 if the file pre-dates writeSensitiveFile.
+  healSensitiveFilePerms(profilePath);
   const raw = JSON.parse(readFileSync(profilePath, 'utf8')) as unknown;
   return agentProfileSchema.parse(raw);
 }
@@ -96,8 +99,9 @@ export function writeAgentProfile(
   });
 
   const profilePath = getAgentProfilePath(rawEnv);
-  mkdirSync(path.dirname(profilePath), { recursive: true });
-  writeFileSync(profilePath, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+  // 0600 mode + parent dir 0700 — see secure-file.ts.
+  // agent-profile carries operator + agent identity; treat as PII-class.
+  writeSensitiveFile(profilePath, `${JSON.stringify(next, null, 2)}\n`);
 
   return { path: profilePath, profile: next };
 }

--- a/src/infra/cli/index.ts
+++ b/src/infra/cli/index.ts
@@ -9,6 +9,7 @@ import { ensureDir, getDataDir } from '../../config/paths.js';
 import { formatCliError, toAppError } from '../../core/errors.js';
 import { resolveVaultSecrets } from '../config/vault-resolve.js';
 import { resolveExitCode } from '../runtime/exit-codes.js';
+import { healAllSensitiveFiles } from '../storage/secure-file.js';
 
 const FIRST_RUN_MARKER = resolve(getDataDir(), '.first-run-checks');
 
@@ -82,6 +83,20 @@ export async function runCli(argv: string[] = process.argv ?? []): Promise<void>
       // `memphis init`) — fall through silently. Subsequent handlers
       // that actually need vault secrets will surface a more specific
       // error than crashing the CLI on every command.
+    }
+
+    // Heal-on-load for sensitive files. This catches existing operator
+    // installs where `vault-entries.json` (and any of the closed set
+    // listed in healAllSensitiveFiles) still has 664 perms on disk
+    // even though the writers now enforce 0600. Without this proactive
+    // call the heal only fires when a specific vault subcommand
+    // (`vault list/get/add/migrate`) lazily reads the file — operator's
+    // 2026-04-30 smoke after #275 left vault-entries.json at 664 because
+    // `service restart` doesn't trigger a vault-entries read.
+    try {
+      healAllSensitiveFiles(process.env);
+    } catch {
+      // Best-effort — never block a CLI command on a failed permission tighten.
     }
 
     if (args.command !== 'doctor' && args.command !== 'repair') {

--- a/src/infra/storage/secure-file.ts
+++ b/src/infra/storage/secure-file.ts
@@ -1,0 +1,125 @@
+import { chmodSync, existsSync, mkdirSync, renameSync, statSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Sensitive-file write/load helpers — POSIX 0600 enforcement.
+ *
+ * Memphis stores several files that carry primary-trust or
+ * operationally-sensitive data and should NOT be group/world readable
+ * even on a single-user box (backups, multi-user hosts, restored from
+ * a tarball with permissive umask, etc.):
+ *
+ *   - vault-entries.json (encrypted seeds, key fingerprints)
+ *   - vault-state.json   (master-key envelope; already 0600 via writer)
+ *   - soul-manifest.json (autonomy_mode, trustRules, tool gating)
+ *   - soul-memory.json   (operator's identity/persona narrative)
+ *   - agent-profile.json (agent + owner names; user-pii adjacent)
+ *   - operator.json      (operator passphrase hash; already 0600)
+ *
+ * Issue #272 (security): "ed25519 signing seed file permissions not
+ * enforced 0600 at init". The seed itself lives inside vault-entries.json
+ * (mp_v0_signing_seed entry) so the underlying file's permissions ARE
+ * the seed's permissions. The fix family extends to every sensitive
+ * config file: enforce 0600 on every write AND heal existing files
+ * with wider perms on every read (operator's existing install pre-dates
+ * the writer fix and has 664 files on disk — heal-on-load tightens
+ * silently with a warn so operators don't have to manually chmod).
+ *
+ * Cross-platform: POSIX modes are ignored on Windows (NTFS uses ACLs).
+ * The chmod is best-effort — write failure on Windows is fine, the
+ * mode flag in writeFileSync is the primary path; chmodSync is the
+ * pre-existing-file heal path.
+ */
+
+const SENSITIVE_PERMS = 0o600;
+const SENSITIVE_DIR_PERMS = 0o700;
+
+const healedPathsThisProcess = new Set<string>();
+
+function isPermissive(mode: number): boolean {
+  // Any non-zero bit in group/other = permissive.
+  return (mode & 0o077) !== 0;
+}
+
+/**
+ * Write a sensitive payload atomically (tmp + rename) with mode 0o600.
+ * Creates the parent directory with 0o700 if missing. Best-effort
+ * chmodSync follows the write so prior pre-existing files at the
+ * destination get their perms tightened too.
+ */
+export function writeSensitiveFile(path: string, content: string): void {
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true, mode: SENSITIVE_DIR_PERMS });
+  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmpPath, content, { mode: SENSITIVE_PERMS, encoding: 'utf8' });
+  try {
+    chmodSync(tmpPath, SENSITIVE_PERMS);
+  } catch {
+    // Best-effort — Windows / non-POSIX filesystems may reject.
+  }
+  // Atomic swap. POSIX rename(2) preserves the destination's inode
+  // perms only if the source already had them — that's why we set the
+  // mode on the tmp file before the rename.
+  renameSync(tmpPath, path);
+  // After rename, ensure the file has the right mode (defensive — some
+  // filesystems may apply umask during the rename).
+  try {
+    chmodSync(path, SENSITIVE_PERMS);
+  } catch {
+    // ignore on non-POSIX
+  }
+}
+
+/**
+ * Heal-on-load: if `path` exists with permissions wider than 0600,
+ * tighten in place and emit a one-time warning. Idempotent within a
+ * single process — repeated calls for the same path skip the stat/chmod
+ * after the first heal succeeds.
+ *
+ * Returns:
+ *   - 'absent'  — file does not exist (no action taken)
+ *   - 'ok'      — file existed with correct perms (or non-POSIX FS)
+ *   - 'healed'  — file had wider perms; chmod 0o600 applied
+ *
+ * Callers should not rely on the return value for control flow; it's
+ * for tests + audit logging. A fail-soft heal (chmod throws) is
+ * treated as 'ok' rather than an error — refusing to load the file
+ * because we couldn't tighten its perms would be worse than logging
+ * and proceeding.
+ */
+export function healSensitiveFilePerms(path: string): 'absent' | 'ok' | 'healed' {
+  if (!existsSync(path)) return 'absent';
+  if (healedPathsThisProcess.has(path)) return 'ok';
+  let mode: number;
+  try {
+    mode = statSync(path).mode;
+  } catch {
+    return 'ok';
+  }
+  if (!isPermissive(mode)) {
+    healedPathsThisProcess.add(path);
+    return 'ok';
+  }
+  try {
+    chmodSync(path, SENSITIVE_PERMS);
+    healedPathsThisProcess.add(path);
+    process.stderr.write(
+      `[memphis-secure-file] tightened perms on ${path} from ${(mode & 0o777).toString(8)} to 600\n`,
+    );
+    return 'healed';
+  } catch {
+    // chmod failed (Windows, foreign filesystem, missing capability) —
+    // log once and proceed; we don't want to block a runtime read on a
+    // best-effort hardening step.
+    healedPathsThisProcess.add(path);
+    return 'ok';
+  }
+}
+
+/**
+ * Test helper — clear the per-process heal cache so each test sees a
+ * fresh lifecycle for the same fixture path.
+ */
+export function __resetSensitiveFileHealCacheForTests(): void {
+  healedPathsThisProcess.clear();
+}

--- a/src/infra/storage/secure-file.ts
+++ b/src/infra/storage/secure-file.ts
@@ -1,6 +1,9 @@
 import { chmodSync, existsSync, mkdirSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
+import { resolveVaultPath } from './vault-paths.js';
+import { getConfigPath } from '../../config/paths.js';
+
 /**
  * Sensitive-file write/load helpers — POSIX 0600 enforcement.
  *
@@ -113,6 +116,39 @@ export function healSensitiveFilePerms(path: string): 'absent' | 'ok' | 'healed'
     // best-effort hardening step.
     healedPathsThisProcess.add(path);
     return 'ok';
+  }
+}
+
+/**
+ * Heal-all-known: walks the closed set of sensitive Memphis files and
+ * tightens any that have wider perms. Called eagerly at CLI startup so
+ * the operator doesn't have to trigger a specific command (e.g.
+ * `vault list`) for the heal to fire on lazy-loaded files like
+ * `vault-entries.json`.
+ *
+ * The set is intentionally finite — heal-all-files-in-data-dir would
+ * be too aggressive (operator may have intentionally-public artefacts
+ * like `ISKRA.md` they edit by hand).
+ *
+ * Failure mode: any individual heal that throws (e.g. EACCES on a file
+ * the user can't chmod) is swallowed — the next file still gets a
+ * chance. We never block CLI startup on a best-effort hardening pass.
+ */
+export function healAllSensitiveFiles(rawEnv: NodeJS.ProcessEnv = process.env): void {
+  const paths = [
+    resolveVaultPath('vault-state.json', rawEnv),
+    resolveVaultPath('vault-entries.json', rawEnv),
+    getConfigPath('soul-manifest.json'),
+    getConfigPath('soul-memory.json'),
+    getConfigPath('agent-profile.json'),
+    getConfigPath('operator.json'),
+  ];
+  for (const p of paths) {
+    try {
+      healSensitiveFilePerms(p);
+    } catch {
+      // Best-effort across the whole set; never propagate.
+    }
   }
 }
 

--- a/src/infra/storage/vault-entry-store.ts
+++ b/src/infra/storage/vault-entry-store.ts
@@ -3,6 +3,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'n
 import { dirname } from 'node:path';
 
 import type { VaultEntry } from './rust-vault-adapter.js';
+import { healSensitiveFilePerms } from './secure-file.js';
 import { resolveVaultPath } from './vault-paths.js';
 import { secureCompare } from '../../security/constant-time.js';
 
@@ -22,6 +23,12 @@ function computeFingerprint(entry: Pick<VaultEntry, 'key' | 'encrypted' | 'iv'>)
 
 function readAll(path: string): StoredVaultEntry[] {
   if (!existsSync(path)) return [];
+  // Heal-on-load: existing operator installs from before PR #275
+  // started enforcing 0600 may still have group/world-readable
+  // vault-entries.json on disk (664 was the umask default).
+  // Tighten silently with a one-time warn so the next CLI invocation
+  // already fixes it without operator intervention.
+  healSensitiveFilePerms(path);
   try {
     const raw = readFileSync(path, 'utf8');
     if (!raw.trim()) return [];

--- a/src/soul/manifest.ts
+++ b/src/soul/manifest.ts
@@ -15,6 +15,7 @@ import { getConfigPath } from '../config/paths.js';
 import { getToolNames } from '../gateway/tool-registry.js';
 import { resolveAgentProfile } from '../infra/agent-profile.js';
 import { getChainAdapterStatus } from '../infra/storage/chain-adapter.js';
+import { healSensitiveFilePerms, writeSensitiveFile } from '../infra/storage/secure-file.js';
 import { getChainNames } from '../memory/chain-catalog.js';
 
 // Sprint 0.5 G2: chain list used to live here as a hard-coded array that
@@ -85,6 +86,13 @@ export function loadSoulManifest(rawEnv: NodeJS.ProcessEnv = process.env): SoulM
   const manifestPath = getSoulManifestPath(rawEnv);
   if (!existsSync(manifestPath)) return null;
 
+  // Heal-on-load: existing operator installs from before the writer
+  // started enforcing 0600 may still have group/world-readable
+  // soul-manifest files. Tighten silently with a one-time warning so
+  // restarting the runtime is enough — operator doesn't have to
+  // manually chmod the file.
+  healSensitiveFilePerms(manifestPath);
+
   let parsed: SoulManifest;
   try {
     const raw = JSON.parse(readFileSync(manifestPath, 'utf8')) as unknown;
@@ -121,12 +129,10 @@ export function writeSoulManifest(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): void {
   const manifestPath = getSoulManifestPath(rawEnv);
-  const dir = path.dirname(manifestPath);
-  mkdirSync(dir, { recursive: true });
-
-  const tmpPath = `${manifestPath}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmpPath, JSON.stringify(manifest, null, 2), 'utf8');
-  renameSync(tmpPath, manifestPath);
+  // 0600 mode + parent dir 0700 + atomic rename — see secure-file.ts.
+  // Issue #272: soul-manifest carries autonomy_mode + trustRules; group
+  // or world readability leaks operator's tool gating policy.
+  writeSensitiveFile(manifestPath, JSON.stringify(manifest, null, 2));
 }
 
 export function ensureSoulManifest(rawEnv: NodeJS.ProcessEnv = process.env): SoulManifest {

--- a/src/soul/memory.ts
+++ b/src/soul/memory.ts
@@ -4,7 +4,6 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
-  unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import path from 'node:path';
@@ -19,6 +18,7 @@ import {
 } from './types.js';
 import { getConfigPath } from '../config/paths.js';
 import { appendBlock } from '../infra/storage/chain-adapter.js';
+import { healSensitiveFilePerms, writeSensitiveFile } from '../infra/storage/secure-file.js';
 import { storeVaultSecret } from '../security/vault-boundary.js';
 
 export function getSoulMemoryPath(_rawEnv: NodeJS.ProcessEnv = process.env): string {
@@ -50,6 +50,11 @@ export function loadSoulMemory(rawEnv: NodeJS.ProcessEnv = process.env): SoulMem
   const memoryPath = getSoulMemoryPath(rawEnv);
   if (!existsSync(memoryPath)) return null;
 
+  // Heal-on-load: tighten 0600 if the file was created before
+  // writeSensitiveFile-based writers landed (existing operator installs
+  // had 664 on disk).
+  healSensitiveFilePerms(memoryPath);
+
   try {
     const raw = JSON.parse(readFileSync(memoryPath, 'utf8')) as unknown;
     return soulMemorySchema.parse(raw);
@@ -60,17 +65,11 @@ export function loadSoulMemory(rawEnv: NodeJS.ProcessEnv = process.env): SoulMem
 
 export function writeSoulMemory(memory: SoulMemory, rawEnv: NodeJS.ProcessEnv = process.env): void {
   const memoryPath = getSoulMemoryPath(rawEnv);
-  const dir = path.dirname(memoryPath);
-  mkdirSync(dir, { recursive: true });
-
-  const tmpPath = `${memoryPath}.tmp-${process.pid}-${Date.now()}`;
-  try {
-    writeFileSync(tmpPath, JSON.stringify(memory, null, 2), 'utf8');
-    renameSync(tmpPath, memoryPath);
-  } catch (error) {
-    unlinkSync(tmpPath);
-    throw error;
-  }
+  // 0600 mode + parent dir 0700 + atomic rename — see secure-file.ts.
+  // soul-memory carries operator's identity narrative + memory entries;
+  // group/world readability is a privacy leak, not just a hardening
+  // gap.
+  writeSensitiveFile(memoryPath, JSON.stringify(memory, null, 2));
 }
 
 export function isSoulMemoryEmpty(memory: SoulMemory): boolean {

--- a/tests/unit/secure-file.test.ts
+++ b/tests/unit/secure-file.test.ts
@@ -1,0 +1,116 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetSensitiveFileHealCacheForTests,
+  healSensitiveFilePerms,
+  writeSensitiveFile,
+} from '../../src/infra/storage/secure-file.js';
+import { realTmpdir } from '../helpers/tmpdir.js';
+
+describe('writeSensitiveFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    __resetSensitiveFileHealCacheForTests();
+    dir = mkdtempSync(join(realTmpdir(), 'memphis-secure-file-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes the payload at mode 0o600', () => {
+    const target = join(dir, 'sensitive.json');
+    writeSensitiveFile(target, '{"k":"v"}');
+    expect(readFileSync(target, 'utf8')).toBe('{"k":"v"}');
+    const mode = statSync(target).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('creates the parent directory with 0o700 when missing', () => {
+    const nested = join(dir, 'nested', 'sub', 'file.json');
+    writeSensitiveFile(nested, '{}');
+    expect(existsSync(nested)).toBe(true);
+    const parentMode = statSync(join(dir, 'nested')).mode & 0o777;
+    // mkdirSync with mode applies after umask — we accept anything that
+    // doesn't grant group/world bits beyond what we set.
+    expect(parentMode & 0o077).toBe(0);
+  });
+
+  it('overwrites a pre-existing wider-permissions file with 0o600', () => {
+    const target = join(dir, 'old.json');
+    writeFileSync(target, '{"old":true}');
+    chmodSync(target, 0o644);
+    expect(statSync(target).mode & 0o777).toBe(0o644);
+    writeSensitiveFile(target, '{"new":true}');
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+    expect(readFileSync(target, 'utf8')).toBe('{"new":true}');
+  });
+});
+
+describe('healSensitiveFilePerms', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    __resetSensitiveFileHealCacheForTests();
+    dir = mkdtempSync(join(realTmpdir(), 'memphis-secure-heal-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns "absent" when the file does not exist', () => {
+    expect(healSensitiveFilePerms(join(dir, 'no.json'))).toBe('absent');
+  });
+
+  it('returns "ok" when the file already has 0o600', () => {
+    const target = join(dir, 'tight.json');
+    writeFileSync(target, '{}', { mode: 0o600 });
+    chmodSync(target, 0o600);
+    expect(healSensitiveFilePerms(target)).toBe('ok');
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  it('returns "healed" and tightens to 0o600 when wider', () => {
+    const target = join(dir, 'wide.json');
+    writeFileSync(target, '{}');
+    chmodSync(target, 0o644);
+    expect(healSensitiveFilePerms(target)).toBe('healed');
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  it('only acts once per process per path (idempotent)', () => {
+    const target = join(dir, 'once.json');
+    writeFileSync(target, '{}');
+    chmodSync(target, 0o644);
+    expect(healSensitiveFilePerms(target)).toBe('healed');
+    // Manually loosen again — heal is cached, should NOT chmod again
+    chmodSync(target, 0o644);
+    expect(healSensitiveFilePerms(target)).toBe('ok');
+    // Cache short-circuits before stat, so the loose perms persist —
+    // that is the contract: heal is best-effort one-time per process.
+    expect(statSync(target).mode & 0o777).toBe(0o644);
+  });
+
+  it('emits a stderr warning when healing', () => {
+    const target = join(dir, 'warn.json');
+    writeFileSync(target, '{}');
+    chmodSync(target, 0o644);
+    const warns: string[] = [];
+    const original = process.stderr.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      warns.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      healSensitiveFilePerms(target);
+    } finally {
+      process.stderr.write = original;
+    }
+    expect(warns.some((w) => w.includes('tightened perms'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #272. Issue reported missing 0600 enforcement on Ed25519 signing seed file. Investigation found the broader bug class: the seed lives inside \`vault-entries.json\` (entry \`mp_v0_signing_seed\`), AND several other sensitive config files were written without explicit mode + had heal-on-load missing entirely.

## Operator-side state before this PR

Wodzu's box (memphischains, 2026-04-30) had these files at 664 (group + world readable):

\`\`\`
-rw-rw-r-- ~/.memphis/vault-entries.json          (encrypted seeds, key fingerprints)
-rw-rw-r-- ~/.memphis/config/agent-profile.json    (operator + agent identity, PII)
-rw-rw-r-- ~/.memphis/config/soul-manifest.json    (autonomy_mode + trustRules policy)
-rw-rw-r-- ~/.memphis/config/soul-memory.json      (operator's identity narrative)
\`\`\`

PR #275 enforced 0600 on \`vault-entries.json\` writes but didn't add heal-on-load — operator's pre-fix files stay 664 on disk until next write.

## Fix

**New helper** \`src/infra/storage/secure-file.ts\`:
- \`writeSensitiveFile(path, content)\` — atomic tmp+rename with mode 0o600, parent dir 0o700, defensive chmodSync after rename for filesystems that apply umask during rename.
- \`healSensitiveFilePerms(path)\` — one-time-per-process tighten on load when mode is wider than 0o600. Emits stderr warning when actually healing.

**Wired into 4 writers/loaders**:
- \`src/soul/manifest.ts\` (writeSoulManifest, loadSoulManifest)
- \`src/soul/memory.ts\` (writeSoulMemory, loadSoulMemory)
- \`src/infra/agent-profile.ts\` (writeAgentProfile, loadAgentProfile)
- \`src/infra/storage/vault-entry-store.ts\` (readAll heal-on-load — write-side already done in #275)

## Intentionally NOT changed

- \`writeIskra\` (markdown narrative) — operator may edit it directly with normal tools; chmod 0o600 would surprise them. No encrypted material in Iskra.
- \`vault-state.json\` — already 0600 via rust-vault-adapter.
- \`operator.json\` — already 0600 via operator-gate.

## Tests

- \`tests/unit/secure-file.test.ts\`: 8 cases — write path, heal paths (absent/ok/healed/idempotent), warning emission.
- \`tests/unit/soul\` + \`tests/unit/agent-profile\` + \`tests/unit/cli.vault\`: 48/48 green.
- Typecheck + lint clean.

## Operator smoke (Wodzu / wvio side after merge)

\`\`\`bash
cd ~/memphis && git pull --rebase origin main && npm run build
memphis service restart

# Heal happens automatically on next read. Verify:
ls -la ~/.memphis/vault-entries.json ~/.memphis/config/{agent-profile,soul-manifest,soul-memory}.json
# Expected: -rw------- (600) on all four

# Heal warnings should appear in journalctl on the first read after upgrade:
journalctl --user -u memphis --since "2 minutes ago" | grep "tightened perms"
# Expected: 4 lines, one per healed file
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)