### PR TITLE
fix(vault): distinguish resolved vs failed vault refs (#276)

### DIFF
--- a/src/infra/config/env.ts
+++ b/src/infra/config/env.ts
@@ -291,7 +291,7 @@ export function loadConfig(rawEnv: NodeJS.ProcessEnv = process.env): AppConfig {
   // Resolve VAULT:key_name references before schema validation.
   // Uses a shallow copy so we don't mutate process.env directly.
   const envCopy = normalizeConfigAliases(rawEnv);
-  const vaultResolved = resolveVaultSecrets(envCopy);
+  const { resolved: vaultResolved, failed: vaultFailed } = resolveVaultSecrets(envCopy);
   if (vaultResolved.length > 0) {
     // Propagate resolved vault secrets back to process.env so that
     // downstream code reading process.env directly (e.g. Telegram adapter)
@@ -303,6 +303,21 @@ export function loadConfig(rawEnv: NodeJS.ProcessEnv = process.env): AppConfig {
     }
     emitConfigInfo(
       `[memphis-config] Resolved ${vaultResolved.length} secret(s) from vault: ${vaultResolved.join(', ')}`,
+    );
+  }
+  if (vaultFailed.length > 0) {
+    // Mirror the resolved-side propagation: clear the rawEnv copy so
+    // downstream code that reads process.env directly sees the same
+    // "absent" state envCopy now reflects. Without this, process.env
+    // could still hold the original `VAULT:<key>` literal even though
+    // envCopy (Zod's input) has been cleaned — telegram-readiness etc.
+    // would still see the literal and produce inconsistent diagnostics.
+    for (const key of vaultFailed) {
+      delete rawEnv[key];
+    }
+    emitConfigInfo(
+      `[memphis-config] Vault decrypt FAILED for ${vaultFailed.length} ref(s): ${vaultFailed.join(', ')}. ` +
+        `These env vars were cleared; subsequent schema validation will treat them as unset.`,
     );
   }
 

--- a/src/infra/config/vault-resolve.ts
+++ b/src/infra/config/vault-resolve.ts
@@ -70,8 +70,20 @@ const VAULT_RESOLVABLE_KEYS = [
  * Returns a list of keys that were resolved from the vault (for
  * audit logging).
  */
-export function resolveVaultSecrets(rawEnv: NodeJS.ProcessEnv): string[] {
+export interface VaultResolveResult {
+  /** Env keys whose VAULT:<key> reference decrypted successfully and
+   * was overwritten with the plaintext. */
+  resolved: string[];
+  /** Env keys whose VAULT:<key> reference failed to decrypt (entry
+   * missing, wrong passphrase, corrupted ciphertext). The env var has
+   * been *removed* (set to undefined) so downstream Zod validation
+   * sees a clean "missing" state and emits its own clear error. */
+  failed: string[];
+}
+
+export function resolveVaultSecrets(rawEnv: NodeJS.ProcessEnv): VaultResolveResult {
   const resolved: string[] = [];
+  const failed: string[] = [];
 
   for (const key of VAULT_RESOLVABLE_KEYS) {
     const raw = rawEnv[key];
@@ -82,11 +94,18 @@ export function resolveVaultSecrets(rawEnv: NodeJS.ProcessEnv): string[] {
       rawEnv[key] = plaintext;
       resolved.push(key);
     } else {
-      // Remove the VAULT: reference so validation treats it as unset
+      // Remove the VAULT: reference so validation treats it as unset.
+      // Issue #276: previously this branch also pushed to `resolved`,
+      // making the log say "Resolved N secret(s) from vault: KEY" even
+      // when KEY actually failed to decrypt. Operators saw the success
+      // line, then a Zod error claiming KEY is missing — and wasted
+      // 20+ minutes debugging Zod before realizing it was a vault
+      // failure. Tracking failures as a distinct list lets callers
+      // emit honest "resolved X / failed Y" telemetry.
       delete rawEnv[key];
-      resolved.push(key);
+      failed.push(key);
     }
   }
 
-  return resolved;
+  return { resolved, failed };
 }

--- a/tests/unit/config.load.stdout-safety.test.ts
+++ b/tests/unit/config.load.stdout-safety.test.ts
@@ -11,7 +11,7 @@ describe('loadConfig stdout safety', () => {
     vi.mock('../../src/infra/config/vault-resolve.js', () => ({
       resolveVaultSecrets: vi.fn((rawEnv: NodeJS.ProcessEnv) => {
         rawEnv.MEMPHIS_API_TOKEN = 'resolved-api-token';
-        return ['MEMPHIS_API_TOKEN'];
+        return { resolved: ['MEMPHIS_API_TOKEN'], failed: [] };
       }),
     }));
 

--- a/tests/unit/vault-resolve.test.ts
+++ b/tests/unit/vault-resolve.test.ts
@@ -83,17 +83,18 @@ describe('resolveVaultSecrets', () => {
       RUST_EMBED_PROVIDER_API_KEY: 'VAULT:embed_key',
     };
 
-    const resolved = resolveVaultSecrets(env);
+    const result = resolveVaultSecrets(env);
 
-    expect(resolved).toContain('SHARED_LLM_API_KEY');
-    expect(resolved).toContain('RUST_EMBED_PROVIDER_API_KEY');
-    expect(resolved).not.toContain('DECENTRALIZED_LLM_API_KEY');
+    expect(result.resolved).toContain('SHARED_LLM_API_KEY');
+    expect(result.resolved).toContain('RUST_EMBED_PROVIDER_API_KEY');
+    expect(result.resolved).not.toContain('DECENTRALIZED_LLM_API_KEY');
+    expect(result.failed).toEqual([]);
     expect(env.SHARED_LLM_API_KEY).toBe('resolved-secret');
     expect(env.DECENTRALIZED_LLM_API_KEY).toBe('plain-key-stays');
     expect(env.RUST_EMBED_PROVIDER_API_KEY).toBe('resolved-secret');
   });
 
-  it('deletes env key when vault resolution fails', () => {
+  it('separates resolved and failed when vault resolution fails (#276)', () => {
     mockedUseVaultSecretByKey.mockReturnValue({
       found: false,
       key: 'missing',
@@ -103,9 +104,12 @@ describe('resolveVaultSecrets', () => {
       SHARED_LLM_API_KEY: 'VAULT:missing',
     };
 
-    resolveVaultSecrets(env);
+    const result = resolveVaultSecrets(env);
 
     expect(env.SHARED_LLM_API_KEY).toBeUndefined();
+    // Failed key is reported as such, NOT as resolved.
+    expect(result.failed).toContain('SHARED_LLM_API_KEY');
+    expect(result.resolved).not.toContain('SHARED_LLM_API_KEY');
   });
 
   it('skips non-VAULT values', () => {
@@ -113,8 +117,9 @@ describe('resolveVaultSecrets', () => {
       SHARED_LLM_API_KEY: 'sk-real-key',
     };
 
-    const resolved = resolveVaultSecrets(env);
-    expect(resolved).toHaveLength(0);
+    const result = resolveVaultSecrets(env);
+    expect(result.resolved).toHaveLength(0);
+    expect(result.failed).toHaveLength(0);
     expect(env.SHARED_LLM_API_KEY).toBe('sk-real-key');
   });
 });


### PR DESCRIPTION
## Summary

Closes #276. \`resolveVaultSecrets()\` returned a single \`string[]\` of "all keys we touched" — successes AND failures together. Caller in \`env.ts\` logged "Resolved N secret(s) from vault: KEY", and operators who hit a wrong-passphrase / missing-entry path saw KEY listed as "resolved" and then a Zod error claiming KEY was missing. Issue title: *"20 minutes wasted debugging Zod before realizing vault decrypt failed."*

## Fix

- \`resolveVaultSecrets\` now returns \`{ resolved: string[], failed: string[] }\`.
- \`env.ts\` logs "Resolved N…" only for resolved set.
- \`env.ts\` logs "Vault decrypt FAILED for N ref(s): KEY1, KEY2…" for failed set + propagates the failure-side delete back to \`rawEnv\` so process.env-direct readers (telegram-readiness, etc.) see the same cleared state \`envCopy\` reflects.

## Operator UX

Before:
\`\`\`
[memphis-config] Resolved 1 secret(s) from vault: STRIPE_API_KEY
Zod error: STRIPE_API_KEY required   ← confusing, "but you said resolved!"
\`\`\`

After:
\`\`\`
[memphis-config] Vault decrypt FAILED for 1 ref(s): STRIPE_API_KEY.
These env vars were cleared; subsequent schema validation will treat them as unset.
Zod error: STRIPE_API_KEY required   ← matches cleared state, no confusion
\`\`\`

## Tests

- \`tests/unit/vault-resolve.test.ts\`: rewrote 3 cases for new shape; added explicit assertion that failed keys appear in \`failed\`, NOT \`resolved\`.
- \`tests/unit/config.load.stdout-safety.test.ts\`: updated mock to return new object shape.
- 9/9 affected tests green; lint clean; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)