### PR TITLE
feat(prompt): show effective surface + max tool tier in <capabilities>

### DIFF
--- a/src/gateway/agent-runtime.ts
+++ b/src/gateway/agent-runtime.ts
@@ -6,6 +6,7 @@ import {
   buildRecalledMemoryFragment,
 } from './system-prompt.js';
 import { executeToolCalls } from './tool-orchestration.js';
+import type { ToolTier } from './tool-registry.js';
 import { getDataDir } from '../config/paths.js';
 import type { TokenUsage } from '../core/types.js';
 import { resolveAgentProfile } from '../infra/agent-profile.js';
@@ -149,6 +150,19 @@ export type AgentPromptOptions = {
   cognitiveContext?: string;
   recalledMemory?: Array<{ content: string; score: number }>;
   rawEnv?: NodeJS.ProcessEnv;
+  /**
+   * Active surface label (e.g. 'telegram', 'http.chat', 'cli.chat',
+   * 'mcp'). Forwarded to `<capabilities>` so the LLM can self-explain
+   * "I'm on telegram tier 1" rather than confabulating about tools the
+   * surface policy stripped from its list.
+   */
+  surface?: string;
+  /**
+   * Effective `maxToolTier` for the active surface (resolved by
+   * `surface-policy.ts`). Forwarded to `<capabilities>` so the LLM
+   * sees WHY some tier-2 tools are missing from `availableTools`.
+   */
+  maxToolTier?: ToolTier;
 };
 
 export function buildRuntimeSystemPrompt(options: AgentPromptOptions = {}): string {
@@ -202,6 +216,8 @@ export function buildRuntimeSystemPrompt(options: AgentPromptOptions = {}): stri
     activeCognitiveMode: cognitiveMode,
     installRoot,
     dataDir,
+    surface: options.surface,
+    maxToolTier: options.maxToolTier,
   });
 
   const soulBlock = soulParts.length > 0 ? soulParts.join('\n\n') : '';

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -72,6 +72,21 @@ export interface SystemPromptContext {
    * product code?".
    */
   dataDir?: string;
+  /**
+   * Effective `maxToolTier` for the active surface (resolved by
+   * `surface-policy.ts:resolveSurfacePolicy`). When present, the
+   * `<capabilities>` block calls it out so the LLM understands WHY some
+   * tier-2 tools are missing from `availableTools` (e.g. Telegram
+   * downgraded to tier 1) instead of confabulating "I'll just call X"
+   * for a tool that surface policy stripped from its list.
+   */
+  maxToolTier?: ToolTier;
+  /**
+   * Active surface label (e.g. 'telegram', 'http.chat', 'cli.chat',
+   * 'mcp'). Rendered in the `<capabilities>` block alongside
+   * `maxToolTier` so the LLM can self-explain "I'm on telegram tier 1".
+   */
+  surface?: string;
 }
 
 // ── Chain Architecture Reference ─────────────────────────────────────────────
