### PR TITLE
docs(stale): STATUS-2026-05-02 markers on 4 obsolete planning docs (post-v1.8.0)

### DIFF
--- a/docs/AS-INTENDED-AUDIT-2026-04-26.md
+++ b/docs/AS-INTENDED-AUDIT-2026-04-26.md
@@ -1,5 +1,9 @@
 # Memphis "as intended" audit — 2026-04-26
 
+> **STATUS 2026-05-02**: snapshot pre-S5/S7/S8/S9/S11 sprints. v1.8.0 closed most of the gaps surfaced here (auth sweep gapCount=0, distribution chain end-to-end, doctor warns triage, force-flag docs, GPG release scaffold). **Do not cite this file as live state in future audits** — it captures the 2026-04-26 baseline before the 2026-04-29 → 2026-05-02 autopilot push (~30 PRs). For current state run `git log --oneline -30` and read `~/.claude/projects/-home-memphis/memory/project_session_2026_05_02_phase1to3.md`.
+
+---
+
 ## Provenance
 
 This document audits Memphis against the operator-defined evaluation function

--- a/memory/bugs-2026-03-27-post-ga.md
+++ b/memory/bugs-2026-03-27-post-ga.md
@@ -1,5 +1,16 @@
 # Post-GA Bug Review - 2026-03-27
 
+> **STATUS 2026-05-02**: all 4 findings closed by v1.8.0. **Do not cite this file as live state in future audits.**
+>
+> - #1 (`bin/memphis.js` `.ts` fallback): **CLOSED.** `bin/memphis.js:58-65` is now fail-closed with a clear "Memphis CLI build is missing" error; no `.ts` fallback path remains.
+> - #2 (`openclaw-plugin` doesn't build): **CLOSED.** Directory deleted entirely from the repo.
+> - #3 (artifact validator only probes `completion bash`): **PARTIALLY CLOSED.** `scripts/validate-package-artifact.mts:230-258` now probes `completion bash` AND `--help`. Adding `tui --check-only --json` is a v1.9.0+ nice-to-have, not a v1.8.0 blocker.
+> - #4 (deprecated OpenClaw docs in `package.json:files[]`): **CLOSED.** `package.json:13-21` ships only `dist`, `bin`, `scripts/install.sh`, `scripts/postinstall-check-native.mjs`, `crates/memphis-napi/index.node`, `README.md`, `LICENSE`. No OpenClaw docs.
+>
+> File kept for historical reference (the original triage process is documented in §"Commands used"). Archive candidate when planning docs are next consolidated.
+
+---
+
 ## Scope
 
 Quick post-`v1.0.0` review focused on concrete bugs or release-grade blind spots visible in the repo after GA.

