### PR TITLE
feat(cli): gate chat/ask/tui on first-run state (S10-5)

### DIFF
--- a/src/infra/cli/commands/interaction.ts
+++ b/src/infra/cli/commands/interaction.ts
@@ -10,6 +10,7 @@ import { createInProcessToolExecutor } from '../../../gateway/tool-executor.js';
 import type { InProcessToolExecutorDeps } from '../../../gateway/tool-executor.js';
 import { CaseChainAdapter } from '../../../infra/storage/case-chain-adapter.js';
 import type { OrchestrationService } from '../../../modules/orchestration/service.js';
+import { inspectFirstRunStatus } from '../../../onboarding/first-run.js';
 import type { RuntimeProvider } from '../../../providers/runtime.js';
 import { sanitizeForTerminal } from '../../security/sanitizers.js';
 import { runTuiHost } from '../../tui-host/index.js';
@@ -32,8 +33,67 @@ function buildToolExecutorDeps(context: CliContext): InProcessToolExecutorDeps {
   };
 }
 
+/**
+ * Commands that REQUIRE a completed first-run before they can do
+ * anything useful. `providers:health` is intentionally excluded — the
+ * operator needs to be able to probe provider reachability before
+ * (and during) onboarding for setup verification.
+ *
+ * S10-5: prior to this gate, `memphis chat` / `memphis tui` / etc.
+ * silently fell back to local-fallback when no first-run was set,
+ * masking the "you forgot to run `memphis init`" case behind a
+ * confusing reply (or no reply at all).
+ */
+const COMMANDS_REQUIRING_INIT = new Set(['ask', 'chat', 'ask-session', 'tui']);
+
+function requireFirstRun(context: CliContext): boolean {
+  const status = inspectFirstRunStatus(process.env);
+  // `initialized-clean` = controlled-init or legacy-repair completed.
+  // `legacy-migrateable` = old data dir, doctor/repair will adopt it
+  //   on first chain access; chat/ask/tui still work, just warn-level.
+  // `legacy-manual` = blocked, operator must run `memphis repair`.
+  if (status.state === 'initialized-clean' || status.state === 'legacy-migrateable') {
+    return true;
+  }
+  // not-initialized: print a clear actionable message and abort.
+  if (context.args.json) {
+    print(
+      {
+        ok: false,
+        error: {
+          code: 'NOT_INITIALIZED',
+          message:
+            'Memphis is not initialized — run `memphis init` first to set vault passphrase, identity, and first-run state.',
+          state: status.state,
+          recommendedAction: status.recommendedAction,
+        },
+      },
+      true,
+    );
+  } else {
+    process.stderr.write(
+      [
+        '',
+        'Memphis is not initialized — run `memphis init` first.',
+        '',
+        '  This sets your vault passphrase, recovery question, identity,',
+        '  and writes the first-run state.  Without it, chat / ask / tui',
+        '  cannot persist memory and only fall back to a local stub.',
+        '',
+        `  Recommended: ${status.recommendedAction}`,
+        '',
+      ].join('\n'),
+    );
+  }
+  process.exitCode = 1;
+  return false;
+}
+
 export async function handleInteractionCommand(context: CliContext): Promise<boolean> {
   const command = context.args.command;
+  if (command && COMMANDS_REQUIRING_INIT.has(command) && !requireFirstRun(context)) {
+    return true;
+  }
   const handlers: Partial<Record<string, InteractionHandler>> = {
     'ask-session': handleAskSessionCommand,
     'providers:health': handleProvidersHealthCommand,

--- a/src/infra/cli/commands/interaction.ts
+++ b/src/infra/cli/commands/interaction.ts
@@ -91,7 +91,12 @@ function requireFirstRun(context: CliContext): boolean {
 
 export async function handleInteractionCommand(context: CliContext): Promise<boolean> {
   const command = context.args.command;
-  if (command && COMMANDS_REQUIRING_INIT.has(command) && !requireFirstRun(context)) {
+  // `tui host` is the stdio-json protocol mode used by GUI consumers
+  // and the tui-host test fixture. It must work pre-init so its
+  // bootstrap protocol can hand-shake before the operator's data dir
+  // even exists. Codex P1 round 1 caught this exclusion.
+  const isTuiHost = command === 'tui' && context.args.subcommand === 'host';
+  if (command && COMMANDS_REQUIRING_INIT.has(command) && !isTuiHost && !requireFirstRun(context)) {
     return true;
   }
   const handlers: Partial<Record<string, InteractionHandler>> = {

--- a/tests/unit/cli.interaction-init-gate.test.ts
+++ b/tests/unit/cli.interaction-init-gate.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runCliResult } from '../helpers/cli.js';
+
+/**
+ * S10-5 regression: chat / ask / ask-session / tui must reject with
+ * a friendly NOT_INITIALIZED error when memphis init hasn't been run,
+ * instead of silently falling back to local-stub responses.
+ */
+describe('CLI interaction commands gate on first-run', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it('rejects `memphis chat` with NOT_INITIALIZED when first-run state is missing', async () => {
+    // Fresh data dir with NO first-run.json, NO chains, NO operator.json.
+    const memphisDir = mkdtempSync(join(tmpdir(), 'memphis-init-gate-'));
+    const result = await runCliResult(['chat', '--input', 'hi', '--json'], {
+      env: {
+        ...originalEnv,
+        NODE_ENV: 'test',
+        MEMPHIS_DATA_DIR: memphisDir,
+        DEFAULT_PROVIDER: 'local-fallback',
+        RUST_CHAIN_ENABLED: 'false',
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.ok).toBe(false);
+    expect(payload.error.code).toBe('NOT_INITIALIZED');
+    expect(payload.error.message).toContain('memphis init');
+  });
+
+  it('error message in non-JSON mode names `memphis init` so the operator knows the next step', async () => {
+    const memphisDir = mkdtempSync(join(tmpdir(), 'memphis-init-gate-'));
+    const result = await runCliResult(['chat', '--input', 'hi'], {
+      env: {
+        ...originalEnv,
+        NODE_ENV: 'test',
+        MEMPHIS_DATA_DIR: memphisDir,
+        DEFAULT_PROVIDER: 'local-fallback',
+        RUST_CHAIN_ENABLED: 'false',
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    // The error goes to stderr; either stderr or stdout must name the
+    // remediation command exactly.
+    const combined = result.stderr + result.stdout;
+    expect(combined).toMatch(/memphis init/);
+  });
+});


### PR DESCRIPTION
## Summary

Fresh-user audit (2026-05-01) caught: a new user running \`memphis chat \"hello\"\` BEFORE \`memphis init\` gets a silent local-fallback stub reply (no chains, no memory) with no signal that init was skipped. The README says to run init first but if the user skips it, Memphis silently degrades.

Add a first-run gate to \`handleInteractionCommand\` for the four commands that genuinely need it: \`ask\`, \`chat\`, \`ask-session\`, \`tui\`. \`providers:health\` is excluded — operators need to probe provider reachability during onboarding.

## Behaviour matrix

| State | Outcome |
|-------|---------|
| \`initialized-clean\` | proceed (post-init, normal operator) |
| \`legacy-migrateable\` | proceed (Wodzu's box; doctor adopts it on first chain access) |
| \`not-initialized\` | block with \`NOT_INITIALIZED\` |
| \`legacy-manual\` | block with \`NOT_INITIALIZED\` (operator must run \`memphis repair\` first) |

JSON mode emits a structured error (\`code: 'NOT_INITIALIZED'\`, \`message\`, \`recommendedAction\`). Human mode prints a 6-line message naming \`memphis init\` as the next command + a reminder that without it chat falls back to local-stub.

## Test plan

- [x] \`tests/unit/cli.interaction-init-gate.test.ts\` — 2 new tests (NOT_INITIALIZED on empty data dir; non-JSON message names \`memphis init\`)
- [x] \`tests/unit/cli.chat.test.ts\`, \`cli.ask-doctor.test.ts\`, \`cli.interaction-runtime.test.ts\` — 9 existing tests still pass (fixtures hit \`legacy-migrateable\`, allowed through)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] **Operator smoke** (Wodzu): on a clean machine, \`memphis chat --input hi\` before \`memphis init\` should print the actionable error, not a stub reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)