### PR TITLE
release: v1.8.0 — security & honesty + per-platform distribution + Linux-canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,31 @@
-## Unreleased — v1.8.0
+## Unreleased
 
-Closes a 73-commit window since `v1.7.2` (2026-04-25 → 2026-05-02).
+## v1.8.0 - 2026-05-02
+
+Closes an 84-commit window since `v1.7.2` (2026-04-25 → 2026-05-02).
 Three primary themes: **security & authorization** hardening, **operator-trust**
-polish, and **npm distribution** readiness.
+polish, and **per-platform npm distribution** readiness.
 
-Highlights:
+### Platform support
+
+**Linux is the canonical v1.8.0 target.** Per-platform NAPI sub-packages
+are configured for `linux-x64-gnu`, `linux-arm64-gnu`, `darwin-x64`, and
+`darwin-arm64` (`prebuilds.yml` builds + publishes all four on tag),
+but macOS is **build-from-source** for v1.8.0: one cli-router test
+fails on `macos-latest` due to a `vi.doMock` timing issue (#407) that
+needs a Mac to debug. Prebuilt darwin sub-packages still ship; the
+`continue-on-error: true` flag on the cross-arch CI matrix stays
+until #407 closes (planned for v1.8.1). macOS operators with the Rust
+toolchain can still use Memphis end-to-end via `npm run build:rust`.
+
+### Highlights
 
 - Every state-mutating CLI command now requires operator authentication
   (`memphis auth audit` surfaces the gate matrix; `gapCount=0` on main).
-- `npm install` finally ships the Rust NAPI bridge binary — Linux x64
-  fresh installs work without a manual `npm run build:rust`.
+- `npm install` finally ships the Rust NAPI bridge — Linux x64 fresh
+  installs work without a manual `npm run build:rust`. Darwin/arm64
+  via build-from-source for v1.8.0 (per-platform prebuilds publish
+  via `prebuilds.yml` on tag, so v1.8.1 picks them up automatically).
 - First-run gate on `memphis chat` / `ask` / `tui` returns a `NOT_INITIALIZED`
   error pointing at `memphis init`, instead of silently falling back to a
   stub provider.
@@ -20,8 +36,9 @@ Highlights:
   the real Ollama provider with availability cache + 3 s probe timeout.
 - Matrix federation deleted (`-3085 LOC`) and the env / path-resolver
   layers consolidated to single sources of truth.
-- macOS cross-arch CI matrix went green for the first time (kept on
-  `continue-on-error: true` until the macOS-parity sprint flips it).
+- Release artifacts ship `SHA256SUMS` for integrity verification. GPG
+  signing scaffold present in `release.yml` — activates automatically
+  once `GPG_PRIVATE_KEY` repo secret is configured (deferred to v1.8.1).
 
 ### Security & Authorization
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Memphis is a local-first cognitive runtime born from [Oswobodzeni](https://oswob
 
 Every decision Memphis makes is recorded. Every secret is encrypted at rest. Every tool it touches requires your authorization. This is not a chatbot — it is a sovereign cognitive system designed for operators who refuse to rent their intelligence from Big Tech.
 
-**Current version: `v1.7.2`** (matches `package.json`) | **Status: production-ready for operator-supervised runtime** — vault hardening (0600 perms + heal-on-load), Rust+TS path resolver alignment, declarative provider cascade, cross-arch CI (linux + ubuntu-arm + macos), Telegram bot + Rust TUI surfaces, expanded secret-scan patterns (OpenAI / Stripe / GitHub / AWS / GCP / Slack / Anthropic). See `docs/CHANGELOG.md` for full history.
+**Current version: `v1.8.0`** (matches `package.json`) | **Status: production-ready for operator-supervised runtime** — vault hardening (0600 perms + heal-on-load), Rust+TS path resolver alignment, declarative provider cascade, cross-arch CI (linux + ubuntu-arm + macos), Telegram bot + Rust TUI surfaces, expanded secret-scan patterns (OpenAI / Stripe / GitHub / AWS / GCP / Slack / Anthropic). See `docs/CHANGELOG.md` for full history.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memphis-chains/memphis",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memphis-chains/memphis",
-      "version": "1.7.2",
+      "version": "1.8.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -56,6 +56,10 @@
         "node": ">=22"
       },
       "optionalDependencies": {
+        "@memphis-chains/memphis-darwin-arm64": "*",
+        "@memphis-chains/memphis-darwin-x64": "*",
+        "@memphis-chains/memphis-linux-arm64-gnu": "*",
+        "@memphis-chains/memphis-linux-x64-gnu": "*",
         "ollama": "^0.5.14"
       },
       "peerDependencies": {
@@ -1336,6 +1340,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@memphis-chains/memphis-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@memphis-chains/memphis-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@memphis-chains/memphis-linux-arm64-gnu": {
+      "optional": true
+    },
+    "node_modules/@memphis-chains/memphis-linux-x64-gnu": {
+      "optional": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memphis-chains/memphis",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Memphis sovereign AI runtime with chain-backed memory, encrypted vault, and a native operator console",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

**v1.8.0 release bump.** After this PR merges, `git tag v1.8.0 && git push --tags` fires the release workflows. Operator's autopilot decisions: scope=full polish; **macOS=build-from-source for v1.8.0** (pivot from 4.B → 4.A — cross-arch CI test #407 needs Mac access, deferred to v1.8.1); GPG signing + public npm publish deferred to v1.8.1.

## Changes

- `package.json` 1.7.2 → **1.8.0**
- `package-lock.json` regenerated to match
- `README.md` "Current version" header updated
- `CHANGELOG.md` "Unreleased — v1.8.0" promoted to "v1.8.0 - 2026-05-02"; added two clarifying sections:
  - **Platform support**: explicit Linux-canonical + macOS-via-source posture for v1.8.0
  - **Release artifacts**: `SHA256SUMS` always; GPG signatures auto-activate once secrets configured

## What this release ships

84 commits since v1.7.2 across three themes:
1. **Security & authorization hardening** (S5 — 6 PRs: auth sweep, audit matrix, rawEnv threading, factory honesty, anti-confabulation guard, vault perm enforcement)
2. **Per-platform npm distribution** (S9 — 5 PRs: NAPI tarball, platform resolver, sub-package skeletons, prebuild matrix, optionalDependencies wiring + 31-case contract test)
3. **Operator-trust polish** (S7+S10 — first-run gate, doctor `--fix --apply`, force-flag docs, RELEASE-PROCESS doc, doctor warns triage)

Plus 12 bug fixes (GLM timeout, MiniMax inline toolcall, vault path split, TUI background refresh, scheduler login shells, secret-scan portability...).

## Tag flow (post-merge)

```
git tag v1.8.0
git push origin v1.8.0
```

Triggers:
- `release.yml` → tarball + SHA256SUMS → GH Release page → npm publish to GH Packages (`@memphis-chains/memphis`)
- `prebuilds.yml` → 4 native-runner platform builds (linux-x64-gnu, linux-arm64-gnu, darwin-x64, darwin-arm64) → 4 sub-package publishes to GH Packages

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/ops/napi-subpackage-contract.test.ts tests/ops/public-status-docs-contract.test.ts` → 34/34 pass
- [x] `package-lock.json` regenerated cleanly via `npm install --package-lock-only`
- [ ] CI quality-gate green (waiting on push)

## Memory + plan

- Phase 1-6 of `~/.claude/plans/glowing-knitting-lobster.md` autopilot plan, capping the 11 PR session.
- After tag fires, monitor `release.yml` + `prebuilds.yml` runs; confirm 4 sub-packages land in GH Packages registry; confirm operator-discoverable Release page on GitHub.