### PR TITLE
ci(prebuilds): per-platform NAPI binary build + publish matrix (S9-3)

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -1,0 +1,138 @@
+name: prebuilds
+
+# S9-3: per-platform NAPI binary prebuilds for the 4 supported triples.
+# Fires on `v*` tag push (in lockstep with release.yml). Each matrix
+# entry runs on its native arch — no cross-compilation. Each publishes
+# its sub-package to GH Packages so the root `@memphis-chains/memphis`
+# can pick up the right one via `optionalDependencies` (S9-1b).
+#
+# Sub-package layout: crates/memphis-napi/npm/<triple>/{package.json,index.node}
+# Sub-package name: @memphis-chains/memphis-<triple>
+# Version: rewritten from `0.0.0-placeholder` → tag name (without `v` prefix).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to prebuild and publish (e.g. v1.8.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  prebuild:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - triple: linux-x64-gnu
+            runner: ubuntu-24.04
+            cargo_target: x86_64-unknown-linux-gnu
+          - triple: linux-arm64-gnu
+            runner: ubuntu-24.04-arm
+            cargo_target: aarch64-unknown-linux-gnu
+          - triple: darwin-x64
+            runner: macos-13
+            cargo_target: x86_64-apple-darwin
+          - triple: darwin-arm64
+            runner: macos-14
+            cargo_target: aarch64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+
+      - name: Validate tag format
+        env:
+          REF_NAME: ${{ inputs.tag || github.ref_name }}
+        run: |
+          case "$REF_NAME" in
+            v*) ;;
+            *)
+              echo "Tag must start with v (got $REF_NAME)." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.cargo_target }}
+
+      - name: Build memphis-napi (release, per-target)
+        run: |
+          cargo build -p memphis-napi --release --target ${{ matrix.cargo_target }}
+
+      # The cdylib lands at:
+      #   target/${{ matrix.cargo_target }}/release/libmemphis_napi.<ext>
+      # where <ext> is `so` on Linux, `dylib` on macOS. We rename to
+      # `index.node` per Node's NAPI convention and drop into the
+      # platform sub-package.
+      - name: Stage binary into sub-package
+        run: |
+          case "${{ matrix.triple }}" in
+            linux-*) ext="so" ;;
+            darwin-*) ext="dylib" ;;
+          esac
+          src="target/${{ matrix.cargo_target }}/release/libmemphis_napi.${ext}"
+          dst="crates/memphis-napi/npm/${{ matrix.triple }}/index.node"
+          if [ ! -f "$src" ]; then
+            echo "Build artifact not found at $src" >&2
+            ls -la "target/${{ matrix.cargo_target }}/release/" || true
+            exit 1
+          fi
+          cp "$src" "$dst"
+          ls -la "$dst"
+
+      # Rewrite the placeholder version in the sub-package package.json
+      # to match the tag (without the `v` prefix). Idempotent if already
+      # rewritten on a previous run.
+      - name: Set sub-package version
+        env:
+          REF_NAME: ${{ inputs.tag || github.ref_name }}
+        run: |
+          version="${REF_NAME#v}"
+          pkg_json="crates/memphis-napi/npm/${{ matrix.triple }}/package.json"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('$pkg_json', 'utf8'));
+            pkg.version = '$version';
+            fs.writeFileSync('$pkg_json', JSON.stringify(pkg, null, 2) + '\n');
+            console.log('Set ' + pkg.name + '@' + pkg.version);
+          "
+          cat "$pkg_json"
+
+      - name: Publish sub-package to GH Packages
+        working-directory: crates/memphis-napi/npm/${{ matrix.triple }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm publish 2>&1 | tee /tmp/npm-publish.log || {
+            if grep -q "Cannot publish over existing version" /tmp/npm-publish.log; then
+              echo "::notice ::Sub-package version already published — skipping (idempotent)."
+              exit 0
+            fi
+            exit 1
+          }
+
+      - name: Upload prebuilt artifact (for release.yml to attach)
+        uses: actions/upload-artifact@v7
+        with:
+          name: memphis-napi-${{ matrix.triple }}
+          path: crates/memphis-napi/npm/${{ matrix.triple }}/index.node
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/dev/RUST-DISTRIBUTION.md
+++ b/docs/dev/RUST-DISTRIBUTION.md
@@ -63,10 +63,10 @@ Adding a new triple = add `crates/memphis-napi/npm/<triple>/package.json`
 | Phase | What | When |
 |-------|------|------|
 | **S9-0** ✅ | npm tarball ships in-tree binary; postinstall probe + glibc/musl detection | shipped 2026-05-02 (#390) |
-| **S9-1a** ✅ | Platform-aware resolver + sub-package skeletons (no publishing) | this PR |
+| **S9-1a** ✅ | Platform-aware resolver + sub-package skeletons (no publishing) | shipped (#401) |
 | **S9-1b** | Add `optionalDependencies` to root `package.json` after sub-packages exist on registry | follow-up |
 | **S9-2** | Drop in-tree `index.node` from npm tarball `files[]` (only platform sub-packages ship binaries) | follow-up |
-| **S9-3** | `prebuilds.yml` workflow: 4-platform matrix builds + publishes each sub-package | follow-up |
+| **S9-3** ✅ | `prebuilds.yml` workflow: 4-platform matrix builds + publishes each sub-package | this PR |
 | **S9-4** | `postinstall-fetch-native.mjs` — fallback download from GH Release for offline/firewalled installs | follow-up |
 | **S9-5** | SHA256SUMS + Sigstore attestations per prebuild | partial via S8-1; full extension follow-up |
 


### PR DESCRIPTION
## Summary

New workflow `.github/workflows/prebuilds.yml` fires on `v*` tag push (parallel to `release.yml`). Builds the `memphis-napi` NAPI bridge in release mode for each of the **4 supported platform triples** on its **native runner** — no cross-compilation orchestration needed:

| Triple | Runner |
|--------|--------|
| `linux-x64-gnu` | `ubuntu-24.04` |
| `linux-arm64-gnu` | `ubuntu-24.04-arm` |
| `darwin-x64` | `macos-13` |
| `darwin-arm64` | `macos-14` |

For each matrix entry:

1. Validate tag format (must start with `v`)
2. `cargo build -p memphis-napi --release --target <triple>`
3. Copy resulting `libmemphis_napi.{so,dylib}` → `npm/<triple>/index.node`
4. Rewrite the placeholder version string in the sub-package's `package.json` to the tag (without `v` prefix)
5. `npm publish` to GH Packages (idempotent — already-published versions skip with a notice instead of failing the run)
6. Upload the prebuilt as a workflow artifact for `release.yml` to attach to the GitHub Release page

The sub-package skeletons (S9-1a, #401) declare `os`/`cpu`/`libc` keys so once these are published, npm picks the right one automatically via `optionalDependencies` (S9-1b follow-up).

## Migration plan progress

| Phase | What | Status |
|-------|------|--------|
| S9-0 ✅ | npm tarball ships in-tree binary | shipped (#390) |
| S9-1a ✅ | Platform-aware resolver + sub-package skeletons | shipped (#401) |
| S9-1b | Add `optionalDependencies` to root `package.json` | follow-up |
| S9-2 | Drop in-tree `index.node` from npm tarball | follow-up |
| **S9-3** ✅ | `prebuilds.yml` workflow | **this PR** |
| S9-4 | `postinstall-fetch-native.mjs` fallback | follow-up |
| S9-5 | Sigstore attestations | follow-up |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` → YAML valid
- [x] Workflow uses native arch runners — avoids the cross-compilation toolchain risk that originally pushed S9-3 toward `@napi-rs/cli`. We get the same outcome with simpler GitHub Actions matrix.
- [ ] Live test fires on first `v*` tag (waiting on Wodzu's tag cut). Until then the workflow is dormant — this PR ships infrastructure, not behavior.
- [ ] CI quality-gate green (waiting on push)

## Risk surface

- **First-tag run is the live test.** If the build fails on a specific platform, only that sub-package skips publishing; root release flow continues. Idempotent re-runs supported.
- **Sub-package version drift** — the rewrite step changes `0.0.0-placeholder` to the tag. If a tag is force-pushed, the second `npm publish` returns `Cannot publish over existing version`; the script catches this with a `::notice` and exits 0.
- **GH Packages permissions** — uses `secrets.GITHUB_TOKEN` with `permissions: contents: read, packages: write` declared at workflow level. No extra secrets needed.

## Memory + plan

- Phase 4 of `~/.claude/plans/glowing-knitting-lobster.md` autopilot plan (2026-05-02). Wodzu picked `1.B/2.B/3.B/4.B/5.A` — full polish path. S9-3 is the matrix-build piece.
- Decision still pending: GPG key strategy (decision 2.B → generate `memphis-release@memphis-chains.org`); see `docs/dev/RELEASE-PROCESS.md`. Until secrets land, the prebuilds ship to GH Packages unsigned alongside the unsigned root tarball — already the v1.7.x pattern, no regression.