### PR TITLE
feat(doctor): surface cron task failures with log path (S4-4)

### DIFF
--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1235,40 +1235,92 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
     const logsDir = join(schedulerDir, 'logs');
     try {
       const tasksRaw = readFileSync(tasksPath, 'utf8');
-      const tasks = JSON.parse(tasksRaw) as Array<{
+      const parsed = JSON.parse(tasksRaw) as unknown;
+      // Codex P2 round 2: runtime-validate the schema. Type assertion
+      // alone lets garbage like `[{}]` produce a passing check
+      // (enabled.filter() returns []), masking corrupted scheduler
+      // state. Mirror the ScheduledTask interface in scheduler.ts.
+      if (!Array.isArray(parsed)) {
+        throw new Error('expected array of tasks at root');
+      }
+      type ValidatedTask = {
         id: string;
         name: string;
         enabled: boolean;
         lastStatus: 'success' | 'failed' | null;
         lastRun: string | null;
         runCount: number;
-      }>;
-      const enabled = tasks.filter((t) => t.enabled);
-      const failed = enabled.filter((t) => t.lastStatus === 'failed');
-      const cronOk = failed.length === 0;
-      checks.push({
-        id: 't6-cron-tasks',
-        tier: 6,
-        title: 'Cron tasks',
-        level: cronOk ? 'pass' : 'warn',
-        ok: cronOk,
-        required: false,
-        detail: cronOk
-          ? `${enabled.length} enabled task(s), 0 failures`
-          : `${failed.length} failing task(s): ${failed.map((t) => t.id).join(', ')}; logs at ${logsDir}/<taskId>.log`,
-        fix: cronOk
-          ? undefined
-          : `Read failure log: tail -n 100 ${logsDir}/${failed[0]?.id}.log; re-run manually with: memphis schedule run ${failed[0]?.id}`,
-        meta: {
-          enabledCount: enabled.length,
-          failedTasks: failed.map((t) => ({
-            id: t.id,
-            name: t.name,
-            lastRun: t.lastRun,
-            logPath: join(logsDir, `${t.id}.log`),
-          })),
-        },
-      });
+      };
+      const tasks: ValidatedTask[] = [];
+      const invalid: Array<{ index: number; reason: string }> = [];
+      for (let i = 0; i < parsed.length; i++) {
+        const t = parsed[i] as Record<string, unknown>;
+        if (typeof t !== 'object' || t === null) {
+          invalid.push({ index: i, reason: 'not an object' });
+          continue;
+        }
+        const reasons: string[] = [];
+        if (typeof t.id !== 'string' || t.id.length === 0) reasons.push('id');
+        if (typeof t.name !== 'string') reasons.push('name');
+        if (typeof t.enabled !== 'boolean') reasons.push('enabled');
+        if (
+          t.lastStatus !== null &&
+          t.lastStatus !== 'success' &&
+          t.lastStatus !== 'failed'
+        )
+          reasons.push('lastStatus');
+        if (reasons.length > 0) {
+          invalid.push({
+            index: i,
+            reason: `missing/invalid: ${reasons.join(', ')}`,
+          });
+          continue;
+        }
+        tasks.push(t as unknown as ValidatedTask);
+      }
+      if (invalid.length > 0) {
+        checks.push({
+          id: 't6-cron-tasks',
+          tier: 6,
+          title: 'Cron tasks',
+          level: 'warn',
+          ok: false,
+          required: false,
+          detail: `${invalid.length} malformed task entry/entries in tasks.json (${invalid
+            .slice(0, 3)
+            .map((e) => `[${e.index}]: ${e.reason}`)
+            .join('; ')})`,
+          fix: `Inspect ${tasksPath} (jq . < ${tasksPath}); fix or remove malformed entries`,
+          meta: { tasksPath, invalid, validCount: tasks.length },
+        });
+      } else {
+        const enabled = tasks.filter((t) => t.enabled);
+        const failed = enabled.filter((t) => t.lastStatus === 'failed');
+        const cronOk = failed.length === 0;
+        checks.push({
+          id: 't6-cron-tasks',
+          tier: 6,
+          title: 'Cron tasks',
+          level: cronOk ? 'pass' : 'warn',
+          ok: cronOk,
+          required: false,
+          detail: cronOk
+            ? `${enabled.length} enabled task(s), 0 failures`
+            : `${failed.length} failing task(s): ${failed.map((t) => t.id).join(', ')}; logs at ${logsDir}/<taskId>.log`,
+          fix: cronOk
+            ? undefined
+            : `Read failure log: tail -n 100 ${logsDir}/${failed[0]?.id}.log; re-run manually with: memphis schedule run ${failed[0]?.id}`,
+          meta: {
+            enabledCount: enabled.length,
+            failedTasks: failed.map((t) => ({
+              id: t.id,
+              name: t.name,
+              lastRun: t.lastRun,
+              logPath: join(logsDir, `${t.id}.log`),
+            })),
+          },
+        });
+      }
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       checks.push({

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1224,10 +1224,16 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
   // failed; nowhere to look". Surface lastStatus from tasks.json plus the
   // log path so a failure leads operators directly to the journal entry
   // instead of grepping ~/.memphis/ blind.
-  try {
-    const schedulerDir = getConfigPath('scheduler');
-    const tasksPath = join(schedulerDir, 'tasks.json');
-    if (existsSync(tasksPath)) {
+  //
+  // Codex P2 round 1: a missing tasks.json is silent (no scheduler
+  // configured), but a *present-but-unreadable* tasks.json (corrupt JSON,
+  // permission error) must surface as a warn — there is no other doctor
+  // check that would otherwise notice.
+  const schedulerDir = getConfigPath('scheduler');
+  const tasksPath = join(schedulerDir, 'tasks.json');
+  if (existsSync(tasksPath)) {
+    const logsDir = join(schedulerDir, 'logs');
+    try {
       const tasksRaw = readFileSync(tasksPath, 'utf8');
       const tasks = JSON.parse(tasksRaw) as Array<{
         id: string;
@@ -1239,7 +1245,6 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
       }>;
       const enabled = tasks.filter((t) => t.enabled);
       const failed = enabled.filter((t) => t.lastStatus === 'failed');
-      const logsDir = join(schedulerDir, 'logs');
       const cronOk = failed.length === 0;
       checks.push({
         id: 't6-cron-tasks',
@@ -1264,10 +1269,20 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
           })),
         },
       });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      checks.push({
+        id: 't6-cron-tasks',
+        tier: 6,
+        title: 'Cron tasks',
+        level: 'warn',
+        ok: false,
+        required: false,
+        detail: `tasks.json unreadable: ${reason}`,
+        fix: `Inspect ${tasksPath} (jq . < ${tasksPath}); restore from backup or rerun memphis schedule add to recreate.`,
+        meta: { tasksPath, error: reason },
+      });
     }
-  } catch {
-    // tasks.json malformed or unreadable — silent skip; doctor's other tier-6
-    // checks will surface the broader scheduler dir issue if it exists.
   }
 
   checks.push({

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1220,6 +1220,56 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
     required: false,
     detail: multiAgentSync ? 'configured' : 'not configured',
   });
+  // Cron / scheduler health — operator pain (S4-4): "morning-raport-wodzu
+  // failed; nowhere to look". Surface lastStatus from tasks.json plus the
+  // log path so a failure leads operators directly to the journal entry
+  // instead of grepping ~/.memphis/ blind.
+  try {
+    const schedulerDir = getConfigPath('scheduler');
+    const tasksPath = join(schedulerDir, 'tasks.json');
+    if (existsSync(tasksPath)) {
+      const tasksRaw = readFileSync(tasksPath, 'utf8');
+      const tasks = JSON.parse(tasksRaw) as Array<{
+        id: string;
+        name: string;
+        enabled: boolean;
+        lastStatus: 'success' | 'failed' | null;
+        lastRun: string | null;
+        runCount: number;
+      }>;
+      const enabled = tasks.filter((t) => t.enabled);
+      const failed = enabled.filter((t) => t.lastStatus === 'failed');
+      const logsDir = join(schedulerDir, 'logs');
+      const cronOk = failed.length === 0;
+      checks.push({
+        id: 't6-cron-tasks',
+        tier: 6,
+        title: 'Cron tasks',
+        level: cronOk ? 'pass' : 'warn',
+        ok: cronOk,
+        required: false,
+        detail: cronOk
+          ? `${enabled.length} enabled task(s), 0 failures`
+          : `${failed.length} failing task(s): ${failed.map((t) => t.id).join(', ')}; logs at ${logsDir}/<taskId>.log`,
+        fix: cronOk
+          ? undefined
+          : `Read failure log: tail -n 100 ${logsDir}/${failed[0]?.id}.log; re-run manually with: memphis schedule run ${failed[0]?.id}`,
+        meta: {
+          enabledCount: enabled.length,
+          failedTasks: failed.map((t) => ({
+            id: t.id,
+            name: t.name,
+            lastRun: t.lastRun,
+            logPath: join(logsDir, `${t.id}.log`),
+          })),
+        },
+      });
+    }
+  } catch {
+    // tasks.json malformed or unreadable — silent skip; doctor's other tier-6
+    // checks will surface the broader scheduler dir issue if it exists.
+  }
+
   checks.push({
     id: 't6-managed-app-catalog',
     tier: 6,

--- a/tests/unit/doctor.cron-tasks.test.ts
+++ b/tests/unit/doctor.cron-tasks.test.ts
@@ -1,0 +1,106 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runDoctorChecksV2 } from '../../src/infra/cli/utils/doctor-v2.js';
+
+describe('doctor t6-cron-tasks check (S4-4)', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it('omits the cron check when tasks.json does not exist', async () => {
+    const memphisDir = mkdtempSync(join(tmpdir(), 'memphis-cron-doctor-'));
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      MEMPHIS_DATA_DIR: memphisDir,
+      RUST_CHAIN_ENABLED: 'false',
+    };
+
+    const report = await runDoctorChecksV2();
+    const cronCheck = report.checks.find((c) => c.id === 't6-cron-tasks');
+    expect(cronCheck).toBeUndefined();
+  });
+
+  it('passes when all enabled tasks have lastStatus !== failed', async () => {
+    const memphisDir = mkdtempSync(join(tmpdir(), 'memphis-cron-doctor-'));
+    const schedulerDir = join(memphisDir, 'config', 'scheduler');
+    mkdirSync(schedulerDir, { recursive: true });
+    writeFileSync(
+      join(schedulerDir, 'tasks.json'),
+      JSON.stringify([
+        {
+          id: 'morning-raport-wodzu',
+          name: 'Morning report',
+          cron: '0 6 * * *',
+          command: { type: 'shell', script: 'echo hi' },
+          enabled: true,
+          lastRun: new Date().toISOString(),
+          nextRun: null,
+          lastStatus: 'success',
+          createdAt: new Date().toISOString(),
+          runCount: 5,
+        },
+      ]),
+    );
+
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      MEMPHIS_DATA_DIR: memphisDir,
+      RUST_CHAIN_ENABLED: 'false',
+    };
+
+    const report = await runDoctorChecksV2();
+    const cronCheck = report.checks.find((c) => c.id === 't6-cron-tasks');
+    expect(cronCheck?.level).toBe('pass');
+    expect(cronCheck?.detail).toContain('1 enabled task(s)');
+    expect(cronCheck?.detail).toContain('0 failures');
+  });
+
+  it('warns and points to the log path when a task last failed', async () => {
+    // Operator pain that motivated this check: a cron task came back
+    // 'failed' in the morning report but the operator could not find
+    // where to look for the failure detail. Now doctor names the file.
+    const memphisDir = mkdtempSync(join(tmpdir(), 'memphis-cron-doctor-'));
+    const schedulerDir = join(memphisDir, 'config', 'scheduler');
+    mkdirSync(schedulerDir, { recursive: true });
+    writeFileSync(
+      join(schedulerDir, 'tasks.json'),
+      JSON.stringify([
+        {
+          id: 'morning-raport-wodzu',
+          name: 'Morning report',
+          cron: '0 6 * * *',
+          command: { type: 'shell', script: 'echo hi' },
+          enabled: true,
+          lastRun: new Date().toISOString(),
+          nextRun: null,
+          lastStatus: 'failed',
+          createdAt: new Date().toISOString(),
+          runCount: 5,
+        },
+      ]),
+    );
+
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      MEMPHIS_DATA_DIR: memphisDir,
+      RUST_CHAIN_ENABLED: 'false',
+    };
+
+    const report = await runDoctorChecksV2();
+    const cronCheck = report.checks.find((c) => c.id === 't6-cron-tasks');
+    expect(cronCheck?.level).toBe('warn');
+    expect(cronCheck?.detail).toContain('morning-raport-wodzu');
+    expect(cronCheck?.detail).toContain('logs at');
+    expect(cronCheck?.fix).toContain('morning-raport-wodzu.log');
+  });
+});

