### PR TITLE
test(mcp): introspection contract — TOOL_REGISTRY ↔ server ↔ client.listTools

### DIFF
--- a/tests/integration/mcp-introspection-contract.test.ts
+++ b/tests/integration/mcp-introspection-contract.test.ts
@@ -1,0 +1,172 @@
+/**
+ * MCP introspection contract — TOOL_REGISTRY ↔ mcp/server.ts ↔ client.listTools().
+ *
+ * Closes the gap surfaced by the 2026-05-03 runtime audit: the MCP
+ * surface registered ~37 tools by hand-rolled `server.registerTool(...)`
+ * calls, but nothing asserted that the set was in lockstep with the
+ * canonical `TOOL_REGISTRY`. Drift between the two means the LLM sees
+ * <tool> docs in the prompt for tools the runtime can't dispatch (or
+ * vice-versa: runtime exposes tools the prompt never describes), which
+ * is a known confabulation amplifier.
+ *
+ * This test ALSO acts as a regression guard for "added a new tool to
+ * TOOL_REGISTRY but forgot to wire it into mcp/server.ts".
+ *
+ * Mechanics:
+ *   - Build the MCP server with a permissive soul manifest (auto-approve
+ *     all tools) so neither approval gates nor trust rules suppress
+ *     registration.
+ *   - Connect an in-memory MCP client and call `listTools`.
+ *   - Compare the returned tool-name set against the canonical
+ *     `TOOL_REGISTRY` filtered by the same feature-flag env the server
+ *     used to build itself.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  TOOL_REGISTRY,
+  isToolEnabledByFeatureFlag,
+} from '../../src/gateway/tool-registry.js';
+import { createMemphisMcpServer } from '../../src/mcp/server.js';
+import type { SoulManifest } from '../../src/soul/types.js';
+
+const PERMISSIVE_MANIFEST: SoulManifest = {
+  schemaVersion: 1,
+  generatedAt: new Date().toISOString(),
+  identity: {
+    agentName: 'mcp-contract-test',
+    ownerName: 'test',
+    runtimeMode: 'test',
+    createdAt: new Date().toISOString(),
+  },
+  capabilities: { tools: [], chains: [], channels: [], providers: [], rustBridge: false },
+  boundaries: {
+    tier0: { auth: 'none', scope: 'test' },
+    tier1: { auth: 'none', scope: 'test' },
+    tier2: { auth: 'none', scope: 'test' },
+  },
+  evolution: {
+    autoApproveReflections: true,
+    requirePassphraseForTier2: false,
+    snapshotBeforeEvolution: false,
+  },
+  mode: 'quiet',
+  trustRules: [{ tool: '*', autoApprove: true, addedAt: new Date().toISOString() }],
+};
+
+async function snapshotMcpToolNames(env: NodeJS.ProcessEnv): Promise<{
+  names: string[];
+  schemas: Record<string, unknown>;
+  cleanup: () => Promise<void>;
+}> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const server = createMemphisMcpServer(PERMISSIVE_MANIFEST, env);
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'mcp-contract', version: '0.1.0' });
+  await client.connect(clientTransport);
+  const { tools } = await client.listTools();
+  const names = tools.map((t) => t.name).sort();
+  const schemas = Object.fromEntries(tools.map((t) => [t.name, t.inputSchema]));
+  return {
+    names,
+    schemas,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe('MCP introspection contract', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  it('registers EVERY non-feature-flagged TOOL_REGISTRY entry on the MCP server (default env)', async () => {
+    // Default env: no MEMPHIS_FEATURES — only non-experimental tools should
+    // be discoverable. Verifies that experimental gating is honored
+    // identically by registry-side `isToolEnabledByFeatureFlag` and
+    // server-side `shouldRegisterTool` (mcp/server.ts).
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    delete env.MEMPHIS_FEATURES;
+    const snap = await snapshotMcpToolNames(env);
+    cleanup = snap.cleanup;
+
+    const expectedNames = Object.values(TOOL_REGISTRY)
+      .filter((tool) => isToolEnabledByFeatureFlag(tool.name, env))
+      .map((tool) => tool.name)
+      .sort();
+
+    expect(snap.names).toEqual(expectedNames);
+  });
+
+  it('registers EVERY TOOL_REGISTRY entry when experimental flag is set', async () => {
+    // With MEMPHIS_FEATURES=experimental-tools, every entry in
+    // TOOL_REGISTRY must show up in MCP discovery — no orphans on either
+    // side. Drift here means a tool was added to one source but not the
+    // other.
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      MEMPHIS_FEATURES: 'experimental-tools',
+    };
+    const snap = await snapshotMcpToolNames(env);
+    cleanup = snap.cleanup;
+
+    const registryNames = Object.values(TOOL_REGISTRY)
+      .map((tool) => tool.name)
+      .sort();
+
+    expect(snap.names, 'symmetric: every registry tool reachable via MCP').toEqual(registryNames);
+
+    const onlyInRegistry = registryNames.filter((n) => !snap.names.includes(n));
+    const onlyInMcp = snap.names.filter((n) => !registryNames.includes(n));
+    expect(onlyInRegistry, 'tools in registry but not in MCP').toEqual([]);
+    expect(onlyInMcp, 'tools in MCP but not in registry').toEqual([]);
+  });
+
+  it('exposes a non-empty inputSchema (object shape) for every registered tool', async () => {
+    // Without inputSchema the LLM has no contract for tool input — the
+    // SDK's `client.listTools()` synthesizes one from the registered
+    // shape, so missing schema = registration bug.
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      MEMPHIS_FEATURES: 'experimental-tools',
+    };
+    const snap = await snapshotMcpToolNames(env);
+    cleanup = snap.cleanup;
+
+    for (const name of snap.names) {
+      const schema = snap.schemas[name] as { type?: string } | undefined;
+      expect(schema, `tool '${name}' has no inputSchema`).toBeTruthy();
+      expect(schema?.type, `tool '${name}' inputSchema.type is not 'object'`).toBe('object');
+    }
+  });
+
+  it('hides experimental tools when MEMPHIS_FEATURES omits the flag', async () => {
+    // Negative-path companion of the symmetric test above. Catches the
+    // class of bug "experimental flag is set in registry but server
+    // registers unconditionally".
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    delete env.MEMPHIS_FEATURES;
+    const snap = await snapshotMcpToolNames(env);
+    cleanup = snap.cleanup;
+
+    const experimental = Object.values(TOOL_REGISTRY).filter(
+      (tool) => tool.featureFlag === 'experimental-tools',
+    );
+    expect(experimental.length, 'fixture: at least one experimental tool registered').toBeGreaterThan(0);
+    for (const tool of experimental) {
+      expect(
+        snap.names,
+        `experimental tool '${tool.name}' must be hidden without MEMPHIS_FEATURES`,
+      ).not.toContain(tool.name);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the gap surfaced by the 2026-05-03 runtime audit: the MCP server registered ~39 tools by hand-rolled `server.registerTool(...)` calls but **nothing asserted the set was in lockstep with `TOOL_REGISTRY`**. Drift between the two means the LLM sees `<tool>` docs in the prompt for tools the runtime can't dispatch (or vice-versa), which is a known confabulation amplifier.

## What it tests

| Test | Assertion |
|------|-----------|
| Default env | MCP discovery == TOOL_REGISTRY entries that pass `isToolEnabledByFeatureFlag` for the env (no `MEMPHIS_FEATURES`). |
| Experimental enabled | With `MEMPHIS_FEATURES=experimental-tools`: MCP discovery == EVERY entry in TOOL_REGISTRY. Symmetric difference (registry-only + mcp-only) == []. |
| Schema present | Every discovered tool has non-empty `inputSchema` of `type: 'object'`. |
| Hidden when flag absent | The 3 `experimental-tools`-flagged entries (`memphis_chain_query`, `memphis_providers`, `memphis_system_info`) MUST be absent without the flag. |

## Why these tests, not the existing `mcp-e2e.test.ts`

`tests/integration/mcp-e2e.test.ts:88-97` already discovers tools but asserts only a 13-tool **subset** with `>=` semantics. New tools added to the registry weren't constrained to also land in MCP — drift could ship undetected. This PR adds full symmetric coverage that flags drift the moment it appears.

## Mechanics

Uses `InMemoryTransport` (same pattern as `mcp-e2e.test.ts`) — no real network, no flakes from port collisions. ~3 sec total runtime. Permissive soul manifest auto-approves all tools so neither approval gates nor trust rules suppress registration.

## Test plan

- [x] `npx vitest run tests/integration/mcp-introspection-contract.test.ts` — 4/4
- [x] `npm run typecheck` — green
- [x] `eslint .` (pre-commit) — green
- [ ] CI workflows green
- [ ] Existing `mcp-e2e.test.ts` continues to pass (no behaviour change to MCP server itself)

## Follow-ups (not in scope)

- Description / tier / capability checks on each registered tool — current test only validates name + inputSchema shape. A richer contract that asserts each MCP-side description aligns with `TOOL_REGISTRY[name].description` is a small follow-up; today the prompt-side and MCP-side descriptions are independent strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)