### PR TITLE
fix(doctor): skip chain.backup-<ts> dirs in repair iterator

### DIFF
--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -450,6 +450,14 @@ async function autoRepair(
     const chainsRoot = getChainPath();
     if (existsSync(chainsRoot)) {
       for (const entry of readdirSync(chainsRoot)) {
+        // Skip backup directories created by prior rebuildChainHashes
+        // runs (they live as siblings: chains/<chain>.backup-<unix-ts>).
+        // Iterating them as if they were chains produces a stream of
+        // "invalid chain name" errors in every doctor --fix run on
+        // boxes that had a chain repair (Wodzu's smoke surfaced this
+        // for cases.backup-1777572129840). Pre-existing noise, not
+        // load-bearing — silent skip.
+        if (/\.backup-\d+$/.test(entry)) continue;
         const chainDir = join(chainsRoot, entry);
         try {
           if (!statSync(chainDir).isDirectory()) continue;


### PR DESCRIPTION
## Summary

Wodzu's 2026-04-30 smoke surfaced a pre-existing repair-loop bug:

\`\`\`
chain hash repair failed for 'cases.backup-1777572129840': invalid chain name
\`\`\`

\`rebuildChainHashes()\` creates a sibling backup at \`chains/<chain>.backup-<unix-ts>/\` before mutating. The auto-repair loop in \`doctor-v2.ts\` then iterates \`chains/\` and tries to repair the backup dir as if it were a chain, throwing "invalid chain name" from \`chain-adapter.ts:408\`.

Silent skip via regex match on \`\.backup-\d+$\`. Non-load-bearing noise.

## Test plan

- [x] \`npx vitest run tests/doctor-v2.test.ts tests/unit/doctor.fresh-install.test.ts tests/unit/doctor.fix-apply.test.ts tests/unit/doctor.cron-tasks.test.ts\` — 24/24 green
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)