### PR TITLE
fix(soul): thread rawEnv through tool-executor + self-modify into manifest reads (S5-4)

### DIFF
--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -792,6 +792,7 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
           rollback: deps.rollback ?? new RollbackManager(getDataDir()),
           caseAdapter: deps.caseAdapter ?? new CaseChainAdapter(),
           projectRoot: deps.projectRoot,
+          rawEnv: deps.rawEnv,
         });
       },
     }),
@@ -1255,7 +1256,14 @@ async function executeTool(
   runtimeTools: Map<string, RuntimeToolDefinition>,
 ): Promise<string> {
   // Enforce tiered authorization before execution
-  const manifest = loadSoulManifest() ?? defaultManifest();
+  // Thread rawEnv from request deps so per-request env overrides
+  // (e.g. MEMPHIS_AUTONOMY_MODE=full carried in the HTTP request env
+  // bag, distinct from the daemon's process.env) propagate into the
+  // manifest read. S5-4: prior call site used the loadSoulManifest
+  // default (process.env), which silently dropped per-request env
+  // intent and stranded the agent on the disk-mode value. Daemon-mode
+  // behavior is identical because deps.rawEnv === process.env there.
+  const manifest = loadSoulManifest(deps.rawEnv) ?? defaultManifest();
   const result = resolveToolPolicy({
     toolName: call.name,
     permissionRepo: deps.permissionRepo,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1044,7 +1044,7 @@ export function createMemphisMcpServer(
         async ({ intent, files, changes, passphrase }) => {
           const result = await runMemphisSelfModify(
             { intent, files, changes, passphrase },
-            { ...evolveDeps },
+            { ...evolveDeps, rawEnv },
           );
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],

--- a/src/mcp/tools/self-modify.ts
+++ b/src/mcp/tools/self-modify.ts
@@ -56,6 +56,9 @@ export interface SelfModifyDeps {
   rollback: RollbackManager;
   caseAdapter: CaseChainAdapter;
   projectRoot?: string;
+  // S5-4: thread per-request env so MEMPHIS_AUTONOMY_MODE overrides
+  // reach the manifest read (mirrors tool-executor.ts pattern).
+  rawEnv?: NodeJS.ProcessEnv;
 }
 
 // ── Path validation ──────────────────────────────────────────────────────────
@@ -228,10 +231,10 @@ export async function runMemphisSelfModify(
   }
 
   // Enforce evolution policy
-  ensureSoulManifest();
+  ensureSoulManifest(deps.rawEnv);
 
   // Passphrase gate for tier 2 self-modification (skipped in full autonomy mode)
-  const manifest = loadSoulManifest();
+  const manifest = loadSoulManifest(deps.rawEnv);
   if (manifest?.evolution?.requirePassphraseForTier2 && manifest.mode !== 'full') {
     if (!manifest.evolution.passphraseHash) {
       return errorResult(

--- a/tests/unit/self-modify-rawenv-threading.test.ts
+++ b/tests/unit/self-modify-rawenv-threading.test.ts
@@ -1,0 +1,93 @@
+/**
+ * S5-4 regression: rawEnv must thread from runMemphisSelfModify deps
+ * into ensureSoulManifest + loadSoulManifest so per-request env
+ * overrides (e.g. MEMPHIS_AUTONOMY_MODE=full carried in an HTTP
+ * request env bag) reach the manifest read.
+ *
+ * Without this thread, prior code called loadSoulManifest() with no
+ * arg → defaulted to process.env → daemon-time env, dropping the
+ * per-request intent.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runMemphisSelfModify } from '../../src/mcp/tools/self-modify.js';
+
+vi.mock('../../src/soul/manifest.js', () => {
+  return {
+    ensureSoulManifest: vi.fn(),
+    loadSoulManifest: vi.fn(() => null),
+  };
+});
+
+vi.mock('../../src/infra/git-utils.js', () => ({
+  isGitRepo: vi.fn().mockResolvedValue(true),
+}));
+
+const manifestModule = (await import('../../src/soul/manifest.js')) as unknown as {
+  ensureSoulManifest: ReturnType<typeof vi.fn>;
+  loadSoulManifest: ReturnType<typeof vi.fn>;
+};
+
+const fakeDeps = {
+  sessionRepo: {
+    create: vi.fn().mockReturnValue({ id: 'sess-1' }),
+    updateStatus: vi.fn(),
+    getById: vi.fn().mockReturnValue(null),
+  },
+  rollback: {
+    createSnapshot: vi.fn().mockResolvedValue('snap-1'),
+    rollback: vi.fn(),
+  },
+  caseAdapter: {
+    appendBlock: vi.fn(),
+  },
+  projectRoot: '/tmp/fake',
+} as unknown as Parameters<typeof runMemphisSelfModify>[1];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runMemphisSelfModify rawEnv threading (S5-4)', () => {
+  it('passes deps.rawEnv to ensureSoulManifest + loadSoulManifest', async () => {
+    const customEnv = {
+      ...process.env,
+      MEMPHIS_AUTONOMY_MODE: 'full',
+      __TEST_MARKER__: 'rawenv-threaded',
+    };
+
+    await runMemphisSelfModify(
+      {
+        intent: 'test',
+        files: ['file.ts'],
+        changes: { 'file.ts': 'content' },
+      },
+      { ...fakeDeps, rawEnv: customEnv },
+    );
+
+    // Both calls receive the per-request env, not undefined or process.env.
+    expect(manifestModule.ensureSoulManifest).toHaveBeenCalledWith(customEnv);
+    expect(manifestModule.loadSoulManifest).toHaveBeenCalledWith(customEnv);
+    // Verify the marker survives — proves the env isn't being filtered
+    // somewhere in the call chain.
+    const calls = manifestModule.loadSoulManifest.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall?.[0]?.__TEST_MARKER__).toBe('rawenv-threaded');
+  });
+
+  it('falls back to undefined (loadSoulManifest default = process.env) when deps.rawEnv omitted', async () => {
+    await runMemphisSelfModify(
+      {
+        intent: 'test',
+        files: ['file.ts'],
+        changes: { 'file.ts': 'content' },
+      },
+      fakeDeps,
+    );
+
+    // ensureSoulManifest() called with undefined → its own default kicks in.
+    expect(manifestModule.ensureSoulManifest).toHaveBeenCalledWith(undefined);
+    expect(manifestModule.loadSoulManifest).toHaveBeenCalledWith(undefined);
+  });
+});
+


### PR DESCRIPTION
## Summary

The 2026-04-30 read-side envMode fix in \`src/soul/manifest.ts:118-122\` made \`loadSoulManifest\` honor \`MEMPHIS_AUTONOMY_MODE\`, but only when the caller passed a \`rawEnv\` argument. Three runtime callers were still calling \`loadSoulManifest()\` with no args, defaulting to \`process.env\`:

- \`src/gateway/tool-executor.ts:1258\` (\`executeTool\`)
- \`src/mcp/tools/self-modify.ts:230,234\` (\`runMemphisSelfModify\`)
- \`src/infra/cli/utils/doctor-v2.ts:610\` (left unchanged — daemon-time sanity check, \`process.env\` is correct)

For tool-executor + self-modify, the per-request env bag carried by HTTP/MCP requests was silently dropped in favor of the daemon's \`process.env\`. Per-request \`MEMPHIS_AUTONOMY_MODE\` overrides couldn't elevate manifest mode for that one call. This was the architectural smell flagged in \`project_tier3_authorization_gap_2026_04_27.md\`.

## Changes

- \`tool-executor.ts\`: pass \`deps.rawEnv\` to \`loadSoulManifest\`. Daemon path unchanged (\`deps.rawEnv === process.env\` there).
- \`self-modify.ts\`: add optional \`rawEnv\` to \`SelfModifyDeps\`; thread to \`ensureSoulManifest\` + \`loadSoulManifest\`.
- \`tool-executor.ts:790\`: pass \`deps.rawEnv\` when invoking \`runMemphisSelfModify\`.
- \`mcp/server.ts:1047\`: pass \`rawEnv\` when invoking \`runMemphisSelfModify\`.

## Test plan

- [x] \`tests/unit/self-modify-rawenv-threading.test.ts\` — 2 new tests assert the env bag (with \`__TEST_MARKER__\`) reaches both manifest functions when supplied; omitting it preserves prior behavior (\`undefined\` → \`loadSoulManifest\` default).
- [x] \`tests/unit/self-modify-passphrase.test.ts\`, \`self-modify-lifecycle.test.ts\`, \`tool-executor-runtime-coverage.test.ts\` — no regressions
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] **Operator smoke** (Wodzu): trigger a tool call from Telegram with \`MEMPHIS_AUTONOMY_MODE=full\` set on daemon; previously identical, should remain identical (daemon path unchanged). Per-request override won't be exercised on this box but the threading is now correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)