### PR TITLE
fix(providers): wire factory.resolveProvider to real OllamaProvider (S5-6)

### DIFF
--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -42,6 +42,25 @@ export async function resolveProvider(opts?: {
   if (!(await provider.isAvailable())) {
     return null;
   }
+  // Codex P1 round 1: when a specific model is requested, verify Ollama
+  // has it installed before returning. Without this, an Ollama instance
+  // running but missing `qwen2.5:0.5b` would still resolve as
+  // "available", so the categorizer's three-tier cascade
+  // (qwen2.5:0.5b → phi3 → default) collapsed to the first tier and
+  // the chat call later threw — caller swallows it and emits zero
+  // suggestions even when a fallback model would have worked.
+  //
+  // Match accepts the canonical Ollama tag form ("phi3:latest") for a
+  // bare-model hint ("phi3") so operators don't have to spell the tag.
+  if (opts?.model) {
+    const installed = await provider.listModels();
+    const wanted = opts.model;
+    const wantedBase = wanted.split(':')[0];
+    const matched = installed.some((name) => name === wanted || name.split(':')[0] === wantedBase);
+    if (!matched) {
+      return null;
+    }
+  }
   return {
     provider: {
       chat: async (messages, options) => {

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -50,13 +50,20 @@ export async function resolveProvider(opts?: {
   // the chat call later threw — caller swallows it and emits zero
   // suggestions even when a fallback model would have worked.
   //
-  // Match accepts the canonical Ollama tag form ("phi3:latest") for a
-  // bare-model hint ("phi3") so operators don't have to spell the tag.
+  // Match policy (Codex P1 round 2): bare-model hint ("phi3") matches
+  // any installed tag with the same base ("phi3:latest"); a tagged
+  // request ("qwen2.5:0.5b") requires an exact tag match. The looser
+  // base-match for tagged requests would have let "qwen2.5:0.5b"
+  // resolve when only "qwen2.5:1.5b" was installed, and the chat call
+  // would later fail on the missing exact tag — so the cascade still
+  // wouldn't fall through to phi3/default.
   if (opts?.model) {
     const installed = await provider.listModels();
     const wanted = opts.model;
-    const wantedBase = wanted.split(':')[0];
-    const matched = installed.some((name) => name === wanted || name.split(':')[0] === wantedBase);
+    const isTagged = wanted.includes(':');
+    const matched = isTagged
+      ? installed.includes(wanted)
+      : installed.some((name) => name === wanted || name.split(':')[0] === wanted);
     if (!matched) {
       return null;
     }

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -88,7 +88,17 @@ export async function resolveProvider(opts?: {
   // would later fail on the missing exact tag — so the cascade still
   // wouldn't fall through to phi3/default.
   if (opts?.model) {
-    const installed = await provider.listModels();
+    // Codex P1 round 4: OllamaProvider.listModels() uses bare fetch
+    // with no timeout, so a slow/hung /api/tags can block classification
+    // indefinitely. Categorizer.classifyWithLLM only wraps the chat
+    // call in a 3s timeout, so this pre-chat probe is unbounded. Race
+    // listModels against a 3s ceiling and treat timeout as
+    // "model unknown, fall through" — same outcome as a missing model,
+    // which is the safe choice for a cascade fallback.
+    const installed = await Promise.race<string[]>([
+      provider.listModels(),
+      new Promise<string[]>((resolve) => setTimeout(() => resolve([]), 3000)),
+    ]);
     const wanted = opts.model;
     const isTagged = wanted.includes(':');
     const matched = isTagged

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,3 +1,6 @@
+import { OllamaProvider } from './index.js';
+import type { ChatMessage } from './index.js';
+
 export interface ResolvedProvider {
   provider: {
     chat: (
@@ -8,8 +11,48 @@ export interface ResolvedProvider {
   model: string;
 }
 
-export async function resolveProvider(
-  _opts?: Record<string, unknown>,
-): Promise<ResolvedProvider | null> {
-  return null;
+/**
+ * Resolve a lightweight provider for fast classification calls (used by
+ * cognitive/categorizer.ts LLM fallback). Returns null when the provider
+ * is unconfigured or unavailable; caller falls back to pattern-only
+ * suggestions.
+ *
+ * S5-6 (Level A plan): the prior implementation returned `null`
+ * unconditionally, so categorizer's `enableLLMFallback: true` was
+ * silent dead code — the three-tier model cascade (qwen2.5:0.5b →
+ * phi3 → default) all collapsed to "no suggestions" with no
+ * operator-visible signal. This adapter wires the real OllamaProvider
+ * so the feature actually works when an operator opts in.
+ *
+ * Scope is intentionally narrow: ollama-only (the only provider any
+ * current caller asks for). Non-ollama hints are rejected explicitly.
+ */
+export async function resolveProvider(opts?: {
+  provider?: 'ollama';
+  model?: string;
+  skipOpenClaw?: boolean;
+}): Promise<ResolvedProvider | null> {
+  if (opts?.provider && opts.provider !== 'ollama') {
+    return null;
+  }
+  const provider = new OllamaProvider(opts?.model ? { model: opts.model } : undefined);
+  if (!provider.isConfigured()) {
+    return null;
+  }
+  if (!(await provider.isAvailable())) {
+    return null;
+  }
+  return {
+    provider: {
+      chat: async (messages, options) => {
+        const response = await provider.chat(messages as ChatMessage[], {
+          model: options?.model,
+          temperature: options?.temperature,
+          maxTokens: options?.max_tokens,
+        });
+        return { content: response.content };
+      },
+    },
+    model: opts?.model ?? provider.defaultModel(),
+  };
 }

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,6 +1,36 @@
 import { OllamaProvider } from './index.js';
 import type { ChatMessage } from './index.js';
 
+// Cache the (baseUrl → reachable) outcome for a short window so the
+// categorizer's three-tier cascade (qwen2.5:0.5b → phi3 → default)
+// doesn't pay 3× the 3-second isAvailable() timeout when Ollama is
+// down (Codex P1 round 3: 9s wall-time before returning [] regressed
+// the prior fast-null behavior). 30s is short enough to recover from
+// transient outages on the next classifier call without spamming the
+// daemon endpoint.
+const AVAILABILITY_CACHE_TTL_MS = 30_000;
+const availabilityCache = new Map<string, { reachable: boolean; expiresAt: number }>();
+
+function cachedIsAvailable(provider: OllamaProvider): Promise<boolean> {
+  const key = (provider as unknown as { baseUrl?: string }).baseUrl ?? '';
+  const cached = availabilityCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return Promise.resolve(cached.reachable);
+  }
+  return provider.isAvailable().then((reachable) => {
+    availabilityCache.set(key, {
+      reachable,
+      expiresAt: Date.now() + AVAILABILITY_CACHE_TTL_MS,
+    });
+    return reachable;
+  });
+}
+
+/** Test-only: clear the cache so unit tests start from a clean state. */
+export function __resetAvailabilityCacheForTests(): void {
+  availabilityCache.clear();
+}
+
 export interface ResolvedProvider {
   provider: {
     chat: (
@@ -39,7 +69,7 @@ export async function resolveProvider(opts?: {
   if (!provider.isConfigured()) {
     return null;
   }
-  if (!(await provider.isAvailable())) {
+  if (!(await cachedIsAvailable(provider))) {
     return null;
   }
   // Codex P1 round 1: when a specific model is requested, verify Ollama

--- a/tests/unit/provider-factory.test.ts
+++ b/tests/unit/provider-factory.test.ts
@@ -27,16 +27,24 @@ describe('providers/factory resolveProvider (S5-6)', () => {
     expect(resolved).toBeNull();
   });
 
-  it('returns a real provider with chat() when ollama is reachable', async () => {
+  it('returns a real provider with chat() when ollama is reachable AND model is installed', async () => {
     process.env.OLLAMA_URL = 'http://127.0.0.1:11434';
-    // First fetch: provider.isAvailable() (HEAD or GET to /api/tags).
-    // Second fetch: chat() POST to /api/chat.
+    // Three fetches: isAvailable probe, listModels probe, chat call.
     let call = 0;
     global.fetch = vi.fn().mockImplementation(() => {
       call += 1;
       if (call === 1) {
-        // isAvailable probe.
-        return Promise.resolve(new Response('{"models":[]}', { status: 200 }));
+        // isAvailable probe (also returns the tag list — Ollama uses
+        // /api/tags for both).
+        return Promise.resolve(
+          new Response(JSON.stringify({ models: [{ name: 'qwen2.5:0.5b' }] }), { status: 200 }),
+        );
+      }
+      if (call === 2) {
+        // listModels probe (model presence check).
+        return Promise.resolve(
+          new Response(JSON.stringify({ models: [{ name: 'qwen2.5:0.5b' }] }), { status: 200 }),
+        );
       }
       // chat() response — Ollama format.
       return Promise.resolve(
@@ -58,6 +66,42 @@ describe('providers/factory resolveProvider (S5-6)', () => {
       model: 'qwen2.5:0.5b',
     });
     expect(reply.content).toContain('feature');
+  });
+
+  it('returns null when ollama is up but the requested model is not installed (Codex P1 round 1)', async () => {
+    // Operator scenario: Ollama is running but qwen2.5:0.5b never pulled.
+    // Without this check, the categorizer cascade collapses to the first
+    // tier and the later chat call throws — emitting zero suggestions.
+    process.env.OLLAMA_URL = 'http://127.0.0.1:11434';
+    global.fetch = vi.fn().mockImplementation(() => {
+      return Promise.resolve(
+        new Response(JSON.stringify({ models: [{ name: 'llama3:latest' }] }), { status: 200 }),
+      );
+    }) as unknown as typeof fetch;
+
+    const resolved = await resolveProvider({ provider: 'ollama', model: 'qwen2.5:0.5b' });
+    expect(resolved).toBeNull();
+  });
+
+  it('matches a bare-model hint ("phi3") against the canonical tag ("phi3:latest")', async () => {
+    process.env.OLLAMA_URL = 'http://127.0.0.1:11434';
+    let call = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      call += 1;
+      const tagsBody = JSON.stringify({ models: [{ name: 'phi3:latest' }] });
+      if (call <= 2) {
+        return Promise.resolve(new Response(tagsBody, { status: 200 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ message: { role: 'assistant', content: 'ok' }, done: true }),
+          { status: 200 },
+        ),
+      );
+    }) as unknown as typeof fetch;
+
+    const resolved = await resolveProvider({ provider: 'ollama', model: 'phi3' });
+    expect(resolved).not.toBeNull();
   });
 
   it('rejects non-ollama provider hints (scope is narrow on purpose)', async () => {

--- a/tests/unit/provider-factory.test.ts
+++ b/tests/unit/provider-factory.test.ts
@@ -83,6 +83,22 @@ describe('providers/factory resolveProvider (S5-6)', () => {
     expect(resolved).toBeNull();
   });
 
+  it('returns null when a tagged request asks for a different tag of the same base (Codex P1 round 2)', async () => {
+    // Operator scenario: requested qwen2.5:0.5b but only qwen2.5:1.5b
+    // installed. Loose base-match would treat them as equivalent and
+    // the chat call would later fail on the missing exact tag — cascade
+    // stays broken. Tagged requests require exact tag match.
+    process.env.OLLAMA_URL = 'http://127.0.0.1:11434';
+    global.fetch = vi.fn().mockImplementation(() => {
+      return Promise.resolve(
+        new Response(JSON.stringify({ models: [{ name: 'qwen2.5:1.5b' }] }), { status: 200 }),
+      );
+    }) as unknown as typeof fetch;
+
+    const resolved = await resolveProvider({ provider: 'ollama', model: 'qwen2.5:0.5b' });
+    expect(resolved).toBeNull();
+  });
+
   it('matches a bare-model hint ("phi3") against the canonical tag ("phi3:latest")', async () => {
     process.env.OLLAMA_URL = 'http://127.0.0.1:11434';
     let call = 0;

--- a/tests/unit/provider-factory.test.ts
+++ b/tests/unit/provider-factory.test.ts
@@ -125,6 +125,34 @@ describe('providers/factory resolveProvider (S5-6)', () => {
     expect(resolved).not.toBeNull();
   });
 
+  it('bounds listModels probe at 3s when /api/tags hangs (Codex P1 round 4)', { timeout: 6000 }, async () => {
+    // OllamaProvider.listModels uses bare fetch with no timeout. A
+    // hung daemon would otherwise block resolveProvider indefinitely.
+    process.env.OLLAMA_URL = 'http://127.0.0.1:11434';
+    let probeCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      probeCount += 1;
+      if (probeCount === 1) {
+        // isAvailable probe — succeeds.
+        return Promise.resolve(
+          new Response(JSON.stringify({ models: [{ name: 'qwen2.5:0.5b' }] }), { status: 200 }),
+        );
+      }
+      // listModels probe — never resolves (simulates hung daemon).
+      return new Promise(() => {});
+    }) as unknown as typeof fetch;
+
+    const start = Date.now();
+    const resolved = await resolveProvider({ provider: 'ollama', model: 'qwen2.5:0.5b' });
+    const elapsed = Date.now() - start;
+    // Timeout treats listModels as empty → resolveProvider returns null
+    // (model considered missing).
+    expect(resolved).toBeNull();
+    // Wall-time bounded at ~3s, not unbounded.
+    expect(elapsed).toBeLessThan(4000);
+    expect(elapsed).toBeGreaterThanOrEqual(2900);
+  });
+
   it('caches isAvailable so cascading calls do not pay 3× the timeout when Ollama is down (Codex P1 round 3)', async () => {
     // Categorizer cascades resolveProvider three times (qwen2.5:0.5b →
     // phi3 → default). Each isAvailable() probe has a 3s timeout, so

--- a/tests/unit/provider-factory.test.ts
+++ b/tests/unit/provider-factory.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveProvider } from '../../src/providers/factory.js';
+import {
+  __resetAvailabilityCacheForTests,
+  resolveProvider,
+} from '../../src/providers/factory.js';
 
 describe('providers/factory resolveProvider (S5-6)', () => {
   const originalEnv = { ...process.env };
@@ -8,12 +11,14 @@ describe('providers/factory resolveProvider (S5-6)', () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
+    __resetAvailabilityCacheForTests();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     global.fetch = realFetch;
     process.env = { ...originalEnv };
+    __resetAvailabilityCacheForTests();
   });
 
   it('returns null when ollama is unreachable (silent dead-path replaced — Level A S5-6)', async () => {
@@ -118,6 +123,28 @@ describe('providers/factory resolveProvider (S5-6)', () => {
 
     const resolved = await resolveProvider({ provider: 'ollama', model: 'phi3' });
     expect(resolved).not.toBeNull();
+  });
+
+  it('caches isAvailable so cascading calls do not pay 3× the timeout when Ollama is down (Codex P1 round 3)', async () => {
+    // Categorizer cascades resolveProvider three times (qwen2.5:0.5b →
+    // phi3 → default). Each isAvailable() probe has a 3s timeout, so
+    // an offline Ollama would have cost up to 9 seconds before the
+    // cache landed. With caching, the 2nd and 3rd calls return the
+    // cached negative result immediately.
+    process.env.OLLAMA_URL = 'http://127.0.0.1:1';
+    let probeCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      probeCount += 1;
+      return Promise.reject(new Error('ECONNREFUSED'));
+    }) as unknown as typeof fetch;
+
+    await resolveProvider({ provider: 'ollama', model: 'qwen2.5:0.5b' });
+    await resolveProvider({ provider: 'ollama', model: 'phi3' });
+    await resolveProvider({ provider: 'ollama' });
+
+    // Only one probe should have hit the network — the other two
+    // resolve from cache.
+    expect(probeCount).toBe(1);
   });
 
   it('rejects non-ollama provider hints (scope is narrow on purpose)', async () => {

--- a/tests/unit/provider-factory.test.ts
+++ b/tests/unit/provider-factory.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveProvider } from '../../src/providers/factory.js';
+
+describe('providers/factory resolveProvider (S5-6)', () => {
+  const originalEnv = { ...process.env };
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = realFetch;
+    process.env = { ...originalEnv };
+  });
+
+  it('returns null when ollama is unreachable (silent dead-path replaced — Level A S5-6)', async () => {
+    // Prior to S5-6 the function returned null unconditionally. This
+    // test pins the unreachable-ollama outcome so a future regression
+    // back to "always null" is caught explicitly.
+    process.env.OLLAMA_URL = 'http://127.0.0.1:1';
+    global.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+
+    const resolved = await resolveProvider({ provider: 'ollama', model: 'qwen2.5:0.5b' });
+    expect(resolved).toBeNull();
+  });
+
+  it('returns a real provider with chat() when ollama is reachable', async () => {
+    process.env.OLLAMA_URL = 'http://127.0.0.1:11434';
+    // First fetch: provider.isAvailable() (HEAD or GET to /api/tags).
+    // Second fetch: chat() POST to /api/chat.
+    let call = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      call += 1;
+      if (call === 1) {
+        // isAvailable probe.
+        return Promise.resolve(new Response('{"models":[]}', { status: 200 }));
+      }
+      // chat() response — Ollama format.
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            model: 'qwen2.5:0.5b',
+            message: { role: 'assistant', content: '[{"tag":"feature","confidence":0.9}]' },
+            done: true,
+          }),
+          { status: 200 },
+        ),
+      );
+    }) as unknown as typeof fetch;
+
+    const resolved = await resolveProvider({ provider: 'ollama', model: 'qwen2.5:0.5b' });
+    expect(resolved).not.toBeNull();
+    expect(resolved?.model).toBe('qwen2.5:0.5b');
+    const reply = await resolved!.provider.chat([{ role: 'user', content: 'classify' }], {
+      model: 'qwen2.5:0.5b',
+    });
+    expect(reply.content).toContain('feature');
+  });
+
+  it('rejects non-ollama provider hints (scope is narrow on purpose)', async () => {
+    const resolved = await resolveProvider({
+      provider: 'minimax' as unknown as 'ollama',
+      model: 'MiniMax-M2.7',
+    });
+    expect(resolved).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

\`src/providers/factory.ts\` was a long-standing stub returning \`null\` unconditionally. \`src/cognitive/categorizer.ts:251\` calls \`resolveProvider\` for its LLM fallback path; with the stub, \`enableLLMFallback: true\` was silent dead code — the three-tier model cascade (\`qwen2.5:0.5b\` → \`phi3\` → default) all collapsed to "no suggestions" with no operator-visible signal.

This is one of the **\"operator-hidden stubs\"** flagged by Plan agent in the 2026-05-01 finish-the-system review (Level A → S5-6).

## Changes

- Wire factory's \`resolveProvider\` to the real \`OllamaProvider\` from \`src/providers/index.ts\`. Existing API contract preserved: returns \`null\` on unconfigured/unavailable, \`ResolvedProvider\` otherwise.
- Categorizer's call shape (\`{provider, model, skipOpenClaw}\`) preserved; \`skipOpenClaw\` is accepted but not consulted (legacy field).
- Non-ollama hints rejected explicitly — no current caller asks for one; future expansion belongs in a dedicated PR.

## Test plan

- [x] \`tests/unit/provider-factory.test.ts\` — 3 new tests (ollama unreachable, ollama reachable + chat works, non-ollama rejected)
- [x] \`tests/cognitive/categorizer.test.ts\` + \`tests/unit/cli.categorize.test.ts\` — no regressions
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] **Operator smoke** (Wodzu): set \`enableLLMFallback: true\` in a categorizer call (or temporarily flip the default in DEFAULT_CONFIG); send a tag-rich phrase; verify suggestions return non-empty (or at least that the timeout fires, not silent empty).

## Out of scope (deferred to other Level A items)

- S5-1 \`requireOperatorAuth\` sweep
- S5-4 tier 3 envMode propagation
- S5-5 Memphis Agent exec un-castration

🤖 Generated with [Claude Code](https://claude.com/claude-code)