### PR TITLE
feat(napi): platform-aware bridge resolver + sub-package skeletons (S9-1a)

### DIFF
--- a/crates/memphis-napi/npm/README.md
+++ b/crates/memphis-napi/npm/README.md
@@ -1,0 +1,76 @@
+# Per-platform NAPI sub-packages
+
+Each directory here is a npm sub-package that ships the prebuilt
+NAPI bridge binary (`index.node`) for one platform/arch/libc triple.
+Operators on supported platforms get the matching binary via npm's
+`optionalDependencies` resolution against `os` / `cpu` / `libc`
+keys in each sub-package's `package.json`.
+
+## Layout
+
+```
+crates/memphis-napi/npm/
+├── linux-x64-gnu/      # Linux x86_64 with glibc (most desktops + ubuntu)
+│   └── package.json
+├── linux-arm64-gnu/    # Linux aarch64 with glibc (Raspberry Pi 4 64-bit, AWS Graviton)
+│   └── package.json
+├── darwin-x64/         # macOS Intel
+│   └── package.json
+└── darwin-arm64/       # macOS Apple Silicon (M1+)
+    └── package.json
+```
+
+Each `package.json` declares `os`, `cpu`, and (for Linux) `libc` so
+npm only installs the sub-package matching the current host. The
+binary itself (`index.node`) is **not committed** — it's built and
+copied in by the prebuilds workflow (see S9-3) at release time.
+
+## How it's loaded
+
+`src/infra/storage/napi-contract.ts:loadPlatformAwareBridge` tries
+`require('@memphis-chains/memphis-${triple}')` first. If the sub-
+package is installed (the operator is on a supported platform AND
+hasn't disabled `optionalDependencies` via `--no-optional`), the
+prebuilt binary loads. Otherwise the loader falls back to the
+in-tree `crates/memphis-napi/index.node` produced by `npm run
+build:rust:release`.
+
+`detectPlatformTriple` in the same file determines the current
+triple. Linux without glibc (Alpine/musl) returns `null` by design —
+no musl prebuild yet, so musl operators always build from source.
+
+## Why split this way
+
+Single-package distribution would inflate the tarball with 4 binaries
+on every install, even though npm only needs one. Per-platform sub-
+packages let npm fetch ~10–20 MiB instead of 4× that. This pattern
+is the napi-rs default and matches Rspack/Turbopack/Parcel.
+
+The trade-off: 4 GH Packages publishes per release. The release
+workflow (`.github/workflows/release.yml`) handles this in S9-3.
+
+## Why not Windows / Alpine yet
+
+- **Windows native**: `scripts/install.sh:152-155` rejects Windows
+  (MINGW guard); operators run Memphis on WSL2 which inherits the
+  Linux x64 prebuild. No native Windows prebuild planned for v1.8.x.
+- **Alpine/musl**: low operator demand, build matrix already at 4
+  triples. Operators on Alpine build from source via `npm run
+  build:rust:release`. Adding a `linux-x64-musl` sub-package is a
+  follow-up if demand emerges.
+
+## Versioning
+
+Each sub-package version mirrors the root `@memphis-chains/memphis`
+version. Bumping the root version (`npm version <kind>`) bumps all
+sub-packages in lockstep — handled by the release workflow.
+
+The `0.0.0-placeholder` strings in committed `package.json` files
+are CI-rewritten at publish time to the actual release version.
+
+## See also
+
+- `src/infra/storage/napi-contract.ts` — platform-aware loader
+- `docs/dev/RUST-DISTRIBUTION.md` — full distribution architecture
+- `.github/workflows/prebuilds.yml` — per-platform build matrix (S9-3)
+- `scripts/postinstall-fetch-native.mjs` — fallback download (S9-4)

--- a/crates/memphis-napi/npm/darwin-arm64/package.json
+++ b/crates/memphis-napi/npm/darwin-arm64/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@memphis-chains/memphis-darwin-arm64",
+  "version": "0.0.0-placeholder",
+  "description": "Memphis NAPI bridge prebuilt binary for darwin arm64 (Apple Silicon)",
+  "main": "index.node",
+  "files": [
+    "index.node"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Memphis-Chains/memphis.git",
+    "directory": "crates/memphis-napi/npm/darwin-arm64"
+  }
+}

