### PR TITLE
chore(readme): bump version v1.4.0 → v1.7.2 + refresh feature highlights (S1-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Memphis is a local-first cognitive runtime born from [Oswobodzeni](https://oswob
 
 Every decision Memphis makes is recorded. Every secret is encrypted at rest. Every tool it touches requires your authorization. This is not a chatbot — it is a sovereign cognitive system designed for operators who refuse to rent their intelligence from Big Tech.
 
-**Current version: `v1.4.0`** (tag 2026-04-19) | **Status: production-ready for first install** — 10-phase production sprint, two security-scan rounds (33 fixes), Phase L offline-invariant gate, Phase A3 Rust sanitizers, bilingual install + debug guides (EN/PL), example installation walkthrough.
+**Current version: `v1.7.2`** (matches `package.json`) | **Status: production-ready for operator-supervised runtime** — vault hardening (0600 perms + heal-on-load), Rust+TS path resolver alignment, declarative provider cascade, cross-arch CI (linux + ubuntu-arm + macos), Telegram bot + Rust TUI surfaces, expanded secret-scan patterns (OpenAI / Stripe / GitHub / AWS / GCP / Slack / Anthropic). See `docs/CHANGELOG.md` for full history.
 
 ---
 


### PR DESCRIPTION
## Summary

S1-5 of the post-autopilot sprint plan — triage of 5 old open PRs (#318–#322).

Outcome:
- **#318** (this README bump) — superseded; reproduced + extended in this PR.
- **#319** (security trio) — closed as superseded by S1-1/S1-2/S1-4 (#375/#376/#378).
- **#320, #321, #322** — already closed (parseBool / vault positional / codebase truth snapshot — work landed via #358 and earlier PRs).

This PR bumps the README badge and refreshes the feature list to reflect what shipped in v1.5.0–v1.7.2: vault hardening (0600 + heal-on-load), Rust+TS path alignment, cross-arch CI, Telegram + Rust TUI, expanded secret-scan patterns.

## Tests

Docs only — no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)