### PR TITLE
security(cli): close 5 auth-gate gaps in secret/trust/backup/evolve/reset (S5-1)

### DIFF
--- a/src/infra/cli/commands/backup.ts
+++ b/src/infra/cli/commands/backup.ts
@@ -22,6 +22,7 @@ import chalk from 'chalk';
 import cliProgress from 'cli-progress';
 
 import { getDataDir } from '../../../config/paths.js';
+import { requireOperatorAuth } from '../../auth/operator-gate.js';
 import { resolveDotEnvPath } from '../../config/dotenv-file.js';
 import { classifyField } from '../../config/mutability.js';
 import type { CliContext } from '../context.js';
@@ -989,6 +990,12 @@ export async function handleBackupCommand(context: CliContext): Promise<boolean>
     if (!file) {
       throw new Error('Usage: memphis backup restore <file> [--yes] [--pepper-restore <old>]');
     }
+    // S5-1: gate restore — overwrites the entire data dir from a
+    // possibly attacker-supplied archive. --yes is operator intent
+    // confirmation; passphrase is operator identity confirmation.
+    if (!(await requireOperatorAuth())) {
+      throw new Error('Operator authentication failed.');
+    }
     const confirmed = args.yes ? true : await askRestoreConfirmation(file);
     if (!confirmed) {
       print({ ok: false, mode: 'restore', aborted: true }, args.json);
@@ -1004,6 +1011,11 @@ export async function handleBackupCommand(context: CliContext): Promise<boolean>
   }
 
   if (subcommand === 'clean') {
+    // S5-1: gate clean — deletes archives that are the only path back
+    // from a botched restore.
+    if (!(await requireOperatorAuth())) {
+      throw new Error('Operator authentication failed.');
+    }
     const cleaned = await cleanBackups({ keep: args.keep, dryRun: args.dryRun });
     print({ ok: true, mode: 'clean', ...cleaned }, args.json);
     return true;

--- a/src/infra/cli/commands/service.ts
+++ b/src/infra/cli/commands/service.ts
@@ -2,6 +2,7 @@ import { readFileSync, rmSync } from 'node:fs';
 import { isAbsolute, resolve } from 'node:path';
 
 import { getDataDir } from '../../../config/paths.js';
+import { requireOperatorAuth } from '../../auth/operator-gate.js';
 import {
   getUserServiceStatus,
   installUserService,
@@ -187,6 +188,12 @@ export async function handleServiceCommand(
     }
     if (!yes) {
       throw new Error('reset requires --yes');
+    }
+    // S5-1: gate reset --runtime --yes — wipes vault state, chains,
+    // and embeddings. Even with --yes intent flag, the operator
+    // identity must be confirmed before destruction.
+    if (!(await requireOperatorAuth())) {
+      throw new Error('Operator authentication failed.');
     }
     const runtimeRoot = runtimeRootFromContext();
     const result = resetRuntimeState(runtimeRoot, process.env, serviceOps);

--- a/src/infra/cli/handlers/auth.handler.ts
+++ b/src/infra/cli/handlers/auth.handler.ts
@@ -67,7 +67,12 @@ function findEnforcingCommands(): Set<string> {
   // `commands/service.ts` handles both `service` and `reset`) marks
   // ALL of its commands as enforcing when it calls requireOperatorAuth.
   // Codex P1 round 4 caught the basename-only mapping miss.
-  const COMMAND_TOKEN_RE = /command\s*[!=]==\s*['"`]([a-z][a-z0-9-]*)['"`]/g;
+  //
+  // \b before `command` is load-bearing: without it, `subcommand ===
+  // 'help'` and `typeof x === 'string'` (the regex matched the
+  // `command` substring of `subcommand`) leaked false-positive names
+  // like `help` and `string` into the enforcing set.
+  const COMMAND_TOKEN_RE = /\bcommand\s*[!=]==\s*['"`]([a-z][a-z0-9-]*)['"`]/g;
   const COMMANDS_ARRAY_RE = /\bcommands\s*:\s*\[([^\]]+)\]/g;
   for (const dir of candidates) {
     let files: string[];

--- a/src/infra/cli/handlers/evolve.handler.ts
+++ b/src/infra/cli/handlers/evolve.handler.ts
@@ -1,4 +1,5 @@
 import type { CommandHandler } from './command-handler.js';
+import { requireOperatorAuth } from '../../auth/operator-gate.js';
 import type { SqliteEvolveSessionRepository } from '../../storage/sqlite/repositories/evolve-session-repository.js';
 import type { CliContext } from '../context.js';
 
@@ -67,6 +68,12 @@ async function handleEvolveRollback(context: CliContext): Promise<boolean> {
   if (!sessionId) {
     console.error('Usage: memphis evolve rollback <session-id>');
     return true;
+  }
+
+  // S5-1: gate before reverting agent self-modification — restoring an
+  // arbitrary snapshot is destructive (loses any work since that point).
+  if (!(await requireOperatorAuth())) {
+    throw new Error('Operator authentication failed.');
   }
 
   const repo = context.getContainer().evolveSessionRepository;

--- a/src/infra/cli/handlers/secret.handler.ts
+++ b/src/infra/cli/handlers/secret.handler.ts
@@ -3,6 +3,7 @@ import {
   readVaultSecretByKey,
   storeVaultSecret,
 } from '../../../security/vault-boundary.js';
+import { requireOperatorAuth } from '../../auth/operator-gate.js';
 import type { CliContext } from '../context.js';
 import type { CommandHandler } from './command-handler.js';
 import { print } from '../utils/render.js';
@@ -15,6 +16,17 @@ export const secretCommandHandler: CommandHandler = {
   },
   async handle(context: CliContext): Promise<boolean> {
     const { subcommand } = context.args;
+    // S5-1: gate add/get/list before any vault touch. Aligns with
+    // GATED_OPERATIONS in operator-gate.ts. Prior to this sweep, the
+    // registry promised a passphrase prompt but the handler ran the
+    // op silently — a local-host adversary could read or write secret
+    // values without the operator passphrase.
+    const gatedSubs = new Set(['add', 'get', 'list']);
+    if (subcommand && gatedSubs.has(subcommand)) {
+      if (!(await requireOperatorAuth())) {
+        throw new Error('Operator authentication failed.');
+      }
+    }
     const handlers: Record<string, () => Promise<boolean>> = {
       add: async () => handleSecretAdd(context),
       get: async () => handleSecretGet(context),
@@ -28,6 +40,10 @@ export const secretCommandHandler: CommandHandler = {
       console.error('  get  --key <name>                       Retrieve and decrypt a secret');
       console.error('  list [--key <name>]                     List stored secrets');
       return true;
+    }
+    // Fall-through to default `list` (no subcommand) also requires auth.
+    if (!subcommand && !(await requireOperatorAuth())) {
+      throw new Error('Operator authentication failed.');
     }
     return handler();
   },

--- a/src/infra/cli/handlers/trust.handler.ts
+++ b/src/infra/cli/handlers/trust.handler.ts
@@ -2,6 +2,7 @@ import type { CommandHandler } from './command-handler.js';
 import { getToolNames } from '../../../gateway/tool-registry.js';
 import { ensureSoulManifest, writeSoulManifest } from '../../../soul/manifest.js';
 import type { AutonomyMode, TrustRule } from '../../../soul/types.js';
+import { requireOperatorAuth } from '../../auth/operator-gate.js';
 import type { CliContext } from '../context.js';
 
 const VALID_MODES: AutonomyMode[] = ['full', 'quiet', 'balanced', 'paranoid'];
@@ -39,6 +40,12 @@ async function handleTrustAdd(context: CliContext): Promise<boolean> {
   if (!toolName) {
     console.error('Usage: memphis trust add <tool> [--auto-approve]');
     return true;
+  }
+
+  // S5-1: gate before mutating manifest. Tool-permission rules
+  // change which tier-2 tools auto-approve — destructive auth state.
+  if (!(await requireOperatorAuth())) {
+    throw new Error('Operator authentication failed.');
   }
 
   // Validate tool name (allow '*' wildcard)
@@ -82,6 +89,11 @@ async function handleTrustRemove(context: CliContext): Promise<boolean> {
     return true;
   }
 
+  // S5-1: gate before mutating manifest.
+  if (!(await requireOperatorAuth())) {
+    throw new Error('Operator authentication failed.');
+  }
+
   const manifest = ensureSoulManifest();
   const rules = manifest.trustRules ?? [];
   const before = rules.length;
@@ -110,6 +122,12 @@ async function handleTrustMode(context: CliContext): Promise<boolean> {
     if (!modeArg || !VALID_MODES.includes(modeArg as AutonomyMode)) {
       console.error(`Usage: memphis trust mode set <${VALID_MODES.join('|')}>`);
       return true;
+    }
+
+    // S5-1: gate before flipping autonomy mode (full unblocks every
+    // tier-2 tool by default — operator decision, not silent).
+    if (!(await requireOperatorAuth())) {
+      throw new Error('Operator authentication failed.');
     }
 
     manifest.mode = modeArg as AutonomyMode;

--- a/tests/unit/cli-auth-audit.test.ts
+++ b/tests/unit/cli-auth-audit.test.ts
@@ -26,19 +26,21 @@ describe('memphis auth audit (S5-3)', () => {
     expect(vault?.gap).toBe(false);
   });
 
-  it('detects the registry-vs-handler gaps Codex flagged (P1 round 2): secret + trust are registered but their handlers do not call requireOperatorAuth', () => {
+  it('S5-1 closed: secret + trust + backup + evolve + reset all enforce after the auth sweep', () => {
+    // Codex P1 round 2 flagged the gap; S5-1 sweep added requireOperatorAuth
+    // to each handler. Audit must now show every previously-gap command
+    // as enforced + zero gaps total.
     const matrix = buildAuthAuditMatrix();
-    const secret = matrix.find((r) => r.command === 'secret');
-    const trust = matrix.find((r) => r.command === 'trust');
-    // Both registered.
-    expect(secret?.registered).toBe(true);
-    expect(trust?.registered).toBe(true);
-    // Both currently NOT enforced (the gap S5-1 closes).
-    expect(secret?.enforced).toBe(false);
-    expect(trust?.enforced).toBe(false);
-    // Therefore both are gaps.
-    expect(secret?.gap).toBe(true);
-    expect(trust?.gap).toBe(true);
+    const formerGaps = ['secret', 'trust', 'backup', 'evolve', 'reset'];
+    for (const cmd of formerGaps) {
+      const row = matrix.find((r) => r.command === cmd);
+      expect(row?.registered, `${cmd} should still be registered`).toBe(true);
+      expect(row?.enforced, `${cmd} should be enforced after S5-1`).toBe(true);
+      expect(row?.gap, `${cmd} should NOT be a gap after S5-1`).toBe(false);
+    }
+    // Total gap count zero.
+    const gaps = matrix.filter((r) => r.gap);
+    expect(gaps.length).toBe(0);
   });
 
   it('handles vault.handler.ts (single-command handler) correctly via commands array + canHandle token', () => {


### PR DESCRIPTION
## Summary

Closes the gaps that #388 (\`memphis auth audit\`) surfaced: 5 commands were registered in \`GATED_OPERATIONS\` but their handlers never called \`requireOperatorAuth\`. A local-host adversary could read/write vault secrets, mutate trust rules, restore from arbitrary archives, revert agent code, or wipe runtime state — without the operator passphrase.

Closes #278 (CLI auth-gating sweep) and #279 (per-command auth surface gap).

## Gap → fix

| Command | Sub | Why gated |
|---|---|---|
| secret | add\|get\|list | reads/writes vault-stored secrets |
| trust | add\|remove | modifies tool-permission rules |
| trust | mode set | flips autonomy mode (full unblocks tier-2) |
| backup | restore | overwrites entire data dir from external archive |
| backup | clean | deletes archives that are the only path back from restore |
| evolve | rollback | reverts agent self-modification |
| reset | --runtime --yes | wipes vault state + chains + embeddings |

Each call uses existing \`requireOperatorAuth()\` from \`operator-gate.ts\` (sudo-like 15-min session cache, file/env/inline passphrase modes for non-interactive runs).

## Audit detector fix

S5-3's regex matched \`subcommand === 'help'\` and \`typeof x === 'string'\` because there was no \`\\b\` before \`command\` in the dispatcher-token regex. Post-sweep matrix mis-flagged read-only commands as enforced. Adding \`\\b\` clears this.

## Verification

\`memphis auth audit --json\` after rebuild:
\`\`\`
registered: 6   enforced: 9   gapCount: 0
\`\`\`

## Test plan

- [x] \`tests/unit/cli-auth-audit.test.ts\` — prior gap-pinning test flipped to assert all 5 former gaps now enforce + zero gaps.
- [x] \`tests/unit/trust-cli.test.ts\`, \`tests/unit/secret-awareness.test.ts\` — no regressions (gate is open in test env without operator.json per first-time-use semantics).
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] **Operator smoke** (Wodzu): after merge + rebuild, every \`memphis secret/trust/backup restore/evolve rollback/reset --runtime --yes\` invocation prompts for operator passphrase exactly once per 15-min session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)