### PR TITLE
fix(release-smoke): first-run stub + force vault re-init (unblock v1.8.0 release.yml)

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -104,12 +104,42 @@ export MEMPHIS_VAULT_STATE_PATH="$TMP_WORK/data/vault-state.json"
 export MEMPHIS_VAULT_PEPPER="memphis-0123456789abcdef0123456789abcdef"
 export RUST_CHAIN_ENABLED=true
 export RUST_CHAIN_BRIDGE_PATH="$BRIDGE_PATH"
+# The smoke is a test scenario, not a production install. The bootstrap
+# wizard above (`onboarding wizard --profile dev-local --force`) writes
+# template vault entries into the fresh tmpdir; the explicit `vault init`
+# step further down then triggers the existing-entries guard
+# (#279 hardening). Setting FORCE_REINIT=1 here lets the smoke wipe and
+# re-initialize the test vault deliberately. Production operators NEVER
+# set this flag silently — see docs/operator/FORCE-FLAGS.md.
+export MEMPHIS_VAULT_FORCE_REINIT=1
 
 run_cli() {
   (cd "$TMP_WORK" && "$ROOT_DIR/node_modules/.bin/tsx" "$ROOT_DIR/src/infra/cli/index.ts" "$@")
 }
 
 run_cli onboarding wizard --write --profile dev-local --out .env --force --json >"$BOOTSTRAP_JSON"
+
+# S10-5 (#393) added a first-run gate on chat/ask/tui — without an
+# `initialized-clean` record the smoke's `chat` invocation below exits 1
+# with NOT_INITIALIZED instead of producing the canonical local-fallback
+# acceptance turn. We can't run the full `memphis init --non-interactive`
+# flow here because it initializes the real vault, conflicting with the
+# explicit `vault init` step further down (and the mock bridge).
+# Instead, write a minimal `initialized-clean` first-run record stub
+# directly at the canonical path: <dataDir>/config/first-run.json.
+mkdir -p "$MEMPHIS_DATA_DIR/config"
+cat >"$MEMPHIS_DATA_DIR/config/first-run.json" <<'EOF'
+{
+  "schemaVersion": 1,
+  "initializedAt": "2026-05-02T00:00:00.000Z",
+  "mode": "minimal-baseline",
+  "createdChains": [],
+  "createdBlocks": 0,
+  "summary": "smoke-test stub for first-run gate (S10-5 bypass)",
+  "origin": "controlled-init"
+}
+EOF
+
 run_cli guide --json >"$GUIDE_JSON"
 
 set +e


### PR DESCRIPTION
## Summary

The release.yml `test` job failed on the v1.8.0 tag (silent exit 1 in `Run shared release gates`). Local trace identified **two** v1.8.0-era guards that landed without updating the smoke-test fixture:

1. **S10-5 (#393) first-run gate** rejects `chat` / `ask` / `tui` when no `<dataDir>/config/first-run.json` exists. The smoke's bootstrap wizard writes `.env` + agent profile but NOT the first-run record. Without it, `run_cli chat` exits 1 with `NOT_INITIALIZED`.

2. **Vault re-init guard (#279)** refuses `vault init` when entries already exist on disk. The bootstrap wizard's `dev-local` profile leaves 4 template entries in the test tmpdir, then the explicit `run_cli vault init` step triggers the guard with: `Vault has 4 existing entries — refusing re-init`.

Both guards landed pre-v1.8.0; v1.7.x release.yml passed because the bootstrap wizard's behaviour or the smoke flow was different at that snapshot. By v1.8.0 the smoke needs both fixes.

## Fix

```diff
+ # Write minimal initialized-clean stub at canonical path so S10-5 gate passes.
+ mkdir -p "$MEMPHIS_DATA_DIR/config"
+ cat >"$MEMPHIS_DATA_DIR/config/first-run.json" <<'EOF'
+ { "schemaVersion": 1, ... "origin": "controlled-init" }
+ EOF

+ # Test scenario, not production — let smoke wipe its throwaway vault.
+ export MEMPHIS_VAULT_FORCE_REINIT=1
```

`MEMPHIS_VAULT_FORCE_REINIT` is **only** set inside `scripts/smoke-test.sh`'s exported test env. Production operators never see it — `docs/operator/FORCE-FLAGS.md` (S7-1, #395) is the canonical reference and explicitly warns against silent use.

## Test plan

- [x] `bash ./scripts/smoke-test.sh` → **SMOKE_TEST_OK**, exit 0 (~3 min on Linux dev box, all 8 CLI invocations green)
- [ ] CI quality-gate green (waiting on push)
- [ ] After merge: re-trigger release for v1.8.0 (force-delete tag + retag, OR cut v1.8.1)

## What's next for the v1.8.0 release

Once this lands the path forward is:

**Option A** — re-tag v1.8.0:
1. `git tag -d v1.8.0 && git push --delete origin v1.8.0` (destructive but acceptable: nothing public consumed v1.8.0 yet because the failed run never created a GH Release page or published the root npm package)
2. `git tag -a v1.8.0 <new-main-sha> && git push origin v1.8.0`
3. Watch release.yml + prebuilds.yml fire green

**Option B** — cut v1.8.1:
1. Bump `package.json` 1.8.0 → 1.8.1 + CHANGELOG entry
2. Tag v1.8.1
3. Watch CI green; sub-packages already at 1.8.0 work via `*` version range

Recommendation: **A**. Smaller blast radius, matches operator's tag intent.