--- a/notes/handoff-2026-04-27.md
+++ b/notes/handoff-2026-04-27.md
@@ -1,0 +1,101 @@
+# Handoff — end of session 2026-04-27
+
+> **STATUS 2026-05-02**: superseded by v1.8.0 release. All 5 PRs cited below (#318–#322) resolved:
+> - #318 CLOSED (superseded by #379 README version bump).
+> - #319 CLOSED (superseded by #375/#376/#378 — S1-1 vault perms + S1-2 secret-scan + S1-4 monitorRuntime cleanup).
+> - #320 / #321 / #322 MERGED 2026-04-29.
+>
+> v1.7.x release window closed; main is on **v1.8.0** as of 2026-05-02. **Do not cite this file as live "what's next" in future audits.** See `~/.claude/projects/-home-memphis/memory/project_session_2026_05_02_phase1to3.md` for current state.
+
+---
+
+## What's saved (everything pushed to origin)
+
+**5 open PRs ready for review/merge** (independent, any order):
+
+| PR | Title | Risk | Effort |
+|---|---|---|---|
+| **#322** | `docs(dev)`: codebase truth snapshot — 2026-04-27 | none (docs only) | merge whenever |
+| **#321** | `fix(cli)`: vault add/get/entry-delete accept positional key | low | merge after CI |
+| **#320** | `fix(env)`: parseBool accepts 1/yes/on truthy | low | merge after CI |
+| **#319** | `fix(security)`: vault file 0600 perms + secret-scan sk-/Stripe + listener cleanup (closes #275, #274, #277, #272) | medium | merge after CI |
+| **#318** | `docs(readme)`: bump version badge v1.4.0 → v1.7.2 | none | merge after CI |
+
+**4 releases shipped** in this session line: v1.7.0, v1.7.1, v1.7.2 + the in-flight fixes above.
+
+## Where the spaghetti is (per `docs/dev/CODEBASE-TRUTH-2026-04-27.md`)
+
+**Critical**: only 1 of 31 CLI handlers calls `requireOperatorAuth()`. 30 handlers do destructive ops (evolve, secret, tier, worker, telegram, consent, schedule, trust, provider) without passphrase challenge. That's issue #278's real surface area.
+
+**Big files**:
+- `crates/memphis-tui/src/app.rs` — 6 250 LOC (S4 split deferred)
+- `src/infra/http/server.ts` — 1 860 LOC
+- `src/infra/cli/utils/doctor-v2.ts` — 1 656 LOC
+- `src/infra/cli/commands/setup.ts` — 1 379 LOC
+
+**Storage adapter family**: `chain-adapter` vs `rust-chain-adapter` vs `case-chain-adapter` boundary undocumented; partial caller overlap.
+
+**Install path proliferation**: 5 entry points (`install.sh`, `bootstrap.sh`, `install-prerequisites.sh`, `06-fresh-install`, `memphis init`) with overlapping responsibilities for `.env`, vault pepper, agent profile, systemd unit. The canonical one (per README) is `curl ... install.sh | bash -s -- --with-init` — works end-to-end post-#316.
+
+**Test coverage gaps**: `turn-runtime.ts` (1118 LOC) has ONE test file. `doctor-v2.ts` and `setup.ts` have 3 each. Bottom-4 are operator-facing hot paths.
+
+## Simple advice — what to do next, ranked
+
+### Tier 1 — pick one of these (5-30 min each, low risk)
+
+1. **Merge #318–#322** when CI is green. They're all small, independent, well-tested. Five clicks of `gh pr merge`. Closes 4 open issues (#272, #274, #275, #277).
+
+2. **Tag v1.7.3** after the merges. Bump `package.json`, write a 5-line changelog, push tag, GitHub release. ~10 min. Marks the truth-snapshot + the operator-UX fixes as a release line.
+
+### Tier 2 — pick ONE focused refactor based on the truth snapshot
+
+Each is ~half-day work. Pick by what hurts you most:
+
+- **Auth-gating sweep (closes #278)**: gate destructive ops in the 9 most-relevant handlers behind `requireOperatorAuth()`. Reference: §5 of CODEBASE-TRUTH. ~3-4h. Highest leverage. Real security fix.
+
+- **Error-message standardization**: 3 outliers (`ask`/`chat`, `provider add`, `schedule add`) brought into the gold-standard pattern. Reference: §6. ~1h. Smallest unifying win.
+
+- **`promptHidden` dedupe**: extract one `src/infra/cli/utils/prompts.ts` helper, kill 3 copies. Reference: §2. ~1h. Removes ~150 lines.
+
+- **`getBridgePath` wrapper cleanup**: 5 vestigial wrappers post-#314 just delegate to `resolveRustBridgePath`. Inline them. Reference: §2. ~30 min.
+
+### Tier 3 — defer, but don't forget
+
+- **S4 app.rs split** — 5-PR fresh stack. Worth its own dedicated cycle.
+- **#270 SEGV on shutdown** — pino flush + Rust embed_shutdown ordering. Needs Rust knowledge.
+- **#271 singleton races** — Promise-based init guard pattern. Theoretical in single-threaded Node but defensible to fix.
+- **Voice runtime end-to-end** — Phase F shipped install deps; runtime hookup unverified.
+
+## Operator-side daily flow (verified working)
+
+```bash
+# Fresh install on any new PC:
+curl -fsSL https://raw.githubusercontent.com/Memphis-Chains/memphis/main/scripts/install.sh | bash -s -- --with-init
+
+# After install:
+memphis provider add minimax       # interactive: operator passphrase, then API key (hidden TTY)
+memphis tui                         # TUI cockpit
+# In TUI:
+#   /reload
+#   /provider minimax
+#   /model MiniMax-M2.7
+#   <ask anything>
+```
+
+**If `vault init` says already-initialized but `vault list` is empty** (today's recovery scenario):
+```bash
+MEMPHIS_VAULT_FORCE_REINIT=true memphis vault init   # =true required; =1 only works post-#320 merge
+```
+
+## Memory updated
+
+New entries:
+- `feedback_truth_before_refactor.md` — workflow for catalog-first, fix-second
+- Existing entries unchanged
+
+## Branch + state
+
+- Current branch: `main` (fresh-pulled)
+- All work pushed; no uncommitted changes in tracked files
+- 5 PRs open as listed above
+- Working tree at `/home/memphis/memphis/` is clean for next session

--- a/notes/sprints/2026-04-26-tui-full-mode-and-self-awareness.md
+++ b/notes/sprints/2026-04-26-tui-full-mode-and-self-awareness.md
@@ -1,0 +1,287 @@
+# Sprint pre-plan: TUI full-mode + agent self-awareness
+
+> **STATUS 2026-05-02**: pre-plan delivered. TUI `/tier 0/1/2` dispatch landed in Sprint S2 (`crates/memphis-tui/src/app.rs:4339-4340`, post 2026-04-26). `/mode A|B|C|D|E` already in `app.rs:325-326`. **Do not cite this file as live "what's missing in TUI" in future audits.** TUI feature parity with Telegram for the tier ladder is achieved as of v1.8.0.
+
+---
+
+**Author:** Claude (deep search 2026-04-26)
+**Status:** Pre-plan — operator review przed `/plan`
+**Triggered by:** dzisiejsza sesja TUI/Telegram. Operator zauważył:
+- Bot LLM mówi *"tier 3 — zablokowane, nie mam takich narzędzi"* (already fixed PR #281)
+- TUI Rust nie obsługuje `/tier 0/1/2`, tylko `/tier 3 <pass>`, `/tier status`, `/tier revoke`
+- Bot nie wie o całym capability surface od startu
+- Logi TUI: *"unsupported command: `/tier 2 xep624624xep&A`. This Rust TUI only runs native or host-backed commands by default. ... rerun it as /legacy tier 2 xep624624xep&A"*
+
+---
+
+## Część 1 — TUI full-mode refactor
+
+### Stan obecny (z deep-search)
+
+**Architektura:** dwa procesy, dwa języki.
+- `crates/memphis-tui/` (Rust, **8009 LoC**, ratatui-based) — UI loop, slash commands, status bar, widgets
+- `src/infra/tui-host/` (TypeScript, **1135 LoC**) — extension host backing native TUI commands przez NDJSON RPC
+
+**Slash command dispatch w Rust TUI** (`app.rs`):
+- *Native commands* — handled w Rust (np. `/help`, `/tier`, `/journal`, `/recall`)
+- *Host-backed commands* — Rust → IPC do TS host przez `ExtensionHostCommand{ label, command, args }` (`security.tier.elevate`, `security.tier.status`, etc.)
+- *Legacy fallback* — `/legacy <cli args>` runs `memphis --json <args>` jako one-shot subprocess
+- *Unknown commands* → `unsupported_tui_command_notice` (linia 4242-4250) z hint do `/legacy`
+
+**Tier slash handler** (`app.rs:4159-4194`):
+```rust
+// Obsługiwane:
+//   /tier              → security.tier.status
+//   /tier status       → security.tier.status
+//   /tier revoke       → security.tier.revoke
+//   /tier 3 <pass>     → security.tier.elevate {tier:3, passphrase}
+// NIE obsługiwane:
+//   /tier 0|1|2 ...    → fallthrough do _ => Ok(None) → "unsupported"
+```
+
+**Gdzie tier 0/1/2 IST obsługiwane:** w **Telegram** (`src/gateway/channels/telegram.ts:170-200`) — full `/tier <0|1|2|3>` handler z TTL 15min na non-default tiers.
+
+### Asymetria
+
+| Surface | `/tier 0` | `/tier 1` | `/tier 2` | `/tier 3 <pass>` | `/tier status` | `/tier revoke` |
+|---|---|---|---|---|---|---|
+| **Telegram** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **TUI** | ❌ "unsupported" | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **CLI** | n/a (separate process) | n/a | n/a | n/a | ⏳ shipping #282 | ❌ |
+
+### Inne brakujące rzeczy w TUI
+
+W deep-search znalazłem (przed-decyzyjnie):
+
+1. **Cognitive mode switching** (`/mode A|B|C|D|E`) — Rust TUI status bar pokazuje `[Mode:B]` ale **nie ma slash command** aby zmienić. LLM potencjalnie może wywołać tool `memphis_cognitive_mode_set` (tier 2)... ale ten tool **NIE MA handlera** (sprawdź sekcję 2 poniżej).
+
+2. **Full slash help discovery** — `/help` istnieje, ale trudno znaleźć "wszystkie slash commands". Surface vs CLI vs MCP commands rozłożone w wielu miejscach.
+
+3. **Restart / config reload** — `/legacy restart` działa ale wymaga full CLI roundtrip. Native slash mógłby być szybszy.
+
+4. **Status bar info elevation** — pokazuje `Mode:B · ctx:32k · tok~ · ready · PULSE:healthy · session:...`, ale NIE pokazuje tier elevation status (tier 3 active? gdy/expires?).
+
+5. **Tools listing** — operator nie ma sposobu wyświetlić `co bot może zrobić` w TUI. Tylko `/help` o slash commands, nie o LLM toolach.
+
+### Proponowany scope refactoringu (do plan mode)
+
+**Faza A: Symmetry — TUI dorównuje Telegramowi (1-2 dni):**
+- A1. `/tier 0`, `/tier 1`, `/tier 2` w Rust TUI (linia 4194 fallthrough → dodać arms)
+- A2. Każdy non-3 tier → host command `security.tier.set` (need TS handler) → `clearSessionAuth` + reset env override
+- A3. Status bar tile dla aktywnego tier 3 (countdown)
+
+**Faza B: Cognitive mode parity (0.5 dnia):**
+- B1. `/mode A|B|C|D|E` slash w Rust TUI → host command `cognitive.mode.set`
+- B2. TS handler in `src/infra/tui-host/commands.ts` dispatching to cognitive engine
+- B3. Wymaga ŻEBY tool `memphis_cognitive_mode_set` faktycznie istniał (zob. Część 2 — to jest **blocker**)
+
+**Faza C: Self-awareness in TUI (1 dzień):**
+- C1. `/tools` slash command — pokazuje aktywny `availableTools` list z tierem każdego
+- C2. `/skills` slash — already exists in CLI, port to TUI
+- C3. `/cognitive` slash — pokazuje aktualny mode + opisy A-E
+- C4. `/surface` slash — pokazuje surface policy (maxToolTier, allow flags)
+
+**Faza D: Status bar enhancement (0.5 dnia):**
+- D1. Pokaż tier 3 active/inactive + remaining time
+- D2. Pokaż czy /tier elevation jest "useful" (czy są tier-2/3 toolsy faktycznie dostępne)
+- D3. Expand mode info — `[Mode:B (Inferred Decisions)]` zamiast tylko `[Mode:B]`
+
+**Faza E: Help unification (0.5 dnia):**
+- E1. `/help slash` — wszystkie slash commands grouped by category
+- E2. `/help tools` — co LLM może wywołać w obecnej sesji
+- E3. `/help cli` — referencja do `memphis --help` i `/legacy`
+
+**Total estimate:** 3-4 dni solo-dev.
+
+### Ścieżki kodu do dotknięcia
+
+Rust:
+- `crates/memphis-tui/src/app.rs` — slash dispatch (linia ~4100-4200), command handlers, status bar (linia ~600-900 ui rendering), help text (linia ~1440-1450)
+- `crates/memphis-tui/src/ui.rs` (385 LoC) — main render loop
+
+TypeScript host:
+- `src/infra/tui-host/commands.ts` — host command dispatch table; nowe handlery dla `security.tier.set`, `cognitive.mode.set`
+- `src/infra/tui-host/protocol.ts` — extend `ExtensionHostCommand` if needed (probably not — `args: json!{}` is generic)
+
+### Risks
+
+- Rust TUI is **8009 LoC in one file** (`app.rs`). Każda zmiana powiększa technical debt. **Sugerowane**: refactor wziąć jako okazję na rozdrobnienie (slash module, status module). Ale to scope creep.
+- Niektóre native commands kolidują z `memphis <command>` CLI. Spójność potrzebna — slash commands muszą mówić "this is TUI-only" jeśli różnią się od CLI.
+- Wymagane testy — dziś `app.rs` ma testy (`#[cfg(test)] mod tests`) na slash parsing (linia ~5350+), ale nie pełen integration test.
+
+---
+
+## Część 2 — Memphis agent self-awareness
+
+### Stan obecny
+
+**Tool registry** (`src/gateway/tool-registry.ts`) ma **37 toolsów** z metadanymi (name, tier, capabilities, description, optional inputSchema, optional featureFlag).
+
+**Tool executor** (`src/gateway/tool-executor.ts:1097`) — `createInProcessToolExecutor` buduje runtime tools przez `createRuntimeTools(deps)` (linia 157). To zwraca `RuntimeToolDefinition[]` z handlerami `execute`.
+
+**`listTools()`** (linia 1100) — filtruje przez `isEnabled()` = `upstreamEnabled() && isToolEnabledByFeatureFlag(tool.name)`.
+
+**Surface policy filter** (`src/gateway/turn-runtime.ts:313-320`) — `constrainToolExecutorToSurface` filtruje przez `isToolAllowedForSurface(tool, policy)` = `meta.tier <= policy.maxToolTier`.
+
+**System prompt** (`src/gateway/system-prompt.ts`) — bierze `availableTools: string[]` (lista NAZW) z calling code, renderuje per-tool blok przez hand-authored `<tool>...</tool>` lub `autoGenToolDoc` (linia 173).
+
+### Krytyczne luki
+
+#### Luka 1: 7 toolsów w registry NIE MAJĄ handlera w executor
+
+Diff between registry and executor (sprawdzone deep-search):
+
+```
+W registry, NIE w executor (LLM nie może ich wywołać, ale widzi w nazwach):
+  memphis_cognitive_mode_set    (tier 2) ← KLUCZOWY dla switching cognitive mode
+  memphis_config_reload          (tier 2)
+  memphis_config_set             (tier 2)
+  memphis_config_show            (tier 0)
+  memphis_loop_step              (tier 2)
+  memphis_presence               (tier 0)
+  memphis_restart                (tier 2)
+```
+
+**Skutek:** LLM widzi `cognitive_mode_set` w docs, próbuje wywołać, dostaje `tool not found` lub similar. Operator obserwuje "bot mówi że nie ma takich narzędzi" — częściowo to dlatego.
+
+**Status:** wymaga 7 nowych runtime handlerów w `tool-executor.ts` lub zastosowanie `executeTool` dispatch do innych modułów (config handler, presence broadcaster, etc.).
+
+#### Luka 2: Tier-2 tools nie są domyślnie dostępne LLM-owi w TUI/Telegram
+
+Surface policy default `maxToolTier: 2` dla TUI i Telegram. **Powinno** odsłaniać tier 0+1+2 (~33 tools). Ale operator's observation:
+
+> Dostępne mi toolsy: memphis_journal, memphis_recall, memphis_search, memphis_decide, memphis_health, memphis_repair, memphis_soul_read, memphis_soul_write — wszystkie tier 0
+
+Tylko 8 tier-0 toolsów. Pozostałych ~25 tier-2 brak.
+
+**Hipoteza:** caller `buildAgentSystemPrompt({availableTools: ...})` nie przekazuje pełnej listy. Może filtruje wcześniej, albo lista jest hard-coded gdzie indziej (np. provider-specific filter for minimax model).
+
+**Trzeba zweryfikować** w plan mode: czy `normalizedToolExecutor.listTools()` (linia 788 turn-runtime.ts) faktycznie zwraca 33 toolsy gdy surface policy maxToolTier=2.
+
+#### Luka 3: System prompt nie agreguje całej capability surface od startu
+
+System prompt (po PR #281 merge) ma `<tier_system>` block, ale **nie ma** `<capabilities>` block z explicit listą:
+
+```
+- Co mogę zrobić jako Memphis Agent z aktualnym tierem
+- Jakie surface policy jest aktywne
+- Co mogę zaproponować operatorowi (slash commands w TUI, /tier elevation)
+- Jakie tool gaps istnieją (np. "memphis_cognitive_mode_set is registered but not yet wired")
+```
+
+Bez tego LLM **odpowiada z niepewnością** — zobacz operator's TUI snippet:
+> "mam ograniczony dostęp (tier 0), więc bez TUI/passphrase nie mogę modyfikować plików ani kodu."
+
+To częściowo prawda (tier 0 = read), ale operator JEST w TUI z tier 3 active. LLM nie *czyta swojego stanu*.
+
+#### Luka 4: Brak `memphis_self_describe` tool
+
+Bot nie może na żądanie przedstawić listy swoich narzędzi z opisami. `memphis_health` (tier 0) zwraca runtime status, ale nie pełen tool inventory.
+
+**Proponowany tool:** `memphis_self_describe` (tier 0, read-only) — zwraca:
+- aktualny surface
+- aktualny tier (z elevation status)
+- aktualny cognitive mode
+- pełną listę `availableTools` z tierem i opisem
+- listę feature flags enabled
+- listę tier-3 sessions (wszystkie surfaces)
+
+Bot wywoła go gdy operator pyta "co umiesz" zamiast halucynować z out-of-date training data.
+
+### Proponowany scope refactoringu (do plan mode)
+
+**Faza A: Wire missing tools (1-2 dni):**
+- A1. `memphis_cognitive_mode_set` handler w tool-executor → wywoła `setCognitiveMode(mode)` w cognitive engine
+- A2. `memphis_config_show` (read-only redacted view; reuse logic z `/v1/ops/config/show`)
+- A3. `memphis_config_set` + `memphis_config_reload` (write — wymaga tier 2 + audit; reuse `setDotEnvValues` + `performHotReload`)
+- A4. `memphis_restart` — graceful self-restart (wymaga operator passphrase per existing pattern w restart.ts)
+- A5. `memphis_presence` — broadcast presence event (hook do federation peer storage)
+- A6. `memphis_loop_step` — debug single-step in cognitive loop engine
+
+**Faza B: Verify tier-2 surface flow (0.5 dnia):**
+- B1. Add integration test: surface=telegram, maxToolTier=2 → `availableTools` ma ~33 names
+- B2. Find regression: dlaczego operator obserwował tylko 8. Może w starym build bez fix #281, albo prov-specific filter w minimax adapter
+
+**Faza C: Self-describe tool (1 dzień):**
+- C1. Add `memphis_self_describe` to registry (tier 0)
+- C2. Handler returns structured snapshot: surface, tier, mode, tools, flags, tier3-sessions
+- C3. Tests: assert returns include real registered tools
+
+**Faza D: System prompt enrichment (0.5 dnia):**
+- D1. Add `<capabilities>` block to system-prompt z structured info (current surface/tier/mode)
+- D2. Add `<known_gaps>` block — listing tools-not-yet-wired (so LLM nie kłamie że są dostępne)
+- D3. Tests: assert gaps disappear gdy Faza A się skończy
+
+**Faza E: Operator-facing CLI (0.5 dnia):**
+- E1. `memphis tools list [--tier 0|1|2|3] [--surface telegram|tui]` — CLI command exposing same data
+- E2. `memphis tools describe <name>` — single tool deep dive
+- E3. Reuse `memphis_self_describe` data via HTTP endpoint similar to PR #282 pattern
+
+**Total estimate:** 4-5 dni solo-dev.
+
+### Ścieżki kodu do dotknięcia
+
+- `src/gateway/tool-executor.ts:157` `createRuntimeTools` — add 7 missing handlers
+- `src/gateway/tool-registry.ts` — add `memphis_self_describe` entry (tier 0)
+- `src/gateway/system-prompt.ts` — add `<capabilities>` + `<known_gaps>` blocks
+- `src/cognitive/modes.ts` + new helper `setCognitiveMode(mode)` if not exists
+- `src/infra/cli/handlers/` — new `tools.handler.ts` for `memphis tools list/describe`
+- `src/infra/http/server.ts` — new `GET /v1/ops/capabilities` endpoint (auth-token gated, mirror PR #282)
+
+### Risks
+
+- **Tool registration audit cascade** — niektóre toolsy mogą wymagać operator-passphrase per call (tier 2 tools z security gate). Trzeba sprawdzić czy `memphis_cognitive_mode_set` ma pre-existing gate logic gdzieś.
+- **`memphis_self_describe` data privacy** — pokazując pełny tool inventory + flags, ujawnia capability ankietę. Dla tier-0 to OK; trzeba zdecydować czy redact featureFlag visibility.
+- **System prompt token budget** — `<capabilities>` block + `<known_gaps>` to ~30-50 tokenów. Niski koszt; warto sprawdzić token tests.
+- **TUI commands re-instalacja** — operator ostrzegł że może re-install Memphisa lokalnie (świeży install z merge'em wszystkich PRów); plan musi tolerować zarówno świeży install jak i live upgrade z aktualnego state.
+
+---
+
+## Wspólne ryzyko: re-install lokalny
+
+Operator powiedział: *"możemy przeinstalować i zrobić nową iterację memphis lokalnie — ale to musi robić operator — czyli ja"*. Czyli plan może wymagać:
+
+1. Merge wszystkich pending PRów do main: #279 (vault bulletproof), #280 (MP v0), #281 (system prompt), #282 (tier status)
+2. Operator: `memphis reset --runtime --yes` LUB ręcznie wipe `~/.memphis/`, potem `memphis init`
+3. Operator: re-add 3 vault entries (minimax/telegram_bot_token/telegram_allowed_user_ids)
+4. Plan-mode work landuje na świeżym main z czystym stanem
+
+To upraszcza testowanie (no legacy migration concerns) ale wymaga operatora mid-sprint.
+
+---
+
+## Materiały referencyjne (file:line index)
+
+### Tier system
+- `src/security/tier3-session.ts` — sessions Map, request/grant/revoke
+- `src/gateway/channels/telegram.ts:113-200` — Telegram /tier full handler
+- `crates/memphis-tui/src/app.rs:4159-4194` — TUI /tier partial handler (only 3+status+revoke)
+- `src/infra/cli/handlers/tier.handler.ts` — CLI tier status (PR #282)
+
+### Tool surface
+- `src/gateway/tool-registry.ts` — 37 tools metadata (single source of truth)
+- `src/gateway/tool-executor.ts:1096-1122` — listTools + execute, createInProcessToolExecutor
+- `src/gateway/turn-runtime.ts:304-343` — constrainToolExecutorToSurface (tier filter)
+- `src/gateway/surface-policy.ts:230-234` — isToolAllowedForSurface
+
+### System prompt
+- `src/gateway/system-prompt.ts` — buildSystemPrompt, autoGenToolDoc, renderCognitiveModesBlock
+- `src/gateway/agent-runtime.ts:170-187` — buildAgentSystemPrompt caller
+
+### Cognitive modes
+- `src/cognitive/modes.ts` — A/B/C/D/E definitions
+- `src/cognitive/mode-dispatch.ts` — runtime dispatch by mode
+
+### TUI host RPC
+- `src/infra/tui-host/commands.ts:1-891` — TS-side command dispatch
+- `src/infra/tui-host/protocol.ts:1-103` — NDJSON protocol shape
+
+---
+
+## Pytania dla operatora przed plan mode
+
+1. **Scope priorytet:** robimy obie części (TUI full-mode + self-awareness) jako jeden duży sprint, czy jako dwa osobne sprinty (TUI najpierw, awareness potem)?
+2. **Re-install timing:** kiedy operator chce zrobić reset? Przed sprintem (czysty start), w środku (po Fazie A każdej części), czy na końcu (verify)?
+3. **`memphis_self_describe` privacy:** czy redact tool descriptions które ujawniają tier-2 capabilities? Default proposed: **no redaction** (operator-only surfaces).
+4. **TUI cognitive mode visibility:** dziś status bar pokazuje `[Mode:B]` (literal). Po Fazie B chcemy `[Mode:B (InferredDecisions)]` — confirm operator preference.
+5. **Tool gaps disclosure:** w `<known_gaps>` system-prompt block — czy podawać konkretną listę nie-wired tools, czy tylko "some tier-2 tools are not yet wired; ask operator"?


### PR DESCRIPTION
## Summary

Memphis Agent (Telegram bot) cited each of these 4 docs as **live state** in follow-up audits this session, despite all 4 being 5+ days stale by the v1.8.0 cut. Adding an explicit `> **STATUS 2026-05-02**: …` header at the top of each file gives the bot a textual signal it can text-grep, instead of parsing the entire file as authoritative current-state.

This is the **cheap-mechanical layer** of the bot-context fix discussed in the parent autopilot session (see chat). Free-prompt-engineering and real-engineering layers ship in v1.8.1 / v1.9.0 separately.

## Files

| File | Status header content |
|------|-----------------------|
| `memory/bugs-2026-03-27-post-ga.md` | All 4 findings closed by v1.8.0 (bin/memphis.js fail-closed, openclaw-plugin deleted, validator probes 2 commands, files[] OpenClaw docs removed) |
| `notes/handoff-2026-04-27.md` | All 5 cited PRs (#318–#322) merged or superseded by 2026-04-29 |
| `docs/AS-INTENDED-AUDIT-2026-04-26.md` | Snapshot pre-S5/S7/S8/S9/S11 sprints; v1.8.0 closed most gaps |
| `notes/sprints/2026-04-26-tui-full-mode-and-self-awareness.md` | TUI `/tier 0/1/2` + `/mode A\|B\|C\|D\|E` already in `app.rs` |

## ⚠️ Heads up — this PR adds 2 previously-untracked files

`notes/handoff-2026-04-27.md` and `notes/sprints/2026-04-26-tui-full-mode-and-self-awareness.md` were **untracked** in your working tree (existed locally, never git-added). My commit added them. If you preferred them untracked-only-locally, drop the file adds and re-commit just the 2 modifications to `memory/bugs-…` and `docs/AS-INTENDED-…`. Otherwise leaving them in git is fine — they get the STALE marker baked in so future bot/dev contexts see them properly framed, and the `Author: Claude (deep search 2026-04-26)` provenance stays intact.

## What this is NOT

- Not deleting these docs (still useful as historical snapshots)
- Not the prompt-engineering or runtime anti-confab work — those are separate
- Not blocking the v1.8.0 tag (already pushed; release.yml + prebuilds.yml in flight)

## Test plan

- [x] All 4 files keep their original content; only the STATUS block prepended.
- [x] Doc-link contract test would pass (no link changes, only metadata header).
- [ ] CI quality-gate green (waiting on push)

## Memory

After this lands, the bot's next planning-doc audit should NOT cite these as live findings. We'll see if it works on the next bot session.