### PR TITLE
feat(providers): Ollama-first cascade order (sovereign-AI default)

### DIFF
--- a/docs/operator/operator-handbook.md
+++ b/docs/operator/operator-handbook.md
@@ -56,8 +56,9 @@ Reference: [GETTING-STARTED.md](./GETTING-STARTED.md),
   meta-cognitive reflection. [cognitive-modes.md](./cognitive-modes.md)
   enumerates all five.
 - **Provider cascade**: the default order is
-  `anthropic → minimax → ollama → local-fallback`. Override with
-  `MEMPHIS_PROVIDER_CASCADE=…` in `.env` + `/config reload`. See
+  `ollama → anthropic → minimax → local-fallback` (sovereign-AI: local
+  model first, online flagship as fallback for harder turns). Override
+  with `MEMPHIS_PROVIDER_CASCADE=…` in `.env` + `/config reload`. See
   the [provider registry](./API-REFERENCE.md#providers) for which
   providers support OAuth vs API-key.
 - **On-the-fly config** — every hot/warm field can be changed without
@@ -142,7 +143,7 @@ Full matrix: [surface-parity.md](./surface-parity.md).
 
 Targets we regress against in CI (see [slo-baseline.md](./slo-baseline.md)):
 
-- Turn p95 ≤ 8s on cascade `anthropic → minimax → ollama`
+- Turn p95 ≤ 8s on cascade `ollama → anthropic → minimax`
 - `/status` ≤ 500ms
 - Vault unlock ≤ 200ms
 - `chain verify` ≤ 30s for a 10 MB archive

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -981,7 +981,7 @@ PARANOID TIER (AutonomyMode='paranoid'):
   permissions; it does not add new tools or require per-call ack).
 
 CIRCUIT BREAKER (per-provider):
-- Each provider (anthropic, minimax, ollama) maintains CLOSED → OPEN →
+- Each provider (ollama, anthropic, minimax, ...) maintains CLOSED → OPEN →
   HALF_OPEN state per src/infra/runtime/circuit-breaker.ts.
 - N failures in an M-ms window trips OPEN; cascade picks the next
   provider automatically. HALF_OPEN probes after cooldown.

