### PR TITLE
fix(secret-scan): add OpenAI/Stripe/Mistral prefixes + mirror in kartograf corpus (#274)

### DIFF
--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -2,10 +2,43 @@
 set -euo pipefail
 
 # Lightweight grep-based baseline (can be replaced by gitleaks/trufflehog later)
-PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|ghp_[0-9A-Za-z]{36}|-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----|api[_-]?key\s*[:=]\s*["\x27][A-Za-z0-9_\-]{16,})'
+#
+# Pattern coverage (issue #274 expanded the set 2026-04-30 to add prefixes
+# common in Memphis's operational environment that the original v1.5.0
+# scan missed):
+#
+#   AKIA[0-9A-Z]{16}                            AWS access-key-id
+#   AIza[0-9A-Za-z\-_]{35}                      GCP API key
+#   xox[baprs]-…                                Slack tokens
+#   ghp_[0-9A-Za-z]{36}                         GitHub PAT
+#   sk-ant-[A-Za-z0-9\-_]{20,}                  Anthropic key (legacy "sk-ant-" form)
+#   sk-(proj|test|live|None)-[A-Za-z0-9\-_]{20,}   OpenAI key (proj/test/live/None scopes)
+#   (sk|rk)_(test|live)_[A-Za-z0-9]{24,}         Stripe secret/restricted keys
+#   whsec_[A-Za-z0-9]{32,}                       Stripe webhook signing secrets
+#   -----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----   PEM private key blocks
+#   api[_-]?key\s*[:=]\s*["\x27]…                generic api_key="…" assignments (quoted to avoid fn-call false-positives)
+#
+# Note on Mistral: their public API keys carry no dedicated prefix — they
+# look like opaque 32-character base64 strings, indistinguishable from
+# many non-secrets. Adding a regex broad enough to catch them would
+# false-positive on UUIDs, hashes, etc. Mistral keys ride the generic
+# `api[_-]?key="…"` pattern instead. If a pattern emerges (e.g. Mistral
+# ships scoped keys with a prefix), add it here.
+PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|ghp_[0-9A-Za-z]{36}|sk-ant-[A-Za-z0-9\-_]{20,}|sk-(proj|test|live|None)-[A-Za-z0-9\-_]{20,}|(sk|rk)_(test|live)_[A-Za-z0-9]{24,}|whsec_[A-Za-z0-9]{32,}|-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----|api[_-]?key\s*[:=]\s*["\x27][A-Za-z0-9_\-]{16,})'
 
-# Exclude data directory (contains npm documentation embeddings, not real secrets)
-if grep -RInE --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=data --exclude='package-lock.json' "$PATTERN" .; then
+# Exclude:
+#  - node_modules / .git / data / package-lock.json — uninteresting payloads
+#  - tests/unit/secret-scan.test.ts — its fixtures are intentional sample
+#    strings shaped like each credential family so the scan itself is
+#    test-able. Without this exclusion the scan flags its own coverage
+#    fixtures and exit 1's on every CI run.
+if grep -RInE \
+    --exclude-dir=node_modules \
+    --exclude-dir=.git \
+    --exclude-dir=data \
+    --exclude='package-lock.json' \
+    --exclude='secret-scan.test.ts' \
+    "$PATTERN" .; then
   echo "[secret-scan] Potential secret detected." >&2
   exit 1
 fi

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -36,11 +36,14 @@ PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|g
 #    Codex P2 (PR #376) caught the basename-only blind spot — fix uses
 #    `find -path !=` for path-aware filtering.
 EXCLUDED_PATH='./tests/unit/secret-scan.test.ts'
-# Use -name on directory names so nested copies are pruned at any depth
-# (e.g. workspaces with `packages/*/node_modules`). Codex round 3 P2:
-# `-path './node_modules'` only matched at the tree root.
+# `find -L` follows symlinks so secrets present via a symlinked path
+# still get scanned — preserves the prior `grep -R --dereference-recursive`
+# behavior (Codex round 4 P1 caught the symlink-bypass regression).
+# `-name` on directory predicates so nested node_modules / .git / data
+# at any depth are pruned (Codex round 3 P2: `-path './node_modules'`
+# only matched at the tree root).
 matches="$(
-  find . \
+  find -L . \
     \( -type d \( -name node_modules -o -name .git -o -name data \) \) -prune -o \
     -type f \
     ! -name 'package-lock.json' \

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -30,15 +30,24 @@ PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|g
 #  - node_modules / .git / data / package-lock.json — uninteresting payloads
 #  - tests/unit/secret-scan.test.ts — its fixtures are intentional sample
 #    strings shaped like each credential family so the scan itself is
-#    test-able. Without this exclusion the scan flags its own coverage
-#    fixtures and exit 1's on every CI run.
-if grep -RInE \
-    --exclude-dir=node_modules \
-    --exclude-dir=.git \
-    --exclude-dir=data \
-    --exclude='package-lock.json' \
-    --exclude='secret-scan.test.ts' \
-    "$PATTERN" .; then
+#    test-able. The exclusion targets the EXACT path, not just a basename
+#    glob, so a future file at any other location with the same basename
+#    (e.g. tests/security/secret-scan.test.ts) would still get scanned.
+#    Codex P2 (PR #376) caught the basename-only blind spot — fix uses
+#    `find -path !=` for path-aware filtering.
+EXCLUDED_PATH='./tests/unit/secret-scan.test.ts'
+matches="$(
+  find . \
+    \( -path './node_modules' -o -path './.git' -o -path './data' \) -prune -o \
+    -type f \
+    ! -name 'package-lock.json' \
+    ! -path "$EXCLUDED_PATH" \
+    -print0 \
+  | xargs -0 grep -InE "$PATTERN" 2>/dev/null \
+  || true
+)"
+if [ -n "$matches" ]; then
+  printf '%s\n' "$matches"
   echo "[secret-scan] Potential secret detected." >&2
   exit 1
 fi

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -36,9 +36,12 @@ PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|g
 #    Codex P2 (PR #376) caught the basename-only blind spot — fix uses
 #    `find -path !=` for path-aware filtering.
 EXCLUDED_PATH='./tests/unit/secret-scan.test.ts'
+# Use -name on directory names so nested copies are pruned at any depth
+# (e.g. workspaces with `packages/*/node_modules`). Codex round 3 P2:
+# `-path './node_modules'` only matched at the tree root.
 matches="$(
   find . \
-    \( -path './node_modules' -o -path './.git' -o -path './data' \) -prune -o \
+    \( -type d \( -name node_modules -o -name .git -o -name data \) \) -prune -o \
     -type f \
     ! -name 'package-lock.json' \
     ! -path "$EXCLUDED_PATH" \

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 #   xox[baprs]-…                                Slack tokens
 #   ghp_[0-9A-Za-z]{36}                         GitHub PAT
 #   sk-ant-[A-Za-z0-9\-_]{20,}                  Anthropic key (legacy "sk-ant-" form)
-#   sk-(proj|test|live|None)-[A-Za-z0-9\-_]{20,}   OpenAI key (proj/test/live/None scopes)
+#   sk-(admin|proj|test|live|None)-[A-Za-z0-9\-_]{20,}   OpenAI key (proj/test/live/None scopes)
 #   (sk|rk)_(test|live)_[A-Za-z0-9]{24,}         Stripe secret/restricted keys
 #   whsec_[A-Za-z0-9]{32,}                       Stripe webhook signing secrets
 #   -----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----   PEM private key blocks
@@ -24,7 +24,7 @@ set -euo pipefail
 # false-positive on UUIDs, hashes, etc. Mistral keys ride the generic
 # `api[_-]?key="…"` pattern instead. If a pattern emerges (e.g. Mistral
 # ships scoped keys with a prefix), add it here.
-PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|ghp_[0-9A-Za-z]{36}|sk-ant-[A-Za-z0-9\-_]{20,}|sk-(proj|test|live|None)-[A-Za-z0-9\-_]{20,}|(sk|rk)_(test|live)_[A-Za-z0-9]{24,}|whsec_[A-Za-z0-9]{32,}|-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----|api[_-]?key\s*[:=]\s*["\x27][A-Za-z0-9_\-]{16,})'
+PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|ghp_[0-9A-Za-z]{36}|sk-ant-[A-Za-z0-9\-_]{20,}|sk-(admin|proj|test|live|None)-[A-Za-z0-9\-_]{20,}|(sk|rk)_(test|live)_[A-Za-z0-9]{24,}|whsec_[A-Za-z0-9]{32,}|-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----|api[_-]?key\s*[:=]\s*["\x27][A-Za-z0-9_\-]{16,})'
 
 # Exclude:
 #  - node_modules / .git / data / package-lock.json — uninteresting payloads

--- a/tests/unit/secret-scan.test.ts
+++ b/tests/unit/secret-scan.test.ts
@@ -75,6 +75,7 @@ describe('scripts/secret-scan.sh — credential prefix detection', () => {
     ['gcp-api-key', `AIza${'SyABCdefghijklmnopqrstuvwxyz123456789'}`],
     ['github-pat', `ghp_${RANDLOOKING_LONG}`],
     ['anthropic-key (legacy sk-ant-)', `${SKHYPHEN}ant-api03_${RANDLOOKING_LONG.slice(0, 26)}`],
+    ['openai-key admin scope (#274 Codex P1)', `${SKHYPHEN}admin-${RANDLOOKING_LONG}`],
     ['openai-key proj scope (#274)', `${SKHYPHEN}proj-${RANDLOOKING_LONG}`],
     ['openai-key live scope (#274)', `${SKHYPHEN}live-${RANDLOOKING_LONG}`],
     ['openai-key None scope (#274)', `${SKHYPHEN}None-${RANDLOOKING_LONG}`],

--- a/tests/unit/secret-scan.test.ts
+++ b/tests/unit/secret-scan.test.ts
@@ -1,0 +1,107 @@
+import { execFileSync, type SpawnSyncReturns } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { realTmpdir } from '../helpers/tmpdir.js';
+
+/**
+ * scripts/secret-scan.sh covers an expanding set of credential prefixes.
+ * This test stages a synthetic file containing each pattern in a fresh
+ * tmpdir and asserts the scan flags it (exit 1). Issue #274 added the
+ * OpenAI/Stripe families on 2026-04-30; if a downstream contributor
+ * tightens the regex too far we want to catch the regression here.
+ */
+
+const SCRIPT_PATH = resolve('scripts/secret-scan.sh');
+
+interface ExecError extends Error {
+  status: number | null;
+  stdout?: Buffer;
+  stderr?: Buffer;
+}
+
+function runScan(cwd: string): SpawnSyncReturns<Buffer> {
+  // Use spawnSync via execFileSync wrapper that returns full result on
+  // failure. execFileSync throws on non-zero exit, but we need to read
+  // the exit code regardless.
+  try {
+    const stdout = execFileSync('bash', [SCRIPT_PATH], { cwd, stdio: 'pipe' });
+    return { status: 0, stdout, stderr: Buffer.from(''), output: [], pid: 0, signal: null };
+  } catch (err) {
+    const e = err as ExecError;
+    return {
+      status: e.status ?? 1,
+      stdout: e.stdout ?? Buffer.from(''),
+      stderr: e.stderr ?? Buffer.from(''),
+      output: [],
+      pid: 0,
+      signal: null,
+    };
+  }
+}
+
+describe('scripts/secret-scan.sh — credential prefix detection', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(realTmpdir(), 'memphis-secret-scan-'));
+    // Stage a minimal package.json so the scan thinks it's at a project
+    // root (avoids walking up); we only care about whether the regex
+    // matches the file we plant, not directory traversal semantics.
+    writeFileSync(join(dir, 'package.json'), '{}');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // Each fixture is a (label, sample-string) pair. Sample is the
+  // representative shape of that credential family — concatenated at
+  // runtime from short literal pieces so this test file itself does
+  // not contain anything that GitHub Push Protection / secret scanners
+  // (or our own scanner!) will flag as a real-looking secret. The
+  // scanner regex matches the runtime-concatenated string just fine.
+  const SK = 'sk';
+  const RK = 'rk';
+  const SKHYPHEN = `${SK}-`;
+  const SKUNDER = `${SK}_`;
+  const RKUNDER = `${RK}_`;
+  const RANDLOOKING_LONG = 'abcdefghijklmnopqrstuvwxyz1234567890';
+  const RANDLOOKING_24 = 'aBcDeFgHiJkLmNoPqRsTuVwX';
+  const fixtures: Array<[string, string]> = [
+    ['aws-access-key', `AKIA${'ABCDEF1234567890'}`],
+    ['gcp-api-key', `AIza${'SyABCdefghijklmnopqrstuvwxyz123456789'}`],
+    ['github-pat', `ghp_${RANDLOOKING_LONG}`],
+    ['anthropic-key (legacy sk-ant-)', `${SKHYPHEN}ant-api03_${RANDLOOKING_LONG.slice(0, 26)}`],
+    ['openai-key proj scope (#274)', `${SKHYPHEN}proj-${RANDLOOKING_LONG}`],
+    ['openai-key live scope (#274)', `${SKHYPHEN}live-${RANDLOOKING_LONG}`],
+    ['openai-key None scope (#274)', `${SKHYPHEN}None-${RANDLOOKING_LONG}`],
+    ['stripe sk_live (#274)', `${SKUNDER}live_${RANDLOOKING_24}`],
+    ['stripe rk_test (#274)', `${RKUNDER}test_${RANDLOOKING_24}`],
+    ['stripe webhook whsec_ (#274)', `whsec_${RANDLOOKING_24}YZ012345`],
+    ['slack token xoxb-', `xoxb-12345-abcdefgh-${'ABCDEFGH1234567890ab'}`],
+    ['pem private key block', '-----BEGIN ' + 'RSA PRIVATE KEY-----'],
+    ['api_key= assignment', `api_key="${RANDLOOKING_LONG.slice(0, 22)}"`],
+  ];
+
+  for (const [label, sample] of fixtures) {
+    it(`flags a file containing a ${label}`, () => {
+      writeFileSync(join(dir, 'fixture.env'), sample);
+      const result = runScan(dir);
+      expect(result.status).toBe(1);
+      const stdout = result.stdout.toString('utf8');
+      expect(stdout).toContain('fixture.env');
+    });
+  }
+
+  it('passes a clean tree with no credential patterns', () => {
+    writeFileSync(join(dir, 'README.md'), '# Memphis test fixture — no secrets here.\n');
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'index.ts'), 'export const ok = true;\n');
+    const result = runScan(dir);
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString('utf8')).toContain('OK');
+  });
+});

--- a/tools/training/kartograf-corpus.py
+++ b/tools/training/kartograf-corpus.py
@@ -123,7 +123,7 @@ SECRET_PATTERNS = [
     # Issue #274 (2026-04-30): OpenAI scopes the `sk-` prefix without
     # `ant-`; we need to catch proj/test/live/None forms or fresh OpenAI
     # keys land in the corpus and ship in embedding space.
-    ("openai-key", re.compile(rb"sk-(proj|test|live|None)-[A-Za-z0-9\-_]{20,}")),
+    ("openai-key", re.compile(rb"sk-(admin|proj|test|live|None)-[A-Za-z0-9\-_]{20,}")),
     # Stripe secret + restricted keys (test + live), and webhook signing
     # secrets. All three appear in operator notes / runbooks if they
     # ever build a billing integration.

--- a/tools/training/kartograf-corpus.py
+++ b/tools/training/kartograf-corpus.py
@@ -120,6 +120,15 @@ SECRET_PATTERNS = [
     ("gcp-api-key", re.compile(rb"AIza[0-9A-Za-z\-_]{35}")),
     ("github-pat", re.compile(rb"ghp_[0-9A-Za-z]{36}")),
     ("anthropic-key", re.compile(rb"sk-ant-[A-Za-z0-9\-_]{20,}")),
+    # Issue #274 (2026-04-30): OpenAI scopes the `sk-` prefix without
+    # `ant-`; we need to catch proj/test/live/None forms or fresh OpenAI
+    # keys land in the corpus and ship in embedding space.
+    ("openai-key", re.compile(rb"sk-(proj|test|live|None)-[A-Za-z0-9\-_]{20,}")),
+    # Stripe secret + restricted keys (test + live), and webhook signing
+    # secrets. All three appear in operator notes / runbooks if they
+    # ever build a billing integration.
+    ("stripe-secret-key", re.compile(rb"(sk|rk)_(test|live)_[A-Za-z0-9]{24,}")),
+    ("stripe-webhook-secret", re.compile(rb"whsec_[A-Za-z0-9]{32,}")),
     ("slack-token", re.compile(rb"xox[baprs]-[0-9A-Za-z\-]{10,}")),
     ("jwt", re.compile(rb"eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+")),
     ("pem-private-key", re.compile(rb"-----BEGIN (RSA |EC |OPENSSH |PGP )?PRIVATE KEY-----")),
@@ -127,6 +136,11 @@ SECRET_PATTERNS = [
     # matches scripts/secret-scan.sh:PATTERN exactly (post-v1.5.0 hotfix)
     ("api-key-assignment", re.compile(rb"api[_-]?key\s*[:=]\s*[\"'][A-Za-z0-9_\-]{16,}")),
     ("password-assignment", re.compile(rb"password\s*[:=]\s*[\"'][^\"']{8,}")),
+    # Mistral keys are opaque 32-char base64 strings without a dedicated
+    # prefix, so they ride `api-key-assignment` rather than getting a
+    # standalone regex (a prefix-less pattern would false-positive on
+    # UUIDs / hashes). Add a Mistral entry here if Mistral ships scoped
+    # keys with a recognizable prefix.
 ]
 
 


### PR DESCRIPTION
## Summary

Closes #274. \`scripts/secret-scan.sh\` and \`tools/training/kartograf-corpus.py\` were missing prefix patterns common in Memphis's likely operational environment.

## New patterns

| Family | Regex |
|--------|-------|
| OpenAI scoped keys | \`sk-(proj\|test\|live\|None)-[A-Za-z0-9\\-_]{20,}\` |
| Stripe secret + restricted | \`(sk\|rk)_(test\|live)_[A-Za-z0-9]{24,}\` |
| Stripe webhook signing | \`whsec_[A-Za-z0-9]{32,}\` |

## Why it matters

- Kartograf corpus builder uses these patterns to refuse training samples containing secrets — a leaked OpenAI key in operator notes would land in \`train.jsonl\` and ship in the embedding space.
- Audit-log redaction relies on the same patterns. Tool args containing fresh Stripe keys would persist to \`~/.memphis/audit/\` unmasked.

## Mistral note

Mistral keys carry no dedicated prefix — opaque 32-char base64 strings indistinguishable from UUIDs / hashes. A regex broad enough to catch them false-positives on non-secrets. Mistral keys ride the existing \`api[_-]?key="…"\` assignment pattern instead. Comment in both files documents this trade-off.

## Tests

\`tests/unit/secret-scan.test.ts\` (14 cases): each credential family staged in tmp + asserts scan exit 1; clean tree asserts exit 0. Fixture strings are runtime-concatenated from short literal pieces so:
- This file itself does not contain anything GitHub Push Protection or our own scanner flags as a secret.
- The scanner regex still matches the runtime-built string.

\`secret-scan.sh\` updated with \`--exclude='secret-scan.test.ts'\` so its intentional fixtures (even concatenated) don't make CI reject its own coverage.

## Operator smoke (post-merge)

\`\`\`bash
cd ~/memphis && git pull --rebase origin main
bash scripts/secret-scan.sh
# Expected: [secret-scan] OK
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)