### PR TITLE
docs(operator): force-flag bypass contract (S7-1 — MEMPHIS_VAULT_FORCE_REINIT + MEMPHIS_RESTART_ALLOW_SUICIDE)

### DIFF
--- a/docs/operator/FORCE-FLAGS.md
+++ b/docs/operator/FORCE-FLAGS.md
@@ -1,0 +1,133 @@
+# Force flags
+
+Memphis treats certain destructive paths as fail-closed by default:
+re-initializing a non-empty vault would orphan every encrypted entry,
+and exiting without a supervisor leaves the agent dead in unsupervised
+shells. Two env flags exist to override these guards. They are
+**operator-deliberate, not operator-curiosity** — set them only when
+you understand which guard you are bypassing and why.
+
+| Flag | Default | Tier (mutability) | Override |
+|------|---------|-------------------|----------|
+| `MEMPHIS_VAULT_FORCE_REINIT` | `false` | reload | Vault re-init guard |
+| `MEMPHIS_RESTART_ALLOW_SUICIDE` | `false` | warm | Self-restart no-supervisor guard |
+
+## `MEMPHIS_VAULT_FORCE_REINIT`
+
+### What it overrides
+
+`memphis vault init` refuses every time `vault-state.json` is present
+and contains a salt + master key. The refusal exists because re-init
+generates a new master key, and old encrypted entries are unreadable
+under the new key — the vault would silently lose every secret without
+the guard.
+
+The guard fires from two paths:
+
+- `src/infra/storage/rust-vault-adapter.ts:553` — `refuseIfVaultStateExists`
+  reads `vault-state.json` directly, throws `VaultAlreadyInitializedError`
+  if both `salt` and an encrypted master key field exist.
+- `src/security/vault-boundary.ts:202` — `initializeVault` lists existing
+  entries and refuses if any are present.
+
+### When to set it
+
+Three legitimate cases:
+
+1. **Disposable test box** — the vault holds nothing irreversible, and
+   you want a fresh DID and master key for a clean smoke run.
+2. **Confirmed wipe** — you have an external backup of every secret you
+   need (passwords, API keys, signing material) and have decided the
+   current vault is unrecoverable. Re-init wipes by design.
+3. **Recovery from corrupt state** — `vault-state.json` exists but
+   parses, and `memphis vault list` returns nothing useful. After
+   manual triage of the file, you commit to discarding the state.
+
+### How to set it
+
+```bash
+# One-shot
+MEMPHIS_VAULT_FORCE_REINIT=1 memphis vault init
+
+# Persistent (writes to ~/.memphis/.env via canonical setter)
+echo 'MEMPHIS_VAULT_FORCE_REINIT=true' >> ~/.memphis/.env
+```
+
+Both `1`, `true`, `yes`, `on` parse as truthy via `parseBool` in
+`src/core/env.ts`. Set to anything falsy or unset to re-arm the guard.
+
+### What it doesn't do
+
+- Does **not** decrypt the existing vault. Only bypasses the refusal.
+  Whatever was in `vault-entries.json` becomes garbage under the new
+  master key.
+- Does **not** export the existing entries. Run `memphis vault export`
+  first if you might want them later.
+- Does **not** persist after the operation — set it once, vault is
+  re-initialized once, the next normal `memphis vault init` is again
+  refused.
+
+### Audit trail
+
+`writeVaultAudit(ctx, 'vault-init', 'blocked', ...)` records every
+refusal with `reason: 'vault_reinit_blocked'`. Allowed re-inits get
+`'vault-init', 'allowed', { did, ... }`. Both end up in
+`data/security-audit.jsonl`.
+
+## `MEMPHIS_RESTART_ALLOW_SUICIDE`
+
+### What it overrides
+
+The self-restart engine refuses to call `process.exit(0)` when no
+process supervisor is detected. Detection looks for systemd
+(`NOTIFY_SOCKET`, `INVOCATION_ID`, or a `memphis.service` unit file),
+PM2 (`pm_id`/`PM2_HOME`), or the Memphis bootstrap unit.
+
+Without a supervisor, exit leaves the agent dead — the process won't
+come back until you manually relaunch.
+
+The guard fires from `src/infra/runtime/self-restart.ts:191`. Setting
+this flag bypasses it.
+
+### When to set it
+
+- **Local dev** — `npm run dev` or direct `node …` runs without a
+  supervisor by design. Setting the flag lets you exercise the drain +
+  audit + PULSE flow end-to-end.
+- **Manual operator drill** — testing what happens after `process.exit`
+  in a controlled environment where you intend to relaunch by hand.
+
+### How to set it
+
+```bash
+# Persistent in dev shell
+export MEMPHIS_RESTART_ALLOW_SUICIDE=true
+
+# Or in ~/.memphis/.env for a dev box
+echo 'MEMPHIS_RESTART_ALLOW_SUICIDE=true' >> ~/.memphis/.env
+```
+
+### What it doesn't do
+
+- Does **not** spawn a replacement process. After exit, you relaunch.
+- Does **not** skip the drain — in-flight turn aborts still happen.
+- Does **not** affect any other restart mechanic. PULSE, audit, drain
+  timeout all behave identically.
+
+For full self-restart context, see [self-restart.md](./self-restart.md).
+
+## Why these are env flags, not CLI flags
+
+Both guards exist because the destructive case is **rare and
+deliberate**. A CLI flag like `memphis vault init --force` is too easy
+to typo into a recovery script, and `--allow-suicide` reads as a UX
+ceremony rather than a real safety bypass. Env flags require the
+operator to type the variable name in shell — the friction is the
+feature.
+
+## Related
+
+- [Self-restart](./self-restart.md) — full restart engine documentation
+- [Vault encryption guard](./CLEAN-INSTALL.md) — fresh-install vault flow
+- [Disaster recovery](./disaster-recovery.md) — when re-init is the
+  wrong tool and you should restore from backup instead

