### PR TITLE
feat(paths): vault-paths.ts uses memphis-paths bridge + drift parity test (2/3)

### DIFF
--- a/src/infra/storage/rust-paths-bridge.ts
+++ b/src/infra/storage/rust-paths-bridge.ts
@@ -1,0 +1,218 @@
+/**
+ * TypeScript wrappers for the `paths_*` NAPI exports added by the
+ * `memphis-paths` crate (PR7). Single source of truth for the runtime
+ * data layout (data dir / vault state / vault entries / chains dir /
+ * embed index / case index / database) shared with the Rust operator.
+ *
+ * Background: Memphis used to resolve these paths independently in TS
+ * (`src/config/paths.ts` + `src/infra/storage/vault-paths.ts`) and Rust
+ * (`crates/memphis-operator/src/config.rs` + the band-aid auto-resolver
+ * in `runtime.rs:1075-1103`). Operator's 2026-04-29 vault-path-split
+ * incident traced to that divergence: `MEMPHIS_VAULT_ENTRIES_PATH`
+ * overridden but `MEMPHIS_VAULT_STATE_PATH` left at default, TS saw
+ * entries the Rust runtime couldn't decrypt.
+ *
+ * Contract: every wrapper takes the env map + `process.cwd()`, posts
+ * them through the NAPI bridge to the Rust crate, and parses the
+ * standard `ApiResult<string>` envelope into either an absolute path
+ * string or a thrown Error. Bridge unavailability throws a clear
+ * "build the Rust bridge first" message rather than silently falling
+ * back to a TS implementation that might disagree with Rust.
+ */
+import {
+  loadPlatformAwareBridge,
+  resolveBridgeContract,
+  type BridgeAliasMap,
+  type BridgeResolution,
+} from './napi-contract.js';
+import { resolveRustBridgePath } from '../runtime/install-root.js';
+
+const PATHS_BRIDGE_ALIASES = {
+  paths_resolve_data_dir: ['paths_resolve_data_dir', 'pathsResolveDataDir'],
+  paths_resolve_vault_state: ['paths_resolve_vault_state', 'pathsResolveVaultState'],
+  paths_resolve_vault_entries: ['paths_resolve_vault_entries', 'pathsResolveVaultEntries'],
+  paths_resolve_chains_dir: ['paths_resolve_chains_dir', 'pathsResolveChainsDir'],
+  paths_resolve_chain_path: ['paths_resolve_chain_path', 'pathsResolveChainPath'],
+  paths_resolve_embed_index: ['paths_resolve_embed_index', 'pathsResolveEmbedIndex'],
+  paths_resolve_case_index: ['paths_resolve_case_index', 'pathsResolveCaseIndex'],
+  paths_resolve_database_path: ['paths_resolve_database_path', 'pathsResolveDatabasePath'],
+  paths_normalize_chain_name: ['paths_normalize_chain_name', 'pathsNormalizeChainName'],
+} satisfies BridgeAliasMap<
+  | 'paths_resolve_data_dir'
+  | 'paths_resolve_vault_state'
+  | 'paths_resolve_vault_entries'
+  | 'paths_resolve_chains_dir'
+  | 'paths_resolve_chain_path'
+  | 'paths_resolve_embed_index'
+  | 'paths_resolve_case_index'
+  | 'paths_resolve_database_path'
+  | 'paths_normalize_chain_name'
+>;
+
+type PathsBridgeKey = keyof typeof PATHS_BRIDGE_ALIASES;
+
+interface ResolvedPathsBridge {
+  paths_resolve_data_dir?: (envJson: string, cwd: string) => string;
+  paths_resolve_vault_state?: (envJson: string, cwd: string) => string;
+  paths_resolve_vault_entries?: (envJson: string, cwd: string) => string;
+  paths_resolve_chains_dir?: (envJson: string, cwd: string) => string;
+  paths_resolve_chain_path?: (envJson: string, cwd: string, chainName: string) => string;
+  paths_resolve_embed_index?: (envJson: string, cwd: string) => string;
+  paths_resolve_case_index?: (envJson: string, cwd: string) => string;
+  paths_resolve_database_path?: (envJson: string, cwd: string) => string;
+  paths_normalize_chain_name?: (input: string) => string;
+}
+
+let cachedBridge: ResolvedPathsBridge | null = null;
+let cachedBridgePath: string | null = null;
+
+function resolvePathsBridge(rawEnv: NodeJS.ProcessEnv): ResolvedPathsBridge {
+  const bridgePath = resolveRustBridgePath(rawEnv);
+  if (cachedBridge && cachedBridgePath === bridgePath) {
+    return cachedBridge;
+  }
+  const resolution: BridgeResolution<PathsBridgeKey> = resolveBridgeContract(
+    loadPlatformAwareBridge(bridgePath),
+    PATHS_BRIDGE_ALIASES,
+  );
+  if (!resolution.bridgeLoaded) {
+    throw new Error(
+      'memphis-paths bridge not loaded — run `npm run build:rust` to build crates/memphis-napi/index.node ' +
+        '(operator runtime ALWAYS has the bridge; this error only fires in tests / dev environments).',
+    );
+  }
+  if (resolution.missing.length > 0) {
+    throw new Error(
+      `memphis-paths bridge is missing exports: ${resolution.missing.join(', ')}. ` +
+        'Rebuild crates/memphis-napi (`npm run build:rust`) — the .node binary is stale.',
+    );
+  }
+  cachedBridge = resolution.resolved as ResolvedPathsBridge;
+  cachedBridgePath = bridgePath;
+  return cachedBridge;
+}
+
+interface ApiResultEnvelope<T> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+}
+
+function parseEnvelope(raw: string, exportName: string): string {
+  let parsed: ApiResultEnvelope<string>;
+  try {
+    parsed = JSON.parse(raw) as ApiResultEnvelope<string>;
+  } catch (cause) {
+    throw new Error(`${exportName}: bridge returned non-JSON envelope: ${String(cause)}`);
+  }
+  if (!parsed.ok || typeof parsed.data !== 'string') {
+    throw new Error(`${exportName}: bridge error — ${parsed.error ?? 'no message'}`);
+  }
+  return parsed.data;
+}
+
+function envJson(rawEnv: NodeJS.ProcessEnv): string {
+  // Drop undefined values — the Rust crate expects a `HashMap<String,String>`.
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rawEnv)) {
+    if (typeof value === 'string') filtered[key] = value;
+  }
+  return JSON.stringify(filtered);
+}
+
+/** Resolves `MEMPHIS_DATA_DIR` (default `~/.memphis`) to an absolute path. */
+export function bridgeResolveDataDir(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  const bridge = resolvePathsBridge(rawEnv);
+  return parseEnvelope(
+    bridge.paths_resolve_data_dir!(envJson(rawEnv), process.cwd()),
+    'paths_resolve_data_dir',
+  );
+}
+
+/** Resolves the `vault-state.json` path (`MEMPHIS_VAULT_STATE_PATH` or default). */
+export function bridgeResolveVaultState(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  const bridge = resolvePathsBridge(rawEnv);
+  return parseEnvelope(
+    bridge.paths_resolve_vault_state!(envJson(rawEnv), process.cwd()),
+    'paths_resolve_vault_state',
+  );
+}
+
+/** Resolves the `vault-entries.json` path (`MEMPHIS_VAULT_ENTRIES_PATH` or default). */
+export function bridgeResolveVaultEntries(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  const bridge = resolvePathsBridge(rawEnv);
+  return parseEnvelope(
+    bridge.paths_resolve_vault_entries!(envJson(rawEnv), process.cwd()),
+    'paths_resolve_vault_entries',
+  );
+}
+
+/** Resolves the canonical chains directory (`<data_dir>/chains`). */
+export function bridgeResolveChainsDir(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  const bridge = resolvePathsBridge(rawEnv);
+  return parseEnvelope(
+    bridge.paths_resolve_chains_dir!(envJson(rawEnv), process.cwd()),
+    'paths_resolve_chains_dir',
+  );
+}
+
+/**
+ * Resolves a specific chain's directory. Empty / whitespace-only `chainName`
+ * collapses to the bare chains dir, matching the Rust crate's contract.
+ */
+export function bridgeResolveChainPath(
+  chainName: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): string {
+  const bridge = resolvePathsBridge(rawEnv);
+  return parseEnvelope(
+    bridge.paths_resolve_chain_path!(envJson(rawEnv), process.cwd(), chainName),
+    'paths_resolve_chain_path',
+  );
+}
+
+/** Resolves the embed-index path (`RUST_EMBED_PERSIST_PATH` or default). */
+export function bridgeResolveEmbedIndex(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  const bridge = resolvePathsBridge(rawEnv);
+  return parseEnvelope(
+    bridge.paths_resolve_embed_index!(envJson(rawEnv), process.cwd()),
+    'paths_resolve_embed_index',
+  );
+}
+
+/** Resolves the case-index SQLite path. */
+export function bridgeResolveCaseIndex(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  const bridge = resolvePathsBridge(rawEnv);
+  return parseEnvelope(
+    bridge.paths_resolve_case_index!(envJson(rawEnv), process.cwd()),
+    'paths_resolve_case_index',
+  );
+}
+
+/** Resolves the operator's `DATABASE_URL` to an absolute file path. */
+export function bridgeResolveDatabasePath(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  const bridge = resolvePathsBridge(rawEnv);
+  return parseEnvelope(
+    bridge.paths_resolve_database_path!(envJson(rawEnv), process.cwd()),
+    'paths_resolve_database_path',
+  );
+}
+
+/**
+ * Normalize a chain name through the Rust alias table. Pure deterministic
+ * lookup; cheap to call. Available so TS doesn't drift from Rust by keeping
+ * its own table.
+ */
+export function bridgeNormalizeChainName(input: string): string {
+  // Use a minimal env map — this NAPI call doesn't read env at all but the
+  // bridge resolver still needs the platform-aware loader to have been hit
+  // once. Cached after first call, so cost is ~free thereafter.
+  const bridge = resolvePathsBridge(process.env);
+  return parseEnvelope(bridge.paths_normalize_chain_name!(input), 'paths_normalize_chain_name');
+}
+
+/** Test-only: clear the cached bridge so tests can reload after rebuilds. */
+export function __resetPathsBridgeCacheForTests(): void {
+  cachedBridge = null;
+  cachedBridgePath = null;
+}

