### PR TITLE
fix(scheduler): spawn task shells as login shells (Wodzu cron regression)

### DIFF
--- a/src/infra/runtime/scheduler.ts
+++ b/src/infra/runtime/scheduler.ts
@@ -401,9 +401,17 @@ function runShell(script: string, cwd: string): Promise<{ success: boolean; outp
     // `cd ~/somewhere`. Without re-cd, `git-pull-build` would run
     // outside resolveSchedulerProjectRoot() and fail as "not a git
     // repository". Pass cwd + script as positional args so the inner
-    // bash sees them safely without any shell quoting in the wrapper
-    // itself ($1 = cwd, $2 = original task script).
-    const wrapper = 'cd "$1" || exit 1; eval "$2"';
+    // bash sees them safely without any shell quoting in the wrapper.
+    //
+    // Then clear $@ before eval (Codex P2 round 2): leaving the
+    // wrapper's positional args populated would leak into the eval'd
+    // task script, so a user script that checks `[ $# -eq 0 ]` or
+    // branches on `$1` would behave differently than under plain
+    // `bash -c script`. The wrapper captures the script into a local
+    // variable, runs `set --` to clear $@, then eval's — preserving
+    // the prior `bash -c` semantic of "task sees no positional args".
+    const wrapper =
+      'cd "$1" || exit 1; __memphis_script="$2"; set --; eval "$__memphis_script"';
     const shell = spawn('/bin/bash', ['-lc', wrapper, 'memphis-scheduler', cwd, script], {
       cwd,
       env: { ...process.env, HOME: homeDir },

--- a/src/infra/runtime/scheduler.ts
+++ b/src/infra/runtime/scheduler.ts
@@ -412,7 +412,12 @@ function runShell(script: string, cwd: string): Promise<{ success: boolean; outp
     // the prior `bash -c` semantic of "task sees no positional args".
     const wrapper =
       'cd "$1" || exit 1; __memphis_script="$2"; set --; eval "$__memphis_script"';
-    const shell = spawn('/bin/bash', ['-lc', wrapper, 'memphis-scheduler', cwd, script], {
+    // Set $0 to 'bash' (Codex P2 round 3): the prior literal
+    // 'memphis-scheduler' would break operator scripts that re-invoke
+    // `$0` (e.g. self-reexec, shell detection). Plain `bash -c script`
+    // sets $0 to '/bin/bash' or 'bash'; matching that keeps the prior
+    // semantics.
+    const shell = spawn('/bin/bash', ['-lc', wrapper, 'bash', cwd, script], {
       cwd,
       env: { ...process.env, HOME: homeDir },
     });

--- a/src/infra/runtime/scheduler.ts
+++ b/src/infra/runtime/scheduler.ts
@@ -395,7 +395,16 @@ function runShell(script: string, cwd: string): Promise<{ success: boolean; outp
     // `memphis: command not found` — exactly the regression Wodzu's
     // 2026-04-30 cron smoke caught (task `morning-raport-wodzu` had
     // been failing daily since 2026-04-26 with that error).
-    const shell = spawn('/bin/bash', ['-lc', script], {
+    //
+    // Re-assert cwd after profile sourcing (Codex P1 round 1):
+    // ~/.bash_profile or ~/.profile commonly contain an unconditional
+    // `cd ~/somewhere`. Without re-cd, `git-pull-build` would run
+    // outside resolveSchedulerProjectRoot() and fail as "not a git
+    // repository". Pass cwd + script as positional args so the inner
+    // bash sees them safely without any shell quoting in the wrapper
+    // itself ($1 = cwd, $2 = original task script).
+    const wrapper = 'cd "$1" || exit 1; eval "$2"';
+    const shell = spawn('/bin/bash', ['-lc', wrapper, 'memphis-scheduler', cwd, script], {
       cwd,
       env: { ...process.env, HOME: homeDir },
     });

--- a/src/infra/runtime/scheduler.ts
+++ b/src/infra/runtime/scheduler.ts
@@ -386,7 +386,16 @@ function runShell(script: string, cwd: string): Promise<{ success: boolean; outp
   // for the dev-machine case).
   const homeDir = process.env.HOME ?? '/home/memphis';
   return new Promise((resolve) => {
-    const shell = spawn('/bin/bash', ['-c', script], {
+    // -lc instead of -c: makes bash a login shell so it sources
+    // /etc/profile + ~/.profile + ~/.bashrc, which is how the
+    // operator's PATH gets entries like ~/.npm-global/bin (where
+    // `memphis` itself lives after npm install -g). Without this, a
+    // task script of `memphis exec "..."` runs in a non-interactive
+    // bash with the systemd-user-service PATH and fails as
+    // `memphis: command not found` — exactly the regression Wodzu's
+    // 2026-04-30 cron smoke caught (task `morning-raport-wodzu` had
+    // been failing daily since 2026-04-26 with that error).
+    const shell = spawn('/bin/bash', ['-lc', script], {
       cwd,
       env: { ...process.env, HOME: homeDir },
     });

--- a/tests/unit/scheduler-deploy-command.test.ts
+++ b/tests/unit/scheduler-deploy-command.test.ts
@@ -96,7 +96,7 @@ describe('scheduler git-pull-build command', () => {
       [
         '-lc',
         'cd "$1" || exit 1; __memphis_script="$2"; set --; eval "$__memphis_script"',
-        'memphis-scheduler',
+        'bash',
         '/repo',
         'git pull origin main',
       ],

--- a/tests/unit/scheduler-deploy-command.test.ts
+++ b/tests/unit/scheduler-deploy-command.test.ts
@@ -93,7 +93,13 @@ describe('scheduler git-pull-build command', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(spawnMock).toHaveBeenCalledWith(
       '/bin/bash',
-      ['-lc', 'cd "$1" || exit 1; eval "$2"', 'memphis-scheduler', '/repo', 'git pull origin main'],
+      [
+        '-lc',
+        'cd "$1" || exit 1; __memphis_script="$2"; set --; eval "$__memphis_script"',
+        'memphis-scheduler',
+        '/repo',
+        'git pull origin main',
+      ],
       expect.objectContaining({
         cwd: '/repo',
       }),

--- a/tests/unit/scheduler-deploy-command.test.ts
+++ b/tests/unit/scheduler-deploy-command.test.ts
@@ -93,7 +93,7 @@ describe('scheduler git-pull-build command', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(spawnMock).toHaveBeenCalledWith(
       '/bin/bash',
-      ['-lc', 'git pull origin main'],
+      ['-lc', 'cd "$1" || exit 1; eval "$2"', 'memphis-scheduler', '/repo', 'git pull origin main'],
       expect.objectContaining({
         cwd: '/repo',
       }),

--- a/tests/unit/scheduler-deploy-command.test.ts
+++ b/tests/unit/scheduler-deploy-command.test.ts
@@ -93,7 +93,7 @@ describe('scheduler git-pull-build command', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(spawnMock).toHaveBeenCalledWith(
       '/bin/bash',
-      ['-c', 'git pull origin main'],
+      ['-lc', 'git pull origin main'],
       expect.objectContaining({
         cwd: '/repo',
       }),

--- a/tests/unit/scheduler-login-shell.test.ts
+++ b/tests/unit/scheduler-login-shell.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { executeCommand } from '../../src/infra/runtime/scheduler.js';
 
 describe('scheduler shell tasks run in login shell', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
   it('honors PATH from ~/.profile / ~/.bashrc so global npm bins resolve', async () => {
     // Operator pain (Wodzu's 2026-04-30 cron smoke): a task script of
     // `memphis exec "..."` failed daily since 2026-04-26 with
@@ -32,5 +46,32 @@ describe('scheduler shell tasks run in login shell', () => {
     // for the exact `=yes` token anywhere in the output.
     expect(result.output).toContain('LOGIN_SHELL_PROBE=yes');
     expect(result.output).not.toContain('LOGIN_SHELL_PROBE=no');
+  });
+
+  it('re-asserts cwd after profile sources `cd` (Codex P1 round 1)', async () => {
+    // Operator profiles (~/.profile, ~/.bash_profile) commonly contain
+    // an unconditional `cd ~/somewhere`. With plain `bash -lc`, that cd
+    // would override the cwd spawn() passed in, so a git-pull-build
+    // task could end up running outside the scheduler's runtimeRoot.
+    // Verify the wrapper re-cd's into the spawn cwd before the script
+    // runs, even when HOME points at a profile that cd's elsewhere.
+    const homeDir = mkdtempSync(join(tmpdir(), 'scheduler-home-'));
+    const decoyDir = mkdtempSync(join(tmpdir(), 'scheduler-decoy-'));
+    // Profile cd's into the decoy dir before the task script runs.
+    writeFileSync(join(homeDir, '.profile'), `cd "${decoyDir}"\n`);
+    process.env.HOME = homeDir;
+
+    const result = await executeCommand(
+      { type: 'shell', script: 'echo "PWD=$(pwd)"' },
+      { taskId: 'test-cwd-after-profile' },
+    );
+
+    expect(result.success).toBe(true);
+    // Wrapper re-cd's into runShell's cwd (scheduler project root)
+    // BEFORE the task script runs. So pwd at script time is NOT the
+    // decoy that profile cd'd into.
+    expect(result.output).not.toContain(`PWD=${decoyDir}`);
+    // And it's some real path other than empty.
+    expect(result.output).toMatch(/PWD=\/.+/);
   });
 });

--- a/tests/unit/scheduler-login-shell.test.ts
+++ b/tests/unit/scheduler-login-shell.test.ts
@@ -74,4 +74,19 @@ describe('scheduler shell tasks run in login shell', () => {
     // And it's some real path other than empty.
     expect(result.output).toMatch(/PWD=\/.+/);
   });
+
+  it('clears positional args ($@) before eval so task scripts see no ghost args (Codex P2 round 2)', async () => {
+    // The wrapper passes cwd + script as positional args to the inner
+    // bash, then clears $@ via `set --` before eval'ing. Without that
+    // clear, a task script of `echo $#` would print `2` (cwd + script)
+    // instead of `0`, and any script branching on positional args
+    // would silently take the wrong path.
+    const result = await executeCommand(
+      { type: 'shell', script: 'echo "ARGC=$#"; echo "ARG1=${1:-EMPTY}"' },
+      { taskId: 'test-positional-args' },
+    );
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('ARGC=0');
+    expect(result.output).toContain('ARG1=EMPTY');
+  });
 });

--- a/tests/unit/scheduler-login-shell.test.ts
+++ b/tests/unit/scheduler-login-shell.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { executeCommand } from '../../src/infra/runtime/scheduler.js';
+
+describe('scheduler shell tasks run in login shell', () => {
+  it('honors PATH from ~/.profile / ~/.bashrc so global npm bins resolve', async () => {
+    // Operator pain (Wodzu's 2026-04-30 cron smoke): a task script of
+    // `memphis exec "..."` failed daily since 2026-04-26 with
+    // `memphis: command not found` because `bash -c` is non-interactive
+    // and skips the operator's profile, so ~/.npm-global/bin (where
+    // `memphis` lives) is never on PATH.
+    //
+    // Verify with `printenv SHLVL` — login shells push SHLVL beyond 1.
+    // Plain `bash -c` runs at SHLVL=1; `bash -lc` at SHLVL=2 because
+    // the profile sourcing nests another shell level. (The exact level
+    // is system-dependent so the test just asserts it crossed 1, which
+    // is the canonical signal that login-shell init ran.)
+    const result = await executeCommand(
+      { type: 'shell', script: 'printenv SHLVL' },
+      { taskId: 'test-login-shell' },
+    );
+    expect(result.success).toBe(true);
+    const lvl = Number(result.output.trim().split('\n')[0]);
+    expect(lvl).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/unit/scheduler-login-shell.test.ts
+++ b/tests/unit/scheduler-login-shell.test.ts
@@ -16,10 +16,21 @@ describe('scheduler shell tasks run in login shell', () => {
     // env and /etc/profile normalization); shopt is the unambiguous
     // signal.
     const result = await executeCommand(
-      { type: 'shell', script: 'shopt -q login_shell && echo yes || echo no' },
+      {
+        type: 'shell',
+        script:
+          'shopt -q login_shell && echo "LOGIN_SHELL_PROBE=yes" || echo "LOGIN_SHELL_PROBE=no"',
+      },
       { taskId: 'test-login-shell' },
     );
     expect(result.success).toBe(true);
-    expect(result.output.trim().split('\n')[0]).toBe('yes');
+    // Codex P2 round 2: profile scripts (/etc/profile, ~/.profile,
+    // ~/.bash_profile) can prepend banner lines to stdout before our
+    // echo, and runShell appends STDERR after stdout — so neither
+    // first-line nor last-line is reliable. Use an explicit marker
+    // pair: the script prints `LOGIN_SHELL_PROBE=yes/no`, and we look
+    // for the exact `=yes` token anywhere in the output.
+    expect(result.output).toContain('LOGIN_SHELL_PROBE=yes');
+    expect(result.output).not.toContain('LOGIN_SHELL_PROBE=no');
   });
 });

--- a/tests/unit/scheduler-login-shell.test.ts
+++ b/tests/unit/scheduler-login-shell.test.ts
@@ -75,6 +75,19 @@ describe('scheduler shell tasks run in login shell', () => {
     expect(result.output).toMatch(/PWD=\/.+/);
   });
 
+  it('preserves $0=bash so scripts that re-invoke $0 still work (Codex P2 round 3)', async () => {
+    // Plain `bash -c script` sets $0 to bash. The prior wrapper used
+    // 'memphis-scheduler' as $0 which broke `$0 -c '...'` patterns
+    // (self-reexec, shell detection). Match the prior semantics.
+    const result = await executeCommand(
+      { type: 'shell', script: 'echo "ARG0=$0"' },
+      { taskId: 'test-arg0' },
+    );
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('ARG0=bash');
+    expect(result.output).not.toContain('ARG0=memphis-scheduler');
+  });
+
   it('clears positional args ($@) before eval so task scripts see no ghost args (Codex P2 round 2)', async () => {
     // The wrapper passes cwd + script as positional args to the inner
     // bash, then clears $@ via `set --` before eval'ing. Without that

--- a/tests/unit/scheduler-login-shell.test.ts
+++ b/tests/unit/scheduler-login-shell.test.ts
@@ -10,17 +10,16 @@ describe('scheduler shell tasks run in login shell', () => {
     // and skips the operator's profile, so ~/.npm-global/bin (where
     // `memphis` lives) is never on PATH.
     //
-    // Verify with `printenv SHLVL` — login shells push SHLVL beyond 1.
-    // Plain `bash -c` runs at SHLVL=1; `bash -lc` at SHLVL=2 because
-    // the profile sourcing nests another shell level. (The exact level
-    // is system-dependent so the test just asserts it crossed 1, which
-    // is the canonical signal that login-shell init ran.)
+    // Probe deterministically with `shopt -q login_shell` — that's
+    // bash's own self-report of whether it was invoked with -l.
+    // Codex P2 round 1 flagged SHLVL as flaky (depends on inherited
+    // env and /etc/profile normalization); shopt is the unambiguous
+    // signal.
     const result = await executeCommand(
-      { type: 'shell', script: 'printenv SHLVL' },
+      { type: 'shell', script: 'shopt -q login_shell && echo yes || echo no' },
       { taskId: 'test-login-shell' },
     );
     expect(result.success).toBe(true);
-    const lvl = Number(result.output.trim().split('\n')[0]);
-    expect(lvl).toBeGreaterThanOrEqual(2);
+    expect(result.output.trim().split('\n')[0]).toBe('yes');
   });
 });


### PR DESCRIPTION
## Summary

Operator regression on Wodzu's box: scheduled task \`morning-raport-wodzu\` (\`memphis exec \"...\"\`) failed daily since 2026-04-26 with \`memphis: command not found\`.

**Root cause**: scheduler's \`runShell()\` used \`bash -c\` (non-interactive, non-login). Non-interactive bash skips \`/etc/profile\` + \`~/.profile\` + \`~/.bashrc\`, so the operator's PATH augmentation (e.g. \`~/.npm-global/bin\` where the global \`memphis\` binary lives) never applied. Daemon-launched bash inherited only the systemd-user-service PATH (\`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\`).

**Fix**: switch to \`bash -lc\`. Login shell sources the operator's profile chain so PATH matches the interactive terminal. Tasks that already used absolute paths (the 3 working ones in Wodzu's setup) are unaffected.

## Test plan

- [x] New \`tests/unit/scheduler-login-shell.test.ts\` verifies SHLVL > 1 (login-shell init signal) on a real spawn
- [x] Updated existing \`scheduler-deploy-command.test.ts\` (was hardcoding \`['-c', ...]\`) to assert \`['-lc', ...]\`
- [x] \`npx vitest run tests/unit/scheduler-*.test.ts\` — 5/5 green
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] **Operator smoke** (Wodzu): after merge + rebuild, wait for next cron run of \`morning-raport-wodzu\` (08:00 UTC) and verify task succeeds; or run \`memphis schedule run shell-moeufn6j\` immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)