### PR TITLE
fix(providers): GLM timeout + cascade-aware error mapping (S4-3)

### DIFF
--- a/src/providers/glm/adapter.ts
+++ b/src/providers/glm/adapter.ts
@@ -7,6 +7,11 @@ import { sanitizeForJsonRequest } from '../../infra/security/sanitizers.js';
 import type { ChatMessage, ChatResponse, ChatToolCall, ChatToolDefinition } from '../index.js';
 
 const DEFAULT_GLM_TIMEOUT_MS = 30_000;
+// Node's setTimeout clamps delays above (2^31 - 1) ms to 1ms and emits
+// TimeoutOverflowWarning — operator-supplied GLM_TIMEOUT_MS values
+// beyond ~24.8 days would silently abort every call immediately
+// (Codex P2 round 4). Clamp to TIMEOUT_MAX before scheduling.
+const NODE_TIMEOUT_MAX_MS = 2_147_483_647;
 
 export class GlmProvider {
   name = 'glm';
@@ -24,9 +29,10 @@ export class GlmProvider {
       'https://open.bigmodel.cn/api/paas/v4'
     ).replace(/\/$/, '');
     const envTimeout = Number.parseInt(process.env.GLM_TIMEOUT_MS ?? '', 10);
-    this.timeoutMs =
+    const requested =
       opts?.timeoutMs ??
       (Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : DEFAULT_GLM_TIMEOUT_MS);
+    this.timeoutMs = Math.min(requested, NODE_TIMEOUT_MAX_MS);
   }
 
   isConfigured() {

--- a/src/providers/glm/adapter.ts
+++ b/src/providers/glm/adapter.ts
@@ -148,21 +148,27 @@ export class GlmProvider {
         signal: controller.signal,
       });
 
-      if (r.status === 429) {
-        throw new AppError('PROVIDER_RATE_LIMIT', 'GLM provider rate limited', 429);
-      }
-      if (r.status === 401 || r.status === 403) {
-        throw errorTemplates.invalidApiKey({ provider: 'glm', status: r.status });
-      }
-      if (r.status >= 500) {
-        throw new AppError(
-          'PROVIDER_UNAVAILABLE',
-          `GLM provider unavailable: HTTP_${r.status}`,
-          503,
-        );
-      }
+      // Codex P2 round 2: drain (or cancel) the response body before
+      // throwing on non-2xx. Undici keeps the connection pinned until
+      // the body is consumed; under repeated 429/5xx the keep-alive
+      // pool exhausts and the cascade slows. Reading r.text() on
+      // every error path releases the socket immediately.
       if (!r.ok) {
-        throw new AppError('INTERNAL_ERROR', `GLM error: ${r.status} ${await r.text()}`, 500);
+        const errBody = await r.text().catch(() => '');
+        if (r.status === 429) {
+          throw new AppError('PROVIDER_RATE_LIMIT', 'GLM provider rate limited', 429);
+        }
+        if (r.status === 401 || r.status === 403) {
+          throw errorTemplates.invalidApiKey({ provider: 'glm', status: r.status });
+        }
+        if (r.status >= 500) {
+          throw new AppError(
+            'PROVIDER_UNAVAILABLE',
+            `GLM provider unavailable: HTTP_${r.status}`,
+            503,
+          );
+        }
+        throw new AppError('INTERNAL_ERROR', `GLM error: ${r.status} ${errBody}`, 500);
       }
 
       data = (await r.json()) as GlmChatBody;