--- a/crates/memphis-napi/npm/darwin-x64/package.json
+++ b/crates/memphis-napi/npm/darwin-x64/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@memphis-chains/memphis-darwin-x64",
+  "version": "0.0.0-placeholder",
+  "description": "Memphis NAPI bridge prebuilt binary for darwin x64",
+  "main": "index.node",
+  "files": [
+    "index.node"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Memphis-Chains/memphis.git",
+    "directory": "crates/memphis-napi/npm/darwin-x64"
+  }
+}

--- a/crates/memphis-napi/npm/linux-arm64-gnu/package.json
+++ b/crates/memphis-napi/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@memphis-chains/memphis-linux-arm64-gnu",
+  "version": "0.0.0-placeholder",
+  "description": "Memphis NAPI bridge prebuilt binary for linux arm64 (glibc)",
+  "main": "index.node",
+  "files": [
+    "index.node"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Memphis-Chains/memphis.git",
+    "directory": "crates/memphis-napi/npm/linux-arm64-gnu"
+  }
+}

--- a/crates/memphis-napi/npm/linux-x64-gnu/package.json
+++ b/crates/memphis-napi/npm/linux-x64-gnu/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@memphis-chains/memphis-linux-x64-gnu",
+  "version": "0.0.0-placeholder",
+  "description": "Memphis NAPI bridge prebuilt binary for linux x64 (glibc)",
+  "main": "index.node",
+  "files": [
+    "index.node"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Memphis-Chains/memphis.git",
+    "directory": "crates/memphis-napi/npm/linux-x64-gnu"
+  }
+}