--- a/src/infra/storage/vault-paths.ts
+++ b/src/infra/storage/vault-paths.ts
@@ -30,8 +30,13 @@
  */
 
 import { existsSync } from 'node:fs';
+import os from 'node:os';
 import { join, resolve } from 'node:path';
 
+import {
+  bridgeResolveVaultEntries,
+  bridgeResolveVaultState,
+} from './rust-paths-bridge.js';
 import { getDataDir } from '../../config/paths.js';
 import { resolveInstallRoot } from '../runtime/install-root.js';
 
@@ -44,16 +49,32 @@ const ENV_KEYS: Record<VaultFile, string> = {
 
 const warnedLegacy = new Set<VaultFile>();
 
+function ensureHome(rawEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  if (rawEnv.HOME && rawEnv.HOME.trim().length > 0) return rawEnv;
+  return { ...rawEnv, HOME: os.homedir() };
+}
+
+function bridgeDefaultFor(file: VaultFile, rawEnv: NodeJS.ProcessEnv): string {
+  // Bridge gives us the canonical default `<data_dir>/<file>` path. If it
+  // fails (rare; pre-build), fall back to the legacy TS path composition.
+  try {
+    return file === 'vault-state.json'
+      ? bridgeResolveVaultState(ensureHome(rawEnv))
+      : bridgeResolveVaultEntries(ensureHome(rawEnv));
+  } catch {
+    return join(getDataDir(rawEnv), file);
+  }
+}
+
 export function resolveVaultPath(file: VaultFile, rawEnv: NodeJS.ProcessEnv): string {
   const envKey = ENV_KEYS[file];
   const explicit = rawEnv[envKey]?.trim();
   if (explicit) {
     // Absolute path → verbatim. Relative override (legacy .env files
     // shipped with `MEMPHIS_VAULT_ENTRIES_PATH=./data/vault-entries.json`)
-    // resolves against installRoot, NOT cwd. Same fix family as
-    // resolveRustBridgePath — without this, running `memphis` from any
-    // dir other than the source checkout points the vault entries at
-    // `<cwd>/data/...` which doesn't exist.
+    // resolves against installRoot, NOT cwd. The bridge resolves against
+    // process.cwd() per its contract, so we keep the install-root anchor
+    // here in TS — operator-friendly behavior preserved across migration.
     if (explicit.startsWith('/') || /^[A-Za-z]:[\\/]/.test(explicit)) {
       return resolve(explicit);
     }
@@ -64,9 +85,12 @@ export function resolveVaultPath(file: VaultFile, rawEnv: NodeJS.ProcessEnv): st
     }
   }
 
-  // Backward-compat: a vault that was initialized before this change lives
-  // at `${installRoot}/data/<file>`. If we see it there, keep using it but
-  // surface a one-time hint so the operator can migrate at their leisure.
+  // Backward-compat: a vault that was initialized before the absolute-path
+  // migration lives at `${installRoot}/data/<file>`. If we see it there,
+  // keep using it but surface a one-time hint so the operator can migrate
+  // at their leisure. This existence check stays in TS — it is a
+  // filesystem-aware fallback the pure Rust resolver intentionally does
+  // not perform (memphis-paths has no I/O by design).
   let installRoot: string | null = null;
   try {
     installRoot = resolveInstallRoot({ rawEnv });
@@ -81,7 +105,7 @@ export function resolveVaultPath(file: VaultFile, rawEnv: NodeJS.ProcessEnv): st
         warnedLegacy.add(file);
         process.stderr.write(
           `[memphis-vault] WARNING: using legacy ${file} at ${legacyPath}. ` +
-            `New default is ${join(getDataDir(rawEnv), file)}. ` +
+            `New default is ${bridgeDefaultFor(file, rawEnv)}. ` +
             `Migrate by moving the file or setting ${envKey}=<absolute-path>.\n`,
         );
       }
@@ -91,8 +115,10 @@ export function resolveVaultPath(file: VaultFile, rawEnv: NodeJS.ProcessEnv): st
 
   // New default: absolute path under MEMPHIS_HOME (~/.memphis by default).
   // Independent of cwd, so smoke tests / one-shot scripts cannot collide
-  // with the production daemon by accident.
-  return join(getDataDir(rawEnv), file);
+  // with the production daemon by accident. Sourced from the Rust
+  // memphis-paths crate so this layer agrees with memphis-operator's
+  // load_vault path resolution down to the byte.
+  return bridgeDefaultFor(file, rawEnv);
 }
 
 /**

--- a/tests/integration/paths-bridge-parity.test.ts
+++ b/tests/integration/paths-bridge-parity.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Parity contract: TS path resolvers (`src/config/paths.ts`) must produce
+ * the SAME output as the Rust `memphis-paths` crate via the NAPI bridge
+ * (`src/infra/storage/rust-paths-bridge.ts`) for identical inputs.
+ *
+ * Why this test exists: PR7 added the Rust crate as the single source of
+ * truth for path policy. PR8 switched `vault-paths.ts` to call the bridge
+ * (the actual split-incident site). `paths.ts` is intentionally NOT
+ * migrated — every TS subprocess that imports `getDataDir` would otherwise
+ * load the NAPI binary, which compounds the known per-process napi
+ * teardown race (issue #270). Keeping the TS table as a parallel
+ * implementation is OK ONLY as long as drift is detected: this test fires
+ * on any divergence.
+ *
+ * If a future change to either side breaks parity, fix the divergent
+ * side rather than relaxing the test.
+ */
+import os from 'node:os';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  getChainPath,
+  getDataDir,
+  normalizeChainName,
+} from '../../src/config/paths.js';
+import {
+  bridgeNormalizeChainName,
+  bridgeResolveChainPath,
+  bridgeResolveDataDir,
+} from '../../src/infra/storage/rust-paths-bridge.js';
+
+function envWithHome(extras: Record<string, string> = {}): NodeJS.ProcessEnv {
+  // Both sides need HOME; TS reads `os.homedir()` directly while Rust
+  // reads the env map. Surface HOME to the env so the bridge sees it.
+  const base: NodeJS.ProcessEnv = { HOME: os.homedir() };
+  return { ...base, ...extras };
+}
+
+describe('TS paths.ts ↔ memphis-paths NAPI bridge parity', () => {
+  it('getDataDir matches bridgeResolveDataDir for default env', () => {
+    const env = envWithHome();
+    expect(getDataDir(env)).toBe(bridgeResolveDataDir(env));
+  });
+
+  it('getDataDir matches for absolute MEMPHIS_DATA_DIR', () => {
+    const env = envWithHome({ MEMPHIS_DATA_DIR: '/var/memphis-prod' });
+    expect(getDataDir(env)).toBe(bridgeResolveDataDir(env));
+  });
+
+  it('getDataDir matches for tilde-prefixed override', () => {
+    const env = envWithHome({ MEMPHIS_DATA_DIR: '~/runtime' });
+    expect(getDataDir(env)).toBe(bridgeResolveDataDir(env));
+  });
+
+  it('getChainPath matches bridge for canonical chain name', () => {
+    const env = envWithHome({ MEMPHIS_DATA_DIR: '/var/memphis-prod' });
+    expect(getChainPath('journal', env)).toBe(bridgeResolveChainPath('journal', env));
+  });
+
+  it('getChainPath matches bridge for aliased chain names (case→cases, etc.)', () => {
+    const env = envWithHome({ MEMPHIS_DATA_DIR: '/var/memphis-prod' });
+    for (const alias of ['case', 'decision', 'pattern', 'reflection']) {
+      expect(getChainPath(alias, env), `alias mismatch for '${alias}'`).toBe(
+        bridgeResolveChainPath(alias, env),
+      );
+    }
+  });
+
+  it('getChainPath matches bridge when chain is undefined (bare chains dir)', () => {
+    const env = envWithHome({ MEMPHIS_DATA_DIR: '/var/memphis-prod' });
+    expect(getChainPath(undefined, env)).toBe(bridgeResolveChainPath('', env));
+  });
+
+  it('normalizeChainName table mirrors the Rust alias table exactly', () => {
+    // TS `normalizeChainName` returns undefined for undefined; the bridge
+    // handles only strings. Compare on real string inputs.
+    for (const alias of ['case', 'decision', 'pattern', 'reflection']) {
+      expect(normalizeChainName(alias), `TS alias '${alias}'`).toBe(
+        bridgeNormalizeChainName(alias),
+      );
+    }
+    // Pass-through cases: non-aliased names stay unchanged on both sides.
+    for (const name of ['cases', 'journal', 'audit', 'patterns', 'reflections']) {
+      expect(normalizeChainName(name), `TS pass-through '${name}'`).toBe(
+        bridgeNormalizeChainName(name),
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

PR8 of the unified path resolution refactor (plan #1 in `~/.claude/plans/memphis-architectural-refactor.md`). Migrates the **actual split-incident site** — `src/infra/storage/vault-paths.ts` — to call the Rust `memphis-paths` crate via the NAPI bridge added in PR #421. The TS and Rust layers now agree on `vault-state.json` and `vault-entries.json` paths down to the byte.

> ⚠️ **Stacked PR**: base is `feat/memphis-paths-crate` (PR #421). Merge in order: #421 → this. GitHub will auto-rebase the base when #421 merges.

## Scope narrowed during implementation

The original plan also migrated `src/config/paths.ts:getDataDir/getChainPath` to the bridge. Implementation surfaced a problem: that file has ~30 caller sites, including TS subprocesses spawned by ops scripts (`tsx scripts/export-incident-bundle.mts` via `npm run -s ops:export-incident-bundle`). Every such subprocess loaded the napi binary, which **reproducibly amplified the known per-process napi teardown race (issue #270)** as `tests/ops/incident-bundle-{exporter,manifest-verify}` exit-code 139 (SIGSEGV) in the full ops/ run. The race never reproduced in isolation, only in bulk subprocess fanout.

| Approach | ops/ result | Full suite |
|----------|-------------|------------|
| Migrate paths.ts + vault-paths.ts (original plan) | **2 SIGSEGV** in 32 files | 2 fail / 2563 |
| Revert paths.ts, keep vault-paths.ts (this PR) | **32/32 pass** | 2568/2570 (2 skipped, 0 fail) |

`vault-paths.ts` has only 2-3 caller sites and is the file the operator's 2026-04-29 incident actually traced to. Migrating it captures the value (TS↔Rust path agreement on the file that matters) without amplifying #270. The deferred `paths.ts` migration unblocks once #270 lands.

## What ships

### 1. `src/infra/storage/rust-paths-bridge.ts` (new, 195 LOC)

- Typed wrappers for all 9 `paths_*` NAPI exports added by PR7
- Cached bridge handle keyed on the resolved bridge path
- Parses `ApiResult<string>` envelope and throws on bridge unavailability with a clear "rebuild the napi binary" message
- Auto-injects `process.cwd()` for resolvers that need a cwd anchor

### 2. `src/infra/storage/vault-paths.ts` migration

- Default-path resolution now goes through the bridge — TS reads the same `<data_dir>/vault-state.json` (and entries) the Rust operator computes
- Explicit env override (`MEMPHIS_VAULT_STATE_PATH` / `MEMPHIS_VAULT_ENTRIES_PATH`) preserved verbatim
- Legacy `${installRoot}/data/<file>` filesystem fallback preserved (existence check stays in TS — the Rust crate has no I/O by design)
- Bridge unavailability falls back to legacy TS composition so dev tooling that runs before `npm run build:rust` still works

### 3. `tests/integration/paths-bridge-parity.test.ts` (new, 7 cases)

The deferred `paths.ts` migration leaves a parallel TS table (alias map, defaults, expandHome). To catch drift between TS and Rust as soon as it appears, this contract test asserts that `getDataDir` / `getChainPath` / `normalizeChainName` produce **identical** output to the bridge for the same inputs:

- Default env (no MEMPHIS_DATA_DIR)
- Absolute MEMPHIS_DATA_DIR override
- Tilde-prefixed override
- Canonical chain name
- All 4 alias names (case→cases, decision→decisions, pattern→patterns, reflection→reflections)
- Undefined chain (bare chains dir)
- Pass-through names

If a future change to either side breaks parity, fix the divergent side rather than relaxing the test.

## Test plan

- [x] `cargo test -p memphis-paths` — 22/22 (carryover from PR7)
- [x] `cargo test -p memphis-napi --lib paths_` — 8/8 (carryover from PR7)
- [x] `tests/integration/paths-bridge-parity.test.ts` — 7/7
- [x] `tests/unit/config.paths.test.ts` — 3/3 unchanged
- [x] `tests/unit/vault-paths.test.ts` — 7/7 (semantics preserved through bridge)
- [x] `tests/ops/` — 32/32 (no SEGV regression)
- [x] Full `npx vitest run` — **2568/2570** (2 skipped, 0 failed)
- [x] `npm run typecheck` + `eslint .` — green
- [ ] CI workflows green
- [ ] PR #421 merged before this

## Follow-up: PR9 (Rust operator migration)

`crates/memphis-operator/runtime.rs:1075-1103` band-aid (`resolve_vault_state_path` + `FALLBACK_NOTICE_EMITTED`) collapses into a single `memphis_paths::resolve_vault_state_path` call. Stays self-contained inside Rust, no TS impact.

## Follow-up: paths.ts migration (after #270 lands)

Once the napi teardown race is fixed in `graceful-shutdown` / NAPI, the broader `paths.ts` migration becomes safe — full bridge subscription and the parity test above can flip to "TS calls bridge, parity test verifies migration was identity-preserving."

🤖 Generated with [Claude Code](https://claude.com/claude-code)