### PR TITLE
fix(test): macOS race in cli-router dispatch (issue #407)

### DIFF
--- a/tests/integration/cli-router.integration.test.ts
+++ b/tests/integration/cli-router.integration.test.ts
@@ -75,10 +75,21 @@ async function importDispatcherWithMock() {
     listCliCompletionCommands: () => [],
   }));
 
-  const [{ executeCommand }, { parseCommand }] = await Promise.all([
-    import('../../src/infra/cli/dispatcher.js'),
-    import('../../src/infra/cli/parser.js'),
-  ]);
+  // macOS CI race fix (issue #407): on Linux Vitest's `vi.doMock` is
+  // observed in the next module-resolve pass without help, but on
+  // macOS-latest the parallel `Promise.all` import block intermittently
+  // resolves dispatcher.js BEFORE the mock registration commits, so
+  // dispatcher pulls the REAL `getCliCommandRegistrations` via its
+  // module-level top-of-file import. The third test (`ask`) was the
+  // only one that flapped because by that point the cached module
+  // graph held the real registry from prior `embed`/`help` runs;
+  // forcing a microtask + sequential imports flushes the doMock
+  // registration before any dynamic import tick. Linux already
+  // tolerates this; the change is no-op there.
+  await Promise.resolve();
+
+  const { executeCommand } = await import('../../src/infra/cli/dispatcher.js');
+  const { parseCommand } = await import('../../src/infra/cli/parser.js');
   return { executeCommand, parseCommand };
 }
 


### PR DESCRIPTION
## Summary

Closes issue #407 — `tests/integration/cli-router.integration.test.ts > routes ask through interaction handler` flapped on `cross-arch (macos-latest)` CI runner while passing 100% on Linux. Combined with PR #405 (secret-scan portable regex) + PR #402 (managed-apps realTmpdir), this is the last known macOS-specific test failure tracked in the cross-arch matrix.

## Root cause

`vi.doMock(...)` registration races dynamic `import()` on macOS. Linux Vitest observes the mock on the next module-resolve pass without help; macOS intermittently resolves dispatcher.js BEFORE the mock commits, so dispatcher pulls the REAL `getCliCommandRegistrations` via its module-level top-of-file import.

Why only the third (`ask`) test caught it: by that point the cached module graph held the real registry from prior `embed`/`help` runs. The first two tests resolved the import freshly enough that the doMock registration sequence happened to win.

## Fix

```diff
-  const [{ executeCommand }, { parseCommand }] = await Promise.all([
-    import('../../src/infra/cli/dispatcher.js'),
-    import('../../src/infra/cli/parser.js'),
-  ]);
+  await Promise.resolve();   // microtask flush — commits doMock registration
+  const { executeCommand } = await import('../../src/infra/cli/dispatcher.js');
+  const { parseCommand } = await import('../../src/infra/cli/parser.js');
```

Two changes:
1. **`await Promise.resolve()` after `vi.doMock`** — flushes the mock registration into the microtask queue before any subsequent dynamic import tick observes module resolution.
2. **Sequential `await import(...)` instead of `Promise.all([…])`** — dispatcher and parser don't race the mock or each other.

Linux already tolerated the unfortified shape; the change is a no-op there. macOS observes the now-committed mock.

## Follow-up (out of scope)

S11-2 — drop `continue-on-error: true` on the cross-arch matrix in `.github/workflows/ci.yml:68` so macOS CI failures become blocking. Should be a separate PR once this one's CI run confirms macOS green for `cli-router`.

## Test plan

- [x] `npx vitest run tests/integration/cli-router.integration.test.ts` — 3/3 on Linux (no regression)
- [x] `npm run typecheck` — green
- [x] `eslint .` (pre-commit) — green
- [ ] CI cross-arch matrix `(macos-latest)` runs the test green
- [ ] After confirmed green, follow-up PR drops `continue-on-error: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)