### PR TITLE
fix(test): unblock cli.tui.test.ts past S10-5 first-run gate (CI v1.8.0)

### DIFF
--- a/tests/unit/cli.tui.test.ts
+++ b/tests/unit/cli.tui.test.ts
@@ -1,11 +1,38 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { runCli } from '../helpers/cli.js';
+import { realTmpdir } from '../helpers/tmpdir.js';
 
 describe('CLI tui output', () => {
-  it('prints framed output for --tui', async () => {
+  it('prints framed output for --tui', { timeout: 60_000 }, async () => {
+    // Post-S10-5 (#393), `ask`/`chat`/`tui` reject with NOT_INITIALIZED
+    // when no first-run record exists. Set up an isolated tmpdir + minimal
+    // initialized-clean stub at <dataDir>/config/first-run.json so the
+    // gate clears and we can exercise the actual --tui rendering.
+    const dataDir = mkdtempSync(join(realTmpdir(), 'memphis-cli-tui-'));
+    mkdirSync(join(dataDir, 'config'), { recursive: true });
+    writeFileSync(
+      join(dataDir, 'config', 'first-run.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        initializedAt: '2026-05-02T00:00:00.000Z',
+        mode: 'minimal-baseline',
+        createdChains: [],
+        createdBlocks: 0,
+        summary: 'cli.tui test stub for first-run gate (S10-5 bypass)',
+        origin: 'controlled-init',
+      }),
+      'utf8',
+    );
+
     const out = await runCli(['ask', '--input', 'hello', '--tui'], {
-      env: { DEFAULT_PROVIDER: 'local-fallback' },
+      env: {
+        DEFAULT_PROVIDER: 'local-fallback',
+        MEMPHIS_DATA_DIR: dataDir,
+      },
     });
 
     expect(out).toContain('memphis ask');


### PR DESCRIPTION
## Summary

After PR #412 fixed `scripts/smoke-test.sh`, the v1.8.0 retag's release.yml `test` job got further but hit the next gate-related failure: `tests/unit/cli.tui.test.ts > prints framed output for --tui` exits with `NOT_INITIALIZED` because it calls `memphis ask --tui` against a runtime with no first-run record.

This PR ships:

1. **first-run stub**: write minimal `initialized-clean` record at `<dataDir>/config/first-run.json` (same pattern as the smoke-test.sh fix).
2. **timeout extension**: bump test timeout 15 s → 60 s. Local repro confirms the actual `ask --tui` flow takes ~20 s on Linux (provider init + tool registry + render). The 15 s default was OK pre-S10-5 because the gate failed fast when not bypassed; now we exercise the full path.

This is the final piece needed for v1.8.0 release.yml to go green.

## Test plan

- [x] `npx vitest run tests/unit/cli.tui.test.ts` → **PASS** (~26 s)
- [ ] CI quality-gate green (waiting on push)
- [ ] After merge: re-tag v1.8.0 again, watch release.yml + prebuilds.yml fire green end-to-end

## After this lands

Force-delete v1.8.0 again and re-tag on the new fix commit. Same pattern as before — nothing public consumed v1.8.0 yet.