### PR TITLE
feat(voice): memphis voice status CLI + doctor ta12-voice-stack (Sprint H PR-C)

### DIFF
--- a/src/infra/cli/handlers/voice.handler.ts
+++ b/src/infra/cli/handlers/voice.handler.ts
@@ -1,0 +1,172 @@
+/**
+ * `memphis voice` — inspect the operator's voice stack (cloud vs
+ * local routing, STT engine, TTS engine, server reachability).
+ *
+ * Sprint H PR-C • 2026-05-04 • depends on PR-A chooser + PR-B Piper
+ * adapter. Live demo prep: operator runs this BEFORE going on-stage to
+ * confirm both engines are reachable and routed correctly.
+ *
+ * Subcommands:
+ *   memphis voice                         # alias for status
+ *   memphis voice status                  # human format
+ *   memphis voice status --json           # JSON format for scripting
+ */
+
+import {
+  MEMPHIS_VOICE_MODE,
+  PIPER_SERVER_URL,
+  WHISPER_SERVER_URL,
+} from '../../../config/env-registry.js';
+import { checkPiperServerHealth } from '../../../gateway/voice/local-piper-adapter.js';
+import { checkWhisperServerHealth } from '../../../gateway/voice/local-whisper-adapter.js';
+import { resolveVoiceConfig } from '../../../gateway/voice/voice-service.js';
+import type { CliContext } from '../context.js';
+import type { CommandHandler } from './command-handler.js';
+
+interface VoiceStatusReport {
+  ok: boolean;
+  rawMode: string;
+  resolvedRoute: 'cloud' | 'local' | 'disabled';
+  stt: {
+    engine: string;
+    model?: string;
+    serverUrl?: string;
+    reachable?: boolean;
+    latencyMs?: number;
+    error?: string;
+  };
+  tts: {
+    engine: string;
+    model?: string;
+    serverUrl?: string;
+    reachable?: boolean;
+    latencyMs?: number;
+    error?: string;
+  };
+  notes: string[];
+}
+
+async function buildStatusReport(rawEnv: NodeJS.ProcessEnv): Promise<VoiceStatusReport> {
+  const config = resolveVoiceConfig(rawEnv);
+  const rawMode = MEMPHIS_VOICE_MODE.read(rawEnv);
+
+  if (!config) {
+    return {
+      ok: false,
+      rawMode,
+      resolvedRoute: 'disabled',
+      stt: { engine: 'none' },
+      tts: { engine: 'none' },
+      notes: [
+        'Voice disabled — MEMPHIS_VOICE_MODE=cloud was set but no HUGGINGFACE_API_TOKEN configured.',
+        'Run `memphis vault get huggingface_api_token` to verify, or switch to MEMPHIS_VOICE_MODE=local.',
+      ],
+    };
+  }
+
+  const notes: string[] = [];
+  if (config.rawMode === 'auto') {
+    notes.push(
+      `auto-resolved to ${config.route} (${config.route === 'cloud' ? 'HF token present' : 'HF token absent'})`,
+    );
+  }
+
+  if (config.route === 'local') {
+    const [sttHealth, ttsHealth] = await Promise.all([
+      checkWhisperServerHealth(),
+      checkPiperServerHealth(),
+    ]);
+    return {
+      ok: sttHealth.ok && ttsHealth.ok,
+      rawMode,
+      resolvedRoute: 'local',
+      stt: {
+        engine: 'faster-whisper / whisper.cpp (local)',
+        serverUrl: WHISPER_SERVER_URL.read(rawEnv),
+        reachable: sttHealth.ok,
+        latencyMs: sttHealth.latencyMs,
+        error: sttHealth.error,
+      },
+      tts: {
+        engine: 'Piper (local)',
+        serverUrl: PIPER_SERVER_URL.read(rawEnv),
+        reachable: ttsHealth.ok,
+        latencyMs: ttsHealth.latencyMs,
+        error: ttsHealth.error,
+      },
+      notes,
+    };
+  }
+
+  // route === 'cloud'
+  return {
+    ok: true,
+    rawMode,
+    resolvedRoute: 'cloud',
+    stt: {
+      engine: 'HuggingFace Whisper (cloud)',
+      model: config.sttModel,
+    },
+    tts: {
+      engine:
+        config.ttsProvider === 'google' && config.googleTtsApiKey
+          ? 'Google Cloud TTS (cloud)'
+          : 'HuggingFace MMS-TTS (cloud)',
+      model: config.ttsModel,
+    },
+    notes,
+  };
+}
+
+function formatHuman(report: VoiceStatusReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `Voice stack: ${report.ok ? '✓ ready' : '✗ degraded'} (mode=${report.rawMode}, route=${report.resolvedRoute})`,
+  );
+  lines.push('');
+  lines.push(`STT  engine: ${report.stt.engine}`);
+  if (report.stt.serverUrl) lines.push(`     server: ${report.stt.serverUrl}`);
+  if (report.stt.model) lines.push(`     model:  ${report.stt.model}`);
+  if (report.stt.reachable !== undefined) {
+    lines.push(
+      `     reachable: ${report.stt.reachable ? `yes (${report.stt.latencyMs ?? '?'}ms)` : `no — ${report.stt.error ?? 'no error message'}`}`,
+    );
+  }
+  lines.push('');
+  lines.push(`TTS  engine: ${report.tts.engine}`);
+  if (report.tts.serverUrl) lines.push(`     server: ${report.tts.serverUrl}`);
+  if (report.tts.model) lines.push(`     model:  ${report.tts.model}`);
+  if (report.tts.reachable !== undefined) {
+    lines.push(
+      `     reachable: ${report.tts.reachable ? `yes (${report.tts.latencyMs ?? '?'}ms)` : `no — ${report.tts.error ?? 'no error message'}`}`,
+    );
+  }
+  if (report.notes.length > 0) {
+    lines.push('');
+    lines.push('notes:');
+    for (const note of report.notes) lines.push(`  - ${note}`);
+  }
+  return lines.join('\n');
+}
+
+async function handleVoiceCommand(context: CliContext): Promise<boolean> {
+  const sub = context.args.subcommand ?? 'status';
+  if (sub !== 'status') {
+    process.stderr.write(`Unknown subcommand: voice ${sub}\nUsage: memphis voice [status] [--json]\n`);
+    return false;
+  }
+  const report = await buildStatusReport(process.env);
+  if (context.args.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatHuman(report)}\n`);
+  }
+  return true;
+}
+
+export const voiceCommandHandler: CommandHandler = {
+  name: 'voice',
+  commands: ['voice'],
+  canHandle: (context: CliContext) => context.args.command === 'voice',
+  handle: handleVoiceCommand,
+};

--- a/src/infra/cli/handlers/voice.handler.ts
+++ b/src/infra/cli/handlers/voice.handler.ts
@@ -152,8 +152,14 @@ function formatHuman(report: VoiceStatusReport): string {
 async function handleVoiceCommand(context: CliContext): Promise<boolean> {
   const sub = context.args.subcommand ?? 'status';
   if (sub !== 'status') {
+    // Return `true` (handled) so the dispatcher doesn't fall through
+    // to "Unknown command: voice" — the error is the bad subcommand,
+    // not the bad verb. Codex P2 #433 caught the duplicate-error UX
+    // mismatch with other handlers (auth, config, vault) which all
+    // return true after writing usage.
     process.stderr.write(`Unknown subcommand: voice ${sub}\nUsage: memphis voice [status] [--json]\n`);
-    return false;
+    process.exitCode = 2;
+    return true;
   }
   const report = await buildStatusReport(process.env);
   if (context.args.json) {

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -300,6 +300,7 @@ export const CLI_COMPLETION_COMMANDS = [
   'onboarding',
   'operator',
   'tier',
+  'voice',
   'tools',
   'evolve',
   'secret',

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -199,6 +199,11 @@ export const CLI_COMMAND_REGISTRY = [
     createLazyHandlerLoader(() => import('./handlers/tier.handler.js'), 'tierCommandHandler'),
   ),
   createCommandRegistration(
+    'voice',
+    ['voice'],
+    createLazyHandlerLoader(() => import('./handlers/voice.handler.js'), 'voiceCommandHandler'),
+  ),
+  createCommandRegistration(
     'tools',
     ['tools'],
     createLazyHandlerLoader(() => import('./handlers/tools.handler.js'), 'toolsCommandHandler'),

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -20,7 +20,12 @@ const PROJECT_ROOT = process.cwd();
 import YAML from 'yaml';
 
 import { checkDependencies } from './dependencies.js';
-import { buildEnvRegistryReport } from '../../../config/env-registry.js';
+import {
+  MEMPHIS_VOICE_MODE,
+  PIPER_SERVER_URL,
+  WHISPER_SERVER_URL,
+  buildEnvRegistryReport,
+} from '../../../config/env-registry.js';
 import {
   getBackupPath,
   getChainPath,
@@ -34,6 +39,9 @@ import {
   buildSurfacePolicySnapshot,
   evaluateSurfacePolicyRisk,
 } from '../../../gateway/surface-policy.js';
+import { checkPiperServerHealth } from '../../../gateway/voice/local-piper-adapter.js';
+import { checkWhisperServerHealth } from '../../../gateway/voice/local-whisper-adapter.js';
+import { resolveVoiceConfig } from '../../../gateway/voice/voice-service.js';
 import { DEFAULT_MCP_HTTP_PORT, buildMcpHttpHealthUrl } from '../../../mcp/transport/defaults.js';
 import { inspectManagedAppCatalog } from '../../../modules/apps/manifest.js';
 import type { FirstRunPlan } from '../../../onboarding/first-run.js';
@@ -1941,6 +1949,51 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
       envReport.count === 0
         ? 'env-registry has no accessors registered'
         : `${envReport.count} accessor(s): ${envSummary}`,
+  });
+
+  // A12 — Voice stack readiness (Sprint H PR-C, 2026-05-04).
+  //
+  // Live demo guard: confirms the operator's voice route is actually
+  // reachable BEFORE going on stage. Cloud route reports the engine
+  // names without round-tripping (we don't want doctor to spend HF
+  // quota on every run). Local route hits the configured Whisper +
+  // Piper servers with a 5s timeout each — enough to flag "I forgot
+  // to start the python server" without slowing doctor noticeably.
+  const voiceConfig = resolveVoiceConfig(process.env);
+  const voiceMode = MEMPHIS_VOICE_MODE.read(process.env);
+  let voiceLevel: 'pass' | 'warn' | 'fail' = 'pass';
+  let voiceDetail: string;
+  if (!voiceConfig) {
+    voiceLevel = 'warn';
+    voiceDetail = `disabled (mode=${voiceMode}, no HF token) — set MEMPHIS_VOICE_MODE=local to opt into offline engines`;
+  } else if (voiceConfig.route === 'local') {
+    const [stt, tts] = await Promise.all([
+      checkWhisperServerHealth(),
+      checkPiperServerHealth(),
+    ]);
+    const sttPart = stt.ok
+      ? `STT@${WHISPER_SERVER_URL.read(process.env)} (${stt.latencyMs ?? '?'}ms)`
+      : `STT unreachable (${stt.error ?? 'no error'})`;
+    const ttsPart = tts.ok
+      ? `TTS@${PIPER_SERVER_URL.read(process.env)} (${tts.latencyMs ?? '?'}ms)`
+      : `TTS unreachable (${tts.error ?? 'no error'})`;
+    if (!stt.ok || !tts.ok) voiceLevel = 'fail';
+    voiceDetail = `route=local, ${sttPart}, ${ttsPart}`;
+  } else {
+    voiceDetail = `route=cloud, STT=${voiceConfig.sttModel}, TTS=${voiceConfig.ttsModel} via ${voiceConfig.ttsProvider}`;
+  }
+  checks.push({
+    id: 'ta12-voice-stack',
+    tier: 'A',
+    title: 'Voice stack readiness',
+    level: voiceLevel,
+    ok: voiceLevel === 'pass',
+    required: false,
+    detail: voiceDetail,
+    fix:
+      voiceLevel === 'fail'
+        ? 'Start the offline engines per docs/operator/voice-local-stt.md + voice-local-tts.md, or switch to MEMPHIS_VOICE_MODE=cloud.'
+        : undefined,
   });
 
   // --post-install narrows the report to tier-1 (Core Infrastructure)

--- a/tests/unit/cli.voice.test.ts
+++ b/tests/unit/cli.voice.test.ts
@@ -152,11 +152,20 @@ describe('voice command handler — `memphis voice status`', () => {
     expect(captured).toMatch(/reachable: yes/);
   });
 
-  it('unknown subcommand returns false + writes usage to stderr', async () => {
+  it('unknown subcommand returns true (handled) + writes usage to stderr + sets exitCode', async () => {
+    // Codex P2 #433: returning `false` here made the dispatcher fall
+    // through to "Unknown command: voice", duplicating the error path.
+    // Other namespace handlers (auth, config, vault) all return true
+    // after writing usage and let the non-zero exit code carry the
+    // "this command failed" signal.
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
     const ok = await voiceCommandHandler.handle(
       buildContext({ subcommand: 'bogus' }) as never,
     );
-    expect(ok).toBe(false);
+    expect(ok).toBe(true);
     expect(capturedErr).toContain('Usage:');
+    expect(process.exitCode).toBe(2);
+    process.exitCode = previousExitCode;
   });
 });

--- a/tests/unit/cli.voice.test.ts
+++ b/tests/unit/cli.voice.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Sprint H PR-C — voice status CLI contract.
+ *
+ * Pin the `memphis voice status` shape:
+ *  - Cloud route reports engine names, no network round-trip
+ *  - Local route hits both checkWhisper + checkPiper, surfaces error
+ *    envelopes when servers are unreachable
+ *  - Disabled (cloud + no token) returns notes pointing at remediation
+ *  - --json emits structured JSON; default emits human-readable lines
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Module mocks are scoped to this file via vi.doMock + dynamic import, so
+// they don't leak into doctor-v2.test.ts when the runner happens to reuse
+// the same worker pool. The earlier static `vi.mock(...)` form hoisted
+// module-level mocks that survived past the file's last `it()` and
+// poisoned doctor-v2's voice-stack check.
+vi.doMock('../../src/gateway/voice/local-piper-adapter.js', () => ({
+  textToSpeechLocal: vi.fn(),
+  checkPiperServerHealth: vi.fn(async () => ({ ok: true, latencyMs: 12 })),
+}));
+vi.doMock('../../src/gateway/voice/local-whisper-adapter.js', () => ({
+  speechToTextLocal: vi.fn(),
+  checkWhisperServerHealth: vi.fn(async () => ({ ok: true, latencyMs: 8 })),
+}));
+
+// Lazy module references resolved once after vi.doMock above is in
+// effect. Static top-level imports would bypass doMock on some
+// module-resolution orderings.
+let checkPiperServerHealth: ReturnType<typeof vi.fn>;
+let checkWhisperServerHealth: ReturnType<typeof vi.fn>;
+let voiceCommandHandler: { handle: (ctx: unknown) => Promise<boolean> };
+
+function buildContext(args: Record<string, unknown>): { args: Record<string, unknown> } {
+  return {
+    args: { command: 'voice', subcommand: 'status', json: false, ...args },
+  };
+}
+
+describe('voice command handler — `memphis voice status`', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let captured = '';
+  let capturedErr = '';
+  const savedEnv = { ...process.env };
+
+  // Resolve the handler + mocked health probes after vi.doMock has
+  // committed. vitest doMock is scoped to this module's import graph.
+  beforeEach(async () => {
+    const piper = await import('../../src/gateway/voice/local-piper-adapter.js');
+    const whisper = await import('../../src/gateway/voice/local-whisper-adapter.js');
+    const handler = await import('../../src/infra/cli/handlers/voice.handler.js');
+    checkPiperServerHealth = piper.checkPiperServerHealth as unknown as ReturnType<typeof vi.fn>;
+    checkWhisperServerHealth = whisper.checkWhisperServerHealth as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    voiceCommandHandler = handler.voiceCommandHandler as unknown as {
+      handle: (ctx: unknown) => Promise<boolean>;
+    };
+  });
+
+  afterAll(() => {
+    vi.doUnmock('../../src/gateway/voice/local-piper-adapter.js');
+    vi.doUnmock('../../src/gateway/voice/local-whisper-adapter.js');
+  });
+
+  beforeEach(() => {
+    captured = '';
+    capturedErr = '';
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(((data: string | Uint8Array) => {
+        captured += String(data);
+        return true;
+      }) as never);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(((data: string | Uint8Array) => {
+        capturedErr += String(data);
+        return true;
+      }) as never);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    for (const key of Object.keys(process.env)) {
+      if (!(key in savedEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+    vi.clearAllMocks();
+  });
+
+  it('local mode + healthy servers → ok=true, both engines reachable', async () => {
+    process.env.MEMPHIS_VOICE_MODE = 'local';
+    delete process.env.HUGGINGFACE_API_TOKEN;
+    const ok = await voiceCommandHandler.handle(
+      buildContext({ json: true }) as never,
+    );
+    expect(ok).toBe(true);
+    const report = JSON.parse(captured);
+    expect(report.ok).toBe(true);
+    expect(report.resolvedRoute).toBe('local');
+    expect(report.stt.reachable).toBe(true);
+    expect(report.tts.reachable).toBe(true);
+    expect(checkWhisperServerHealth).toHaveBeenCalledTimes(1);
+    expect(checkPiperServerHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it('local mode + unreachable STT → ok=false, surfaces error', async () => {
+    vi.mocked(checkWhisperServerHealth).mockResolvedValueOnce({
+      ok: false,
+      error: 'ECONNREFUSED',
+    });
+    process.env.MEMPHIS_VOICE_MODE = 'local';
+    delete process.env.HUGGINGFACE_API_TOKEN;
+    await voiceCommandHandler.handle(buildContext({ json: true }) as never);
+    const report = JSON.parse(captured);
+    expect(report.ok).toBe(false);
+    expect(report.stt.reachable).toBe(false);
+    expect(report.stt.error).toContain('ECONNREFUSED');
+  });
+
+  it('cloud mode + HF token → reports cloud engines, no network probes', async () => {
+    process.env.MEMPHIS_VOICE_MODE = 'cloud';
+    process.env.HUGGINGFACE_API_TOKEN = 'hf_xxx';
+    await voiceCommandHandler.handle(buildContext({ json: true }) as never);
+    const report = JSON.parse(captured);
+    expect(report.resolvedRoute).toBe('cloud');
+    expect(report.stt.engine).toContain('HuggingFace');
+    expect(checkWhisperServerHealth).not.toHaveBeenCalled();
+    expect(checkPiperServerHealth).not.toHaveBeenCalled();
+  });
+
+  it('cloud mode + no HF token → disabled, with remediation notes', async () => {
+    process.env.MEMPHIS_VOICE_MODE = 'cloud';
+    delete process.env.HUGGINGFACE_API_TOKEN;
+    await voiceCommandHandler.handle(buildContext({ json: true }) as never);
+    const report = JSON.parse(captured);
+    expect(report.ok).toBe(false);
+    expect(report.resolvedRoute).toBe('disabled');
+    expect(report.notes.join(' ')).toMatch(/MEMPHIS_VOICE_MODE=local/);
+  });
+
+  it('default human format includes engine + reachability lines', async () => {
+    process.env.MEMPHIS_VOICE_MODE = 'local';
+    delete process.env.HUGGINGFACE_API_TOKEN;
+    await voiceCommandHandler.handle(buildContext({ json: false }) as never);
+    expect(captured).toMatch(/Voice stack: . ready/);
+    expect(captured).toContain('STT  engine:');
+    expect(captured).toContain('TTS  engine:');
+    expect(captured).toMatch(/reachable: yes/);
+  });
+
+  it('unknown subcommand returns false + writes usage to stderr', async () => {
+    const ok = await voiceCommandHandler.handle(
+      buildContext({ subcommand: 'bogus' }) as never,
+    );
+    expect(ok).toBe(false);
+    expect(capturedErr).toContain('Usage:');
+  });
+});


### PR DESCRIPTION
## Summary

Sprint H PR-C — closing piece. Operator visibility for the voice stack via `memphis voice status` + `memphis doctor` `ta12-voice-stack`. Demo prep: confirms both engines reachable BEFORE going on-stage.

> ⚠️ **Stacked PR.** Base: `feat/voice-piper-tts` (PR #432). Merge order: #431 → #432 → this. GitHub auto-rebases.

## What changed

### `src/infra/cli/handlers/voice.handler.ts` (new)

```bash
memphis voice                  # alias for status
memphis voice status           # human-readable
memphis voice status --json    # structured for scripting
```

Reports: `rawMode`, `resolvedRoute`, STT engine + model + reachability + latency, TTS engine + model + reachability + latency, plus remediation notes when voice is disabled (cloud + no HF token).

### `src/infra/cli/registry.ts`

Registers `voice` lazily, same shape as `tier`/`tools`.

### `src/infra/cli/utils/doctor-v2.ts` — `ta12-voice-stack`

- Cloud route → reports engine names without network probes (no HF quota burn on every doctor run)
- Local route → hits Whisper + Piper `/healths` with 5s timeout each. Flags "I forgot to start the python server" loudly.
- Disabled (cloud + no token) → `warn` with "set `MEMPHIS_VOICE_MODE=local`" remediation hint
- Failed probe → `fail` level + actionable `fix` field

### `tests/unit/cli.voice.test.ts` (new, 6 cases)

Pin: local healthy / local unreachable / cloud + HF / cloud disabled / human format / unknown subcommand.

**Mock isolation**: uses `vi.doMock` (file-scoped) instead of `vi.mock` (module-hoisted). The earlier static `vi.mock(...)` form leaked the health-probe mocks into `doctor-v2.test.ts` when the runner reused a worker pool — the doctor's `ta12-voice-stack` then saw fake "ok" probes. Caught locally with both files in the same bundle; fixed before merge.

## Test plan

- [x] `tests/unit/cli.voice.test.ts` — 6/6
- [x] `tests/integration/voice-local-stt.test.ts` — 9/9 (carryover from PR-A)
- [x] `tests/integration/voice-local-tts.test.ts` — 5/5 (carryover from PR-B)
- [x] `tests/unit/config.env-registry.test.ts` — 12/12 (carryover from PR #428)
- [x] `tests/doctor-v2.test.ts` — 12/12 (no leak from voice mocks)
- [x] Combined bundle (cli.voice + voice-local-stt + voice-local-tts + env-registry + doctor-v2) — 44/44, no flakes
- [x] `npm run typecheck` + `eslint .` — green
- [ ] CI workflows green
- [ ] Manual: `MEMPHIS_VOICE_MODE=local` + servers up → `memphis voice status` shows both green
- [ ] Manual: `memphis doctor 2>&1 | grep voice` → `ta12-voice-stack: pass`

## Sprint H summary (3 PR-y stacked)

| PR | Branch | Scope | Status |
|----|--------|-------|--------|
| #431 | feat/voice-stt-chooser | STT chooser + faster-whisper runbook | open |
| #432 | feat/voice-piper-tts | Piper TTS adapter + runbook | open |
| **this** | feat/voice-status-cli | voice status CLI + doctor check | open |

After all three merge, demo box runbook = three install commands + `MEMPHIS_VOICE_MODE=local`. Demo-ready offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)