### PR TITLE
fix(cli): cleanup tick listener in monitorRuntime — symmetric on/off (#277)

### DIFF
--- a/src/infra/cli/commands/debug.ts
+++ b/src/infra/cli/commands/debug.ts
@@ -244,23 +244,42 @@ export async function monitorRuntime(
   let tick = 0;
   let queryCount = 0;
 
-  emitter.on('tick', () => {
+  // Issue #277: extract the handler reference so the listener can be
+  // removed on shutdown. The emitter is local to this function, so the
+  // immediate leak risk is limited (it goes out of scope when the
+  // function returns) — but a future "memphis debug monitor --watch"
+  // mode that reuses the emitter, or a test that calls monitorRuntime
+  // in a loop, would accumulate listeners until Node fires the
+  // 11-listener warning. Cleanup pairs `on()` with `off()` via
+  // try/finally so the symmetric guarantee holds even if interval
+  // callbacks throw.
+  const tickHandler = (): void => {
     const start = performance.now();
     queryCount += 1;
     const latencyMs = Number((performance.now() - start + Math.random() * 5).toFixed(2));
     const rss = process.memoryUsage().rss;
     points.push({ tick: tick + 1, queryCount, latencyMs, rss });
     tick += 1;
-  });
+  };
+  emitter.on('tick', tickHandler);
 
   const timer = setInterval(() => emitter.emit('tick'), intervalMs);
 
-  await new Promise<void>((resolve) => {
-    setTimeout(() => {
-      clearInterval(timer);
-      resolve();
-    }, durationMs);
-  });
+  try {
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        clearInterval(timer);
+        resolve();
+      }, durationMs);
+    });
+  } finally {
+    // Symmetric to emitter.on('tick', tickHandler) above. Belt-and-
+    // braces: clearInterval already happened inside the timeout, but a
+    // pathological throw in the resolve path would still drop the
+    // listener via this finally.
+    clearInterval(timer);
+    emitter.off('tick', tickHandler);
+  }
 
   const latencies = points.map((p) => p.latencyMs).sort((a, b) => a - b);
   const p95Index = Math.max(0, Math.ceil(latencies.length * 0.95) - 1);

--- a/tests/debug/monitor.test.ts
+++ b/tests/debug/monitor.test.ts
@@ -9,4 +9,33 @@ describe('debug monitor', () => {
     expect(result.summary.ticks).toBe(result.points.length);
     expect(result.summary.avgLatencyMs).toBeGreaterThanOrEqual(0);
   });
+
+  it('does not leak listeners across repeated calls (#277)', async () => {
+    // Issue #277: monitorRuntime used to call emitter.on('tick', …)
+    // without ever pairing emitter.off(). The internal emitter is
+    // local-scoped so each call discards its own emitter at function
+    // return — but this is the "doesn't accumulate" smoke test.
+    // We capture process-level Node EventEmitter warning counter to
+    // catch the regression if anyone reintroduces a long-lived emitter
+    // and forgets cleanup.
+    const before = process.listenerCount('warning');
+    let warningSeen = false;
+    const onWarn = (warning: Error & { name: string }) => {
+      if (warning.name === 'MaxListenersExceededWarning') warningSeen = true;
+    };
+    process.on('warning', onWarn);
+    try {
+      // 20 sequential 60ms-window calls. Each call attaches one tick
+      // listener; with proper cleanup the local emitter is GC'd. With
+      // a leak we'd hit Node's default 10-listener threshold long
+      // before the loop ends.
+      for (let i = 0; i < 20; i += 1) {
+        await monitorRuntime(20, 60);
+      }
+    } finally {
+      process.off('warning', onWarn);
+    }
+    expect(warningSeen).toBe(false);
+    expect(process.listenerCount('warning')).toBe(before);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #277. \`monitorRuntime\` attached a \`'tick'\` listener via \`emitter.on()\` without pairing \`emitter.off()\`. The internal emitter is local-scoped so each call discards its own emitter at function return — limited blast radius today — but it's a footgun:

- Test environments: vitest reuses Node process across files. Any longer-lived emitter would accumulate listeners until Node fires \`MaxListenersExceededWarning\` at the 11-listener threshold.
- Future \`memphis debug monitor --watch\` or any code that lifts the emitter out of function scope hits the leak immediately.

## Fix

Extract the inline arrow into a named \`tickHandler\` so the reference is stable, then wrap the await in \`try/finally\` so \`clearInterval\` AND \`emitter.off(handler)\` fire on every exit path — including thrown errors. The pre-existing inline \`clearInterval\` inside \`setTimeout\` still fires on the happy path; \`finally\` is the symmetric guarantee.

## Tests

- New regression in \`tests/debug/monitor.test.ts\`: 20 sequential \`monitorRuntime\` calls, fail if Node emits \`MaxListenersExceededWarning\`. Catches regression if anyone reintroduces a long-lived emitter without paired off.
- 2/2 monitor tests green; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)