### PR TITLE
feat(tools): ToolDescriptor foundation — helpText + cliFlags (Sprint E Phase 1)

### DIFF
--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -13,6 +13,27 @@ import { isFeatureFlagEnabled } from '../infra/features/flags.js';
 export type ToolTier = 0 | 1 | 2 | 3;
 export type ToolCapability = 'read' | 'write' | 'network' | 'execute';
 
+/**
+ * A single CLI flag exposed by a tool, used to drive declarative CLI
+ * help generation (Sprint E Phase 1 foundation, plan #2 in
+ * `~/.claude/plans/memphis-architectural-refactor.md`). Once Phase 2
+ * lands, the parser + help renderer iterate over these instead of
+ * each tool re-declaring its own help text in
+ * `src/infra/cli/handlers/system.handler.ts`.
+ */
+export interface ToolCliFlag {
+  /** Long form, e.g. `--input` or `--cron-pattern`. */
+  readonly name: string;
+  /** Optional short alias, e.g. `-i`. */
+  readonly alias?: string;
+  /** One-line operator-facing description. */
+  readonly description: string;
+  /** Whether the flag accepts a value (`--input hello`) or is boolean. */
+  readonly takesValue?: boolean;
+  /** Required vs optional — null/undefined ≡ optional. */
+  readonly required?: boolean;
+}
+
 export interface ToolMeta {
   name: string;
   tier: ToolTier;
@@ -30,6 +51,20 @@ export interface ToolMeta {
    * deferred to keep the diff isolated to the registry.
    */
   inputSchema?: z.ZodTypeAny;
+  /**
+   * Operator-facing rich help text. Longer than `description`; used by
+   * CLI `--help`, TUI `?` overlay, Telegram `/help`, MCP introspection
+   * blurbs. When absent the surface falls back to `description`.
+   * Sprint E Phase 1 (this PR) populates 5 high-traffic tools as proof
+   * — see plan #2.
+   */
+  helpText?: string;
+  /**
+   * Declarative CLI flag list. When present the help renderer can build
+   * the `--flag <value> # description` block without bespoke help text.
+   * Phase 1 populates the same 5 high-traffic tools as `helpText`.
+   */
+  cliFlags?: readonly ToolCliFlag[];
 }
 
 export const TOOL_REGISTRY: Record<string, ToolMeta> = {
@@ -45,6 +80,21 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Append a journal entry to the operator-private journal chain. The chain is local-only by default; entries persist across restarts and feed cognitive Mode E (weekly reflection). Use for thoughts, decisions in flight, observations — NOT as the response channel back to the operator.',
+    cliFlags: [
+      {
+        name: '--content',
+        description: 'Journal entry text. Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--tags',
+        description: 'Comma-separated tags applied to the entry (optional).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_recall: {
     name: 'memphis_recall',
@@ -59,6 +109,21 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Vector-similarity search over every indexed chain (journal, decisions, cases, patterns, reflections, system, collective, proactive, insights, soul, messages). Returns up to `limit` hits ranked by embedding cosine. Prefer over memphis_search when the query is conceptual rather than literal.',
+    cliFlags: [
+      {
+        name: '--query',
+        description: 'Natural-language query. Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--limit',
+        description: 'Max number of hits to return (default 10, cap 50).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_search: {
     name: 'memphis_search',
@@ -75,6 +140,27 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Literal substring / regex search over chain blocks. Faster than memphis_recall but only matches exact text. Use for "find the block that contains X". `--chain` narrows the scan to a single chain by name (uses the same alias table as memphis_chain_query).',
+    cliFlags: [
+      {
+        name: '--query',
+        description: 'Phrase to match (literal substring; quote it if it has spaces).',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--chain',
+        description:
+          'Optional chain to scan (e.g. journal, decisions). Omit to search every chain.',
+        takesValue: true,
+      },
+      {
+        name: '--limit',
+        description: 'Max number of hits to return (default 10, cap 50).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_decide: {
     name: 'memphis_decide',
@@ -100,6 +186,9 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Compact health snapshot: runtime uptime, provider readiness, vault cipher probe, chain integrity, embed pipeline status, recent telemetry. Counterpart to `memphis doctor` but JSON-shaped and faster — use this for programmatic gating, doctor for human triage.',
+    cliFlags: [],
   },
   memphis_self_describe: {
     name: 'memphis_self_describe',

--- a/tests/unit/tool-registry-descriptors.test.ts
+++ b/tests/unit/tool-registry-descriptors.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Sprint E Phase 1 (PR #430) — ToolDescriptor foundation contract.
+ *
+ * Plan #2 in `~/.claude/plans/memphis-architectural-refactor.md` is the
+ * declarative tool registry refactor. Phase 1 ships the descriptor
+ * fields (`helpText`, `cliFlags`) on the existing `ToolMeta` shape +
+ * populates 4 high-traffic tier-0 tools as proof. This test pins:
+ *
+ *  1. Every "rich descriptor" tool in the proof set has both fields.
+ *  2. Each cliFlag is well-formed (long-form name, description).
+ *  3. Tools without descriptors gracefully fall back to `description`.
+ *
+ * As Phase 2/3 land more migrations, this file's PROOF_SET grows. When
+ * every TOOL_REGISTRY entry has a descriptor, the test asserts global
+ * coverage and the static `description`-only fallback can be removed.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { TOOL_REGISTRY } from '../../src/gateway/tool-registry.js';
+
+const PROOF_SET = [
+  'memphis_journal',
+  'memphis_recall',
+  'memphis_search',
+  'memphis_health',
+] as const;
+
+describe('ToolDescriptor — Phase 1 foundation', () => {
+  it.each(PROOF_SET)('%s exposes helpText (richer than description)', (name) => {
+    const meta = TOOL_REGISTRY[name];
+    expect(meta, `tool ${name} not in registry`).toBeDefined();
+    expect(meta.helpText, `${name} should expose helpText`).toBeDefined();
+    expect(meta.helpText!.length).toBeGreaterThan(meta.description.length);
+  });
+
+  it.each(PROOF_SET)('%s exposes cliFlags array (possibly empty)', (name) => {
+    const meta = TOOL_REGISTRY[name];
+    expect(Array.isArray(meta.cliFlags), `${name} cliFlags should be an array`).toBe(true);
+  });
+
+  it('every cliFlag entry has long-form name + description', () => {
+    for (const name of PROOF_SET) {
+      const meta = TOOL_REGISTRY[name];
+      for (const flag of meta.cliFlags ?? []) {
+        expect(flag.name.startsWith('--'), `${name} flag ${flag.name} must start with --`).toBe(
+          true,
+        );
+        expect(flag.description.length, `${name} flag ${flag.name} needs description`).toBeGreaterThan(
+          0,
+        );
+      }
+    }
+  });
+
+  it('non-proof tools work without a descriptor (fallback to description)', () => {
+    // Every other entry in TOOL_REGISTRY can lack helpText / cliFlags
+    // and surfaces still render `description`. This pins the soft-rollout
+    // contract — Phase 2/3 expand the proof set without touching consumers.
+    const nonProof = Object.values(TOOL_REGISTRY).filter(
+      (meta) => !PROOF_SET.includes(meta.name as (typeof PROOF_SET)[number]),
+    );
+    expect(nonProof.length).toBeGreaterThan(0);
+    for (const meta of nonProof) {
+      expect(meta.description.length, `${meta.name} must keep its description`).toBeGreaterThan(0);
+    }
+  });
+
+  it('proof set covers a representative tier-0 sample', () => {
+    // Drift detection: if someone narrows the proof set without expanding
+    // it, we'd lose coverage of the foundation pattern.
+    expect(PROOF_SET.length).toBeGreaterThanOrEqual(4);
+    for (const name of PROOF_SET) {
+      expect(TOOL_REGISTRY[name].tier, `${name} should be tier 0 in proof set`).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Foundation PR for plan #2 in `~/.claude/plans/memphis-architectural-refactor.md` ("Declarative tool registry"). The 39 tools currently scatter their metadata across **3 places**:

| Location | What it owns |
|---|---|
| `src/mcp/tools/<name>.ts` | Handler implementation |
| `src/mcp/server.ts` | Hand-rolled `server.registerTool(name, schema, handler)` (39 stanzas) |
| `src/infra/cli/handlers/system.handler.ts` | Per-tool CLI help text |

Adding a new tool = edits in 3+ places, easy to drift. PR #352 patched the `--cron` vs `--cron-pattern` drift with aliases — both forms still live in two files.

This PR is **Phase 1 — additive foundation only**. No consumer rewires yet:

| Phase | Scope |
|-------|-------|
| **1 (this PR)** | Extend `ToolMeta` with `helpText?` + `cliFlags?` (both optional). Populate 4 proof tools. |
| 2 (next PR) | CLI help renderer + MCP introspection iterate over descriptors. |
| 3 (batched) | Expand proof set to all 39 tools; remove per-tool help branches in `system.handler.ts`. |

## What ships here

### `src/gateway/tool-registry.ts`

- New `ToolCliFlag` interface: `{ name, alias?, description, takesValue?, required? }`
- New optional fields on `ToolMeta`: `helpText?: string` (richer than `description`), `cliFlags?: readonly ToolCliFlag[]`
- 4 high-traffic tier-0 tools populated as proof:
  - `memphis_journal` — write
  - `memphis_recall` — semantic search
  - `memphis_search` — literal search
  - `memphis_health` — read

### `tests/unit/tool-registry-descriptors.test.ts` (11 cases)

Pin the contract: every proof-set tool has helpText longer than description, every cliFlag is well-formed (long-form `--name`, non-empty description), non-proof tools gracefully fall back on `description`, proof set is tier-0-representative.

## Backward compatibility

Both new fields are **optional**. Tools without descriptors still surface `description` everywhere — no consumer breaks. Soft rollout. The Phase 2 consumer migration explicitly checks for `helpText` and falls through:

```ts
const text = meta.helpText ?? meta.description;
```

## Test plan

- [x] `tests/unit/tool-registry-descriptors.test.ts` — 11/11
- [x] `tests/integration/mcp-e2e.test.ts` — passes (MCP behavior unchanged because `mcp/server.ts` doesn't read the new fields yet — Phase 2 wires it)
- [x] `tests/unit/gateway.system-prompt.test.ts` — passes
- [x] `npm run typecheck` + `eslint .` — green
- [ ] CI workflows green

## Migration risk

Zero. Both new fields are optional, the 4 proof tools' existing handlers and schemas are untouched, no consumer code reads the new fields yet. Phase 2 is the migration moment; this PR is the surface to migrate ONTO.

## Follow-up: Phase 2

Phase 2 (next PR) does the consumer wiring:
- `src/infra/cli/handlers/system.handler.ts` iterates over `cliFlags` to build `--help` output for each tool with a descriptor; falls back to existing per-tool help for tools without
- TUI `?` overlay reads `helpText` when available
- Telegram `/help` reads `helpText`
- MCP introspection adds richer descriptions

Phase 3 then batches the remaining 35 tools' descriptor population, after which Phase 2's per-tool fallback can drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)