### PR TITLE
feat(operator): collapse path resolvers + band-aid into memphis-paths (3/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ dependencies = [
  "memphis-case-index",
  "memphis-core",
  "memphis-embed",
+ "memphis-paths",
  "memphis-vault",
  "regex",
  "rusqlite",

--- a/crates/memphis-operator/Cargo.toml
+++ b/crates/memphis-operator/Cargo.toml
@@ -13,6 +13,7 @@ memphis-core = { path = "../memphis-core" }
 memphis-case-index = { path = "../memphis-case-index" }
 memphis-embed = { path = "../memphis-embed" }
 memphis-vault = { path = "../memphis-vault" }
+memphis-paths = { path = "../memphis-paths" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 aes-gcm = "0.10"
 base64 = "0.22"

--- a/crates/memphis-operator/src/config.rs
+++ b/crates/memphis-operator/src/config.rs
@@ -6,9 +6,6 @@ use std::{
 
 use memphis_embed::{EmbedConfig, EmbedMode, EmbedPersistenceConfig};
 
-const DEFAULT_MEMPHIS_DATA_DIR: &str = "~/.memphis";
-const DEFAULT_DATABASE_URL: &str = "file:./data/memphis.db";
-
 #[derive(Debug, Clone)]
 pub struct OperatorConfig {
     pub raw_env: HashMap<String, String>,
@@ -43,30 +40,19 @@ impl OperatorConfig {
             .map(|(key, value)| (key.into(), value.into()))
             .collect::<HashMap<String, String>>();
 
-        let data_dir = resolve_data_dir(&env_map);
-        let database_path = resolve_database_path(&env_map);
-        let case_index_path = data_dir.join("case-index.sqlite");
-        // Align with src/infra/storage/vault-paths.ts: vault files live under
-        // data_dir (i.e. ~/.memphis/) by default. The previous Rust defaults
-        // ./data/vault-state.json and ./data/vault-entries.json resolved
-        // against cwd — when memphis ran from anywhere outside the repo
-        // checkout, the Rust runtime pointed at non-existent files while the
-        // TS layer (and operator's actual files) lived under ~/.memphis/.
-        // Operator's 2026-04-29 vault-path-split incident traced to exactly
-        // this divergence; fix is to make the two layers agree at the
-        // default-resolution step.
-        let vault_state_path = env_map
-            .get("MEMPHIS_VAULT_STATE_PATH")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| data_dir.join("vault-state.json"));
-        let vault_entries_path = env_map
-            .get("MEMPHIS_VAULT_ENTRIES_PATH")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| data_dir.join("vault-entries.json"));
-        let embed_persist_path = env_map
-            .get("RUST_EMBED_PERSIST_PATH")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| data_dir.join("embed").join("index-v1.json"));
+        // PR9 of plan #1 (`memphis-architectural-refactor.md`): every
+        // path is resolved through the shared `memphis-paths` crate so
+        // this config object agrees with the TS-side `vault-paths.ts`
+        // bridge consumer down to the byte. Operator's 2026-04-29
+        // vault-path-split incident lived in the gap between the two
+        // independent resolvers — that gap no longer exists.
+        let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let data_dir = memphis_paths::resolve_data_dir(&env_map, &cwd);
+        let database_path = memphis_paths::resolve_database_path(&env_map, &cwd);
+        let case_index_path = memphis_paths::resolve_case_index_path(&env_map, &cwd);
+        let vault_state_path = memphis_paths::resolve_vault_state_path(&env_map, &cwd);
+        let vault_entries_path = memphis_paths::resolve_vault_entries_path(&env_map, &cwd);
+        let embed_persist_path = memphis_paths::resolve_embed_index_path(&env_map, &cwd);
         let embed_persist_enabled = parse_bool(
             env_map
                 .get("RUST_EMBED_PERSIST_ENABLED")
@@ -132,51 +118,6 @@ impl OperatorConfig {
             .get(key)
             .map(String::as_str)
             .filter(|value| !value.trim().is_empty())
-    }
-}
-
-fn expand_home(input: &str) -> PathBuf {
-    if input == "~" {
-        return PathBuf::from(env::var("HOME").unwrap_or_else(|_| ".".to_string()));
-    }
-
-    if let Some(suffix) = input.strip_prefix("~/") {
-        return PathBuf::from(env::var("HOME").unwrap_or_else(|_| ".".to_string())).join(suffix);
-    }
-
-    PathBuf::from(input)
-}
-
-fn resolve_data_dir(env_map: &HashMap<String, String>) -> PathBuf {
-    let configured = env_map
-        .get("MEMPHIS_DATA_DIR")
-        .map(String::as_str)
-        .unwrap_or(DEFAULT_MEMPHIS_DATA_DIR);
-
-    absolute_path(expand_home(configured))
-}
-
-fn resolve_database_path(env_map: &HashMap<String, String>) -> PathBuf {
-    let database_url = env_map
-        .get("DATABASE_URL")
-        .map(String::as_str)
-        .unwrap_or(DEFAULT_DATABASE_URL);
-
-    let raw = database_url
-        .strip_prefix("file:")
-        .unwrap_or(database_url)
-        .to_string();
-
-    absolute_path(PathBuf::from(raw))
-}
-
-fn absolute_path(path: PathBuf) -> PathBuf {
-    if path.is_absolute() {
-        path
-    } else {
-        env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join(path)
     }
 }
 

--- a/crates/memphis-operator/src/runtime.rs
+++ b/crates/memphis-operator/src/runtime.rs
@@ -1066,67 +1066,17 @@ fn read_vault_state_version(path: &Path) -> Option<u8> {
         .or(Some(1))
 }
 
-/// Auto-resolve the vault-state path with fallbacks. The configured path
-/// (from MEMPHIS_VAULT_STATE_PATH or default ./data/vault-state.json) wins
-/// when it exists. Otherwise, before failing, look in two well-known places:
-///   1. the directory containing vault_entries_path (operator probably moved
-///      entries via env override and the state moved with them)
-///   2. ~/.memphis/vault-state.json (the legacy / TS-side default)
-/// Returns the configured path unchanged if neither fallback exists, so the
-/// caller can produce the existing operator-actionable error message.
-///
-/// Notice is process-once via FALLBACK_NOTICE_EMITTED — load_vault is hit
-/// many times per process (chat init, status probes, vault reads), and
-/// printing the same notice 4+ times per TUI launch is hostile.
-fn resolve_vault_state_path(config: &OperatorConfig) -> std::path::PathBuf {
-    if config.vault_state_path.exists() {
-        return config.vault_state_path.clone();
-    }
-    if let Some(parent) = config.vault_entries_path.parent() {
-        let sibling = parent.join("vault-state.json");
-        if sibling.exists() {
-            emit_fallback_notice_once(&format!(
-                "[memphis-vault] using sibling vault-state at {} (configured path {} does not exist)",
-                sibling.display(),
-                config.vault_state_path.display(),
-            ));
-            return sibling;
-        }
-    }
-    if let Some(home) = std::env::var_os("HOME") {
-        let legacy = std::path::PathBuf::from(home)
-            .join(".memphis")
-            .join("vault-state.json");
-        if legacy.exists() {
-            emit_fallback_notice_once(&format!(
-                "[memphis-vault] using legacy ~/.memphis/vault-state.json (configured path {} does not exist); set MEMPHIS_VAULT_STATE_PATH to silence this notice",
-                config.vault_state_path.display(),
-            ));
-            return legacy;
-        }
-    }
-    config.vault_state_path.clone()
-}
-
-static FALLBACK_NOTICE_EMITTED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
-fn emit_fallback_notice_once(message: &str) {
-    if FALLBACK_NOTICE_EMITTED
-        .compare_exchange(
-            false,
-            true,
-            std::sync::atomic::Ordering::SeqCst,
-            std::sync::atomic::Ordering::SeqCst,
-        )
-        .is_ok()
-    {
-        eprintln!("{message}");
-    }
-}
+// PR9 of plan #1: the legacy `resolve_vault_state_path` band-aid plus its
+// `FALLBACK_NOTICE_EMITTED` once-flag are gone. Both vault_state_path and
+// vault_entries_path now come from `memphis_paths` (see config.rs), so they
+// already resolve under the same `data_dir` — there is no longer any
+// "configured path doesn't exist, look beside entries / ~/.memphis"
+// asymmetry to detect. The remaining loud "vault path split" diagnostic
+// inside `load_vault` still catches the genuinely broken case where an
+// operator overrides only one of the two env vars.
 
 fn load_vault(config: &OperatorConfig, optional: bool) -> Result<Option<Vault>, OperatorError> {
-    let state_path = resolve_vault_state_path(config);
+    let state_path = config.vault_state_path.clone();
     if optional && !state_path.exists() {
         // Silent-split detection: if the entries file exists at a different
         // path than the missing state file, the operator probably set


### PR DESCRIPTION
## Summary

Final PR of plan #1 (`~/.claude/plans/memphis-architectural-refactor.md`, "Unified vault path resolution"). With PR #421 shipping the leaf crate and PR #422 wiring the TS layer, this PR rips the duplicated Rust-side resolvers out and points everything at `memphis-paths`. The TS bridge and Rust operator now read the SAME function for every shared path.

> ⚠️ **Stacked PR**. Base: `feat/memphis-paths-ts-migration` (PR #422). Merge order: #421 → #422 → this.

**Net change: 131 LOC → 24 LOC (-107).**

## Removed

### `config.rs`

- `DEFAULT_MEMPHIS_DATA_DIR` + `DEFAULT_DATABASE_URL` constants
- `expand_home()` / `absolute_path()` locals
- `resolve_data_dir()` / `resolve_database_path()` locals
- Hand-rolled `data_dir.join("vault-state.json")` / `data_dir.join("vault-entries.json")` / `data_dir.join("embed").join("index-v1.json")` / `data_dir.join("case-index.sqlite")` construction. Every path now goes through `memphis_paths::*`.

### `runtime.rs`

- **`resolve_vault_state_path()`** band-aid (40 LOC). The "configured path missing → look beside entries → look in `~/.memphis`" auto-resolver was added on 2026-04-29 to mask the TS↔Rust divergence. With both layers reading `memphis-paths`, the divergence cannot exist, so the auto-resolver has nothing to do and is gone.
- `FALLBACK_NOTICE_EMITTED` + `emit_fallback_notice_once()` that powered the once-per-process warning print.

## Preserved

- **Silent-split detection** inside `load_vault` still fires for the genuinely broken case (operator overrides entries but not state or vice versa). That diagnostic catches misconfiguration; this PR removes the *auto-correction* band-aid that masked it as "everything's fine, just slightly slow log."
- All env override semantics: `MEMPHIS_VAULT_STATE_PATH` / `MEMPHIS_VAULT_ENTRIES_PATH` / `MEMPHIS_DATA_DIR` / `DATABASE_URL` / `RUST_EMBED_PERSIST_PATH` all parsed identically — `memphis-paths` is the single resolver for all of them.
- 61/61 operator tests + all path-touching TS tests pass without semantic change.

## Migration risk

Operators with `vault-state.json` at a path different from `data_dir` (e.g. left over from before PR #422/9) AND no `MEMPHIS_VAULT_STATE_PATH` override will now hit the "vault path split" hard error instead of silently using a fallback. **This is intentional** — the auto-resolver masked silent-splits; it surfaced incorrectly-configured runtimes as "everything fine, just slightly slow log." Now the operator sees an actionable error pointing at the env var to set. The error message in `load_vault` already lists the recovery paths (`~/.memphis/vault-state.json` and "beside entries") so operators can find the file by hand if needed.

## Test plan

- [x] `cargo test --workspace` — 319 passed (cumulative of PR7 + PR8 + this; no regressions in operator/napi/embed/etc.)
- [x] `cargo test -p memphis-operator` — 61/61 (config + runtime tests semantically unchanged)
- [x] `cargo test -p memphis-paths` — 22/22
- [x] `cargo test -p memphis-napi --lib paths_` — 8/8
- [x] `npx vitest run tests/unit/config.paths.test.ts tests/unit/vault-paths.test.ts tests/integration/paths-bridge-parity.test.ts` — 17/17
- [x] `npm run typecheck` — green
- [x] `eslint .` — green
- [ ] CI workflows green (memphis-paths is now in the operator crate's dependency graph; cargo build picks it up automatically since `members = ["crates/*"]`)
- [ ] PR #421 → #422 → this merged in order

## Architecture diff after the 3-PR stack

Before:
- `src/config/paths.ts` — TS resolver
- `src/infra/storage/vault-paths.ts` — TS resolver with legacy detection
- `crates/memphis-operator/src/config.rs` — Rust resolver
- `crates/memphis-operator/src/runtime.rs:1075-1109` — band-aid auto-resolver
- 4 independent path policy implementations.

After:
- `crates/memphis-paths/` — single source of truth (Rust, no I/O, pure)
- `src/infra/storage/rust-paths-bridge.ts` — TS bridge thinking through NAPI
- `src/infra/storage/vault-paths.ts` — calls bridge for defaults + keeps legacy filesystem detection (TS-only because it does I/O the pure crate doesn't)
- `src/config/paths.ts` — keeps parallel TS implementation (parity-tested) until issue #270 lands and broader migration becomes safe
- `crates/memphis-operator/src/config.rs` — calls memphis-paths
- `crates/memphis-operator/src/runtime.rs` — band-aid gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

classification:
- memphis-paths = stable-platform: internal Memphis workspace crate (path = "../memphis-paths"), MIT, pure-function path resolvers, zero external runtime deps, already shipped via PR #421
