### PR TITLE
feat(cli): memphis auth audit — surface CLI auth-gate matrix (S5-3)

### DIFF
--- a/src/infra/auth/operator-gate.ts
+++ b/src/infra/auth/operator-gate.ts
@@ -28,21 +28,55 @@ export interface OperatorConfig {
 
 // ─── Gated operations registry ───────────────────────────────────────
 
-interface GateRule {
+export interface GateRule {
   command: string;
   subcommand?: string | string[];
   condition?: (args: CliArgs) => boolean;
+  /**
+   * Free-form description of why this gate exists. Used by
+   * `memphis auth audit` to render the matrix in operator-readable form.
+   */
+  reason?: string;
 }
 
-const GATED_OPERATIONS: GateRule[] = [
-  { command: 'vault', subcommand: 'init' },
-  { command: 'vault', subcommand: ['add', 'get', 'list'] },
-  { command: 'secret', subcommand: ['add', 'get', 'list'] },
-  { command: 'trust', subcommand: ['add', 'remove'] },
-  { command: 'trust', subcommand: 'mode', condition: (a) => a.target === 'set' },
-  { command: 'evolve', subcommand: 'rollback' },
-  { command: 'backup', condition: (a) => !!a.restore || a.clean },
-  { command: 'reset', condition: (a) => a.runtime || a.yes },
+export const GATED_OPERATIONS: GateRule[] = [
+  { command: 'vault', subcommand: 'init', reason: 'creates encrypted vault, sets master key' },
+  {
+    command: 'vault',
+    subcommand: ['add', 'get', 'list'],
+    reason: 'reads/writes vault entries (secrets in plaintext)',
+  },
+  {
+    command: 'secret',
+    subcommand: ['add', 'get', 'list'],
+    reason: 'reads/writes vault-stored secrets',
+  },
+  {
+    command: 'trust',
+    subcommand: ['add', 'remove'],
+    reason: 'modifies tool-permission rules',
+  },
+  {
+    command: 'trust',
+    subcommand: 'mode',
+    condition: (a) => a.target === 'set',
+    reason: 'changes autonomy mode (paranoid/balanced/quiet/full)',
+  },
+  {
+    command: 'evolve',
+    subcommand: 'rollback',
+    reason: 'reverts agent self-modification',
+  },
+  {
+    command: 'backup',
+    condition: (a) => !!a.restore || a.clean,
+    reason: 'restores from backup or deletes archives',
+  },
+  {
+    command: 'reset',
+    condition: (a) => a.runtime || a.yes,
+    reason: 'wipes runtime state',
+  },
 ];
 
 // ─── Session cache ───────────────────────────────────────────────────

--- a/src/infra/cli/handlers/auth.handler.ts
+++ b/src/infra/cli/handlers/auth.handler.ts
@@ -51,8 +51,17 @@ interface AuditRow {
 function findEnforcingCommands(): Set<string> {
   const enforcing = new Set<string>();
   const here = dirname(fileURLToPath(import.meta.url));
-  // here = src/infra/cli/handlers/. Sibling: ../commands/.
+  // `here` is either `src/infra/cli/handlers/` (dev / ts-node / vitest)
+  // or `dist/infra/cli/handlers/` (production npm package). Codex P1
+  // round 3 caught this: scanning only `.ts` skipped every file in dist
+  // and reported every registered rule as a gap. Accept either source
+  // tree relative to the running module.
   const candidates = [here, join(here, '..', 'commands')];
+  // Match a real call site: `requireOperatorAuth(` (with the open
+  // paren). The bare identifier appears in this file's own JSDoc
+  // comments, which Codex P2 round 3 caught — `auth.handler.ts` was
+  // counted as enforcing despite never calling the function.
+  const CALL_SITE_RE = /\brequireOperatorAuth\s*\(/;
   for (const dir of candidates) {
     let files: string[];
     try {
@@ -61,18 +70,28 @@ function findEnforcingCommands(): Set<string> {
       continue;
     }
     for (const file of files) {
-      if (!file.endsWith('.ts')) continue;
+      if (!file.endsWith('.ts') && !file.endsWith('.js')) continue;
+      // Skip declaration files and source maps.
+      if (file.endsWith('.d.ts')) continue;
       let content: string;
       try {
         content = readFileSync(join(dir, file), 'utf8');
       } catch {
         continue;
       }
-      // Imports DON'T count — only call sites. Cheap signal: the
-      // identifier appearing outside an import line.
-      const lines = content.split('\n').filter((l) => !/^\s*import\b/.test(l));
-      if (!lines.some((l) => l.includes('requireOperatorAuth'))) continue;
-      const name = file.replace(/\.handler\.ts$/, '').replace(/\.ts$/, '');
+      // Filter out import/require lines (where the symbol appears
+      // legitimately but isn't a call) and JSDoc/inline comments
+      // (where the operator-readable rationale mentions the function).
+      const codeLines = content.split('\n').filter((line) => {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('import ') || trimmed.startsWith('//')) return false;
+        if (trimmed.startsWith('*') || trimmed.startsWith('/*')) return false;
+        return true;
+      });
+      if (!codeLines.some((line) => CALL_SITE_RE.test(line))) continue;
+      const name = file
+        .replace(/\.handler\.(ts|js)$/, '')
+        .replace(/\.(ts|js)$/, '');
       enforcing.add(name);
     }
   }

--- a/src/infra/cli/handlers/auth.handler.ts
+++ b/src/infra/cli/handlers/auth.handler.ts
@@ -1,3 +1,7 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import type { CommandHandler } from './command-handler.js';
 import { runOAuthBrowserFlow } from '../../../providers/anthropic/oauth-flow.js';
 import { storeVaultSecret } from '../../../security/vault-boundary.js';
@@ -7,12 +11,72 @@ import { CLI_COMPLETION_COMMANDS } from '../registry.js';
 
 interface AuditRow {
   command: string;
-  gated: boolean;
+  /**
+   * True iff GATED_OPERATIONS contains a rule for this command.
+   * "Registered" intent — what the operator-gate.ts registry says.
+   */
+  registered: boolean;
+  /**
+   * True iff the command's handler file actually invokes
+   * `requireOperatorAuth`. Real enforcement (Codex P1 round 2 caught
+   * the gap: secret/trust are registered but their handlers never call
+   * requireOperatorAuth, so the registry was misleading).
+   */
+  enforced: boolean;
+  /**
+   * registered ∧ ¬enforced — registry promises a gate but the handler
+   * runs the destructive op silently. This is the exact gap S5-1
+   * closes. False for ungated read-only commands.
+   */
+  gap: boolean;
   rules: Array<{
     subcommand: string | null;
     conditional: boolean;
     reason: string | null;
   }>;
+}
+
+/**
+ * Scan handler + command files for `requireOperatorAuth` invocations
+ * to derive the real enforcement set. Per-file granularity (not
+ * per-subcommand) because the audit is a triage tool — granular
+ * subcommand-level analysis is the operator's job once the matrix
+ * names a suspicious file.
+ *
+ * Codex P1 round 2: prior audit derived "gated" purely from the
+ * registry, which is intent-only — secret/trust were listed in
+ * GATED_OPERATIONS but their handlers don't call requireOperatorAuth,
+ * so the audit reported gating that didn't exist.
+ */
+function findEnforcingCommands(): Set<string> {
+  const enforcing = new Set<string>();
+  const here = dirname(fileURLToPath(import.meta.url));
+  // here = src/infra/cli/handlers/. Sibling: ../commands/.
+  const candidates = [here, join(here, '..', 'commands')];
+  for (const dir of candidates) {
+    let files: string[];
+    try {
+      files = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.endsWith('.ts')) continue;
+      let content: string;
+      try {
+        content = readFileSync(join(dir, file), 'utf8');
+      } catch {
+        continue;
+      }
+      // Imports DON'T count — only call sites. Cheap signal: the
+      // identifier appearing outside an import line.
+      const lines = content.split('\n').filter((l) => !/^\s*import\b/.test(l));
+      if (!lines.some((l) => l.includes('requireOperatorAuth'))) continue;
+      const name = file.replace(/\.handler\.ts$/, '').replace(/\.ts$/, '');
+      enforcing.add(name);
+    }
+  }
+  return enforcing;
 }
 
 /**
@@ -33,13 +97,18 @@ export function buildAuthAuditMatrix(): AuditRow[] {
     list.push(rule);
     rulesByCommand.set(rule.command, list);
   }
+  const enforcing = findEnforcingCommands();
 
   const rows: AuditRow[] = [];
   for (const command of CLI_COMPLETION_COMMANDS) {
     const matched = rulesByCommand.get(command) ?? [];
+    const registered = matched.length > 0;
+    const enforced = enforcing.has(command);
     rows.push({
       command,
-      gated: matched.length > 0,
+      registered,
+      enforced,
+      gap: registered && !enforced,
       rules: matched.map((rule) => ({
         subcommand: Array.isArray(rule.subcommand)
           ? rule.subcommand.join('|')
@@ -55,16 +124,18 @@ export function buildAuthAuditMatrix(): AuditRow[] {
 async function handleAuthAudit(context: CliContext): Promise<boolean> {
   const matrix = buildAuthAuditMatrix();
   const totalCommands = matrix.length;
-  const gated = matrix.filter((r) => r.gated).length;
-  const ungated = totalCommands - gated;
+  const registered = matrix.filter((r) => r.registered).length;
+  const enforced = matrix.filter((r) => r.enforced).length;
+  const gaps = matrix.filter((r) => r.gap);
 
   if (context.args.json) {
     console.log(
       JSON.stringify(
         {
           totalCommands,
-          gated,
-          ungated,
+          registered,
+          enforced,
+          gapCount: gaps.length,
           rules: GATED_OPERATIONS.length,
           matrix,
         },
@@ -76,26 +147,36 @@ async function handleAuthAudit(context: CliContext): Promise<boolean> {
   }
 
   console.log(`Memphis CLI auth-audit — ${totalCommands} top-level commands`);
-  console.log(`Gated: ${gated}   Ungated: ${ungated}   Rules in registry: ${GATED_OPERATIONS.length}`);
+  console.log(
+    `Registered: ${registered}   Enforced: ${enforced}   Gaps (registered but not enforced): ${gaps.length}`,
+  );
   console.log('');
-  for (const row of matrix) {
-    const tag = row.gated ? '✓ gated  ' : '  ungated';
-    if (row.gated) {
-      const ruleSummary = row.rules
-        .map((r) => {
-          const sub = r.subcommand ? ` ${r.subcommand}` : '';
-          const cond = r.conditional ? ' (conditional)' : '';
-          return `${row.command}${sub}${cond}`;
-        })
-        .join(', ');
-      console.log(`${tag}  ${row.command.padEnd(18)} → ${ruleSummary}`);
-    } else {
-      console.log(`${tag}  ${row.command}`);
+  if (gaps.length > 0) {
+    console.log('GAP — registry promises a gate but the handler runs the op silently:');
+    for (const row of gaps) {
+      console.log(`  ✗ ${row.command}`);
     }
+    console.log('');
+  }
+  for (const row of matrix) {
+    const tag = row.gap
+      ? '✗ gap     '
+      : row.enforced
+        ? '✓ enforced'
+        : row.registered
+          ? '○ regd'
+          : '  ungated ';
+    const ruleSummary =
+      row.rules.length > 0
+        ? ` → ${row.rules
+            .map((r) => `${r.subcommand ?? '*'}${r.conditional ? '(cond)' : ''}`)
+            .join(', ')}`
+        : '';
+    console.log(`${tag}  ${row.command.padEnd(18)}${ruleSummary}`);
   }
   console.log('');
   console.log(
-    `For each ungated command, decide whether it mutates state and, if yes, add a rule to GATED_OPERATIONS in src/infra/auth/operator-gate.ts.`,
+    `Gaps above are the S5-1 work list: add requireOperatorAuth to the matching handler.`,
   );
   return true;
 }

--- a/src/infra/cli/handlers/auth.handler.ts
+++ b/src/infra/cli/handlers/auth.handler.ts
@@ -62,6 +62,13 @@ function findEnforcingCommands(): Set<string> {
   // comments, which Codex P2 round 3 caught — `auth.handler.ts` was
   // counted as enforcing despite never calling the function.
   const CALL_SITE_RE = /\brequireOperatorAuth\s*\(/;
+  // Match `command === 'X'`, `command !== 'X'`, or
+  // `commands: ['X', 'Y']` so a multi-command dispatcher (e.g.
+  // `commands/service.ts` handles both `service` and `reset`) marks
+  // ALL of its commands as enforcing when it calls requireOperatorAuth.
+  // Codex P1 round 4 caught the basename-only mapping miss.
+  const COMMAND_TOKEN_RE = /command\s*[!=]==\s*['"`]([a-z][a-z0-9-]*)['"`]/g;
+  const COMMANDS_ARRAY_RE = /\bcommands\s*:\s*\[([^\]]+)\]/g;
   for (const dir of candidates) {
     let files: string[];
     try {
@@ -71,7 +78,6 @@ function findEnforcingCommands(): Set<string> {
     }
     for (const file of files) {
       if (!file.endsWith('.ts') && !file.endsWith('.js')) continue;
-      // Skip declaration files and source maps.
       if (file.endsWith('.d.ts')) continue;
       let content: string;
       try {
@@ -79,20 +85,34 @@ function findEnforcingCommands(): Set<string> {
       } catch {
         continue;
       }
-      // Filter out import/require lines (where the symbol appears
-      // legitimately but isn't a call) and JSDoc/inline comments
-      // (where the operator-readable rationale mentions the function).
+      // Strip import lines and comment lines so we don't match the
+      // identifier inside docs.
       const codeLines = content.split('\n').filter((line) => {
         const trimmed = line.trim();
         if (trimmed.startsWith('import ') || trimmed.startsWith('//')) return false;
         if (trimmed.startsWith('*') || trimmed.startsWith('/*')) return false;
         return true;
       });
-      if (!codeLines.some((line) => CALL_SITE_RE.test(line))) continue;
-      const name = file
-        .replace(/\.handler\.(ts|js)$/, '')
-        .replace(/\.(ts|js)$/, '');
-      enforcing.add(name);
+      const code = codeLines.join('\n');
+      if (!CALL_SITE_RE.test(code)) continue;
+
+      // Collect every command this file dispatches.
+      const dispatched = new Set<string>();
+      for (const m of code.matchAll(COMMAND_TOKEN_RE)) dispatched.add(m[1]);
+      for (const m of code.matchAll(COMMANDS_ARRAY_RE)) {
+        for (const part of m[1].split(',')) {
+          const cleaned = part.trim().replace(/^['"`]|['"`]$/g, '');
+          if (cleaned && /^[a-z][a-z0-9-]*$/.test(cleaned)) dispatched.add(cleaned);
+        }
+      }
+      // Fallback: if the file has no explicit dispatcher tokens (e.g.
+      // a single-command handler that uses canHandle()), use the
+      // basename. This keeps vault.handler.ts → 'vault' working.
+      if (dispatched.size === 0) {
+        const name = file.replace(/\.handler\.(ts|js)$/, '').replace(/\.(ts|js)$/, '');
+        dispatched.add(name);
+      }
+      for (const name of dispatched) enforcing.add(name);
     }
   }
   return enforcing;

--- a/src/infra/cli/handlers/auth.handler.ts
+++ b/src/infra/cli/handlers/auth.handler.ts
@@ -1,7 +1,104 @@
+import type { CommandHandler } from './command-handler.js';
 import { runOAuthBrowserFlow } from '../../../providers/anthropic/oauth-flow.js';
 import { storeVaultSecret } from '../../../security/vault-boundary.js';
+import { GATED_OPERATIONS, type GateRule } from '../../auth/operator-gate.js';
 import type { CliContext } from '../context.js';
-import type { CommandHandler } from './command-handler.js';
+import { CLI_COMPLETION_COMMANDS } from '../registry.js';
+
+interface AuditRow {
+  command: string;
+  gated: boolean;
+  rules: Array<{
+    subcommand: string | null;
+    conditional: boolean;
+    reason: string | null;
+  }>;
+}
+
+/**
+ * Build the auth-audit matrix. Top-level commands come from
+ * CLI_COMPLETION_COMMANDS (the canonical operator-facing surface);
+ * GATED_OPERATIONS supplies the auth rules. A command is "gated" when
+ * any rule references it — even with a condition or subcommand
+ * filter, because the operator-relevant question is "is there ANY
+ * passphrase prompt path here, or none at all?"
+ *
+ * S5-3: this is the matrix the S5-1 sweep will work from. A row with
+ * `gated: false` for a destructive command is the gap that S5-1 closes.
+ */
+export function buildAuthAuditMatrix(): AuditRow[] {
+  const rulesByCommand = new Map<string, GateRule[]>();
+  for (const rule of GATED_OPERATIONS) {
+    const list = rulesByCommand.get(rule.command) ?? [];
+    list.push(rule);
+    rulesByCommand.set(rule.command, list);
+  }
+
+  const rows: AuditRow[] = [];
+  for (const command of CLI_COMPLETION_COMMANDS) {
+    const matched = rulesByCommand.get(command) ?? [];
+    rows.push({
+      command,
+      gated: matched.length > 0,
+      rules: matched.map((rule) => ({
+        subcommand: Array.isArray(rule.subcommand)
+          ? rule.subcommand.join('|')
+          : (rule.subcommand ?? null),
+        conditional: !!rule.condition,
+        reason: rule.reason ?? null,
+      })),
+    });
+  }
+  return rows;
+}
+
+async function handleAuthAudit(context: CliContext): Promise<boolean> {
+  const matrix = buildAuthAuditMatrix();
+  const totalCommands = matrix.length;
+  const gated = matrix.filter((r) => r.gated).length;
+  const ungated = totalCommands - gated;
+
+  if (context.args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          totalCommands,
+          gated,
+          ungated,
+          rules: GATED_OPERATIONS.length,
+          matrix,
+        },
+        null,
+        2,
+      ),
+    );
+    return true;
+  }
+
+  console.log(`Memphis CLI auth-audit — ${totalCommands} top-level commands`);
+  console.log(`Gated: ${gated}   Ungated: ${ungated}   Rules in registry: ${GATED_OPERATIONS.length}`);
+  console.log('');
+  for (const row of matrix) {
+    const tag = row.gated ? '✓ gated  ' : '  ungated';
+    if (row.gated) {
+      const ruleSummary = row.rules
+        .map((r) => {
+          const sub = r.subcommand ? ` ${r.subcommand}` : '';
+          const cond = r.conditional ? ' (conditional)' : '';
+          return `${row.command}${sub}${cond}`;
+        })
+        .join(', ');
+      console.log(`${tag}  ${row.command.padEnd(18)} → ${ruleSummary}`);
+    } else {
+      console.log(`${tag}  ${row.command}`);
+    }
+  }
+  console.log('');
+  console.log(
+    `For each ungated command, decide whether it mutates state and, if yes, add a rule to GATED_OPERATIONS in src/infra/auth/operator-gate.ts.`,
+  );
+  return true;
+}
 
 async function handleAuthAnthropic(context: CliContext): Promise<boolean> {
   console.log('Memphis — Anthropic OAuth login\n');
@@ -59,11 +156,15 @@ export const authCommandHandler: CommandHandler = {
     if (sub === 'anthropic') {
       return handleAuthAnthropic(context);
     }
+    if (sub === 'audit') {
+      return handleAuthAudit(context);
+    }
 
-    console.log('usage: memphis auth <provider>');
+    console.log('usage: memphis auth <subcommand>');
     console.log('');
-    console.log('providers:');
+    console.log('subcommands:');
     console.log('  anthropic    Browser-based OAuth login for Anthropic/Claude');
+    console.log('  audit        Show auth-gate matrix for all CLI commands [--json]');
     return true;
   },
 };

--- a/tests/unit/cli-auth-audit.test.ts
+++ b/tests/unit/cli-auth-audit.test.ts
@@ -41,6 +41,21 @@ describe('memphis auth audit (S5-3)', () => {
     expect(trust?.gap).toBe(true);
   });
 
+  it('does not count auth.handler.ts as enforcing despite mentioning requireOperatorAuth in JSDoc (Codex P2 round 3)', () => {
+    // auth.handler.ts has the symbol in its own JSDoc but never calls
+    // the function. Comment text must not count as a call site.
+    // Re-import to bypass any module-level cache that may have been
+    // populated during prior test runs in this file.
+    const matrix = buildAuthAuditMatrix();
+    const auth = matrix.find((r) => r.command === 'auth');
+    // 'auth' isn't in CLI_COMPLETION_COMMANDS today (auth is a namespace
+    // verb), so the row is undefined — but if it ever appears, comment
+    // text must not flip it to enforced.
+    if (auth) {
+      expect(auth.enforced).toBe(false);
+    }
+  });
+
   it('marks read-only/diagnostic commands as neither registered nor enforced (doctor, models, ascii)', () => {
     const matrix = buildAuthAuditMatrix();
     const readOnly = ['doctor', 'models', 'ascii', 'help', 'progress', 'celebrate', 'guide'];

--- a/tests/unit/cli-auth-audit.test.ts
+++ b/tests/unit/cli-auth-audit.test.ts
@@ -33,14 +33,19 @@ describe('memphis auth audit (S5-3)', () => {
     }
   });
 
-  it('every gated command name in the rule registry resolves to a known CLI command', () => {
+  it('every gated command name in the rule registry resolves to a known CLI command (Codex P2 round 1)', async () => {
     // S5-3 acceptance: GATED_OPERATIONS cannot reference phantom commands.
-    // If this fails, GATED_OPERATIONS has a typo or the command was renamed
-    // and the rule wasn't updated.
-    const matrix = buildAuthAuditMatrix();
-    const knownCommands = new Set(matrix.map((r) => r.command));
-    for (const row of matrix.filter((r) => r.gated)) {
-      expect(knownCommands.has(row.command)).toBe(true);
+    // Compare GATED_OPERATIONS commands against CLI_COMPLETION_COMMANDS
+    // *directly* — not against the matrix (which is built from the same
+    // input), since that would be tautological.
+    const { GATED_OPERATIONS } = await import('../../src/infra/auth/operator-gate.js');
+    const { CLI_COMPLETION_COMMANDS } = await import('../../src/infra/cli/registry.js');
+    const knownCommands = new Set<string>(CLI_COMPLETION_COMMANDS);
+    for (const rule of GATED_OPERATIONS) {
+      expect(
+        knownCommands.has(rule.command),
+        `GATED_OPERATIONS rule references unknown command "${rule.command}" — rename or typo?`,
+      ).toBe(true);
     }
   });
 });

--- a/tests/unit/cli-auth-audit.test.ts
+++ b/tests/unit/cli-auth-audit.test.ts
@@ -3,33 +3,52 @@ import { describe, expect, it } from 'vitest';
 import { buildAuthAuditMatrix } from '../../src/infra/cli/handlers/auth.handler.js';
 
 describe('memphis auth audit (S5-3)', () => {
-  it('lists every CLI command with its gated status', () => {
+  it('lists every CLI command with registered + enforced status', () => {
     const matrix = buildAuthAuditMatrix();
     expect(matrix.length).toBeGreaterThan(0);
     // Each row has the canonical shape.
     for (const row of matrix) {
       expect(typeof row.command).toBe('string');
-      expect(typeof row.gated).toBe('boolean');
+      expect(typeof row.registered).toBe('boolean');
+      expect(typeof row.enforced).toBe('boolean');
+      expect(typeof row.gap).toBe('boolean');
       expect(Array.isArray(row.rules)).toBe(true);
+      // gap is computed: registered ∧ ¬enforced.
+      expect(row.gap).toBe(row.registered && !row.enforced);
     }
   });
 
-  it('marks vault and secret as gated (sanity — these are in GATED_OPERATIONS)', () => {
+  it('marks vault as both registered and enforced (vault.handler.ts calls requireOperatorAuth)', () => {
     const matrix = buildAuthAuditMatrix();
     const vault = matrix.find((r) => r.command === 'vault');
-    const secret = matrix.find((r) => r.command === 'secret');
-    expect(vault?.gated).toBe(true);
-    expect(secret?.gated).toBe(true);
-    // Reasons are surfaced for operator review.
-    expect(vault?.rules.some((r) => r.reason?.includes('vault'))).toBe(true);
+    expect(vault?.registered).toBe(true);
+    expect(vault?.enforced).toBe(true);
+    expect(vault?.gap).toBe(false);
   });
 
-  it('marks read-only/diagnostic commands as ungated (regression: doctor, models, ascii should never be gated)', () => {
+  it('detects the registry-vs-handler gaps Codex flagged (P1 round 2): secret + trust are registered but their handlers do not call requireOperatorAuth', () => {
     const matrix = buildAuthAuditMatrix();
-    const ungatedExpected = ['doctor', 'models', 'ascii', 'help', 'progress', 'celebrate', 'guide'];
-    for (const cmd of ungatedExpected) {
+    const secret = matrix.find((r) => r.command === 'secret');
+    const trust = matrix.find((r) => r.command === 'trust');
+    // Both registered.
+    expect(secret?.registered).toBe(true);
+    expect(trust?.registered).toBe(true);
+    // Both currently NOT enforced (the gap S5-1 closes).
+    expect(secret?.enforced).toBe(false);
+    expect(trust?.enforced).toBe(false);
+    // Therefore both are gaps.
+    expect(secret?.gap).toBe(true);
+    expect(trust?.gap).toBe(true);
+  });
+
+  it('marks read-only/diagnostic commands as neither registered nor enforced (doctor, models, ascii)', () => {
+    const matrix = buildAuthAuditMatrix();
+    const readOnly = ['doctor', 'models', 'ascii', 'help', 'progress', 'celebrate', 'guide'];
+    for (const cmd of readOnly) {
       const row = matrix.find((r) => r.command === cmd);
-      expect(row?.gated, `${cmd} should be ungated`).toBe(false);
+      expect(row?.registered, `${cmd} should not be registered`).toBe(false);
+      expect(row?.enforced, `${cmd} should not be enforced`).toBe(false);
+      expect(row?.gap, `${cmd} should not be a gap`).toBe(false);
     }
   });
 

--- a/tests/unit/cli-auth-audit.test.ts
+++ b/tests/unit/cli-auth-audit.test.ts
@@ -41,6 +41,15 @@ describe('memphis auth audit (S5-3)', () => {
     expect(trust?.gap).toBe(true);
   });
 
+  it('handles vault.handler.ts (single-command handler) correctly via commands array + canHandle token', () => {
+    // vault.handler.ts has both `commands: ['vault']` and
+    // `command === 'vault'` plus a real requireOperatorAuth() call.
+    // The matrix should flip vault to enforced.
+    const matrix = buildAuthAuditMatrix();
+    const vault = matrix.find((r) => r.command === 'vault');
+    expect(vault?.enforced).toBe(true);
+  });
+
   it('does not count auth.handler.ts as enforcing despite mentioning requireOperatorAuth in JSDoc (Codex P2 round 3)', () => {
     // auth.handler.ts has the symbol in its own JSDoc but never calls
     // the function. Comment text must not count as a call site.

--- a/tests/unit/cli-auth-audit.test.ts
+++ b/tests/unit/cli-auth-audit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAuthAuditMatrix } from '../../src/infra/cli/handlers/auth.handler.js';
+
+describe('memphis auth audit (S5-3)', () => {
+  it('lists every CLI command with its gated status', () => {
+    const matrix = buildAuthAuditMatrix();
+    expect(matrix.length).toBeGreaterThan(0);
+    // Each row has the canonical shape.
+    for (const row of matrix) {
+      expect(typeof row.command).toBe('string');
+      expect(typeof row.gated).toBe('boolean');
+      expect(Array.isArray(row.rules)).toBe(true);
+    }
+  });
+
+  it('marks vault and secret as gated (sanity — these are in GATED_OPERATIONS)', () => {
+    const matrix = buildAuthAuditMatrix();
+    const vault = matrix.find((r) => r.command === 'vault');
+    const secret = matrix.find((r) => r.command === 'secret');
+    expect(vault?.gated).toBe(true);
+    expect(secret?.gated).toBe(true);
+    // Reasons are surfaced for operator review.
+    expect(vault?.rules.some((r) => r.reason?.includes('vault'))).toBe(true);
+  });
+
+  it('marks read-only/diagnostic commands as ungated (regression: doctor, models, ascii should never be gated)', () => {
+    const matrix = buildAuthAuditMatrix();
+    const ungatedExpected = ['doctor', 'models', 'ascii', 'help', 'progress', 'celebrate', 'guide'];
+    for (const cmd of ungatedExpected) {
+      const row = matrix.find((r) => r.command === cmd);
+      expect(row?.gated, `${cmd} should be ungated`).toBe(false);
+    }
+  });
+
+  it('every gated command name in the rule registry resolves to a known CLI command', () => {
+    // S5-3 acceptance: GATED_OPERATIONS cannot reference phantom commands.
+    // If this fails, GATED_OPERATIONS has a typo or the command was renamed
+    // and the rule wasn't updated.
+    const matrix = buildAuthAuditMatrix();
+    const knownCommands = new Set(matrix.map((r) => r.command));
+    for (const row of matrix.filter((r) => r.gated)) {
+      expect(knownCommands.has(row.command)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Operator gap (issue #279): no programmatic way to ask "which CLI commands prompt for the operator passphrase, and which run silently?" Without an audit surface, the S5-1 sweep on missing \`requireOperatorAuth\` calls is guesswork.

Adds \`memphis auth audit\` (and \`--json\`) that builds a matrix from:
- \`CLI_COMPLETION_COMMANDS\` (canonical operator-facing surface — 64 commands)
- \`GATED_OPERATIONS\` (registry of passphrase-gated rules)

For each top-level command, the matrix marks \`gated: true/false\` and lists each matching rule with its subcommand filter, conditional flag, and free-form reason.

\`\`\`bash
memphis auth audit            # human-readable
memphis auth audit --json     # machine-readable
\`\`\`

## Side change

\`GATED_OPERATIONS\` is now exported (was module-private). Each rule gains an optional \`reason\` string surfaced in the matrix; existing 8 rules annotated.

## Why this comes before S5-1

This is the input to S5-1 (the \`requireOperatorAuth\` sweep). A row with \`gated: false\` for a destructive command is the gap that S5-1 closes. Building the matrix first means S5-1 can drive from data instead of grep.

## Test plan

- [x] \`tests/unit/cli-auth-audit.test.ts\` — 4 tests (matrix shape, vault/secret gated, doctor/models/ascii ungated, registry consistency)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] **Operator smoke** (Wodzu): run \`memphis auth audit\` and review the matrix; the gap (ungated commands that mutate state) is the S5-1 work list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)