### PR TITLE
test(macos): switch managed-apps.vault-boundary to realTmpdir (S11-1 partial)

### DIFF
--- a/tests/unit/managed-apps.vault-boundary.test.ts
+++ b/tests/unit/managed-apps.vault-boundary.test.ts
@@ -1,5 +1,4 @@
 import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -16,6 +15,7 @@ import {
   type ManagedAppManifestRef,
   planManagedAppAction,
 } from '../../src/modules/apps/manifest.js';
+import { realTmpdir as tmpdir } from '../helpers/tmpdir.js';
 
 function buildManifestRef(): ManagedAppManifestRef {
   return {


### PR DESCRIPTION
## Summary

Last test file in the planned realTmpdir sweep that was still importing `tmpdir` directly from `node:os`. Six sister files (`cli.apps`, `install-root`, `managed-apps.registry`, `managed-apps.manifest`, `self-modify-path-validation`, `vault-paths`) already use the `realpathSync`-aware helper from `tests/helpers/tmpdir.ts` (introduced in #372).

This regression slipped in via PR #260 (vault-boundary expansion) — new test file copied the `node:os` import pattern from elsewhere.

## Why it matters on macOS

macOS routes `/var/folders/<…>` through a `/private/var/folders/<…>` symlink that `resolveInstallRoot()` (and friends) dereference via `realpathSync`. Any assertion that compares a fixture path built with raw `os.tmpdir()` against a memphis-resolved path fails on macOS because the two strings differ by one symlink hop.

`realTmpdir()` from `tests/helpers/tmpdir.ts` returns `realpathSync(tmpdir())` — once at module load — so both sides of the comparison are dereferenced consistently. Linux is unaffected (no `/private/var/...` symlink to follow).

## What this PR is NOT

The autopilot plan listed S11-1 as "sweep 8 failing macOS tests". Re-reading the cross-arch CI logs for current `main` (run `25247783173`), the real macOS failure picture is broader:

- `secret-scan.test.ts` fails **14/15** on macos-latest (not realTmpdir-shaped — separate root cause, likely platform-conditional regex or env probe)
- `napi chain append lock timeout for /Users/runner/.memphis/chains` (NAPI-side, possibly fs sync semantics)
- Various scattered `vault decrypt FAILED` warnings (not test-failing in isolation)

These are **out of scope** for this PR. S11-2 (drop `continue-on-error: true` on cross-arch matrix) cannot land until those independent failures are addressed. Will file a tracking issue post-merge.

## Test plan

- [x] `npx vitest run tests/unit/managed-apps.vault-boundary.test.ts` → 2/2 pass on Linux
- [x] `npx eslint tests/unit/managed-apps.vault-boundary.test.ts` clean
- [ ] Cross-arch matrix on macos-latest: this specific file's tests should now pass; the broader failures persist (out of scope)

## Memory + plan

- Phase 6 (S11) of `~/.claude/plans/glowing-knitting-lobster.md` autopilot plan, partial. Wodzu picked `4.B` (wait for S11 macOS parity before tag) — this is the start of that work, narrowly scoped to the realTmpdir-shaped subset.
- Sibling Phase 4 PR: #401 (S9-1a NAPI platform resolver).