--- a/docs/operator/self-restart.md
+++ b/docs/operator/self-restart.md
@@ -49,7 +49,7 @@ same passphrase gate as fs-overwrite and freeform-exec.
 | Env                                | Default | Tier (Sprint 6) | What                                                                                                      |
 | ---------------------------------- | ------- | --------------- | --------------------------------------------------------------------------------------------------------- |
 | `MEMPHIS_RESTART_DRAIN_TIMEOUT_MS` | `10000` | `hot`           | How long to wait for in-flight turns before exiting. `0` skips the drain.                                 |
-| `MEMPHIS_RESTART_ALLOW_SUICIDE`    | `false` | `warm`          | When `true`, allows `process.exit(0)` even without a detected supervisor. Operator must manually restart. |
+| `MEMPHIS_RESTART_ALLOW_SUICIDE`    | `false` | `warm`          | When `true`, allows `process.exit(0)` even without a detected supervisor. Operator must manually restart. See [FORCE-FLAGS.md](./FORCE-FLAGS.md#memphis_restart_allow_suicide) for the full bypass contract. |
 
 `hot` means change with `/config set MEMPHIS_RESTART_DRAIN_TIMEOUT_MS=20000` →
 `/config reload` and the very next restart honors the new ceiling.

--- a/src/infra/runtime/self-restart.ts
+++ b/src/infra/runtime/self-restart.ts
@@ -241,7 +241,7 @@ export async function requestRestart(input: RequestRestartInput): Promise<Restar
       ok: false,
       reason: 'no-supervisor',
       message:
-        'restart refused — no supervisor detected (systemd/pm2/memphis-service). Set MEMPHIS_RESTART_ALLOW_SUICIDE=true to exit anyway; operator must manually restart.',
+        'restart refused — no supervisor detected (systemd/pm2/memphis-service). Set MEMPHIS_RESTART_ALLOW_SUICIDE=true to exit anyway; operator must manually restart. See docs/operator/FORCE-FLAGS.md for the full bypass contract.',
       supervisor,
     };
   }