@@ -206,12 +221,36 @@ function tierDescription(tier: ToolTier): string {
  *
  * Token cost: ~10-15 lines. Cheap relative to the full per-tool docs.
  */
-function renderCapabilitiesBlock(toolNames: string[]): string {
+function renderCapabilitiesBlock(
+  toolNames: string[],
+  surface?: string,
+  maxToolTier?: ToolTier,
+): string {
   const lines = [
     'CAPABILITIES — what you can actually do RIGHT NOW (read this before',
     'answering "what can you do" questions; do NOT guess from training data):',
     '',
     `- Available tools this turn: ${toolNames.length}.`,
+  ];
+  // Effective surface + tier. Surfaced after the gap-analysis 2026-05-03 —
+  // Telegram session-tier downgrades clip the tool list (surface-policy
+  // resolves `MEMPHIS_SURFACE_TELEGRAM_MAX_TOOL_TIER` per turn) but the
+  // model never saw WHY: it just got a shorter list and confabulated
+  // "I'll call X" on a tool stripped by policy. Putting the effective
+  // tier here gives the model a self-check: if it's about to call a
+  // tier-2 tool and `Effective tier: 1`, the call will be blocked with
+  // `error: tool blocked by surface policy` (turn-runtime.ts:331-337).
+  if (surface || typeof maxToolTier === 'number') {
+    const surfaceLabel = surface ?? 'unknown';
+    const tierLabel = typeof maxToolTier === 'number' ? `${maxToolTier}` : 'unbounded';
+    lines.push(
+      `- Effective surface: ${surfaceLabel}, max tool tier: ${tierLabel}.`,
+      '  Tools with a higher tier than this max have been stripped from',
+      '  the list above by `surface-policy`. Do NOT pretend to call them —',
+      '  the runtime will return `error: tool blocked by surface policy`.',
+    );
+  }
+  lines.push(
     '- The full <tool> blocks above show name, tier, capabilities, and',
     '  input shape for each one. That list is authoritative for THIS turn.',
     '- For runtime self-introspection (active surface, effective tier,',
@@ -221,7 +260,7 @@ function renderCapabilitiesBlock(toolNames: string[]): string {
     '  operator can read in TUI / Telegram / HTTP / CLI.',
     '- Tier 3 elevation: see <tier_system> below. Tier 3 does NOT add new',
     '  tools — it lifts permissions on the existing tier-2 set.',
-  ];
+  );
   if (toolNames.includes('memphis_self_describe')) {
     lines.push(
       '- `memphis_self_describe` is in your available-tools list above.',
@@ -1024,7 +1063,7 @@ SELF-MODIFY GUARDS:
   There is no auto-push on the release pipeline.
 </safety_invariants>
 <capabilities>
-${renderCapabilitiesBlock(tools)}
+${renderCapabilitiesBlock(tools, context.surface, context.maxToolTier)}
 </capabilities>
 <tier_system>
 ${renderTierSystemBlock()}

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -390,6 +390,8 @@ function buildEffectiveSystemPrompt(options: {
   sessionMemory?: string;
   compactions?: Array<{ summary: string; startSequence: number; endSequence: number }>;
   rawEnv?: NodeJS.ProcessEnv;
+  surface?: string;
+  surfacePolicy?: SurfacePolicy;
 }): string {
   const base = options.baseSystemPrompt?.trim();
   const basePrompt = base
@@ -399,6 +401,8 @@ function buildEffectiveSystemPrompt(options: {
         cognitiveContext: options.cognitiveContext,
         recalledMemory: options.recalledMemory,
         rawEnv: options.rawEnv,
+        surface: options.surface,
+        maxToolTier: options.surfacePolicy?.maxToolTier,
       });
 
   const fragments: string[] = [];
@@ -536,6 +540,8 @@ async function prepareTextTurn(
       sessionMemory: conversationOverlay?.sessionMemory,
       compactions: conversationOverlay?.compactions,
       rawEnv: options.rawEnv,
+      surface: options.auditSurface ?? options.surface,
+      surfacePolicy,
     }),
     originalUserText: input,
     sessionUserText,
@@ -633,6 +639,8 @@ async function prepareMessagesTurn(
       sessionMemory: conversationOverlay?.sessionMemory,
       compactions: conversationOverlay?.compactions,
       rawEnv: options.rawEnv,
+      surface: options.auditSurface ?? options.surface,
+      surfacePolicy,
     }),
     originalUserText,
     sessionUserText: highRisk

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -172,6 +172,33 @@ describe('gateway system prompt', () => {
     );
   });
 
+  it('renders the effective surface + maxToolTier in <capabilities> when both are supplied (gap-analysis 2026-05-03)', () => {
+    // Telegram session-tier downgrades clip the tool list via surface-policy
+    // before the prompt is built. Without this line, the model saw a shorter
+    // list with no explanation and confabulated "I'll call X" on tier-2
+    // tools the policy had stripped. PR4 plumbs surface + maxToolTier
+    // through `buildRuntimeSystemPrompt` so the prompt names them.
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_journal', 'memphis_self_describe'],
+      surface: 'telegram',
+      maxToolTier: 1,
+    });
+
+    expect(prompt).toContain('Effective surface: telegram, max tool tier: 1.');
+    expect(prompt).toContain(
+      'Tools with a higher tier than this max have been stripped from',
+    );
+    expect(prompt).toContain('error: tool blocked by surface policy');
+  });
+
+  it('omits the effective-tier line when neither surface nor maxToolTier are supplied (back-compat)', () => {
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_journal'],
+    });
+    expect(prompt).not.toContain('Effective surface:');
+    expect(prompt).not.toContain('max tool tier:');
+  });
+
   it('emits a <tier_system> block clarifying tier 3 is a permissions flag, not a tool tier', () => {
     // 2026-04-26 operator session: bot answered "I see no tier-3 tools, so
     // tier 3 is not useful" — correct observation, wrong conclusion. Tier 3


### PR DESCRIPTION
## Summary

Telegram session-tier downgrades **already** clip the tool list via `surface-policy` — `turn-runtime.ts:817` calls `listTools()` against a constrained executor, so the LLM sees only tools at or below the surface's effective `maxToolTier`. What was missing: **the prompt didn't tell the LLM its tier**. The model saw a shorter list with no explanation and sometimes confabulated "I'll call X" on a tool the policy had stripped.

The runtime would catch the attempt with `error: tool blocked by surface policy` (turn-runtime.ts:331-337) and the honesty guard catches the success-claim variant downstream. **The cheaper fix is upstream**: tell the model its effective tier in the prompt so it stops trying.

## What changed

This PR threads `surface` + `maxToolTier` through the prompt chain:

```
turn-runtime  (already has surfacePolicy via resolveSurfacePolicy)
  → buildEffectiveSystemPrompt({ surface, surfacePolicy })
  → buildRuntimeSystemPrompt({ surface, maxToolTier })
  → buildSystemPrompt({ surface, maxToolTier })
  → renderCapabilitiesBlock(tools, surface, maxToolTier)
```

Resulting `<capabilities>` block now contains:

```
- Effective surface: telegram, max tool tier: 1.
  Tools with a higher tier than this max have been stripped from
  the list above by `surface-policy`. Do NOT pretend to call them —
  the runtime will return `error: tool blocked by surface policy`.
```

## Files

| File | Change |
|------|--------|
| `src/gateway/system-prompt.ts` | `SystemPromptContext` accepts `surface?` + `maxToolTier?`; `renderCapabilitiesBlock` adds the new line when either is set |
| `src/gateway/agent-runtime.ts` | `AgentPromptOptions` accepts `surface?` + `maxToolTier?`; forwards to `buildMemphisSystemPrompt` |
| `src/gateway/turn-runtime.ts` | `buildEffectiveSystemPrompt` accepts `surface` + `surfacePolicy`; both call-sites (`prepareTextTurn`, `prepareMessagesTurn`) pass them through using the canonical `auditSurface` and the resolved `surfacePolicy` |
| `tests/unit/gateway.system-prompt.test.ts` | 2 new cases: positive (line rendered) + back-compat (line absent when fields omitted) |

## Backward compatibility

Both fields are **optional** everywhere. Callers that don't pass them produce the prior prompt verbatim — verified by the back-compat test (`expect(prompt).not.toContain('Effective surface:')`).

## Why this is the right level of fix

The runtime layer **already** does the right thing: tools above the surface tier are filtered from the executor before LLM ever sees them. The attempt-to-call path is also defended (returns blocked error). What was unsolved was the model's mental model — it would see e.g. 6 tools instead of 12 on telegram tier-1 and have no clue what changed. With this line in `<capabilities>`, the model can self-explain "I'm on tier 1, X is tier 2, skip it."

This is **not** a workaround for missing surface enforcement — that already exists. It's an LLM-readable annotation on the existing enforcement so the model doesn't waste a tool call on something the runtime will block anyway.

## Test plan

- [x] `tests/unit/gateway.system-prompt.test.ts` — 26/26 (24 existing + 2 new)
- [x] `tests/unit/cli.agent-runtime.test.ts` — passes
- [x] `tests/unit/honesty-guard.test.ts` — 6/6
- [x] `tests/unit/confabulation-detector.test.ts` — 22/22
- [x] `tests/unit/surface-policy.test.ts` — passes (no behavioural change to surface-policy itself)
- [x] `tests/unit/cli.providers-health.test.ts` — passes
- [x] `npm run typecheck` — green
- [x] `eslint .` (pre-commit) — green
- [ ] CI workflows green
- [ ] No prompt change for existing callers that don't supply `surface` / `maxToolTier`

## Follow-ups (not in scope)

- Render the **active session tier** (Telegram tier-3 elevation, currently expressed as the surface override env) alongside the static `maxToolTier` — useful if operator is on a transient tier-3 session. The `<tier_system>` block already explains the mechanism; surfacing the live state in `<capabilities>` is a small follow-up.
- Operator-handbook page on per-surface defaults — `TELEGRAM_SURFACE_DEFAULTS.maxToolTier = 2` is non-obvious for operators reading from outside the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)