--- a/docs/dev/RUST-DISTRIBUTION.md
+++ b/docs/dev/RUST-DISTRIBUTION.md
@@ -1,0 +1,103 @@
+# Rust NAPI distribution
+
+This doc covers how the Rust-side of Memphis (vault encryption, chain
+hashing, embeddings, case index) ships to npm-installing operators.
+
+## Architecture
+
+The Rust workspace lives under `crates/`. The `memphis-napi` crate
+exports a Node-N-API surface (`crate-type = ["cdylib"]`) that the TS
+layer loads via `createRequire(...)`. The bridge module exposes
+~17 functions covering vault, chain, embed, and case-index ops.
+
+### Two distribution paths
+
+Operators get the bridge via one of:
+
+1. **Prebuilt platform sub-package** (preferred). Per-platform npm
+   sub-packages under `crates/memphis-napi/npm/<triple>/` ship just
+   the matching `index.node`. Root `package.json:optionalDependencies`
+   lists all four; npm picks the right one via `os`/`cpu`/`libc` keys.
+   This is the S9-1+S9-3 architecture.
+
+2. **Build from source** (fallback). When no platform sub-package is
+   installable (musl Linux, exotic arch, `--no-optional` install,
+   pre-publish source checkout), the postinstall script triggers
+   `npm run build:rust:release` and the resulting in-tree
+   `crates/memphis-napi/index.node` is loaded by `loadBridgeModule`.
+
+### Resolver flow
+
+`src/infra/storage/napi-contract.ts:loadPlatformAwareBridge` runs:
+
+```
+detect platform triple  → detectPlatformTriple(process)
+                        ↓
+try platform sub-package → require('@memphis-chains/memphis-<triple>')
+                        ↓ (caught)
+fall back to in-tree    → loadBridgeModule(<inTreePath>)
+                        ↓ (returns BridgeModule | null)
+contract resolution     → resolveBridgeContract(bridge, aliases)
+```
+
+The in-tree path is produced by `resolveRustBridgePath` in
+`src/infra/runtime/install-root.ts` (anchors on installRoot, allows
+`RUST_CHAIN_BRIDGE_PATH` env override).
+
+## Supported platforms
+
+| Triple | Tested in CI | Notes |
+|--------|--------------|-------|
+| `linux-x64-gnu` | ✅ | Primary target — most operator desktops + AWS x86 |
+| `linux-arm64-gnu` | ✅ (post S9-3) | Raspberry Pi 4 64-bit, AWS Graviton |
+| `darwin-x64` | ✅ (post S9-3) | macOS Intel |
+| `darwin-arm64` | ✅ (post S9-3) | macOS Apple Silicon (M1+) |
+| `linux-x64-musl` | ❌ | Alpine — build from source |
+| `win32-x64` | ❌ | Memphis rejects Windows native; use WSL2 |
+
+Adding a new triple = add `crates/memphis-napi/npm/<triple>/package.json`
++ extend `detectPlatformTriple` + extend the prebuilds.yml matrix.
+
+## Migration plan
+
+| Phase | What | When |
+|-------|------|------|
+| **S9-0** ✅ | npm tarball ships in-tree binary; postinstall probe + glibc/musl detection | shipped 2026-05-02 (#390) |
+| **S9-1a** ✅ | Platform-aware resolver + sub-package skeletons (no publishing) | this PR |
+| **S9-1b** | Add `optionalDependencies` to root `package.json` after sub-packages exist on registry | follow-up |
+| **S9-2** | Drop in-tree `index.node` from npm tarball `files[]` (only platform sub-packages ship binaries) | follow-up |
+| **S9-3** | `prebuilds.yml` workflow: 4-platform matrix builds + publishes each sub-package | follow-up |
+| **S9-4** | `postinstall-fetch-native.mjs` — fallback download from GH Release for offline/firewalled installs | follow-up |
+| **S9-5** | SHA256SUMS + Sigstore attestations per prebuild | partial via S8-1; full extension follow-up |
+
+The order matters: **S9-1a** establishes the resolver shape so the
+runtime can find platform sub-packages once they exist. **S9-3**
+publishes them. **S9-1b** then adds `optionalDependencies` so npm
+auto-installs the matching one. **S9-2** drops the in-tree binary
+from the main tarball (last to land — the in-tree fallback stays
+working until per-platform publishing is proven).
+
+## Why napi-rs CLI not adopted
+
+The plan originally considered `@napi-rs/cli` adoption (replacing
+`cargo build` with `napi build --release --platform`). On closer
+read this is unnecessary churn:
+
+- `napi-derive 3` (already in `Cargo.toml`) generates the JS bindings.
+- The cdylib output from `cargo build` is exactly what we need.
+- `napi build` mostly handles cross-compilation orchestration —
+  GitHub Actions does that fine via per-platform matrix runners.
+
+The sub-package layout copies the `@napi-rs/cli` convention without
+inheriting the build tool. Lower migration risk; same operator-
+facing experience.
+
+## See also
+
+- `src/infra/storage/napi-contract.ts` — bridge contract + loader
+- `src/infra/runtime/install-root.ts` — install-root + env override
+  resolution for the in-tree path
+- `crates/memphis-napi/npm/README.md` — sub-package layout reference
+- `scripts/postinstall-check-native.mjs` — postinstall probe (S9-0)
+- `docs/operator/CLEAN-INSTALL.md` — operator-side install walkthrough
+- `docs/dev/RELEASE-PROCESS.md` — GPG signing for release artifacts

--- a/src/infra/storage/napi-contract.ts
+++ b/src/infra/storage/napi-contract.ts
@@ -2,6 +2,108 @@ import { createRequire } from 'node:module';
 
 type BridgeModule = Record<string, unknown>;
 
+/**
+ * Platform triples we publish prebuilt NAPI binaries for. Operators on
+ * other triples build from source via `npm run build:rust:release`.
+ *
+ * Format: `<os>-<arch>-<libc>?` matching the napi-rs CLI convention.
+ * `gnu` libc is the glibc default on Linux; `musl` is Alpine. Darwin/Windows
+ * have no libc suffix.
+ */
+export type SupportedPlatformTriple =
+  | 'linux-x64-gnu'
+  | 'linux-arm64-gnu'
+  | 'darwin-x64'
+  | 'darwin-arm64';
+
+/**
+ * Detect the running platform triple. Returns `null` when the platform/arch
+ * combination is not in the prebuilt matrix — caller should fall back to the
+ * in-tree bridge path. Linux without glibc (e.g. Alpine/musl) returns null
+ * by design; we don't ship a musl prebuild yet.
+ */
+export function detectPlatformTriple(
+  rawProcess: typeof process = process,
+): SupportedPlatformTriple | null {
+  const platform = rawProcess.platform;
+  const arch = rawProcess.arch;
+
+  if (platform === 'linux' && arch === 'x64' && isGlibcLinux(rawProcess)) {
+    return 'linux-x64-gnu';
+  }
+  if (platform === 'linux' && arch === 'arm64' && isGlibcLinux(rawProcess)) {
+    return 'linux-arm64-gnu';
+  }
+  if (platform === 'darwin' && arch === 'x64') return 'darwin-x64';
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64';
+
+  return null;
+}
+
+/**
+ * `process.report.getReport().header.glibcVersionRuntime` is set to a string
+ * on glibc Linux, undefined on musl Linux. Mirrors the same probe used in
+ * `scripts/postinstall-check-native.mjs` (S9-0) so distribution + load-side
+ * checks stay aligned.
+ */
+function isGlibcLinux(rawProcess: typeof process): boolean {
+  if (rawProcess.platform !== 'linux') return false;
+  try {
+    const report =
+      typeof rawProcess.report?.getReport === 'function'
+        ? (rawProcess.report.getReport() as { header?: { glibcVersionRuntime?: string } })
+        : {};
+    return typeof report.header?.glibcVersionRuntime === 'string';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Sub-package name on the npm registry for a given platform triple.
+ * Mirrors the per-platform packages published by S9-3 (prebuilds.yml).
+ *
+ * Naming convention: `@memphis-chains/memphis-<triple>` (e.g.
+ * `@memphis-chains/memphis-linux-x64-gnu`). This pairs with
+ * `optionalDependencies` in the root package.json so npm picks the right
+ * one based on `os`/`cpu`/`libc` keys in each sub-package's package.json.
+ */
+export function platformPackageName(triple: SupportedPlatformTriple): string {
+  return `@memphis-chains/memphis-${triple}`;
+}
+
+/**
+ * Try the platform sub-package first; fall back to the in-tree bridge
+ * module path. Returns the loaded bridge or null if both fail.
+ *
+ * The platform sub-package path is what S9-1 distribution targets — once
+ * published via S9-3 prebuilds.yml workflow, fresh `npm install` on supported
+ * platforms picks the right `.node` automatically through `optionalDependencies`.
+ * The in-tree fallback covers (a) source checkouts pre-publish, (b) build-from-
+ * source on unsupported platforms, (c) operator override via env var.
+ *
+ * `inTreePath` is the directory containing the legacy `index.node` (per
+ * resolveRustBridgePath in install-root.ts).
+ */
+export function loadPlatformAwareBridge(
+  inTreePath: string,
+  rawProcess: typeof process = process,
+): BridgeModule | null {
+  const triple = detectPlatformTriple(rawProcess);
+  if (triple !== null) {
+    try {
+      const req = createRequire(`${rawProcess.cwd()}/`);
+      const platformPkg = req(platformPackageName(triple)) as BridgeModule;
+      if (platformPkg) return platformPkg;
+    } catch {
+      // Platform sub-package not installed (operator on a build-from-source
+      // path, or pre-publish state where sub-packages don't exist yet).
+      // Fall through to in-tree fallback.
+    }
+  }
+  return loadBridgeModule(inTreePath);
+}
+
 export type BridgeAliasMap<T extends string> = Record<T, readonly [string, ...string[]]>;
 
 export type BridgeResolution<T extends string> = {

--- a/tests/unit/napi-contract.test.ts
+++ b/tests/unit/napi-contract.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  detectPlatformTriple,
   hasRequiredBridgeExports,
+  platformPackageName,
   resolveBridgeContract,
   type BridgeAliasMap,
 } from '../../src/infra/storage/napi-contract.js';
@@ -44,5 +46,63 @@ describe('napi-contract helpers', () => {
     expect(resolution.missing).toEqual(['embed_reset']);
     expect(hasRequiredBridgeExports(resolution, ['embed_store'])).toBe(true);
     expect(hasRequiredBridgeExports(resolution, ['embed_store', 'embed_reset'])).toBe(false);
+  });
+});
+
+describe('detectPlatformTriple', () => {
+  function fakeProcess(
+    platform: NodeJS.Platform,
+    arch: string,
+    glibcVersionRuntime?: string,
+  ): typeof process {
+    return {
+      platform,
+      arch,
+      report: {
+        getReport: () => ({
+          header: glibcVersionRuntime !== undefined ? { glibcVersionRuntime } : {},
+        }),
+      },
+      cwd: () => '/tmp',
+    } as unknown as typeof process;
+  }
+
+  it('returns linux-x64-gnu for glibc Linux on x64', () => {
+    expect(detectPlatformTriple(fakeProcess('linux', 'x64', '2.39'))).toBe('linux-x64-gnu');
+  });
+
+  it('returns linux-arm64-gnu for glibc Linux on arm64', () => {
+    expect(detectPlatformTriple(fakeProcess('linux', 'arm64', '2.39'))).toBe('linux-arm64-gnu');
+  });
+
+  it('returns null for musl Linux (no prebuild yet)', () => {
+    // glibcVersionRuntime undefined ⇒ musl/Alpine.
+    expect(detectPlatformTriple(fakeProcess('linux', 'x64'))).toBe(null);
+  });
+
+  it('returns darwin-x64 for macOS Intel', () => {
+    expect(detectPlatformTriple(fakeProcess('darwin', 'x64'))).toBe('darwin-x64');
+  });
+
+  it('returns darwin-arm64 for Apple Silicon', () => {
+    expect(detectPlatformTriple(fakeProcess('darwin', 'arm64'))).toBe('darwin-arm64');
+  });
+
+  it('returns null for Windows (no native prebuild — operators use WSL2)', () => {
+    expect(detectPlatformTriple(fakeProcess('win32', 'x64'))).toBe(null);
+  });
+
+  it('returns null for unsupported arch on supported platform', () => {
+    // e.g. armv7 / mips — out of matrix
+    expect(detectPlatformTriple(fakeProcess('linux', 'arm', '2.39'))).toBe(null);
+  });
+});
+
+describe('platformPackageName', () => {
+  it('builds npm scope/name for each supported triple', () => {
+    expect(platformPackageName('linux-x64-gnu')).toBe('@memphis-chains/memphis-linux-x64-gnu');
+    expect(platformPackageName('linux-arm64-gnu')).toBe('@memphis-chains/memphis-linux-arm64-gnu');
+    expect(platformPackageName('darwin-x64')).toBe('@memphis-chains/memphis-darwin-x64');
+    expect(platformPackageName('darwin-arm64')).toBe('@memphis-chains/memphis-darwin-arm64');
   });
 });


### PR DESCRIPTION
## Summary

Establishes the SHAPE for per-platform NAPI binary distribution without changing runtime behaviour for current operators. Behaviour-zero PR — the resolver is added but not yet wired into adapters; sub-package publishing (S9-3) and root-package `optionalDependencies` wiring (S9-1b) land in follow-up PRs once the structure is proven.

This is **S9-1a** of a 5-step migration:

| Phase | What | When |
|-------|------|------|
| S9-0 ✅ | npm tarball ships in-tree binary; postinstall probe + glibc/musl detection | shipped 2026-05-02 (#390) |
| **S9-1a** | Platform-aware resolver + sub-package skeletons (no publishing) | **this PR** |
| S9-1b | Add `optionalDependencies` to root `package.json` after sub-packages exist on registry | follow-up |
| S9-2 | Drop in-tree `index.node` from npm tarball `files[]` | follow-up |
| S9-3 | `prebuilds.yml` workflow: 4-platform matrix builds + publishes each sub-package | follow-up |
| S9-4 | `postinstall-fetch-native.mjs` — fallback download from GH Release | follow-up |
| S9-5 | Sigstore attestations per prebuild | follow-up |

## What's in this PR

### Platform-aware resolver (`src/infra/storage/napi-contract.ts`)

- `detectPlatformTriple(process)` — returns `linux-x64-gnu`, `linux-arm64-gnu`, `darwin-x64`, `darwin-arm64`, or `null` for unsupported (musl Linux, Windows, exotic arches build from source). Mirrors the glibc detection in `scripts/postinstall-check-native.mjs` (S9-0) so distribution + load-side checks stay aligned.
- `platformPackageName(triple)` — returns `@memphis-chains/memphis-<triple>`.
- `loadPlatformAwareBridge(inTreePath, process)` — tries `require('@memphis-chains/memphis-<triple>')` first, falls back to `loadBridgeModule(inTreePath)`. Currently a NOP behaviour-wise because no sub-packages are published yet; activates when S9-3 lands.

### Sub-package skeletons (`crates/memphis-napi/npm/`)

- `linux-x64-gnu/`, `linux-arm64-gnu/`, `darwin-x64/`, `darwin-arm64/`
- Each `package.json` declares `os`/`cpu`/`libc` so npm picks the right one, plus `publishConfig.registry = npm.pkg.github.com`.
- Version `0.0.0-placeholder` — CI rewrites to release version at publish time (S9-3).
- Shared `crates/memphis-napi/npm/README.md` documents the layout.

### Architecture doc (`docs/dev/RUST-DISTRIBUTION.md`)

Covers the resolver flow, supported platforms, and full S9-0 → S9-5 migration plan. Explains why `@napi-rs/cli` adoption is skipped — `napi-derive 3` (already in `Cargo.toml`) produces the right cdylib; CLI's value is mostly cross-compile orchestration which GH Actions handles directly.

## Behaviour change

**Zero for current operators.** The resolver is added but not yet wired into adapters; existing `loadBridgeModule(path)` calls still work. S9-1b switches over the call sites once sub-packages exist on the registry.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/unit/napi-contract.test.ts` → **10/10** pass (2 original + 8 new):
  - linux-x64-gnu/arm64-gnu/musl-null detection
  - darwin-x64/arm64 detection
  - Windows/unsupported-arch null returns
  - `platformPackageName` for all 4 triples
- [x] Sister bridge tests still green: `chain-adapter.bridge-shape`, `durable-write-contract`, `rust-vault-bridge-path`
- [ ] CI quality-gate green (waiting on push)

## Memory + plan

- Phase 4 of `~/.claude/plans/glowing-knitting-lobster.md` autopilot plan (2026-05-02). Wodzu picked `1.B/2.B/3.B/4.B/5.A` — full polish path including S9-1+S9-3+S9-4+S9-5. This PR opens the migration.
- Sibling `feedback_no_blind_spots.md` discipline: every Codex P1+P2 in-PR; structural decision (skip @napi-rs/cli adoption) documented in `docs/dev/RUST-DISTRIBUTION.md` not deferred.