--- a/src/infra/storage/rust-vault-adapter.ts
+++ b/src/infra/storage/rust-vault-adapter.ts
@@ -578,7 +578,8 @@ function refuseIfVaultStateExists(rawEnv: NodeJS.ProcessEnv): void {
       `Vault state already initialized at ${statePath}. ` +
         `Refusing to re-initialize — this would generate a new master key and ` +
         `leave existing encrypted entries unreadable. ` +
-        `If you intentionally want to wipe the vault, set MEMPHIS_VAULT_FORCE_REINIT=1.`,
+        `If you intentionally want to wipe the vault, set MEMPHIS_VAULT_FORCE_REINIT=1. ` +
+        `See docs/operator/FORCE-FLAGS.md for the full bypass contract.`,
     );
   }
 }

--- a/src/security/vault-boundary.ts
+++ b/src/security/vault-boundary.ts
@@ -214,7 +214,8 @@ export function initializeVault(
     throw new VaultAlreadyInitializedError(
       `Vault has ${existingEntries.length} existing entries — refusing re-init. ` +
         `A new master key would leave them unreadable. ` +
-        `Set MEMPHIS_VAULT_FORCE_REINIT=1 only if you intentionally want to wipe the vault.`,
+        `Set MEMPHIS_VAULT_FORCE_REINIT=1 only if you intentionally want to wipe the vault. ` +
+        `See docs/operator/FORCE-FLAGS.md for the full bypass contract.`,
     );
   }
 


### PR DESCRIPTION
## Summary

Operators hitting the **vault re-init guard** or the **no-supervisor restart guard** see an env-flag name in the error message — until now they had no canonical doc explaining when it's safe to set, what it bypasses, and what it doesn't do. They had to grep source comments or scratch handoff notes to reason about the bypass.

This ships:

- **new `docs/operator/FORCE-FLAGS.md`** — covers both flags side-by-side: override, when to set, how to set, what it doesn't do, audit trail. Cross-links to existing `self-restart.md`.
- **runtime error messages** in vault-init refusal + self-restart no-supervisor refusal now point operators at the doc (one-line append per call site).
- **existing `self-restart.md`** env table cross-links to FORCE-FLAGS.md so the network is bidirectional.

## Scope cut from original S7-1 plan

Dropped the `memphis doctor --explain <topic>` sub-flag from the autopilot plan. The doc + an actionable error message that names the file is enough surface; adding a doctor sub-flag is feature creep. Per `feedback_cut_complexity_first.md` — ship the value, skip the gilding. Reopen if operators ask.

## Why these are env flags

Both guards exist because the destructive case is rare and deliberate. A CLI flag like `memphis vault init --force` is too easy to typo into a recovery script, and `--allow-suicide` reads as UX ceremony rather than a real safety bypass. Env flags require the operator to type the variable name in shell — the friction is the feature. (Doc covers this.)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/unit/vault-double-init-guard.test.ts tests/unit/self-restart-engine.test.ts tests/unit/self-restart-supervisor.test.ts` → 24/24 pass
- [x] Confirmed no tests pin the prose message text — assertions are on `.reason` (`'no-supervisor'`, `'vault_reinit_blocked'`) and audit details, so the message-suffix change is invisible to tests.
- [ ] CI quality-gate + cross-arch matrix green (waiting on push)

## Affected files

- new `docs/operator/FORCE-FLAGS.md`
- `docs/operator/self-restart.md` (1-line cross-link)
- `src/infra/storage/rust-vault-adapter.ts` (error message append)
- `src/security/vault-boundary.ts` (error message append)
- `src/infra/runtime/self-restart.ts` (error message append)

## Memory + plan context

- Phase 1 of `~/.claude/plans/glowing-knitting-lobster.md` autopilot plan (2026-05-02).
- S7-3a (VALID_MODES include 'full') was a no-op — already shipped; memory `project_autonomy_mode_switching_followup.md` updated to reflect.
- Next in Phase 1: **S8-2 CHANGELOG.md** generation from `git log v1.7.2..HEAD`.