### PR TITLE
feat(napi): wire loadPlatformAwareBridge across 5 adapters + optionalDependencies (S9-1b)

### DIFF
--- a/docs/dev/RUST-DISTRIBUTION.md
+++ b/docs/dev/RUST-DISTRIBUTION.md
@@ -64,9 +64,9 @@ Adding a new triple = add `crates/memphis-napi/npm/<triple>/package.json`
 |-------|------|------|
 | **S9-0** ✅ | npm tarball ships in-tree binary; postinstall probe + glibc/musl detection | shipped 2026-05-02 (#390) |
 | **S9-1a** ✅ | Platform-aware resolver + sub-package skeletons (no publishing) | shipped (#401) |
-| **S9-1b** | Add `optionalDependencies` to root `package.json` after sub-packages exist on registry | follow-up |
+| **S9-1b** ✅ | Add `optionalDependencies` + wire 5 callsites to `loadPlatformAwareBridge` | this PR |
 | **S9-2** | Drop in-tree `index.node` from npm tarball `files[]` (only platform sub-packages ship binaries) | follow-up |
-| **S9-3** ✅ | `prebuilds.yml` workflow: 4-platform matrix builds + publishes each sub-package | this PR |
+| **S9-3** ✅ | `prebuilds.yml` workflow: 4-platform matrix builds + publishes each sub-package | shipped (#404) |
 | **S9-4** | `postinstall-fetch-native.mjs` — fallback download from GH Release for offline/firewalled installs | follow-up |
 | **S9-5** | SHA256SUMS + Sigstore attestations per prebuild | partial via S8-1; full extension follow-up |
 

--- a/package.json
+++ b/package.json
@@ -206,7 +206,11 @@
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
-    "ollama": "^0.5.14"
+    "ollama": "^0.5.14",
+    "@memphis-chains/memphis-linux-x64-gnu": "*",
+    "@memphis-chains/memphis-linux-arm64-gnu": "*",
+    "@memphis-chains/memphis-darwin-x64": "*",
+    "@memphis-chains/memphis-darwin-arm64": "*"
   },
   "peerDependencies": {
     "ollama": ">=0.5.0"

--- a/src/infra/storage/case-chain-adapter.ts
+++ b/src/infra/storage/case-chain-adapter.ts
@@ -11,7 +11,7 @@ import {
   type NapiBlockData,
 } from './chain-file-io.js';
 import {
-  loadBridgeModule,
+  loadPlatformAwareBridge,
   resolveBridgeContract,
   type BridgeAliasMap,
   type BridgeResolution,
@@ -49,7 +49,10 @@ function getBridgePath(rawEnv: NodeJS.ProcessEnv): string {
 function resolveCaseBridge(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): BridgeResolution<CaseBridgeKey> {
-  return resolveBridgeContract(loadBridgeModule(getBridgePath(rawEnv)), CASE_BRIDGE_ALIASES);
+  return resolveBridgeContract(
+    loadPlatformAwareBridge(getBridgePath(rawEnv)),
+    CASE_BRIDGE_ALIASES,
+  );
 }
 
 function getIndexDbPath(rawEnv: NodeJS.ProcessEnv = process.env): string {

--- a/src/infra/storage/chain-adapter.ts
+++ b/src/infra/storage/chain-adapter.ts
@@ -2,7 +2,7 @@ import { lstatSync } from 'node:fs';
 
 import {
   hasRequiredBridgeExports,
-  loadBridgeModule,
+  loadPlatformAwareBridge,
   resolveBridgeContract,
   type BridgeAliasMap,
 } from './napi-contract.js';
@@ -44,7 +44,10 @@ export function getChainAdapterStatus(rawEnv: NodeJS.ProcessEnv = process.env): 
     };
   }
 
-  const resolution = resolveBridgeContract(loadBridgeModule(rustBridgePath), CHAIN_STATUS_ALIASES);
+  const resolution = resolveBridgeContract(
+    loadPlatformAwareBridge(rustBridgePath),
+    CHAIN_STATUS_ALIASES,
+  );
   if (!resolution.bridgeLoaded) {
     return {
       backend: 'ts-legacy',

--- a/src/infra/storage/rust-chain-adapter.ts
+++ b/src/infra/storage/rust-chain-adapter.ts
@@ -11,7 +11,7 @@ import {
   type NapiBlockData,
 } from './chain-file-io.js';
 import {
-  loadBridgeModule,
+  loadPlatformAwareBridge,
   resolveBridgeContract,
   type BridgeAliasMap,
   type BridgeResolution,
@@ -150,7 +150,10 @@ function getBridgePath(rawEnv: NodeJS.ProcessEnv): string {
 function resolveChainBridge(
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): BridgeResolution<ChainBridgeKey> {
-  return resolveBridgeContract(loadBridgeModule(getBridgePath(rawEnv)), CHAIN_BRIDGE_ALIASES);
+  return resolveBridgeContract(
+    loadPlatformAwareBridge(getBridgePath(rawEnv)),
+    CHAIN_BRIDGE_ALIASES,
+  );
 }
 
 function normalizeData(data: Record<string, unknown>): NapiBlockData {

--- a/src/infra/storage/rust-embed-adapter.ts
+++ b/src/infra/storage/rust-embed-adapter.ts
@@ -1,6 +1,6 @@
 import {
   hasRequiredBridgeExports,
-  loadBridgeModule,
+  loadPlatformAwareBridge,
   resolveBridgeContract,
   type BridgeAliasMap,
 } from './napi-contract.js';
@@ -104,7 +104,10 @@ function setToCache(key: string, value: EmbedSearchResult, ttlMs: number, now: n
 
 function resolveEmbedBridge(rawEnv: NodeJS.ProcessEnv = process.env) {
   const rustBridgePath = getBridgePath(rawEnv);
-  const resolution = resolveBridgeContract(loadBridgeModule(rustBridgePath), EMBED_BRIDGE_ALIASES);
+  const resolution = resolveBridgeContract(
+    loadPlatformAwareBridge(rustBridgePath),
+    EMBED_BRIDGE_ALIASES,
+  );
 
   return {
     rustBridgePath,

--- a/src/infra/storage/rust-vault-adapter.ts
+++ b/src/infra/storage/rust-vault-adapter.ts
@@ -17,7 +17,7 @@ import { dirname } from 'node:path';
 
 import {
   hasRequiredBridgeExports,
-  loadBridgeModule,
+  loadPlatformAwareBridge,
   resolveBridgeContract,
   type BridgeAliasMap,
   type BridgeResolution,
@@ -382,7 +382,11 @@ function resolveVaultBridge(rawEnv: NodeJS.ProcessEnv = process.env): {
   legacyContract: BridgeResolution<LegacyVaultBridgeKey>;
 } {
   const rustBridgePath = getBridgePath(rawEnv);
-  const bridge = loadBridgeModule(rustBridgePath);
+  // S9-1b: try platform sub-package first (`@memphis-chains/memphis-<triple>`),
+  // fall back to the in-tree bridge path. Behaviour-zero pre-publish; once
+  // sub-packages exist on the registry (S9-3 pipeline), this picks them up
+  // automatically without further code changes.
+  const bridge = loadPlatformAwareBridge(rustBridgePath);
   return {
     rustBridgePath,
     newContract: resolveBridgeContract(bridge, NEW_VAULT_BRIDGE_ALIASES),

--- a/src/onboarding/doctor.ts
+++ b/src/onboarding/doctor.ts
@@ -5,7 +5,7 @@ import { getDataDir } from '../config/paths.js';
 import { checkNodeVersion, checkRustToolchain } from '../infra/cli/utils/dependencies.js';
 import { resolveRustBridgePath } from '../infra/runtime/install-root.js';
 import {
-  loadBridgeModule,
+  loadPlatformAwareBridge,
   resolveBridgeContract,
   hasRequiredBridgeExports,
 } from '../infra/storage/napi-contract.js';
@@ -42,7 +42,7 @@ export class Doctor {
 
   private checkBridge(): DoctorResult['bridge'] {
     const bridgePath = resolveRustBridgePath();
-    const bridge = loadBridgeModule(bridgePath);
+    const bridge = loadPlatformAwareBridge(bridgePath);
     const resolution = resolveBridgeContract(bridge, CHAIN_BRIDGE_ALIASES);
 
     if (!resolution.bridgeLoaded) {


### PR DESCRIPTION
## Summary

Activates the per-platform sub-package distribution path that S9-1a (#401) scaffolded. Each adapter that loads the NAPI bridge now tries `@memphis-chains/memphis-<triple>` first via createRequire and falls back to the in-tree path on miss.

**Pre-publish the fallback always wins** (sub-packages don't exist on the registry yet), so behaviour for current operators is **unchanged**. Once the first `v*` tag fires `prebuilds.yml` (S9-3, #404) and 4 sub-packages are published, npm's `optionalDependencies` resolver picks the right one automatically and `loadPlatformAwareBridge` picks it up at runtime.

## Files changed

### Resolver wiring (5 adapters + 1 onboarding doctor)

Each callsite switched from `loadBridgeModule(path)` to `loadPlatformAwareBridge(path)`:

- `src/infra/storage/rust-vault-adapter.ts:resolveVaultBridge`
- `src/infra/storage/chain-adapter.ts:getChainAdapterStatus`
- `src/infra/storage/rust-chain-adapter.ts:getBridge`
- `src/infra/storage/rust-embed-adapter.ts:loadEmbedBridge`
- `src/infra/storage/case-chain-adapter.ts:resolveCaseBridge`
- `src/onboarding/doctor.ts:checkBridge`

### `package.json:optionalDependencies`

Added the 4 platform sub-packages with `*` version:

```json
"@memphis-chains/memphis-linux-x64-gnu": "*",
"@memphis-chains/memphis-linux-arm64-gnu": "*",
"@memphis-chains/memphis-darwin-x64": "*",
"@memphis-chains/memphis-darwin-arm64": "*"
```

`*` matches whatever's on the registry; npm picks the one matching `os`/`cpu`/`libc` declared in each sub-package.

## Pre-publish risk

`npm install` will warn about `optionalDependencies` that fail to install (the 4 sub-packages don't exist on the registry yet). This is **expected** — npm continues without them, the in-tree fallback handles all loads. After the first `v*` tag publishes (post v1.8.0), warnings disappear and platform sub-packages take over the load path.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Bridge-touching tests:
  - `tests/unit/napi-contract.test.ts` — **10/10 pass**
  - `tests/unit/chain-adapter.bridge-shape.test.ts` — **3/3 pass**
  - `tests/unit/durable-write-contract.test.ts` — **4/4 pass**
  - `tests/unit/rust-vault-bridge-path.test.ts` — **3/3 pass**
  - **Total: 20/20 pass on Linux**. Behaviour unchanged because the in-tree fallback hits first when no sub-package is installed.
- [ ] CI quality-gate green (waiting on push)

## Migration plan progress

| Phase | What | Status |
|-------|------|--------|
| S9-0 ✅ | npm tarball ships in-tree binary | shipped (#390) |
| S9-1a ✅ | Platform-aware resolver + sub-package skeletons | shipped (#401) |
| **S9-1b** ✅ | optionalDependencies + wire 5 callsites | **this PR** |
| S9-2 | Drop in-tree `index.node` from npm tarball `files[]` | follow-up (after first publish proven) |
| S9-3 ✅ | `prebuilds.yml` 4-platform matrix | shipped (#404) |
| S9-4 | postinstall fetch fallback from GH Release | follow-up |
| S9-5 | Sigstore attestations | follow-up |

## Memory + plan

- Phase 4 of `~/.claude/plans/glowing-knitting-lobster.md` autopilot plan, advancing the distribution chain.
- Sibling: #402 (S11-1 macOS realTmpdir partial), #405 (S11-2 secret-scan portable regex, just merged).
- Wodzu's `4.B` macOS path: secret-scan cluster fixed (PR #405 just merged); cli-router 1-test failure remains; napi-chain-append-lock-timeout is log noise not test failure.