--- a/src/infra/cli/commands/readiness.ts
+++ b/src/infra/cli/commands/readiness.ts
@@ -139,7 +139,7 @@ async function checkEmbedPipeline(env: NodeJS.ProcessEnv): Promise<ReadinessRow>
 }
 
 async function checkDefaultProvider(env: NodeJS.ProcessEnv): Promise<ReadinessRow> {
-  const provider = env.DEFAULT_PROVIDER ?? 'anthropic';
+  const provider = env.DEFAULT_PROVIDER ?? 'ollama';
 
   // No-key providers: local-fallback is built in, ollama runs over HTTP
   // without a key and has its own reachability check below.

--- a/src/infra/config/env.ts
+++ b/src/infra/config/env.ts
@@ -177,14 +177,14 @@ function pickCascadeFallback(
   unavailableProvider: AppConfig['DEFAULT_PROVIDER'],
 ): AppConfig['DEFAULT_PROVIDER'] {
   // Honor the operator's MEMPHIS_PROVIDER_CASCADE order if set; otherwise
-  // use the documented default (anthropic → minimax → ollama → local-fallback).
+  // use the documented default (ollama → anthropic → minimax → local-fallback).
   const cascadeRaw = (config as { MEMPHIS_PROVIDER_CASCADE?: string }).MEMPHIS_PROVIDER_CASCADE;
   const cascade = cascadeRaw
     ? cascadeRaw
         .split(',')
         .map((s) => s.trim())
         .filter(Boolean)
-    : ['anthropic', 'minimax', 'ollama', 'local-fallback'];
+    : ['ollama', 'anthropic', 'minimax', 'local-fallback'];
 
   for (const candidate of cascade) {
     if (candidate === unavailableProvider) continue;

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -43,13 +43,13 @@ export const envSchema = z.object({
   MEMPHIS_AGENT_NAME: z.string().default('Memphis Agent'),
   MEMPHIS_OWNER_NAME: z.string().default('local operator'),
 
-  DEFAULT_PROVIDER: z.enum(PROVIDER_NAMES).optional().default('anthropic'),
+  DEFAULT_PROVIDER: z.enum(PROVIDER_NAMES).optional().default('ollama'),
 
   /**
    * Comma-separated cascade order for provider fallback.
-   * Example: `anthropic,minimax,ollama,local-fallback`
+   * Example: `ollama,anthropic,minimax,local-fallback`
    * Each name must match PROVIDER_NAMES; unknown names throw at startup.
-   * Omit to use DEFAULT_PROVIDER_CASCADE (anthropic → minimax → ollama → local-fallback).
+   * Omit to use DEFAULT_PROVIDER_CASCADE (ollama → anthropic → minimax → local-fallback).
    */
   MEMPHIS_PROVIDER_CASCADE: z.string().optional(),
 

--- a/src/modules/orchestration/service.ts
+++ b/src/modules/orchestration/service.ts
@@ -18,14 +18,16 @@ import type { ChatOptions } from '../../providers/index.js';
 import { normalizeRuntimeProvider, type RuntimeProvider } from '../../providers/runtime.js';
 
 /**
- * Operator-preferred default cascade order. Anthropic primary, Minimax second
- * fallback, Ollama offline third, local-fallback always-succeeds safety net.
+ * Operator-preferred default cascade order. Ollama primary (sovereign-AI:
+ * local model first, no key required, runs on the operator's box), Anthropic
+ * second (online flagship for harder turns), Minimax third (cheap volume),
+ * local-fallback always-succeeds safety net.
  * Override with MEMPHIS_PROVIDER_CASCADE=comma,separated,list.
  */
 export const DEFAULT_PROVIDER_CASCADE: ProviderName[] = [
+  'ollama',
   'anthropic',
   'minimax',
-  'ollama',
   'local-fallback',
 ];
 
@@ -216,7 +218,7 @@ export class OrchestrationService {
    * slot (the requested provider if explicit, or the default otherwise). Later
    * tiers are whichever position in the cascade actually served the request.
    *
-   * Operator default cascade: anthropic → minimax → ollama → local-fallback
+   * Operator default cascade: ollama → anthropic → minimax → local-fallback
    * (see DEFAULT_PROVIDER_CASCADE). Override with MEMPHIS_PROVIDER_CASCADE.
    *
    * NEVER throws when local-fallback is registered (which parseCascadeOrder

--- a/tests/unit/cascade-order.test.ts
+++ b/tests/unit/cascade-order.test.ts
@@ -78,38 +78,38 @@ describe('OrchestrationService cascade walk', () => {
 
   function service(cascadeOrder?: ProviderName[]) {
     return new OrchestrationService({
-      defaultProvider: 'anthropic',
+      defaultProvider: 'ollama',
       providers: [anthropic, minimax, ollama, fallback],
       providerCooldownMs: 5000,
       cascadeOrder,
     });
   }
 
-  it('lands on anthropic when requested=auto and nothing is degraded', () => {
+  it('lands on ollama when requested=auto and nothing is degraded', () => {
     const result = service().getCascadeResult('auto');
-    expect(result.actualProvider).toBe('anthropic');
+    expect(result.actualProvider).toBe('ollama');
     expect(result.tier).toBe(1);
     expect(result.degraded).toBe(false);
   });
 
-  it('cascades auto→minimax→ollama→local-fallback when each upstream fails', () => {
+  it('cascades auto→anthropic→minimax→local-fallback when each upstream fails', () => {
     const orchestration = service();
     const policy = (
       orchestration as unknown as { providerPolicy: { markFailure: (n: string) => void } }
     ).providerPolicy;
 
-    policy.markFailure('anthropic');
+    policy.markFailure('ollama');
     let result = orchestration.getCascadeResult('auto');
-    expect(result.actualProvider).toBe('minimax');
+    expect(result.actualProvider).toBe('anthropic');
     expect(result.tier).toBe(2);
     expect(result.degraded).toBe(true);
 
-    policy.markFailure('minimax');
+    policy.markFailure('anthropic');
     result = orchestration.getCascadeResult('auto');
-    expect(result.actualProvider).toBe('ollama');
+    expect(result.actualProvider).toBe('minimax');
     expect(result.tier).toBe(3);
 
-    policy.markFailure('ollama');
+    policy.markFailure('minimax');
     result = orchestration.getCascadeResult('auto');
     expect(result.actualProvider).toBe('local-fallback');
     expect(result.tier).toBe(4);
@@ -152,8 +152,8 @@ describe('OrchestrationService cascade walk', () => {
 
     const result = orchestration.getCascadeResult('minimax');
     // tier 1 = minimax (cooldown → skip)
-    // tier 2 = defaultProvider anthropic
-    expect(result.actualProvider).toBe('anthropic');
+    // tier 2 = defaultProvider ollama
+    expect(result.actualProvider).toBe('ollama');
     expect(result.tier).toBe(2);
     expect(result.degraded).toBe(true);
     expect(result.reason).toContain('minimax in cooldown');

--- a/tests/unit/default-provider-cascade-fallback.test.ts
+++ b/tests/unit/default-provider-cascade-fallback.test.ts
@@ -72,7 +72,7 @@ describe('loadConfig — DEFAULT_PROVIDER cascade fallback', () => {
 
   it('walks past minimax to local-fallback when minimax also unconfigured and OLLAMA_URL unset', () => {
     const config = loadConfig(envWith({ DEFAULT_PROVIDER: 'anthropic' }));
-    // Default cascade: anthropic → minimax → ollama → local-fallback.
+    // Default cascade: ollama → anthropic → minimax → local-fallback.
     // Without minimax creds and without OLLAMA_URL (operator hasn't opted
     // into ollama), cascade lands on local-fallback.
     expect(config.DEFAULT_PROVIDER).toBe('local-fallback');

--- a/tests/unit/orchestration-cascade.test.ts
+++ b/tests/unit/orchestration-cascade.test.ts
@@ -97,7 +97,9 @@ describe('Provider Cascade', () => {
       const result = orchestration.getCascadeResult('minimax' as ProviderName);
 
       expect(result.degraded).toBe(true);
-      expect(result.tier).toBe(4);
+      // Walk: minimax (not registered) → deepseek (cooldown) → ollama (tier 3)
+      // under DEFAULT_PROVIDER_CASCADE = ['ollama','anthropic','minimax','local-fallback'].
+      expect(result.tier).toBe(3);
       expect(result.originalRequested).toBe('minimax');
       expect(result.actualProvider).toBe('ollama');
       expect(result.reason).toContain('unavailable');


### PR DESCRIPTION
## Summary

Restores the architectural promise from `project_memphis.md`: **sovereign AI runs Ollama first**. Local model on the operator's own box, no API key needed. Anthropic stays in the cascade as the online flagship for harder turns; Minimax third for cheap volume; local-fallback always terminates the walk.

**Before:** `anthropic → minimax → ollama → local-fallback`
**After:**  `ollama → anthropic → minimax → local-fallback`

## What changed

| File | Change |
|------|--------|
| `src/modules/orchestration/service.ts` | `DEFAULT_PROVIDER_CASCADE` reorder + comment rewrite |
| `src/infra/config/schema.ts` | `DEFAULT_PROVIDER` zod default `'anthropic'` → `'ollama'` + cascade comment |
| `src/infra/config/env.ts` | `pickCascadeFallback()` default array reorder + comment |
| `src/infra/cli/commands/readiness.ts` | Default-provider `??` fallback `'anthropic'` → `'ollama'` |
| `src/gateway/system-prompt.ts` | Circuit breaker example list reordered (LLM-visible text) |
| `docs/operator/operator-handbook.md` | 2 cascade-order references updated (Day 30 tuning + SLO baseline) |

## What did NOT change

- `parseCascadeOrder()` invariants — local-fallback still always terminates, unknown names still throw at startup.
- Operator override — `MEMPHIS_PROVIDER_CASCADE=…` still wins over the default.
- `runtime-registry.ts` registration order — only affects what providers are *available*, not the cascade walk order (which is governed by `DEFAULT_PROVIDER_CASCADE` in `service.ts:25-31`).
- Anthropic OAuth resolution chain (refresh-token → client-credentials → API-key) — same as before.
- Per-PR-#80 cascade-fallback semantics — `loadConfig` still walks the cascade when `DEFAULT_PROVIDER`'s creds are missing; the walk just starts from a different name now.

## Test plan

- [x] `tests/unit/cascade-order.test.ts` — 9/9 (default-provider tests flipped to expect `ollama`)
- [x] `tests/unit/orchestration-cascade.test.ts` — 13/13 (Tier 3 walk re-derived: minimax-not-registered → deepseek-cooldown → ollama is tier **3** now, was tier 4)
- [x] `tests/unit/default-provider-cascade-fallback.test.ts` — 8/8 (behavioural assertions still hold: ollama needs `OLLAMA_URL` to register, walk continues to anthropic/minimax/local-fallback as before)
- [x] `tests/unit/provider-models.test.ts` — 5/5
- [x] `tests/integration/config-reload-provider-swap.test.ts` — 4/4 (explicit `DEFAULT_PROVIDER=anthropic` setup, not impacted)
- [x] `tests/unit/orchestration-default-provider-swap.test.ts` + `provider-adapter-defaults.test.ts` + `p2-env-honoring.test.ts` + `cli.providers-health.test.ts` + `provider-factory.test.ts` — 25/25
- [x] `tests/unit/config-hot-reload.test.ts` + `cli.provider-enroll.test.ts` + `cli.provider.test.ts` + `cognitive-config-loader.test.ts` + `provider-policy.e2e.test.ts` — 36/36
- [x] `npm run typecheck` — green
- [x] `eslint .` (pre-commit) — green
- [ ] CI workflows green
- [ ] No operator-facing behaviour change for setups with explicit `DEFAULT_PROVIDER=anthropic` in `.env` (existing operators already pinned)

## Operator impact

- **Fresh installs** (no `.env` yet): default provider becomes `ollama`. They need an Ollama daemon at `OLLAMA_URL` (default `http://127.0.0.1:11434`) to actually serve responses; without it `pickCascadeFallback()` walks to `anthropic` → `minimax` → `local-fallback` as today.
- **Existing operators** with `DEFAULT_PROVIDER=anthropic` in `.env`: zero behaviour change — explicit env wins, cascade walk still ends up the same.
- **Existing operators with no env override** (relying on the zod default): cascade now leads with `ollama`. If they have Anthropic configured but no Ollama daemon, `loadConfig` cascade-walks past ollama to anthropic and they continue working transparently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)