### PR TITLE
fix(napi): auto-install exit guard on bridge load (issue #270 script-spawn variant)

### DIFF
--- a/src/infra/runtime/napi-shutdown.ts
+++ b/src/infra/runtime/napi-shutdown.ts
@@ -1,0 +1,151 @@
+/**
+ * Auto-installed teardown guard for any process that loads the Memphis
+ * NAPI bridge. Closes the issue #270 NEW variant where short-lived
+ * tsx-spawned scripts (e.g. `npm run -s ops:export-incident-bundle`)
+ * import a module that transitively loads `crates/memphis-napi/index.node`,
+ * use the bridge, then exit through the standard Node teardown path
+ * WITHOUT going through `performGracefulShutdown` from the runtime
+ * server boot path. The original issue #270 fix (PR #333) wired
+ * `embed_shutdown()` + `flushAllPinoStreamsSync()` into
+ * `performGracefulShutdown` (which `memphis serve` and `mcp serve`
+ * call), but scripts and tests don't reach that codepath. They rely
+ * on V8 process exit to tear down everything — and the EmbedPipeline
+ * `OnceLock<Mutex<…>>` plus pino's async sonic-boom destination can
+ * race with FD invalidation, producing SIGSEGV exit codes (139).
+ *
+ * The PR8 vault path migration surfaced this: the full `tests/ops/`
+ * run started reproducibly emitting 1-2 SEGV per 32-file run because
+ * the new TS bridge import added one more codepath that loaded the
+ * NAPI binary in those subprocesses. Reverting to keep paths.ts in
+ * pure-TS (and parity-testing it) un-tripped the race, but the bug
+ * is still there for any future caller.
+ *
+ * Fix: when `loadBridgeModule()` resolves the binary, register a
+ * single-shot exit guard that invokes the same teardown sequence as
+ * the runtime's `performGracefulShutdown`, just without the drain /
+ * HTTP / OTel pieces (those don't apply to scripts).
+ *
+ * Idempotency: a module-level flag prevents duplicate registration
+ * when multiple TS modules load the same bridge. Sibling consumers
+ * (chain-adapter, vault-adapter, paths-bridge…) all share the same
+ * `index.node`, so once is enough — and re-registering would attach
+ * N handlers that all race on the same EmbedPipeline mutex.
+ *
+ * Test seams: `__resetNapiShutdownGuardForTests()` clears the flag
+ * + removes the registered handler so test-side reload cycles can
+ * re-exercise the registration path.
+ */
+
+import { flushAllPinoStreamsSync } from '../logging/pino.js';
+
+let installed = false;
+let cachedBeforeExit: ((...args: unknown[]) => void) | null = null;
+let cachedExit: ((...args: unknown[]) => void) | null = null;
+
+type BridgeModule = Record<string, unknown>;
+
+interface NapiShutdownOptions {
+  /**
+   * Test seam: substitute for the bridge's `embed_shutdown` export.
+   * Production callers leave this undefined; the resolver picks the
+   * function off the bridge module itself.
+   */
+  embedShutdownFn?: () => void;
+  /**
+   * Test seam: substitute for `flushAllPinoStreamsSync`. Production
+   * callers leave this undefined; we lazy-import the real flusher
+   * so the guard module stays cheap to load (pino has heavy
+   * transitive deps).
+   */
+  pinoFlushFn?: () => void;
+}
+
+/**
+ * Best-effort sync exit handler. Runs on `beforeExit` AND `exit` so we
+ * cover both clean returns (event loop drained) and explicit
+ * `process.exit(code)` calls. Each side guards against the other
+ * having already run via the module-level flag.
+ */
+function buildHandler(
+  bridge: BridgeModule,
+  options: NapiShutdownOptions,
+): () => void {
+  let alreadyRan = false;
+  return function memphisNapiShutdownGuard(): void {
+    if (alreadyRan) return;
+    alreadyRan = true;
+    // 1. Tell the Rust EmbedPipeline to release its global Mutex
+    //    BEFORE the V8 isolate tears down the napi env. Skipping this
+    //    is the original issue #270 SEGV signature.
+    try {
+      const embedShutdown =
+        options.embedShutdownFn ??
+        (typeof bridge.embed_shutdown === 'function'
+          ? (bridge.embed_shutdown as () => void)
+          : undefined);
+      if (embedShutdown) {
+        embedShutdown();
+      }
+    } catch {
+      // Swallowed — the guard runs at exit; surfacing here would
+      // bypass the second step that has nothing to do with the embed
+      // crate's state.
+    }
+    // 2. Flush pino sonic-boom destinations. Without this, log lines
+    //    queued in the async backend try to fsync() FDs the V8
+    //    teardown is in the middle of invalidating.
+    try {
+      const pinoFlush = options.pinoFlushFn ?? flushAllPinoStreamsSync;
+      pinoFlush();
+    } catch {
+      // Pino flushing failure is never worth crashing exit. The
+      // operator gets the next-best signal: the not-yet-flushed log
+      // lines simply don't appear, but the process exits cleanly.
+    }
+  };
+}
+
+/**
+ * Attach the exit guard. Safe to call repeatedly: only the FIRST call
+ * registers handlers; subsequent calls are no-ops. Returns whether
+ * registration happened on this call (true on first, false on later).
+ */
+export function installNapiShutdownGuard(
+  bridge: BridgeModule | null,
+  options: NapiShutdownOptions = {},
+): boolean {
+  if (installed || !bridge) return false;
+  const handler = buildHandler(bridge, options);
+  // Wrap the handler so we don't accidentally hand the bound `this`
+  // (or the listener-array slot) to any later caller of removeListener.
+  cachedBeforeExit = (): void => handler();
+  cachedExit = (): void => handler();
+  process.on('beforeExit', cachedBeforeExit);
+  process.on('exit', cachedExit);
+  installed = true;
+  return true;
+}
+
+/**
+ * Test-only: clear the installed flag and remove the registered
+ * handlers so a test can re-exercise the registration path. Production
+ * code never calls this — there is exactly one bridge per process.
+ */
+export function __resetNapiShutdownGuardForTests(): void {
+  if (cachedBeforeExit) {
+    process.off('beforeExit', cachedBeforeExit);
+    cachedBeforeExit = null;
+  }
+  if (cachedExit) {
+    process.off('exit', cachedExit);
+    cachedExit = null;
+  }
+  installed = false;
+}
+
+/**
+ * Test-only: read the current registration flag for assertions.
+ */
+export function __isNapiShutdownGuardInstalled(): boolean {
+  return installed;
+}

--- a/src/infra/storage/napi-contract.ts
+++ b/src/infra/storage/napi-contract.ts
@@ -1,5 +1,7 @@
 import { createRequire } from 'node:module';
 
+import { installNapiShutdownGuard } from '../runtime/napi-shutdown.js';
+
 type BridgeModule = Record<string, unknown>;
 
 /**
@@ -127,7 +129,19 @@ export function hasRequiredBridgeExports<T extends string>(
 export function loadBridgeModule(path: string): BridgeModule | null {
   try {
     const req = createRequire(`${process.cwd()}/`);
-    return req(path) as BridgeModule;
+    const bridge = req(path) as BridgeModule;
+    // Issue #270 NEW variant fix (2026-05-03): when ANY caller resolves
+    // the napi binary, register the exit guard so process teardown
+    // calls embed_shutdown() + flushAllPinoStreamsSync() before V8
+    // tears down the napi env. Idempotent — re-loaders are no-ops.
+    // Covers tsx-spawned scripts (npm run -s ops:*) that bypass the
+    // runtime's performGracefulShutdown and would otherwise SIGSEGV
+    // on exit. Production runtime servers also call installShutdownHandlers
+    // and run performGracefulShutdown explicitly; the auto guard still
+    // installs but is a no-op there because embed_shutdown was already
+    // called and pino streams were already flushed.
+    installNapiShutdownGuard(bridge);
+    return bridge;
   } catch {
     return null;
   }

--- a/tests/integration/script-shutdown-segv-stress.test.ts
+++ b/tests/integration/script-shutdown-segv-stress.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Stress test for the issue #270 NEW variant: short-lived
+ * `tsx`-spawned (or plain `node`-spawned) scripts that load the
+ * Memphis NAPI bridge through any TS module, use it briefly, and
+ * exit. Without the auto-install guard wired into `loadBridgeModule`,
+ * V8 isolate teardown raced the EmbedPipeline `OnceLock<Mutex<…>>`
+ * Drop, producing SIGSEGV (exit code 139) at random.
+ *
+ * The original issue #270 fix (PR #333) wired `embed_shutdown()` +
+ * `flushAllPinoStreamsSync()` into `performGracefulShutdown` — but
+ * scripts and one-shot tools never call that function, they rely on
+ * V8 process exit. The guard added by `napi-shutdown.ts` runs on
+ * `beforeExit` + `exit` so the same teardown sequence executes
+ * regardless of how the process winds down.
+ *
+ * This test spawns 10 short-lived child processes that:
+ *   1. Load the bridge (transitively triggers the guard registration).
+ *   2. Call any cheap export so the bridge actually engages the
+ *      Rust side, not just the dlopen.
+ *   3. Exit.
+ *
+ * All 10 must exit with code 0. A single 139 means the guard
+ * regressed and the original issue is back. Skipped when the napi
+ * binary isn't built (fresh checkout / no Rust toolchain) — CI
+ * always builds before vitest, so it runs there.
+ *
+ * Stress level: 10 iterations is enough to surface the race
+ * empirically (PR8 caught it at 1-2 SEGVs per 32 spawns) without
+ * stretching CI runtime past a few seconds. The standing
+ * `shutdown-segv-stress.test.ts` suite covers the full-bootstrap
+ * path; this one is the script-path counterpart.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+function resolveRepoRoot(): string {
+  return resolve(__dirname, '../..');
+}
+
+function napiBinaryPath(): string {
+  return resolve(resolveRepoRoot(), 'crates/memphis-napi/index.node');
+}
+
+function bridgeBuildAvailable(): boolean {
+  return (
+    existsSync(napiBinaryPath()) &&
+    existsSync(resolve(resolveRepoRoot(), 'dist/infra/storage/napi-contract.js'))
+  );
+}
+
+const RUNNER_SOURCE = `
+  // Replicate the minimum codepath a tsx-spawned ops script takes:
+  // import napi-contract → loadBridgeModule → install guard → call a
+  // cheap NAPI export → exit naturally. If the guard is wired
+  // correctly, V8 teardown emits 'beforeExit' / 'exit' (sequence
+  // depending on whether the event loop drained), the guard fires
+  // embed_shutdown() + pino flush, and the process exits 0.
+  const { loadPlatformAwareBridge } = await import(REPO_ROOT_PLACEHOLDER + '/dist/infra/storage/napi-contract.js');
+  const { resolveRustBridgePath } = await import(REPO_ROOT_PLACEHOLDER + '/dist/infra/runtime/install-root.js');
+  const bridgePath = resolveRustBridgePath(process.env);
+  const bridge = loadPlatformAwareBridge(bridgePath);
+  if (!bridge) {
+    process.stderr.write('runner: bridge not loadable from ' + bridgePath + '\\n');
+    process.exit(2);
+  }
+  // Engage the Rust side. embed_shutdown is callable even before
+  // any embed_store, and is the actual function the guard re-runs
+  // at exit — exercising it now lets the guard's idempotency
+  // protect against double-shutdown panics.
+  if (typeof bridge.embed_shutdown === 'function') {
+    bridge.embed_shutdown();
+  }
+  // Exit cleanly. The auto-installed guard will run on 'beforeExit'.
+`;
+
+function spawnRunner(): { code: number | null; stdout: string; stderr: string } {
+  const repoRoot = resolveRepoRoot();
+  const source = RUNNER_SOURCE.replace(/REPO_ROOT_PLACEHOLDER/g, JSON.stringify(repoRoot));
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      ['--input-type=module', '-e', source],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 30_000,
+        env: { ...process.env, MEMPHIS_LOG_LEVEL: 'error' },
+      },
+    );
+    return { code: 0, stdout: String(stdout), stderr: '' };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & {
+      stdout?: Buffer | string;
+      stderr?: Buffer | string;
+      status?: number | null;
+      signal?: string | null;
+    };
+    return {
+      code: typeof e.status === 'number' ? e.status : null,
+      stdout: e.stdout ? e.stdout.toString() : '',
+      stderr: e.stderr ? e.stderr.toString() : '',
+    };
+  }
+}
+
+describe.skipIf(!bridgeBuildAvailable())(
+  'NAPI bridge auto-shutdown — script-style spawn ×10',
+  () => {
+    it('every iteration exits cleanly (no SIGSEGV from V8 teardown race)', () => {
+      const failures: Array<{ iteration: number; code: number | null; stderr: string }> = [];
+      for (let i = 0; i < 10; i += 1) {
+        const result = spawnRunner();
+        if (result.code !== 0) {
+          failures.push({ iteration: i, code: result.code, stderr: result.stderr.slice(0, 400) });
+        }
+      }
+      expect(failures, `${failures.length} iterations failed: ${JSON.stringify(failures, null, 2)}`).toEqual([]);
+    });
+  },
+);

--- a/tests/unit/napi-shutdown.test.ts
+++ b/tests/unit/napi-shutdown.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the auto-installed NAPI exit guard. The integration
+ * stress test (`tests/integration/script-shutdown-segv-stress.test.ts`)
+ * spawns real subprocesses and asserts no SIGSEGV; this file pins the
+ * registration semantics: idempotency, handler invocation, test-seam
+ * substitution, missing-bridge-export tolerance.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __isNapiShutdownGuardInstalled,
+  __resetNapiShutdownGuardForTests,
+  installNapiShutdownGuard,
+} from '../../src/infra/runtime/napi-shutdown.js';
+
+describe('installNapiShutdownGuard', () => {
+  beforeEach(() => {
+    __resetNapiShutdownGuardForTests();
+  });
+
+  afterEach(() => {
+    __resetNapiShutdownGuardForTests();
+  });
+
+  it('is a no-op when the bridge module is null (binary not loadable)', () => {
+    expect(installNapiShutdownGuard(null)).toBe(false);
+    expect(__isNapiShutdownGuardInstalled()).toBe(false);
+  });
+
+  it('registers exit listeners on first call and reports back true', () => {
+    const before = process.listenerCount('beforeExit');
+    const exit = process.listenerCount('exit');
+    expect(installNapiShutdownGuard({ embed_shutdown: () => {} })).toBe(true);
+    expect(__isNapiShutdownGuardInstalled()).toBe(true);
+    expect(process.listenerCount('beforeExit')).toBe(before + 1);
+    expect(process.listenerCount('exit')).toBe(exit + 1);
+  });
+
+  it('subsequent calls are no-ops and do NOT add more listeners', () => {
+    installNapiShutdownGuard({ embed_shutdown: () => {} });
+    const before = process.listenerCount('beforeExit');
+    const exit = process.listenerCount('exit');
+    expect(installNapiShutdownGuard({ embed_shutdown: () => {} })).toBe(false);
+    expect(installNapiShutdownGuard({ embed_shutdown: () => {} })).toBe(false);
+    expect(process.listenerCount('beforeExit')).toBe(before);
+    expect(process.listenerCount('exit')).toBe(exit);
+  });
+
+  it('handler invokes embed_shutdown + pino flush exactly once even if both events fire', () => {
+    const embedShutdown = vi.fn();
+    const pinoFlush = vi.fn();
+    installNapiShutdownGuard({}, { embedShutdownFn: embedShutdown, pinoFlushFn: pinoFlush });
+
+    process.emit('beforeExit', 0);
+    process.emit('exit', 0);
+
+    expect(embedShutdown).toHaveBeenCalledTimes(1);
+    expect(pinoFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('handler swallows embed_shutdown throws and still flushes pino', () => {
+    const embedShutdown = vi.fn(() => {
+      throw new Error('napi teardown panicked');
+    });
+    const pinoFlush = vi.fn();
+    installNapiShutdownGuard({}, { embedShutdownFn: embedShutdown, pinoFlushFn: pinoFlush });
+
+    expect(() => process.emit('beforeExit', 0)).not.toThrow();
+    expect(embedShutdown).toHaveBeenCalledTimes(1);
+    expect(pinoFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('handler tolerates a bridge missing embed_shutdown (older / partial binary)', () => {
+    const pinoFlush = vi.fn();
+    installNapiShutdownGuard({ chain_append: () => {} }, { pinoFlushFn: pinoFlush });
+
+    expect(() => process.emit('beforeExit', 0)).not.toThrow();
+    expect(pinoFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('handler swallows pino flush throws — exit must never be blocked by telemetry', () => {
+    const embedShutdown = vi.fn();
+    const pinoFlush = vi.fn(() => {
+      throw new Error('sonic-boom flushSync failed');
+    });
+    installNapiShutdownGuard({}, { embedShutdownFn: embedShutdown, pinoFlushFn: pinoFlush });
+
+    expect(() => process.emit('exit', 0)).not.toThrow();
+    expect(embedShutdown).toHaveBeenCalledTimes(1);
+    expect(pinoFlush).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **script-spawn variant of issue #270**. The original 2026-04-29 fix (PR #333) wired `embed_shutdown()` + `flushAllPinoStreamsSync()` into `performGracefulShutdown` for the runtime servers (`memphis serve`, `mcp serve`). That codepath also has the standing stress test `tests/integration/shutdown-segv-stress.test.ts` (30/30 clean) — runtime servers stay SEGV-free.

**What was NOT covered**: short-lived `tsx`-spawned scripts and ad-hoc tests. Anything that imports a module which transitively loads `crates/memphis-napi/index.node` and then exits through plain V8 process teardown (rather than `performGracefulShutdown`). Specifically:

- `npm run -s ops:export-incident-bundle` (and other `ops:*` scripts run through `tsx`)
- `node --input-type=module -e "..."` test-spawn helpers
- Any future tooling that imports `chain-adapter` / `vault-adapter` / `rust-paths-bridge` and exits

The `EmbedPipeline` `OnceLock<Mutex<…>>` plus pino's async sonic-boom destination then race FD invalidation and produce SIGSEGV (exit code 139). Empirically: the PR8 vault-paths migration work tripped this — the full `tests/ops/` run started reproducibly emitting 1-2 SEGVs across 32 spawned subprocesses because one more TS module now loaded the napi binary in those scripts. Reverting that migration to pure-TS untripped the race, but the underlying gap stayed open for future callers.

## Fix

When `loadBridgeModule()` resolves the binary, register a **single-shot exit guard** that runs the same teardown sequence as `performGracefulShutdown`, minus the drain / HTTP / OTel pieces (those don't apply to scripts):

| Step | Why |
|------|-----|
| `embed_shutdown()` | Releases the Rust EmbedPipeline `Mutex` before V8 tears down the napi env. Skipping this is the original SEGV signature. |
| `flushAllPinoStreamsSync()` | Flushes pino's async sonic-boom destination before its FDs are invalidated. |

Both calls are wrapped in `try/catch` — exit must NEVER be blocked by telemetry. The guard registers on both `process.on('beforeExit')` and `process.on('exit')`, with a `alreadyRan` flag so the body runs at most once regardless of which event fires.

## Files

| File | Change |
|------|--------|
| `src/infra/runtime/napi-shutdown.ts` (new) | `installNapiShutdownGuard(bridge)` — idempotent registration, test seams for both teardown calls |
| `src/infra/storage/napi-contract.ts:loadBridgeModule` | Calls `installNapiShutdownGuard(bridge)` after successful require |
| `tests/unit/napi-shutdown.test.ts` (new) | 7 cases — null-bridge no-op, idempotency, single-invocation, swallow throws, tolerate missing `embed_shutdown` |
| `tests/integration/script-shutdown-segv-stress.test.ts` (new) | Spawns 10 child processes that load bridge + exit; asserts code===0 across all |

## Idempotency vs runtime servers

Production runtime servers (`memphis serve`, `mcp serve`) already call `installShutdownHandlers` and run `performGracefulShutdown` explicitly. The auto guard still installs there but the handler body becomes a no-op because embed_shutdown was already called and pino streams were already flushed. Costs nothing.

## Test plan

- [x] `tests/unit/napi-shutdown.test.ts` — 7/7
- [x] `tests/integration/script-shutdown-segv-stress.test.ts` — 1/1 (10 spawns all clean)
- [x] `tests/ops/` — 32/32 (191 tests including the new ones, no regression)
- [x] `MEMPHIS_SEGV_STRESS=1 npx vitest run tests/integration/shutdown-segv-stress.test.ts` — 2/2 (30 spawns, original #270 fix stays clean)
- [x] `npm run typecheck` + `eslint .` — green
- [ ] CI workflows green

## Why this PR is independent

It does NOT depend on PR #421 / #422 / #423 (the path-resolution refactor stack). The fix is in the bridge loader itself — every napi consumer benefits, including the existing `chain-adapter` / `vault-adapter` callers. Mergeable on main directly. Once it lands, the deferred `paths.ts` migration in the path stack becomes safe again (currently parity-tested as a stand-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)