--- a/tests/unit/doctor.cron-tasks.test.ts
+++ b/tests/unit/doctor.cron-tasks.test.ts
@@ -64,6 +64,30 @@ describe('doctor t6-cron-tasks check (S4-4)', () => {
     expect(cronCheck?.detail).toContain('0 failures');
   });
 
+  it('warns when tasks.json is present but unreadable (Codex P2 round 1)', async () => {
+    // Operator pain: silent skip on malformed tasks.json hid the
+    // scheduler-misconfig signal entirely. Now doctor surfaces a warn
+    // with the parse error and a recovery hint.
+    const memphisDir = mkdtempSync(join(tmpdir(), 'memphis-cron-doctor-'));
+    const schedulerDir = join(memphisDir, 'config', 'scheduler');
+    mkdirSync(schedulerDir, { recursive: true });
+    writeFileSync(join(schedulerDir, 'tasks.json'), '{not valid json');
+
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      MEMPHIS_DATA_DIR: memphisDir,
+      RUST_CHAIN_ENABLED: 'false',
+    };
+
+    const report = await runDoctorChecksV2();
+    const cronCheck = report.checks.find((c) => c.id === 't6-cron-tasks');
+    expect(cronCheck?.level).toBe('warn');
+    expect(cronCheck?.ok).toBe(false);
+    expect(cronCheck?.detail).toContain('tasks.json unreadable');
+    expect(cronCheck?.fix).toContain('jq .');
+  });
+
   it('warns and points to the log path when a task last failed', async () => {
     // Operator pain that motivated this check: a cron task came back
     // 'failed' in the morning report but the operator could not find

--- a/tests/unit/doctor.cron-tasks.test.ts
+++ b/tests/unit/doctor.cron-tasks.test.ts
@@ -64,6 +64,31 @@ describe('doctor t6-cron-tasks check (S4-4)', () => {
     expect(cronCheck?.detail).toContain('0 failures');
   });
 
+  it('warns on schema-invalid task entries instead of false-green pass (Codex P2 round 2)', async () => {
+    // [{}] used to filter via `enabled` undefined and emit a passing
+    // check — masked corrupt scheduler state. Now validate the
+    // id/name/enabled/lastStatus shape and warn with the entry index
+    // + missing fields.
+    const memphisDir = mkdtempSync(join(tmpdir(), 'memphis-cron-doctor-'));
+    const schedulerDir = join(memphisDir, 'config', 'scheduler');
+    mkdirSync(schedulerDir, { recursive: true });
+    writeFileSync(join(schedulerDir, 'tasks.json'), JSON.stringify([{}]));
+
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      MEMPHIS_DATA_DIR: memphisDir,
+      RUST_CHAIN_ENABLED: 'false',
+    };
+
+    const report = await runDoctorChecksV2();
+    const cronCheck = report.checks.find((c) => c.id === 't6-cron-tasks');
+    expect(cronCheck?.level).toBe('warn');
+    expect(cronCheck?.ok).toBe(false);
+    expect(cronCheck?.detail).toContain('malformed task entry');
+    expect(cronCheck?.detail).toContain('id, name, enabled');
+  });
+
   it('warns when tasks.json is present but unreadable (Codex P2 round 1)', async () => {
     // Operator pain: silent skip on malformed tasks.json hid the
     // scheduler-misconfig signal entirely. Now doctor surfaces a warn


### PR DESCRIPTION
## Summary

Operator pain: a scheduled task (e.g. \`morning-raport-wodzu\`) came back \"failed\" in the morning notification but there was no signal in the doctor output and no documented path to read the failure log. Operator had to grep \`~/.memphis/\` blind to find the journal.

Doctor now reads \`tasks.json\` (the same file \`scheduler.ts\` writes), and when any enabled task has \`lastStatus='failed'\` it emits a warn-level \`t6-cron-tasks\` check naming the failed task IDs and the log directory. The \`fix\` field contains the exact \`tail -n 100\` command for the first failed task so the operator can read the failure in one paste.

The check is silent when \`tasks.json\` doesn't exist (no scheduler configured) and when all enabled tasks are passing. Failures elsewhere in the scheduler dir are left to other doctor checks.

## Test plan

- [x] \`npx vitest run tests/unit/doctor.cron-tasks.test.ts\` — 3 new tests (no tasks.json, all passing, one failed)
- [x] \`npx vitest run tests/doctor-v2.test.ts tests/unit/doctor.fresh-install.test.ts\` — no regressions
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] Operator smoke: simulate a cron failure (\`memphis schedule add\` a failing shell, wait for next run, then \`memphis doctor\`) — verify the t6-cron-tasks check appears with the correct log path

🤖 Generated with [Claude Code](https://claude.com/claude-code)