--- a/src/providers/glm/adapter.ts
+++ b/src/providers/glm/adapter.ts
@@ -113,48 +113,16 @@ export class GlmProvider {
     // cascade for another 30s. Untyped throws were previously routed
     // through the breaker as non-transient (countAsTrip=false) and the
     // provider stayed in a flaky-loop instead of falling through.
+    //
+    // Codex P1 round 1: keep AbortController active across body parsing.
+    // fetch() resolves on response *headers*, so clearing the timeout
+    // before `r.json()` lets a stalled body hang the call forever and
+    // bypass the GLM_TIMEOUT_MS safeguard. Wrap the whole flow (fetch
+    // + body read) in one try; clearTimeout only in the outer finally.
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
 
-    let r: Response;
-    try {
-      r = await fetch(`${this.baseUrl}/chat/completions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.apiKey}`,
-        },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw new AppError('PROVIDER_TIMEOUT', `GLM provider timeout (${this.timeoutMs}ms)`, 504);
-      }
-      throw errorTemplates.network({
-        target: this.baseUrl,
-        message: 'GLM provider unreachable',
-        cause: error,
-      });
-    } finally {
-      clearTimeout(timeout);
-    }
-
-    if (r.status === 429) {
-      throw new AppError('PROVIDER_RATE_LIMIT', 'GLM provider rate limited', 429);
-    }
-    if (r.status === 401 || r.status === 403) {
-      throw errorTemplates.invalidApiKey({ provider: 'glm', status: r.status });
-    }
-    if (r.status >= 500) {
-      throw new AppError(
-        'PROVIDER_UNAVAILABLE',
-        `GLM provider unavailable: HTTP_${r.status}`,
-        503,
-      );
-    }
-    if (!r.ok) throw new Error(`GLM error: ${r.status} ${await r.text()}`);
-    const data = (await r.json()) as {
+    type GlmChatBody = {
       choices?: Array<{
         message: {
           content: string | null;
@@ -167,6 +135,50 @@ export class GlmProvider {
       }>;
       usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
     };
+
+    let data: GlmChatBody;
+    try {
+      const r = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (r.status === 429) {
+        throw new AppError('PROVIDER_RATE_LIMIT', 'GLM provider rate limited', 429);
+      }
+      if (r.status === 401 || r.status === 403) {
+        throw errorTemplates.invalidApiKey({ provider: 'glm', status: r.status });
+      }
+      if (r.status >= 500) {
+        throw new AppError(
+          'PROVIDER_UNAVAILABLE',
+          `GLM provider unavailable: HTTP_${r.status}`,
+          503,
+        );
+      }
+      if (!r.ok) {
+        throw new AppError('INTERNAL_ERROR', `GLM error: ${r.status} ${await r.text()}`, 500);
+      }
+
+      data = (await r.json()) as GlmChatBody;
+    } catch (error) {
+      if (error instanceof AppError) throw error;
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new AppError('PROVIDER_TIMEOUT', `GLM provider timeout (${this.timeoutMs}ms)`, 504);
+      }
+      throw errorTemplates.network({
+        target: this.baseUrl,
+        message: 'GLM provider unreachable',
+        cause: error,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
 
     const msg = data.choices?.[0]?.message;
     const toolCalls: ChatToolCall[] | undefined = msg?.tool_calls?.map((tc) => {

--- a/src/providers/glm/adapter.ts
+++ b/src/providers/glm/adapter.ts
@@ -148,26 +148,33 @@ export class GlmProvider {
         signal: controller.signal,
       });
 
-      // Codex P2 round 2: drain (or cancel) the response body before
-      // throwing on non-2xx. Undici keeps the connection pinned until
-      // the body is consumed; under repeated 429/5xx the keep-alive
-      // pool exhausts and the cascade slows. Reading r.text() on
-      // every error path releases the socket immediately.
+      // Classify by status first, then dispose of the body without
+      // awaiting (Codex P2 round 3): a stalled 429/5xx body would
+      // otherwise throw AbortError mid-await and the outer catch
+      // would remap the error to PROVIDER_TIMEOUT, losing
+      // INVALID_API_KEY / RATE_LIMIT / UNAVAILABLE semantics. body.cancel()
+      // is sync and releases the Undici socket without reading.
       if (!r.ok) {
-        const errBody = await r.text().catch(() => '');
         if (r.status === 429) {
+          void r.body?.cancel();
           throw new AppError('PROVIDER_RATE_LIMIT', 'GLM provider rate limited', 429);
         }
         if (r.status === 401 || r.status === 403) {
+          void r.body?.cancel();
           throw errorTemplates.invalidApiKey({ provider: 'glm', status: r.status });
         }
         if (r.status >= 500) {
+          void r.body?.cancel();
           throw new AppError(
             'PROVIDER_UNAVAILABLE',
             `GLM provider unavailable: HTTP_${r.status}`,
             503,
           );
         }
+        // 4xx other than 401/403/429: include body for diagnosis.
+        // Aborts during the read are caught and we still throw the
+        // mapped INTERNAL_ERROR so the outer catch sees AppError.
+        const errBody = await r.text().catch(() => '');
         throw new AppError('INTERNAL_ERROR', `GLM error: ${r.status} ${errBody}`, 500);
       }
 

--- a/src/providers/glm/adapter.ts
+++ b/src/providers/glm/adapter.ts
@@ -1,17 +1,21 @@
 import { randomUUID } from 'node:crypto';
 
 import type { LLMProvider } from '../../core/contracts/llm-provider.js';
+import { AppError, errorTemplates } from '../../core/errors.js';
 import type { GenerateInput, GenerateResult, ProviderHealth } from '../../core/types.js';
 import { sanitizeForJsonRequest } from '../../infra/security/sanitizers.js';
 import type { ChatMessage, ChatResponse, ChatToolCall, ChatToolDefinition } from '../index.js';
+
+const DEFAULT_GLM_TIMEOUT_MS = 30_000;
 
 export class GlmProvider {
   name = 'glm';
   private apiKey: string;
   private model: string;
   private baseUrl: string;
+  private timeoutMs: number;
 
-  constructor(opts?: { apiKey?: string; model?: string; baseUrl?: string }) {
+  constructor(opts?: { apiKey?: string; model?: string; baseUrl?: string; timeoutMs?: number }) {
     this.apiKey = opts?.apiKey || process.env.GLM_API_KEY || '';
     this.model = opts?.model || process.env.GLM_MODEL || 'glm-4-flash';
     this.baseUrl = (
@@ -19,6 +23,10 @@ export class GlmProvider {
       process.env.GLM_BASE_URL ||
       'https://open.bigmodel.cn/api/paas/v4'
     ).replace(/\/$/, '');
+    const envTimeout = Number.parseInt(process.env.GLM_TIMEOUT_MS ?? '', 10);
+    this.timeoutMs =
+      opts?.timeoutMs ??
+      (Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : DEFAULT_GLM_TIMEOUT_MS);
   }
 
   isConfigured() {
@@ -98,15 +106,53 @@ export class GlmProvider {
       body.tools = glmTools;
     }
 
-    const r = await fetch(`${this.baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.apiKey}`,
-      },
-      body: JSON.stringify(body),
-    });
+    // Cascade-aware error mapping: typed AppErrors with PROVIDER_TIMEOUT /
+    // PROVIDER_RATE_LIMIT / PROVIDER_UNAVAILABLE codes let the circuit
+    // breaker (turn-runtime.ts ~890) count this provider's transient
+    // faults and fail fast on the next call rather than blocking the
+    // cascade for another 30s. Untyped throws were previously routed
+    // through the breaker as non-transient (countAsTrip=false) and the
+    // provider stayed in a flaky-loop instead of falling through.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
 
+    let r: Response;
+    try {
+      r = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new AppError('PROVIDER_TIMEOUT', `GLM provider timeout (${this.timeoutMs}ms)`, 504);
+      }
+      throw errorTemplates.network({
+        target: this.baseUrl,
+        message: 'GLM provider unreachable',
+        cause: error,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (r.status === 429) {
+      throw new AppError('PROVIDER_RATE_LIMIT', 'GLM provider rate limited', 429);
+    }
+    if (r.status === 401 || r.status === 403) {
+      throw errorTemplates.invalidApiKey({ provider: 'glm', status: r.status });
+    }
+    if (r.status >= 500) {
+      throw new AppError(
+        'PROVIDER_UNAVAILABLE',
+        `GLM provider unavailable: HTTP_${r.status}`,
+        503,
+      );
+    }
     if (!r.ok) throw new Error(`GLM error: ${r.status} ${await r.text()}`);
     const data = (await r.json()) as {
       choices?: Array<{
@@ -161,7 +207,7 @@ export class GlmLlmProvider implements LLMProvider {
   public readonly name = 'glm' as const;
   private readonly inner: GlmProvider;
 
-  constructor(opts?: { apiKey?: string; model?: string; baseUrl?: string }) {
+  constructor(opts?: { apiKey?: string; model?: string; baseUrl?: string; timeoutMs?: number }) {
     this.inner = new GlmProvider(opts);
   }
 

--- a/tests/unit/glm-timeout.test.ts
+++ b/tests/unit/glm-timeout.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppError } from '../../src/core/errors.js';
+import { GlmProvider } from '../../src/providers/glm/adapter.js';
+
+describe('GlmProvider timeout + cascade-aware error mapping (S4-3)', () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    delete process.env.GLM_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = realFetch;
+  });
+
+  it('throws PROVIDER_TIMEOUT (504) when fetch aborts past the configured timeout', async () => {
+    const provider = new GlmProvider({ apiKey: 'k', timeoutMs: 30 });
+    global.fetch = vi.fn().mockImplementation(
+      (_url, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+          signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    await expect(provider.chat([{ role: 'user', content: 'hi' }])).rejects.toMatchObject({
+      code: 'PROVIDER_TIMEOUT',
+      statusCode: 504,
+    });
+  });
+
+  it('maps HTTP 429 to PROVIDER_RATE_LIMIT so the circuit breaker counts the trip', async () => {
+    const provider = new GlmProvider({ apiKey: 'k' });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response('{"error":"rate"}', { status: 429 })) as unknown as typeof fetch;
+
+    await expect(provider.chat([{ role: 'user', content: 'hi' }])).rejects.toMatchObject({
+      code: 'PROVIDER_RATE_LIMIT',
+      statusCode: 429,
+    });
+  });
+
+  it('maps HTTP 5xx to PROVIDER_UNAVAILABLE so the cascade falls through', async () => {
+    const provider = new GlmProvider({ apiKey: 'k' });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response('{"error":"down"}', { status: 503 })) as unknown as typeof fetch;
+
+    const err = await provider.chat([{ role: 'user', content: 'hi' }]).catch((e) => e);
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.code).toBe('PROVIDER_UNAVAILABLE');
+    expect(err.statusCode).toBe(503);
+  });
+
+  it('honors GLM_TIMEOUT_MS env override', async () => {
+    process.env.GLM_TIMEOUT_MS = '50';
+    const provider = new GlmProvider({ apiKey: 'k' });
+    global.fetch = vi.fn().mockImplementation(
+      (_url, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+          signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const start = Date.now();
+    await expect(provider.chat([{ role: 'user', content: 'hi' }])).rejects.toMatchObject({
+      code: 'PROVIDER_TIMEOUT',
+    });
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+});

--- a/tests/unit/glm-timeout.test.ts
+++ b/tests/unit/glm-timeout.test.ts
@@ -111,4 +111,28 @@ describe('GlmProvider timeout + cascade-aware error mapping (S4-3)', () => {
     });
     expect(Date.now() - start).toBeLessThan(2000);
   });
+
+  it('clamps oversized timeout below Node setTimeout max (Codex P2 round 4)', async () => {
+    // Node clamps delays above 2^31-1 ms to 1ms with a
+    // TimeoutOverflowWarning. An operator setting GLM_TIMEOUT_MS=
+    // 999999999999 would otherwise see *every* call immediately abort
+    // as PROVIDER_TIMEOUT. Clamping at NODE_TIMEOUT_MAX_MS preserves
+    // the configured value's intent (very long wait) without overflow.
+    process.env.GLM_TIMEOUT_MS = String(Number.MAX_SAFE_INTEGER);
+    const provider = new GlmProvider({ apiKey: 'k' });
+    // Mock fetch to resolve immediately so the test doesn't actually wait.
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }), {
+          status: 200,
+        }),
+      ) as unknown as typeof fetch;
+
+    const start = Date.now();
+    const result = await provider.chat([{ role: 'user', content: 'hi' }]);
+    // Should NOT abort early — call resolves normally.
+    expect(result.content).toBe('ok');
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
 });

--- a/tests/unit/glm-timeout.test.ts
+++ b/tests/unit/glm-timeout.test.ts
@@ -59,6 +59,37 @@ describe('GlmProvider timeout + cascade-aware error mapping (S4-3)', () => {
     expect(err.statusCode).toBe(503);
   });
 
+  it('aborts when headers arrive but body stalls past timeout (Codex P1 round 1)', async () => {
+    // fetch() resolves on response headers, not on full body consumption.
+    // Without keeping the timeout active across `r.json()`, a slow body
+    // would hang the call forever and bypass GLM_TIMEOUT_MS. This test
+    // sends headers immediately, then leaves the body unresolved
+    // until the AbortController fires — the call must reject as
+    // PROVIDER_TIMEOUT, not hang.
+    const provider = new GlmProvider({ apiKey: 'k', timeoutMs: 50 });
+    global.fetch = vi.fn().mockImplementation((_url, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      const body = new ReadableStream({
+        start(controller) {
+          signal?.addEventListener('abort', () => {
+            controller.error(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+          });
+          // Never push any data — simulate stalled body.
+        },
+      });
+      return Promise.resolve(
+        new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      );
+    }) as unknown as typeof fetch;
+
+    const start = Date.now();
+    await expect(provider.chat([{ role: 'user', content: 'hi' }])).rejects.toMatchObject({
+      code: 'PROVIDER_TIMEOUT',
+      statusCode: 504,
+    });
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
   it('honors GLM_TIMEOUT_MS env override', async () => {
     process.env.GLM_TIMEOUT_MS = '50';
     const provider = new GlmProvider({ apiKey: 'k' });


### PR DESCRIPTION
## Summary

The GLM adapter previously called `fetch` with no timeout, no AbortController, and threw a plain `Error` on non-2xx — so an intermittent 1206ms slow response or transient 5xx blocked the cascade for 30s+ and never tripped the turn-runtime circuit breaker (which only counts `AppError` codes `PROVIDER_TIMEOUT` / `PROVIDER_RATE_LIMIT` / `PROVIDER_UNAVAILABLE` per turn-runtime.ts:907).

Operator symptom: GLM provider responses occasionally take 1206ms with no clear failover signal in the chat UI.

## Changes

Mirrors the shared-llm / decentralized-llm pattern:
- AbortController-bounded fetch with \`GLM_TIMEOUT_MS\` env override (default 30s)
- HTTP 429 → \`PROVIDER_RATE_LIMIT\` (429)
- HTTP 401/403 → \`invalidApiKey\` template
- HTTP 5xx → \`PROVIDER_UNAVAILABLE\` (503)
- AbortError → \`PROVIDER_TIMEOUT\` (504)
- Network failures → \`errorTemplates.network\`

Cascade now falls through GLM cleanly on transient slowness instead of hanging the call until the operator notices.

## Test plan

- [x] \`npx vitest run tests/unit/glm-timeout.test.ts\` — 4 new tests pass (timeout abort, 429, 503, env override)
- [x] \`npx vitest run tests/unit/provider-models.test.ts\` — no regressions
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] Operator smoke: send 3 GLM prompts; verify cascade falls through on simulated 503 (set \`GLM_BASE_URL\` to bad endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)