### PR TITLE
feat(observability): tag confabulation events with originating surface

### DIFF
--- a/src/gateway/agent-runtime.ts
+++ b/src/gateway/agent-runtime.ts
@@ -270,6 +270,13 @@ export async function runAgentLoop(options: {
    */
   temperature?: number;
   maxTokens?: number;
+  /**
+   * Originating channel surface (telegram | http | cli | mcp | …),
+   * forwarded to confabulation events so operators can see WHICH channel
+   * produced bad assistant claims. Optional; omitted callers land under
+   * 'unknown' in the recorded span.
+   */
+  surface?: string;
 }): Promise<AgentLoopResult> {
   const toolExecutor = options.toolExecutor;
   const tools = toolExecutor?.listTools() ?? [];
@@ -309,11 +316,12 @@ export async function runAgentLoop(options: {
               {
                 rule: event.rule,
                 tool: event.toolName,
+                surface: options.surface ?? 'unknown',
                 evidence: event.evidence.slice(0, 100),
               },
               'confabulation detected',
             );
-            recordConfabulationEvent(event);
+            recordConfabulationEvent(event, undefined, options.surface);
           }
         } catch (err) {
           log.warn({ err }, 'confabulation detector error — continuing');

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -884,6 +884,11 @@ async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntim
         // maxTokens ceiling.
         temperature: prepared.cognitiveModeContribution?.temperature,
         maxTokens: prepared.cognitiveModeContribution?.maxTokens,
+        // Stamp confabulation events with the originating channel so
+        // operators can see WHICH surface (telegram, http, cli, mcp …)
+        // produced the bad claim. Audit surface tracks the canonical
+        // origin even when the runtime is impersonating another tier.
+        surface: auditSurface,
       });
     } catch (error) {
       metrics.recordProviderCall(llm.provider, false, Date.now() - startedAt);

--- a/src/infra/observability/confabulation-detector.ts
+++ b/src/infra/observability/confabulation-detector.ts
@@ -232,10 +232,17 @@ export function detectConfabulation(
  * `recordLocalSpan` so the event lands alongside other observability
  * spans, keyed by the stable name `confabulation.event`. Cron-driven
  * watch tasks can grep deterministically.
+ *
+ * `surface` (optional) lets the caller stamp which channel produced the
+ * confabulation (telegram | http | cli | mcp | …) so the operator can
+ * see "telegram is the noisy one" without having to correlate against
+ * sibling spans. Defaults to 'unknown' when the caller is a generic
+ * agent loop with no channel context.
  */
 export function recordConfabulationEvent(
   event: ConfabulationEvent,
   rawEnv: NodeJS.ProcessEnv = process.env,
+  surface: string = 'unknown',
 ): void {
   recordLocalSpan(
     {
@@ -243,6 +250,7 @@ export function recordConfabulationEvent(
       attrs: {
         'confabulation.rule': event.rule,
         'confabulation.tool': event.toolName ?? 'none',
+        'confabulation.surface': surface,
         'confabulation.evidence_length': event.evidence.length,
         // Truncate evidence for storage (full text would balloon JSONL on
         // long claims). 200 chars is enough for human triage in PULSE.md.

--- a/tests/unit/confabulation-detector.test.ts
+++ b/tests/unit/confabulation-detector.test.ts
@@ -11,7 +11,7 @@
  * the expected count.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -222,5 +222,62 @@ describe('countConfabulationEventsInWindow — 7d rolling counter', () => {
     // windowMs = 0 → cutoff = fixedFuture; recorded event ts = now ≪
     // 2099 → tsMs < cutoffMs → excluded → count must be 0.
     expect(countConfabulationEventsInWindow(0, process.env, fixedFuture)).toBe(0);
+  });
+});
+
+describe('recordConfabulationEvent — surface tagging', () => {
+  let tmpDir: string;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'memphis-confab-surface-'));
+    process.env.MEMPHIS_DATA_DIR = tmpDir;
+    delete process.env.MEMPHIS_OTEL_ENDPOINT;
+    delete process.env.MEMPHIS_TELEMETRY_LOCAL_SINK;
+    __resetLocalSinkForTests();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    for (const key of Object.keys(process.env)) {
+      if (!(key in savedEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+    __resetLocalSinkForTests();
+  });
+
+  function readSpanFile(): Array<Record<string, unknown>> {
+    const dir = path.join(tmpDir, 'telemetry');
+    if (!existsSync(dir)) return [];
+    const files = readdirSync(dir).filter((f) => /^spans-.*\.jsonl$/.test(f));
+    return files
+      .flatMap((f) =>
+        readFileSync(path.join(dir, f), 'utf8')
+          .split('\n')
+          .filter(Boolean)
+          .map((line) => JSON.parse(line) as Record<string, unknown>),
+      )
+      .filter((row) => row.name === 'confabulation.event');
+  }
+
+  it('stamps the supplied surface onto the recorded span', () => {
+    recordConfabulationEvent(
+      { rule: 'A', evidence: 'udało się', toolName: 'memphis_exec' },
+      undefined,
+      'telegram',
+    );
+    const events = readSpanFile();
+    expect(events).toHaveLength(1);
+    const attrs = events[0].attrs as Record<string, unknown>;
+    expect(attrs['confabulation.surface']).toBe('telegram');
+    expect(attrs['confabulation.rule']).toBe('A');
+  });
+
+  it('defaults to "unknown" when caller omits the surface argument', () => {
+    recordConfabulationEvent({ rule: 'B', evidence: 'ALLOW_EXEC=true' });
+    const events = readSpanFile();
+    expect(events).toHaveLength(1);
+    const attrs = events[0].attrs as Record<string, unknown>;
+    expect(attrs['confabulation.surface']).toBe('unknown');
   });
 });


### PR DESCRIPTION
## Summary

The Sprint 0.2 confabulation detector was already wired into `runAgentLoop` (agent-runtime.ts:316), so events fire on every gateway turn — telegram, chat, http, and mcp paths all go through `runTurnRuntime → runAgentLoop`. **What was missing: the recorded span had no surface attribute.**

That meant 7-day rolling counters in `/v1/health/json` and PULSE.md aggregated all channels into one opaque number. The operator could see "12 confabulations this week" but not _"telegram is the noisy one — go look at the bot's prompt."_

This PR threads `surface` through the call chain:

```
runTurnRuntime  (already knows auditSurface from caller)
  → runAgentLoop({ ..., surface: auditSurface })
  → recordConfabulationEvent(event, env, surface)
  → recordLocalSpan attrs.\"confabulation.surface\" = surface
```

## What changed

| File | Change |
|------|--------|
| `src/infra/observability/confabulation-detector.ts` | `recordConfabulationEvent` accepts optional `surface` (3rd arg, default `'unknown'`); attribute emitted on the span |
| `src/gateway/agent-runtime.ts` | `runAgentLoop` accepts optional `surface`; passed through to `recordConfabulationEvent`; `log.warn` includes surface for live triage |
| `src/gateway/turn-runtime.ts` | `runAgentLoop({ ..., surface: auditSurface })` — uses canonical surface even when impersonating tier |
| `tests/unit/confabulation-detector.test.ts` | New `describe('recordConfabulationEvent — surface tagging')` reads the JSONL sink and asserts `confabulation.surface` lands in the recorded span |

## Backward compatibility

- `surface` is **optional** in both `recordConfabulationEvent` and `runAgentLoop` options.
- All existing callers continue to compile and run without modification.
- Spans without an explicit surface land under `'unknown'` (visible in telemetry as a distinct bucket from real channels).

## Why this matters now

Per `project_memphis_agent_confabulation_2026_05_02.md`: the Telegram bot produced an 8-bullet code audit, 7 of 8 claims were demonstrably false. The runtime detector was firing during those turns but the operator couldn't tell from telemetry that telegram was the source — every confab event landed in one bucket. With surface tagging, the next time this happens we get a clean signal: \"3 telegram confabs in the last hour, all from chatId X\".

## Test plan

- [x] `tests/unit/confabulation-detector.test.ts` — 22/22 (20 existing + 2 new surface-tagging cases)
- [x] `tests/unit/honesty-guard.test.ts` — 6/6 (other `runAgentLoop` caller, signature compat)
- [x] `tests/unit/cli.agent-runtime.test.ts` — passes
- [x] `npm run typecheck` — green
- [x] `eslint .` (pre-commit) — green
- [ ] CI workflows green
- [ ] No behaviour change for sites that don't pass `surface` (default `'unknown'`)

## Follow-ups (not in scope)

- Health endpoint `/v1/health/json` could expose per-surface counts when summing the 7-day rolling window. Currently the aggregator (`countConfabulationEventsInWindow`) doesn't bucket — adding that is a small follow-up if operators want a `confabulation_by_surface: { telegram: 4, http: 0, mcp: 1 }` field.
- Rule D (LLM-as-judge tier for fabricated code claims like the 7-of-8 audit incident) is documented in the detector docstring but remains intentionally unimplemented in v1 (false-positive cost vs deterministic regex baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)