### PR TITLE
fix(cognitive): rename model-e-types Insight to ModelEInsight (closes #397)

### DIFF
--- a/src/cognitive/index.ts
+++ b/src/cognitive/index.ts
@@ -58,7 +58,7 @@ export type {
   Recommendation,
   Topic,
   KnowledgeGap,
-  Insight as ModelEInsight,
+  ModelEInsight,
   ProactiveSuggestion,
 } from './model-e-types.js';
 export type { InsightReport } from './insight-generator.js';

--- a/src/cognitive/insight-generator.ts
+++ b/src/cognitive/insight-generator.ts
@@ -1,13 +1,13 @@
 import { ConnectionDiscovery } from './connection-discovery.js';
 import { KnowledgeSynthesizer } from './knowledge-synthesizer.js';
-import type { Insight } from './model-e-types.js';
+import type { ModelEInsight } from './model-e-types.js';
 import { ChainStore, IStore } from './store.js';
 import { normalizeChainName } from '../config/paths.js';
 import type { Block } from '../memory/chain.js';
 
 export interface InsightReport {
   generated: Date;
-  insights: Insight[];
+  insights: ModelEInsight[];
   quickWins: string[];
   mood: 'productive' | 'exploring' | 'reflective' | 'struggling';
   summary: string;
@@ -35,7 +35,7 @@ export class InsightGenerator {
   /**
    * Generates and persists insights for the last 24 hours of activity.
    */
-  async generateDailyInsights(): Promise<Insight[]> {
+  async generateDailyInsights(): Promise<ModelEInsight[]> {
     const since = Date.now() - 24 * 60 * 60 * 1000;
     const insights = await this.generateForWindow(since, ['journal', 'decisions']);
     await this.persistInsights('daily', insights);
@@ -45,7 +45,7 @@ export class InsightGenerator {
   /**
    * Generates and persists insights for the last 7 days of activity.
    */
-  async generateWeeklyInsights(): Promise<Insight[]> {
+  async generateWeeklyInsights(): Promise<ModelEInsight[]> {
     const since = Date.now() - 7 * 24 * 60 * 60 * 1000;
     const insights = await this.generateForWindow(since, ['journal', 'decisions', 'reflections']);
     await this.persistInsights('weekly', insights);
@@ -55,9 +55,9 @@ export class InsightGenerator {
   /**
    * Generates and persists insights centered on a specific topic.
    */
-  async generateTopicInsights(topic: string): Promise<Insight[]> {
+  async generateTopicInsights(topic: string): Promise<ModelEInsight[]> {
     const connected = await this.synthesizer.findConnections(topic, 'decisions');
-    const insights: Insight[] = connected.map((c) => ({
+    const insights: ModelEInsight[] = connected.map((c) => ({
       type: c.novelty > 0.65 ? 'prediction' : 'pattern',
       title: `Topic insight: ${topic}`,
       description: c.description,
@@ -111,7 +111,7 @@ export class InsightGenerator {
     return lines.join('\n');
   }
 
-  private async generateForWindow(sinceTs: number, chains: string[]): Promise<Insight[]> {
+  private async generateForWindow(sinceTs: number, chains: string[]): Promise<ModelEInsight[]> {
     const selected = this.blocks.filter((b) => {
       const ts = new Date(b.timestamp ?? 0).getTime();
       return ts >= sinceTs;
@@ -120,7 +120,7 @@ export class InsightGenerator {
     const synthesized = await this.synthesizer.synthesizeInsights(chains);
     const bridges = await this.discovery.findBridgeTopics();
 
-    const bridgeInsights: Insight[] = bridges.slice(0, 2).map((t) => ({
+    const bridgeInsights: ModelEInsight[] = bridges.slice(0, 2).map((t) => ({
       type: 'recommendation',
       title: `Bridge topic: ${t.name}`,
       description: `Topic links multiple contexts (bridge score ${t.bridgeScore.toFixed(1)}).`,
@@ -135,7 +135,7 @@ export class InsightGenerator {
 
   private async persistInsights(
     window: 'daily' | 'weekly' | 'topic',
-    insights: Insight[],
+    insights: ModelEInsight[],
     metadata: Record<string, unknown> = {},
   ): Promise<void> {
     await this.store.append('insights', {
@@ -150,7 +150,7 @@ export class InsightGenerator {
     });
   }
 
-  private detectMood(insights: Insight[]): InsightReport['mood'] {
+  private detectMood(insights: ModelEInsight[]): InsightReport['mood'] {
     if (insights.length >= 5) return 'productive';
     if (insights.some((i) => i.type === 'prediction')) return 'exploring';
     if (insights.length >= 2) return 'reflective';

--- a/src/cognitive/knowledge-synthesizer.ts
+++ b/src/cognitive/knowledge-synthesizer.ts
@@ -1,4 +1,4 @@
-import type { Connection, Insight, Recommendation } from './model-e-types.js';
+import type { Connection, ModelEInsight, Recommendation } from './model-e-types.js';
 import { normalizeChainName } from '../config/paths.js';
 import { embedSearch } from '../infra/storage/rust-embed-adapter.js';
 import type { Block } from '../memory/chain.js';
@@ -37,7 +37,7 @@ export class KnowledgeSynthesizer {
   /**
    * Synthesizes cross-chain insights from the supplied chain names.
    */
-  async synthesizeInsights(chains: string[]): Promise<Insight[]> {
+  async synthesizeInsights(chains: string[]): Promise<ModelEInsight[]> {
     const normalizedChains = chains.map((chain) => normalizeChainName(chain) ?? chain);
     const selected = this.blocks.filter((b) =>
       normalizedChains.includes(normalizeChainName(b.chain ?? 'journal') ?? 'journal'),

--- a/src/cognitive/model-e-types.ts
+++ b/src/cognitive/model-e-types.ts
@@ -28,7 +28,21 @@ export interface KnowledgeGap {
   suggestedAction: string;
 }
 
-export interface Insight {
+/**
+ * Model E's view of an insight, distinct from the broader cognitive
+ * `Insight` shape in `cognitive/types.ts`. The two interfaces are
+ * incompatible (different `type` unions, `evidence: Block[]` vs
+ * `string[]`, `actions?: string[]` vs `suggestedAction?: string`),
+ * so they live under different names. Issue #397 required this split
+ * because any callsite that imported both ended up with a name
+ * collision and ambiguous semantics.
+ *
+ * Choose `ModelEInsight` when the producer reasons about Block[]
+ * evidence (Model E reflective passes); choose `Insight` from
+ * `cognitive/types.ts` for the broader cognitive layer (Model B/C
+ * decisions, peak-hour productivity reports, etc.).
+ */
+export interface ModelEInsight {
   type: 'pattern' | 'anomaly' | 'prediction' | 'recommendation';
   title: string;
   description: string;

--- a/src/cognitive/proactive-assistant.ts
+++ b/src/cognitive/proactive-assistant.ts
@@ -10,7 +10,7 @@
 
 import { appendDurableBlock } from './durable-write.js';
 import { InsightGenerator, InsightReport } from './insight-generator.js';
-import type { Insight } from './model-e-types.js';
+import type { ModelEInsight } from './model-e-types.js';
 import { ChainStore, IStore } from './store.js';
 import { createLogger } from '../infra/logging/logger.js';
 import type { Block } from '../memory/chain.js';
@@ -200,7 +200,7 @@ export class ProactiveAssistant {
   /**
    * Create insight message
    */
-  private createInsightMessage(insight: Insight): ProactiveMessage {
+  private createInsightMessage(insight: ModelEInsight): ProactiveMessage {
     return {
       type: 'insight',
       priority: 'high',

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1854,30 +1854,40 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
         : undefined,
   });
 
-  // A9 — Insight type duplication (documented, requires typecheck)
+  // A9 — Insight type duplication (resolved 2026-05-03 / issue #397).
+  //
+  // The two interfaces had different `type` unions, different `evidence`
+  // shapes (`string[]` vs `Block[]`), and different action fields. The
+  // `model-e-types.ts:Insight` declaration was renamed to `ModelEInsight`
+  // to make the distinction explicit and unblock concurrent imports.
+  //
+  // The doctor check below now reads BOTH files and looks for a literal
+  // `export interface Insight ` (with trailing space, to avoid matching
+  // `ModelEInsight`/`InsightReport`/etc.). If the canonical-name still
+  // appears in two files, the duplication has come back — fail loud
+  // with a pointer at the resolution.
   const insightTypesPath = resolve(PROJECT_ROOT, 'src/cognitive/types.ts');
   const insightModelEPath = resolve(PROJECT_ROOT, 'src/cognitive/model-e-types.ts');
-  const hasInsightInTypes = existsSync(insightTypesPath);
-  const hasInsightInModelE = existsSync(insightModelEPath);
-  const insightDuplicated = hasInsightInTypes && hasInsightInModelE;
-  // S7-2 triage: this is filed as an architectural-debt Y1 issue
-  // (#397) — the heuristic check is heuristic, the duplication is
-  // real but resolution is a typed-import sweep across cognitive/agent
-  // surfaces. Demote to `pass` with a pointer to the tracking issue
-  // so doctor stops re-litigating it on every run; reopen the warn
-  // only if a fresh duplication appears outside the known pair.
+  const insightDeclPattern = /^export interface Insight /m;
+  const insightInTypes =
+    existsSync(insightTypesPath) &&
+    insightDeclPattern.test(readFileSync(insightTypesPath, 'utf8'));
+  const insightInModelE =
+    existsSync(insightModelEPath) &&
+    insightDeclPattern.test(readFileSync(insightModelEPath, 'utf8'));
+  const insightDuplicated = insightInTypes && insightInModelE;
   checks.push({
     id: 'ta9-insight-duplication',
     tier: 'A',
     title: 'Insight type duplication',
-    level: 'pass',
-    ok: true,
+    level: insightDuplicated ? 'warn' : 'pass',
+    ok: !insightDuplicated,
     required: false,
     detail: insightDuplicated
-      ? 'Insight defined in cognitive/types.ts AND cognitive/model-e-types.ts — tracked as Y1 architectural debt in issue #397'
-      : 'Insight type not duplicated',
+      ? 'Insight redeclared in BOTH cognitive/types.ts AND cognitive/model-e-types.ts — issue #397 resolution regressed'
+      : 'Insight type not duplicated (model-e-types renamed to ModelEInsight per #397)',
     fix: insightDuplicated
-      ? 'See issue #397 for the canonical-resolution plan; no operator action required'
+      ? 'Rename one declaration; see issue #397 PR (commit 0691aa8 family) for the canonical resolution.'
       : undefined,
   });
 


### PR DESCRIPTION
## Summary

Closes architectural-debt issue #397. The two `Insight` interfaces were **incompatible**, not just duplicated:

| | `src/cognitive/types.ts:79` | `src/cognitive/model-e-types.ts:31` |
|---|---|---|
| `type` | `'pattern'\|'anomaly'\|'trend'\|'opportunity'\|'risk'` | `'pattern'\|'anomaly'\|'prediction'\|'recommendation'` |
| `evidence` | `string[]` | `Block[]` |
| action | `suggestedAction?: string` | `actions?: string[]` |

TypeScript permits the duplication since the interfaces live in different modules, but `src/cognitive/index.ts:61` had to re-export the model-e variant as `ModelEInsight` (`Insight as ModelEInsight`) to resolve the name clash for external consumers. Any concurrent in-package import was a foot-gun.

## Resolution

Option 2 from issue #397: `model-e-types.ts:Insight` → `ModelEInsight`. The richer Block-typed shape stays bound to Model E's reflective passes (`InsightGenerator`, `KnowledgeSynthesizer`, `ProactiveAssistant`); the broader cognitive layer keeps `Insight` from `types.ts` (Model E `extractInsights` peak-hour productivity reports etc.). No semantic change to either interface — just naming.

## Files

- `src/cognitive/model-e-types.ts` — declaration + JSDoc explaining when to choose `ModelEInsight` vs `Insight`
- `src/cognitive/insight-generator.ts` — 9 type references (field, return types, parameters). Class names + method names unchanged — `InsightGenerator`, `generateDailyInsights`, etc. still describe what they generate (a `ModelEInsight[]`)
- `src/cognitive/knowledge-synthesizer.ts` — import + return type
- `src/cognitive/proactive-assistant.ts` — import + parameter type
- `src/cognitive/index.ts` — simplified `Insight as ModelEInsight` re-export to direct `ModelEInsight`
- `src/infra/cli/utils/doctor-v2.ts:1857+` — upgrade `ta9-insight-duplication` from heuristic file-existence check to actual content grep (`^export interface Insight ` with trailing space). Returns `pass` after this PR, returns `warn` if duplication regresses.

## Test plan

- [x] `tests/cognitive/*` — 24/24 (110 tests, including `insight-full-flow.test.ts`)
- [x] `tests/doctor-v2.test.ts` + `tests/unit/doctor.fresh-install.test.ts` — passes
- [x] `tests/unit/cognitive-config-loader.test.ts` — passes
- [x] `npm run typecheck` — green
- [x] `eslint .` (pre-commit) — green
- [ ] CI workflows green
- [ ] `memphis doctor` shows `ta9-insight-duplication: pass — Insight type not duplicated (model-e-types renamed to ModelEInsight per #397)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)