### PR TITLE
fix(secret-scan): replace GNU-only regex constructs with portable POSIX ERE (#403, S11-2 partial)

### DIFF
--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -8,15 +8,15 @@ set -euo pipefail
 # scan missed):
 #
 #   AKIA[0-9A-Z]{16}                            AWS access-key-id
-#   AIza[0-9A-Za-z\-_]{35}                      GCP API key
+#   AIza[0-9A-Za-z_-]{35}                       GCP API key
 #   xox[baprs]-…                                Slack tokens
 #   ghp_[0-9A-Za-z]{36}                         GitHub PAT
-#   sk-ant-[A-Za-z0-9\-_]{20,}                  Anthropic key (legacy "sk-ant-" form)
-#   sk-(admin|proj|test|live|None)-[A-Za-z0-9\-_]{20,}   OpenAI key (proj/test/live/None scopes)
+#   sk-ant-[A-Za-z0-9_-]{20,}                   Anthropic key (legacy "sk-ant-" form)
+#   sk-(admin|proj|test|live|None)-[A-Za-z0-9_-]{20,}   OpenAI key (proj/test/live/None scopes)
 #   (sk|rk)_(test|live)_[A-Za-z0-9]{24,}         Stripe secret/restricted keys
 #   whsec_[A-Za-z0-9]{32,}                       Stripe webhook signing secrets
 #   -----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----   PEM private key blocks
-#   api[_-]?key\s*[:=]\s*["\x27]…                generic api_key="…" assignments (quoted to avoid fn-call false-positives)
+#   api[_-]?key[[:space:]]*[:=][[:space:]]*["']…  generic api_key="…" assignments (quoted to avoid fn-call false-positives)
 #
 # Note on Mistral: their public API keys carry no dedicated prefix — they
 # look like opaque 32-character base64 strings, indistinguishable from
@@ -24,7 +24,28 @@ set -euo pipefail
 # false-positive on UUIDs, hashes, etc. Mistral keys ride the generic
 # `api[_-]?key="…"` pattern instead. If a pattern emerges (e.g. Mistral
 # ships scoped keys with a prefix), add it here.
-PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|ghp_[0-9A-Za-z]{36}|sk-ant-[A-Za-z0-9\-_]{20,}|sk-(admin|proj|test|live|None)-[A-Za-z0-9\-_]{20,}|(sk|rk)_(test|live)_[A-Za-z0-9]{24,}|whsec_[A-Za-z0-9]{32,}|-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----|api[_-]?key\s*[:=]\s*["\x27][A-Za-z0-9_\-]{16,})'
+#
+# Portability note (S11-2 fix, 2026-05-02): the regex is POSIX ERE,
+# not GNU-extended ERE. macOS BSD grep silently rejects three GNU-only
+# constructs we used to ship:
+#   * `\s`  (Perl shorthand for whitespace) — replaced with `[[:space:]]`
+#   * `\-`  inside `[A-Za-z0-9\-_]` (BSD treats `\` as literal in classes,
+#           yielding `[A-Za-z0-9\-_]` matching `\` not the intended hyphen)
+#           — replaced with hyphen at the END of the class, where it's
+#           always literal in both BSD and GNU
+#   * `\x27` (hex single-quote escape) — not a POSIX ERE feature
+#           — replaced with a literal single quote, injected via shell
+#           variable assembly so this script remains valid bash regardless
+#           of how it's quoted
+# With those constructs in place, BSD grep silently fails the whole
+# pattern (returns 0 matches), `xargs` with `2>/dev/null` swallows the
+# error, the `|| true` keeps the script alive, and `matches` ends up
+# empty so we falsely claim OK. This script appeared to work on Linux
+# (GNU grep) only — every macOS CI run reported `secret-scan.test.ts`
+# 14/15 failing.
+SQ="'"  # single quote, injected as variable so the PATTERN string can
+        # safely contain it under outer single-quote shell quoting.
+PATTERN='(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|xox[baprs]-[0-9A-Za-z-]{10,}|ghp_[0-9A-Za-z]{36}|sk-ant-[A-Za-z0-9_-]{20,}|sk-(admin|proj|test|live|None)-[A-Za-z0-9_-]{20,}|(sk|rk)_(test|live)_[A-Za-z0-9]{24,}|whsec_[A-Za-z0-9]{32,}|-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----|api[_-]?key[[:space:]]*[:=][[:space:]]*["'"$SQ"'][A-Za-z0-9_-]{16,})'
 
 # Exclude:
 #  - node_modules / .git / data / package-lock.json — uninteresting payloads


### PR DESCRIPTION
## Summary

macOS BSD grep silently rejects three GNU-only ERE extensions that `scripts/secret-scan.sh` PATTERN relied on:

| Construct | Why GNU accepts | Why BSD rejects | Replacement |
|-----------|-----------------|-----------------|-------------|
| `\s` (Perl whitespace) | GNU silently treats as whitespace | not POSIX, error or literal `s` | `[[:space:]]` |
| `\-` inside `[A-Za-z0-9\-_]` | GNU collapses to `-` | BSD treats `\` as literal; class becomes "alpha-num + backslash + underscore" missing `-` | move `-` to END of class |
| `\x27` (hex escape) | GNU collapses to `'` | not POSIX, treated as 4 literal chars | inject literal `'` via shell variable concat |

## Failure mode (why CI was green on Linux)

BSD grep silently rejects the regex → `xargs ... 2>/dev/null` swallows the error → `|| true` keeps the script alive → `matches` ends up empty → script claims OK with exit 0 even when fixtures clearly contained credentials. **Linux GNU grep silently accepted the GNU-only constructs**, so CI looked green there. The cross-arch matrix on `macos-latest` is the only thing that surfaced this.

This closes the **dominant cluster** of macOS test failures: 14 of 15 `tests/unit/secret-scan.test.ts` cases. Issue #403 listed this as the headline failure.

## Bonus

Single-quoted credentials (`api_key='abc...'`) now match too. The old pattern's `["\x27]` character class was effectively `["\\x27]` (literal backslash + `x` + `2` + `7`) on **both** BSD and GNU, so the single-quote case never matched anywhere. Now `["']` matches both quote styles.

## Test plan

- [x] Linux GNU grep, 6 representative fixtures (AWS, GitHub PAT, OpenAI, single-quoted api_key, double-quoted api_key, PEM private key block) — **all flagged**.
- [x] `npx vitest run tests/unit/secret-scan.test.ts` → **15/15 pass** on Linux.
- [x] Pattern reasoned-through against POSIX ERE spec: every replacement maintains semantic intent.
- [ ] CI quality-gate green (waiting on push).
- [ ] `cross-arch (macos-latest)` job: secret-scan cluster should now report 15/15 pass on macos-latest. Verifies live on this PR's run.

## What this is NOT

Issue #403 has two clusters:
1. **secret-scan failures** — this PR.
2. **napi chain append lock timeout** on `~/.memphis/chains` — still open. Likely requires Mac access to debug Rust-side lock semantics.

So #403 stays open after this lands; only the secret-scan subtree closes. S11-2 (drop `continue-on-error: true` on cross-arch) still waits on the napi cluster.

## Files

- `scripts/secret-scan.sh` — PATTERN rewritten, portability rationale documented inline as a multi-line comment.

## Memory + plan

- Phase 6 of `~/.claude/plans/glowing-knitting-lobster.md` autopilot plan, partial. Wodzu's `4.B` (wait macOS parity before tag) inches forward.
- Sibling Phase 6 PR: #402 (S11-1 realTmpdir partial — managed-apps.vault-boundary).
- Sibling Phase 4: #401 (S9-1a NAPI resolver), #404 (S9-3 prebuilds workflow) both shipped.