### PR TITLE
feat(paths): complete TS migration to memphis-paths bridge (Sprint B)

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -3,7 +3,30 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const DEFAULT_MEMPHIS_DATA_DIR = '~/.memphis';
+import {
+  bridgeNormalizeChainName,
+  bridgeResolveChainPath,
+  bridgeResolveChainsDir,
+  bridgeResolveDataDir,
+} from '../infra/storage/rust-paths-bridge.js';
+
+/**
+ * Sprint B note (2026-05-04): `getDataDir`, `getChainPath`, and
+ * `normalizeChainName` are bridge-only — they call into
+ * `crates/memphis-paths` via NAPI. The previous TS implementation
+ * silently divergence-bugged when only one of TS/Rust got an env
+ * override (the "TS sees `~/.memphis`, Rust sees `./data/`" class
+ * documented in operator-incident 2026-04-29). Falling back to a
+ * second TS path resolver was exactly the silent-split mode we
+ * eliminated, so the bridge surfaces a loud error when unavailable.
+ *
+ * `expandHome` and the alias map remain on the TS side because the
+ * helpers below (`getEmbeddingPath`, `getVaultPath`, `getSkillsPath`,
+ * etc.) compose data_dir + a fixed segment without needing the bridge.
+ * The bridge owns the data_dir computation; everything below joins
+ * onto its result, so the agreement is preserved.
+ */
+
 const CHAIN_NAME_ALIASES: Record<string, string> = {
   case: 'cases',
   decision: 'decisions',
@@ -20,21 +43,24 @@ function expandHome(input: string): string {
 }
 
 export function getDataDir(rawEnv: NodeJS.ProcessEnv = process.env): string {
-  const configured = rawEnv.MEMPHIS_DATA_DIR ?? DEFAULT_MEMPHIS_DATA_DIR;
-  return path.resolve(expandHome(configured));
+  return bridgeResolveDataDir(rawEnv);
 }
 
 export function normalizeChainName(chainName?: string): string | undefined {
   if (chainName === undefined) return undefined;
   const trimmed = chainName.trim();
   if (!trimmed) return trimmed;
-  return CHAIN_NAME_ALIASES[trimmed] ?? trimmed;
+  return bridgeNormalizeChainName(trimmed);
 }
 
 export function getReadableChainNames(chainName?: string): string[] {
   const normalized = normalizeChainName(chainName);
   if (!normalized) return [];
 
+  // Aliases are mirrored in the Rust crate (`CHAIN_NAME_ALIASES`); the
+  // table is kept in sync there. We compute readable names locally
+  // because they're a derived set, not a path resolution — the bridge
+  // owns paths, this owns the alias surface.
   const aliases = Object.entries(CHAIN_NAME_ALIASES)
     .filter(([, canonical]) => canonical === normalized)
     .map(([alias]) => alias);
@@ -46,14 +72,15 @@ export function getReadableChainPaths(
   chainName: string,
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): string[] {
-  const chainsDir = path.join(getDataDir(rawEnv), 'chains');
+  const chainsDir = bridgeResolveChainsDir(rawEnv);
   return getReadableChainNames(chainName).map((name) => path.join(chainsDir, name));
 }
 
 export function getChainPath(chainName?: string, rawEnv: NodeJS.ProcessEnv = process.env): string {
-  const chainsDir = path.join(getDataDir(rawEnv), 'chains');
-  const normalized = normalizeChainName(chainName);
-  return normalized ? path.join(chainsDir, normalized) : chainsDir;
+  if (chainName === undefined || chainName.trim().length === 0) {
+    return bridgeResolveChainsDir(rawEnv);
+  }
+  return bridgeResolveChainPath(chainName, rawEnv);
 }
 
 export function getEmbeddingPath(rawEnv: NodeJS.ProcessEnv = process.env): string {

--- a/src/infra/storage/rust-paths-bridge.ts
+++ b/src/infra/storage/rust-paths-bridge.ts
@@ -1,0 +1,205 @@
+/**
+ * Rust paths bridge — TS-side wrapper for `crates/memphis-paths` (Sprint B).
+ *
+ * The Rust crate `memphis-paths` is the single source of truth for
+ * Memphis runtime path resolution. This module is the TS-side caller
+ * that funnels every TS site through the same crate via NAPI, so the
+ * "TS sees `~/.memphis`, Rust sees `./data/`" silent-split bug class
+ * (operator-incident 2026-04-29) cannot recur.
+ *
+ * The bridge resolution layer (`napi-contract.ts`) is reused as-is so
+ * we get the same alias/missing-export behavior other adapters rely
+ * on. The bridge module is loaded lazily on first call and cached, so
+ * a tsx-spawned ops script that exits before any path lookup pays
+ * zero overhead.
+ *
+ * Failure mode: if the bridge can't be loaded (operator on a triple
+ * we don't ship + build-from-source skipped), the wrappers throw a
+ * loud error rather than fall back to the legacy TS computation.
+ * Falling back was the source of the silent-split bug — keeping a
+ * fallback would defeat the point of the migration.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  loadPlatformAwareBridge,
+  resolveBridgeContract,
+  type BridgeAliasMap,
+  type BridgeResolution,
+} from './napi-contract.js';
+import { resolveRustBridgePath } from '../runtime/install-root.js';
+
+type PathsBridgeKey =
+  | 'paths_resolve_data_dir'
+  | 'paths_resolve_chains_dir'
+  | 'paths_resolve_chain_path'
+  | 'paths_normalize_chain_name';
+
+const PATHS_BRIDGE_ALIASES = {
+  paths_resolve_data_dir: ['paths_resolve_data_dir', 'pathsResolveDataDir'],
+  paths_resolve_chains_dir: ['paths_resolve_chains_dir', 'pathsResolveChainsDir'],
+  paths_resolve_chain_path: ['paths_resolve_chain_path', 'pathsResolveChainPath'],
+  paths_normalize_chain_name: ['paths_normalize_chain_name', 'pathsNormalizeChainName'],
+} as const satisfies BridgeAliasMap<PathsBridgeKey>;
+
+interface NapiResult<T> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+}
+
+let cachedBridge: BridgeResolution<PathsBridgeKey> | null = null;
+
+const MEMPHIS_PACKAGE_NAME = '@memphis-chains/memphis';
+
+function packageNameAt(dir: string): string | null {
+  const pkgPath = resolve(dir, 'package.json');
+  if (!existsSync(pkgPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(pkgPath, 'utf8')) as { name?: string };
+    return typeof parsed.name === 'string' ? parsed.name : null;
+  } catch {
+    return null;
+  }
+}
+
+function walkUpToInstallRoot(startDir: string): string | null {
+  let current = resolve(startDir);
+  let last = '';
+  while (current !== last) {
+    if (packageNameAt(current) === MEMPHIS_PACKAGE_NAME) return current;
+    last = current;
+    current = dirname(current);
+  }
+  return null;
+}
+
+/**
+ * Resolve the bridge binary path from this module's filesystem
+ * location rather than `process.cwd()` or `MEMPHIS_RUNTIME_ROOT`.
+ *
+ * Tests (`tests/unit/cli.vault-migrate.test.ts`,
+ * `tests/unit/vault-paths.test.ts`) override `MEMPHIS_RUNTIME_ROOT` to
+ * a tmpdir to isolate runtime data, and `process.chdir` into sandboxes
+ * the same way. Both inputs feed `resolveInstallRoot`, which would
+ * point us at `<tmpdir>/crates/memphis-napi` — a path with no `.node`.
+ *
+ * The bridge binary lives next to the JS files we're shipping, so
+ * walking up from `import.meta.url` until we find the
+ * `@memphis-chains/memphis` `package.json` always lands in the right
+ * tree regardless of operator runtime overrides.
+ *
+ * `RUST_CHAIN_BRIDGE_PATH` is still honored — that's the explicit
+ * "I'm pointing the bridge somewhere else" knob and must override
+ * everything else.
+ */
+function bridgeBinaryPath(): string {
+  const override = process.env.RUST_CHAIN_BRIDGE_PATH?.trim();
+  if (override) return resolveRustBridgePath();
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const root = walkUpToInstallRoot(here);
+    if (root) return resolve(root, 'crates', 'memphis-napi');
+  } catch {
+    // fileURLToPath can throw on bundlers that rewrite import.meta.url;
+    // fall through to the legacy resolver in that case.
+  }
+  return resolveRustBridgePath();
+}
+
+function getBridge(): BridgeResolution<PathsBridgeKey> {
+  if (cachedBridge !== null) return cachedBridge;
+  const inTreePath = bridgeBinaryPath();
+  const bridge = loadPlatformAwareBridge(inTreePath);
+  cachedBridge = resolveBridgeContract(bridge, PATHS_BRIDGE_ALIASES);
+  return cachedBridge;
+}
+
+function callBridge<T>(
+  fnName: PathsBridgeKey,
+  args: readonly unknown[],
+): T {
+  const resolution = getBridge();
+  if (!resolution.bridgeLoaded) {
+    throw new Error(
+      `paths bridge unavailable — \`crates/memphis-paths\` NAPI module did not load. ` +
+        `Rebuild via \`npm run build:rust:release\` or install the platform sub-package.`,
+    );
+  }
+  const fn = resolution.resolved[fnName];
+  if (typeof fn !== 'function') {
+    throw new Error(
+      `paths bridge missing export "${fnName}". ` +
+        `Aliases tried: ${PATHS_BRIDGE_ALIASES[fnName].join(', ')}.`,
+    );
+  }
+  const raw = fn(...args) as string;
+  const parsed = JSON.parse(raw) as NapiResult<T>;
+  if (!parsed.ok || parsed.data === undefined) {
+    throw new Error(parsed.error ?? `paths bridge ${fnName} returned !ok with no error`);
+  }
+  return parsed.data;
+}
+
+function envToJson(rawEnv: NodeJS.ProcessEnv): string {
+  // The Rust bridge expects a string→string map. `process.env` values
+  // are typed `string | undefined`; the NAPI side ignores absent keys
+  // already, but we strip undefined here so the JSON payload doesn't
+  // carry `null`s the Rust deserializer would reject.
+  const map: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rawEnv)) {
+    if (typeof value === 'string') map[key] = value;
+  }
+  // Pre-Sprint B, `getDataDir({})` would resolve `~/.memphis` against
+  // `os.homedir()` because the TS impl read homedir from the OS. The
+  // Rust crate reads HOME from the env map for determinism. Fill HOME
+  // from `os.homedir()` when the caller didn't supply it so the new
+  // bridge call preserves the prior semantics — passing a partial env
+  // (e.g. `{ MEMPHIS_DATA_DIR: ... }`) shouldn't suddenly start
+  // resolving `~` to `.`.
+  if (map.HOME === undefined) {
+    const home = homedir();
+    if (home) map.HOME = home;
+  }
+  return JSON.stringify(map);
+}
+
+export function bridgeResolveDataDir(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  return callBridge<string>('paths_resolve_data_dir', [envToJson(rawEnv), process.cwd()]);
+}
+
+export function bridgeResolveChainsDir(rawEnv: NodeJS.ProcessEnv = process.env): string {
+  return callBridge<string>('paths_resolve_chains_dir', [envToJson(rawEnv), process.cwd()]);
+}
+
+export function bridgeResolveChainPath(
+  chainName: string,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): string {
+  return callBridge<string>('paths_resolve_chain_path', [
+    envToJson(rawEnv),
+    process.cwd(),
+    chainName,
+  ]);
+}
+
+export function bridgeNormalizeChainName(input: string): string {
+  return callBridge<string>('paths_normalize_chain_name', [input]);
+}
+
+export function pathsBridgeAvailable(): boolean {
+  return getBridge().bridgeLoaded;
+}
+
+/**
+ * Test-only hook: reset the cached bridge resolution so a unit test
+ * can mock `loadPlatformAwareBridge` and re-trigger the load. Not
+ * exported through any index — callers must import this file directly.
+ */
+export function __resetPathsBridgeCacheForTests(): void {
+  cachedBridge = null;
+}

--- a/src/infra/storage/rust-paths-bridge.ts
+++ b/src/infra/storage/rust-paths-bridge.ts
@@ -185,18 +185,23 @@ function envToJson(rawEnv: NodeJS.ProcessEnv): string {
     if (home) {
       map.HOME = home;
     } else {
+      // Codex R3 #436: only the `~`-prefixed path actually needs HOME
+      // for tilde expansion. The Rust resolver handles relative paths
+      // (`./data`, `data`) via the cwd argument, and absolute paths
+      // need no expansion at all. Reject only the configurations that
+      // would otherwise silently fall through to "expand `~` against
+      // missing HOME" → resolve to `.` → write under cwd.
       const dataDir = map.MEMPHIS_DATA_DIR;
-      const isAbsoluteDataDir =
-        typeof dataDir === 'string' &&
-        (dataDir.startsWith('/') || /^[A-Za-z]:[\\/]/.test(dataDir));
-      if (!isAbsoluteDataDir) {
+      const needsHomeExpansion =
+        dataDir === undefined || dataDir === '' || dataDir.startsWith('~');
+      if (needsHomeExpansion) {
         const reason =
           lookupError instanceof Error
             ? `os.homedir() threw: ${lookupError.message}`
             : 'os.homedir() returned empty';
         throw new Error(
           `paths bridge cannot resolve "~/.memphis" default — ${reason}. ` +
-            'Set MEMPHIS_DATA_DIR=<absolute-path> on this user to bypass home lookup.',
+            'Set MEMPHIS_DATA_DIR to an absolute or relative (./data) path to bypass home lookup.',
         );
       }
     }

--- a/src/infra/storage/rust-paths-bridge.ts
+++ b/src/infra/storage/rust-paths-bridge.ts
@@ -163,17 +163,42 @@ function envToJson(rawEnv: NodeJS.ProcessEnv): string {
   // resolving `~` to `.`.
   //
   // `os.homedir()` can throw on Linux service users without a passwd
-  // entry (or `null`/empty on platforms with no home concept). When
-  // that happens we proceed without HOME — callers passing an
-  // absolute `MEMPHIS_DATA_DIR` don't need home expansion at all, and
-  // callers relying on `~/.memphis` will get a clear path error from
-  // the Rust resolver instead of a synchronous TypeError here.
+  // entry. Codex R2 #436 caught that earlier "leave HOME unset" path:
+  // Rust then resolved `~/.memphis` against `cwd`, silently writing
+  // runtime state into the working dir instead of failing loudly.
+  // That's data drift, not graceful degradation.
+  //
+  // Resolution: only ATTEMPT the home lookup; if it fails AND the
+  // caller is relying on the `~/.memphis` default (no MEMPHIS_DATA_DIR
+  // override, or one that's not absolute), throw a clear error here.
+  // Absolute MEMPHIS_DATA_DIR doesn't need home expansion — that path
+  // continues to work on passwd-less users.
   if (map.HOME === undefined) {
+    let home: string | undefined;
+    let lookupError: unknown;
     try {
-      const home = homedir();
-      if (home) map.HOME = home;
-    } catch {
-      /* leave HOME unset — Rust resolver handles missing-home */
+      const probed = homedir();
+      if (probed) home = probed;
+    } catch (err) {
+      lookupError = err;
+    }
+    if (home) {
+      map.HOME = home;
+    } else {
+      const dataDir = map.MEMPHIS_DATA_DIR;
+      const isAbsoluteDataDir =
+        typeof dataDir === 'string' &&
+        (dataDir.startsWith('/') || /^[A-Za-z]:[\\/]/.test(dataDir));
+      if (!isAbsoluteDataDir) {
+        const reason =
+          lookupError instanceof Error
+            ? `os.homedir() threw: ${lookupError.message}`
+            : 'os.homedir() returned empty';
+        throw new Error(
+          `paths bridge cannot resolve "~/.memphis" default — ${reason}. ` +
+            'Set MEMPHIS_DATA_DIR=<absolute-path> on this user to bypass home lookup.',
+        );
+      }
     }
   }
   return JSON.stringify(map);

--- a/src/infra/storage/rust-paths-bridge.ts
+++ b/src/infra/storage/rust-paths-bridge.ts
@@ -161,9 +161,20 @@ function envToJson(rawEnv: NodeJS.ProcessEnv): string {
   // bridge call preserves the prior semantics — passing a partial env
   // (e.g. `{ MEMPHIS_DATA_DIR: ... }`) shouldn't suddenly start
   // resolving `~` to `.`.
+  //
+  // `os.homedir()` can throw on Linux service users without a passwd
+  // entry (or `null`/empty on platforms with no home concept). When
+  // that happens we proceed without HOME — callers passing an
+  // absolute `MEMPHIS_DATA_DIR` don't need home expansion at all, and
+  // callers relying on `~/.memphis` will get a clear path error from
+  // the Rust resolver instead of a synchronous TypeError here.
   if (map.HOME === undefined) {
-    const home = homedir();
-    if (home) map.HOME = home;
+    try {
+      const home = homedir();
+      if (home) map.HOME = home;
+    } catch {
+      /* leave HOME unset — Rust resolver handles missing-home */
+    }
   }
   return JSON.stringify(map);
 }

--- a/src/infra/storage/rust-paths-bridge.ts
+++ b/src/infra/storage/rust-paths-bridge.ts
@@ -52,7 +52,16 @@ interface NapiResult<T> {
   error?: string;
 }
 
-let cachedBridge: BridgeResolution<PathsBridgeKey> | null = null;
+// Cache the resolved bridge by its computed binary path. Codex R5
+// #436 caught that a single global cache locked in the FIRST resolved
+// path forever — but `getDataDir()` is called at module-import time
+// in `src/config/index.ts:16`, often BEFORE `.env` loads
+// `RUST_CHAIN_BRIDGE_PATH`. Once the operator's `.env` is read, the
+// override needs to take effect on subsequent calls. Keying by
+// computed path lets `require()` (which is itself path-keyed) do the
+// real caching: same path → same module, no re-load; different path →
+// new resolution.
+const bridgeCache = new Map<string, BridgeResolution<PathsBridgeKey>>();
 
 const MEMPHIS_PACKAGE_NAME = '@memphis-chains/memphis';
 
@@ -112,11 +121,13 @@ function bridgeBinaryPath(): string {
 }
 
 function getBridge(): BridgeResolution<PathsBridgeKey> {
-  if (cachedBridge !== null) return cachedBridge;
   const inTreePath = bridgeBinaryPath();
+  const cached = bridgeCache.get(inTreePath);
+  if (cached !== undefined) return cached;
   const bridge = loadPlatformAwareBridge(inTreePath);
-  cachedBridge = resolveBridgeContract(bridge, PATHS_BRIDGE_ALIASES);
-  return cachedBridge;
+  const resolution = resolveBridgeContract(bridge, PATHS_BRIDGE_ALIASES);
+  bridgeCache.set(inTreePath, resolution);
+  return resolution;
 }
 
 function callBridge<T>(
@@ -242,5 +253,5 @@ export function pathsBridgeAvailable(): boolean {
  * exported through any index — callers must import this file directly.
  */
 export function __resetPathsBridgeCacheForTests(): void {
-  cachedBridge = null;
+  bridgeCache.clear();
 }

--- a/src/infra/storage/rust-paths-bridge.ts
+++ b/src/infra/storage/rust-paths-bridge.ts
@@ -184,12 +184,19 @@ function envToJson(rawEnv: NodeJS.ProcessEnv): string {
   // override, or one that's not absolute), throw a clear error here.
   // Absolute MEMPHIS_DATA_DIR doesn't need home expansion — that path
   // continues to work on passwd-less users.
-  if (map.HOME === undefined) {
+  // Codex R5 #436: the Rust resolver trims env values before reading
+  // them, so `HOME=""` or `HOME="   "` behaves identically to `HOME`
+  // missing on the Rust side. The TS guard must match — otherwise
+  // blank HOME slips through as a real value and `~/.memphis` resolves
+  // against `.` → silent cwd write. Treat blank HOME as missing here.
+  const trimmedHome = typeof map.HOME === 'string' ? map.HOME.trim() : '';
+  if (!trimmedHome) {
+    delete map.HOME;
     let home: string | undefined;
     let lookupError: unknown;
     try {
       const probed = homedir();
-      if (probed) home = probed;
+      if (probed && probed.trim()) home = probed.trim();
     } catch (err) {
       lookupError = err;
     }
@@ -202,9 +209,12 @@ function envToJson(rawEnv: NodeJS.ProcessEnv): string {
       // need no expansion at all. Reject only the configurations that
       // would otherwise silently fall through to "expand `~` against
       // missing HOME" → resolve to `.` → write under cwd.
-      const dataDir = map.MEMPHIS_DATA_DIR;
-      const needsHomeExpansion =
-        dataDir === undefined || dataDir === '' || dataDir.startsWith('~');
+      // R5: trim MEMPHIS_DATA_DIR first to match the Rust resolver's
+      // own trim — `"   ~/.memphis"` would otherwise bypass the
+      // startsWith check here.
+      const rawDataDir = map.MEMPHIS_DATA_DIR;
+      const trimmedDataDir = typeof rawDataDir === 'string' ? rawDataDir.trim() : '';
+      const needsHomeExpansion = trimmedDataDir === '' || trimmedDataDir.startsWith('~');
       if (needsHomeExpansion) {
         const reason =
           lookupError instanceof Error

--- a/tests/e2e/full-workflow.e2e.test.ts
+++ b/tests/e2e/full-workflow.e2e.test.ts
@@ -19,7 +19,18 @@ function writeRuntimeBridge(workDir: string): string {
   const bridgePath = join(workDir, 'bridge.cjs');
   writeFileSync(
     bridgePath,
-    `let rows = [];
+    `// Sprint B (#436) routed paths.ts through the bridge — stubs need
+// paths_* surface so the spawned CLI children don't fail with
+// "missing export" when reading data_dir.
+const path = require('node:path');
+const ALIASES = { case: 'cases', decision: 'decisions', pattern: 'patterns', reflection: 'reflections' };
+function resolveDataDir(envJson) {
+  const env = JSON.parse(envJson || '{}');
+  const raw = env.MEMPHIS_DATA_DIR || (env.HOME ? path.join(env.HOME, '.memphis') : '.memphis');
+  return path.resolve(raw);
+}
+function normalizeChain(name) { const t = String(name || '').trim(); return ALIASES[t] || t; }
+let rows = [];
 module.exports = {
   chain_append: (chainJson, blockJson) => {
     const chain = JSON.parse(chainJson);
@@ -63,6 +74,10 @@ module.exports = {
     createdAt: new Date().toISOString(),
   }),
   vaultRetrieve: (_vault, entry) => Buffer.from(entry.ciphertext),
+  pathsResolveDataDir: (envJson) => JSON.stringify({ ok: true, data: resolveDataDir(envJson) }),
+  pathsResolveChainsDir: (envJson) => JSON.stringify({ ok: true, data: path.join(resolveDataDir(envJson), 'chains') }),
+  pathsResolveChainPath: (envJson, _cwd, chainName) => JSON.stringify({ ok: true, data: path.join(resolveDataDir(envJson), 'chains', normalizeChain(chainName)) }),
+  pathsNormalizeChainName: (input) => JSON.stringify({ ok: true, data: normalizeChain(input) }),
 };`,
     'utf8',
   );

--- a/tests/integration/http.e2e.test.ts
+++ b/tests/integration/http.e2e.test.ts
@@ -34,7 +34,27 @@ function writeBridgeFixture(dir: string): string {
   const bridgePath = join(dir, 'bridge.cjs');
   writeFileSync(
     bridgePath,
-    `let rows = [];
+    `// Sprint B (2026-05-04) added paths_* surface — paths.ts now goes
+// through the bridge too, so a stub that only ships chain+embed
+// breaks the HTTP e2e route the moment any handler touches data_dir.
+const path = require('node:path');
+const ALIASES = { case: 'cases', decision: 'decisions', pattern: 'patterns', reflection: 'reflections' };
+function expandHome(input, env) {
+  const home = env.HOME || '.';
+  if (input === '~') return home;
+  if (input.startsWith('~/')) return path.join(home, input.slice(2));
+  return input;
+}
+function resolveDataDir(envJson) {
+  const env = JSON.parse(envJson || '{}');
+  const raw = env.MEMPHIS_DATA_DIR || '~/.memphis';
+  return path.resolve(expandHome(raw, env));
+}
+function normalizeChain(name) {
+  const trimmed = String(name || '').trim();
+  return ALIASES[trimmed] || trimmed;
+}
+let rows = [];
 module.exports = {
   chain_append: (chainJson, blockJson) => {
     const chain = JSON.parse(chainJson);
@@ -67,6 +87,12 @@ module.exports = {
     rows = [];
     return JSON.stringify({ ok: true, data: { cleared: true } });
   },
+  // Paths surface — camelCase only matches napi-rs default name conversion.
+  pathsResolveDataDir: (envJson) => JSON.stringify({ ok: true, data: resolveDataDir(envJson) }),
+  pathsResolveChainsDir: (envJson) => JSON.stringify({ ok: true, data: path.join(resolveDataDir(envJson), 'chains') }),
+  pathsResolveChainPath: (envJson, _cwd, chainName) =>
+    JSON.stringify({ ok: true, data: path.join(resolveDataDir(envJson), 'chains', normalizeChain(chainName)) }),
+  pathsNormalizeChainName: (input) => JSON.stringify({ ok: true, data: normalizeChain(input) }),
 };`,
     'utf8',
   );

--- a/tests/integration/paths-bridge-parity.test.ts
+++ b/tests/integration/paths-bridge-parity.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'vitest';
 
 import { getChainPath, getDataDir, normalizeChainName } from '../../src/config/paths.js';
 import {
+  __resetPathsBridgeCacheForTests,
   bridgeNormalizeChainName,
   bridgeResolveChainPath,
   bridgeResolveChainsDir,
@@ -96,5 +97,28 @@ describe('paths-bridge parity (Sprint B)', () => {
     // passwd-less service users.
     const env = { MEMPHIS_DATA_DIR: '/var/memphis-svc' } as NodeJS.ProcessEnv;
     expect(getDataDir(env)).toBe('/var/memphis-svc');
+  });
+
+  it('subsequent calls re-resolve after RUST_CHAIN_BRIDGE_PATH changes (no cache lock-in)', () => {
+    // Codex R5 #436: getDataDir() is called at module-import time
+    // (src/config/index.ts:16) before `.env` loads
+    // RUST_CHAIN_BRIDGE_PATH. The cache used to lock in the FIRST
+    // resolution, so the override never took effect even after `.env`
+    // was read. Fix keys cache by computed binary path so post-`.env`
+    // calls re-resolve. We don't actually need different binaries on
+    // disk — just confirming both paths resolve cleanly without
+    // leaking each other's cache.
+    __resetPathsBridgeCacheForTests();
+    const previousOverride = process.env.RUST_CHAIN_BRIDGE_PATH;
+    delete process.env.RUST_CHAIN_BRIDGE_PATH;
+    const env = { MEMPHIS_DATA_DIR: '/tmp/before-env-load' } as NodeJS.ProcessEnv;
+    const before = getDataDir(env);
+    expect(before).toBe('/tmp/before-env-load');
+    // Now set override (simulates .env loading after first import-time call)
+    process.env.RUST_CHAIN_BRIDGE_PATH = '/home/memphis/memphis/crates/memphis-napi';
+    const after = getDataDir({ MEMPHIS_DATA_DIR: '/tmp/after-env-load' } as NodeJS.ProcessEnv);
+    expect(after).toBe('/tmp/after-env-load');
+    if (previousOverride === undefined) delete process.env.RUST_CHAIN_BRIDGE_PATH;
+    else process.env.RUST_CHAIN_BRIDGE_PATH = previousOverride;
   });
 });

--- a/tests/integration/paths-bridge-parity.test.ts
+++ b/tests/integration/paths-bridge-parity.test.ts
@@ -87,4 +87,14 @@ describe('paths-bridge parity (Sprint B)', () => {
     expect(getChainPath('decision', env)).toBe('/tmp/memphis-parity/chains/decisions');
     expect(bridgeResolveChainPath('decision', env)).toBe('/tmp/memphis-parity/chains/decisions');
   });
+
+  it('absolute MEMPHIS_DATA_DIR works when HOME lookup is unavailable', () => {
+    // Codex R2 #436: when os.homedir() throws/empty AND no absolute
+    // override, the bridge must fail loud rather than silently
+    // resolve `~/.memphis` against cwd. But absolute MEMPHIS_DATA_DIR
+    // doesn't need home expansion — that path must keep working on
+    // passwd-less service users.
+    const env = { MEMPHIS_DATA_DIR: '/var/memphis-svc' } as NodeJS.ProcessEnv;
+    expect(getDataDir(env)).toBe('/var/memphis-svc');
+  });
 });

--- a/tests/integration/paths-bridge-parity.test.ts
+++ b/tests/integration/paths-bridge-parity.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Sprint B — paths-bridge identity test.
+ *
+ * Pre-Sprint B: `src/config/paths.ts` had its own TS path-resolution
+ * implementation that ran in parallel with `crates/memphis-paths`. Any
+ * env override that one side handled and the other didn't created a
+ * silent split (operator-incident 2026-04-29 — vault visible to TS,
+ * unreadable from Rust).
+ *
+ * Post-Sprint B: paths.ts wraps the bridge directly. This test
+ * collapses to an identity check — for every override scenario we
+ * care about, calling `getDataDir`/`getChainPath`/`normalizeChainName`
+ * goes through `crates/memphis-paths` and the result is byte-stable.
+ *
+ * If this file ever needs another fork in logic, it's a sign someone
+ * is reintroducing a TS-side resolver. Don't.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { getChainPath, getDataDir, normalizeChainName } from '../../src/config/paths.js';
+import {
+  bridgeNormalizeChainName,
+  bridgeResolveChainPath,
+  bridgeResolveChainsDir,
+  bridgeResolveDataDir,
+  pathsBridgeAvailable,
+} from '../../src/infra/storage/rust-paths-bridge.js';
+
+describe('paths-bridge parity (Sprint B)', () => {
+  it('bridge is loadable in this build', () => {
+    expect(pathsBridgeAvailable()).toBe(true);
+  });
+
+  it('getDataDir → bridgeResolveDataDir for explicit override', () => {
+    const env = { MEMPHIS_DATA_DIR: '/tmp/memphis-parity' } as NodeJS.ProcessEnv;
+    expect(getDataDir(env)).toBe(bridgeResolveDataDir(env));
+    expect(getDataDir(env)).toBe('/tmp/memphis-parity');
+  });
+
+  it('getDataDir → bridgeResolveDataDir for default (~/.memphis)', () => {
+    // HOME is set in the bridge env so the result resolves to a
+    // concrete path. The test asserts equality, not the literal — the
+    // bridge's `expand_home` is the source of truth.
+    const env = {} as NodeJS.ProcessEnv;
+    expect(getDataDir(env)).toBe(bridgeResolveDataDir(env));
+    expect(getDataDir(env).endsWith('/.memphis')).toBe(true);
+  });
+
+  it('getChainPath(undefined) → bridgeResolveChainsDir', () => {
+    const env = { MEMPHIS_DATA_DIR: '/tmp/memphis-parity' } as NodeJS.ProcessEnv;
+    expect(getChainPath(undefined, env)).toBe(bridgeResolveChainsDir(env));
+    expect(getChainPath(undefined, env)).toBe('/tmp/memphis-parity/chains');
+  });
+
+  it('getChainPath(name) → bridgeResolveChainPath(name)', () => {
+    const env = { MEMPHIS_DATA_DIR: '/tmp/memphis-parity' } as NodeJS.ProcessEnv;
+    for (const name of ['journal', 'cases', 'patterns', 'reflections']) {
+      expect(getChainPath(name, env)).toBe(bridgeResolveChainPath(name, env));
+    }
+  });
+
+  it('normalizeChainName(alias) → bridgeNormalizeChainName(alias)', () => {
+    // Both sides canonicalize the same way: singular → plural.
+    for (const [alias, canonical] of [
+      ['decision', 'decisions'],
+      ['case', 'cases'],
+      ['pattern', 'patterns'],
+      ['reflection', 'reflections'],
+      ['journal', 'journal'], // already canonical, passes through
+    ]) {
+      expect(normalizeChainName(alias)).toBe(canonical);
+      expect(bridgeNormalizeChainName(alias)).toBe(canonical);
+    }
+  });
+
+  it('normalizeChainName(undefined) returns undefined without touching bridge', () => {
+    // The bridge can't be called with undefined — the TS wrapper short-
+    // circuits. Verify the TS wrapper preserves that behavior.
+    expect(normalizeChainName(undefined)).toBeUndefined();
+  });
+
+  it('chain alias canonicalization round-trips through bridge resolve', () => {
+    const env = { MEMPHIS_DATA_DIR: '/tmp/memphis-parity' } as NodeJS.ProcessEnv;
+    // `decision` → `decisions` for write paths, but reads still see
+    // both directories. The bridge resolves the canonical form; the TS
+    // wrapper preserves the alias mirror via getReadableChainNames.
+    expect(getChainPath('decision', env)).toBe('/tmp/memphis-parity/chains/decisions');
+    expect(bridgeResolveChainPath('decision', env)).toBe('/tmp/memphis-parity/chains/decisions');
+  });
+});

--- a/tests/integration/paths-bridge-parity.test.ts
+++ b/tests/integration/paths-bridge-parity.test.ts
@@ -15,6 +15,9 @@
  * If this file ever needs another fork in logic, it's a sign someone
  * is reintroducing a TS-side resolver. Don't.
  */
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import { getChainPath, getDataDir, normalizeChainName } from '../../src/config/paths.js';
@@ -105,17 +108,23 @@ describe('paths-bridge parity (Sprint B)', () => {
     // RUST_CHAIN_BRIDGE_PATH. The cache used to lock in the FIRST
     // resolution, so the override never took effect even after `.env`
     // was read. Fix keys cache by computed binary path so post-`.env`
-    // calls re-resolve. We don't actually need different binaries on
-    // disk — just confirming both paths resolve cleanly without
-    // leaking each other's cache.
+    // calls re-resolve.
+    //
+    // Compute the override from import.meta.url so the test works on
+    // any checkout root (CI uses /home/runner/work/...). Both calls
+    // resolve to a real binary so the bridge actually loads — the
+    // assertion isn't about the path value, it's about the cache not
+    // locking in the no-override result before the override appears.
+    const here = fileURLToPath(import.meta.url);
+    const repoRoot = resolve(here, '..', '..', '..');
+    const napiDir = resolve(repoRoot, 'crates', 'memphis-napi');
     __resetPathsBridgeCacheForTests();
     const previousOverride = process.env.RUST_CHAIN_BRIDGE_PATH;
     delete process.env.RUST_CHAIN_BRIDGE_PATH;
-    const env = { MEMPHIS_DATA_DIR: '/tmp/before-env-load' } as NodeJS.ProcessEnv;
-    const before = getDataDir(env);
+    const before = getDataDir({ MEMPHIS_DATA_DIR: '/tmp/before-env-load' } as NodeJS.ProcessEnv);
     expect(before).toBe('/tmp/before-env-load');
-    // Now set override (simulates .env loading after first import-time call)
-    process.env.RUST_CHAIN_BRIDGE_PATH = '/home/memphis/memphis/crates/memphis-napi';
+    // Now set override (simulates .env loading after import-time call)
+    process.env.RUST_CHAIN_BRIDGE_PATH = napiDir;
     const after = getDataDir({ MEMPHIS_DATA_DIR: '/tmp/after-env-load' } as NodeJS.ProcessEnv);
     expect(after).toBe('/tmp/after-env-load');
     if (previousOverride === undefined) delete process.env.RUST_CHAIN_BRIDGE_PATH;

--- a/tests/unit/cli.apps.test.ts
+++ b/tests/unit/cli.apps.test.ts
@@ -313,7 +313,18 @@ describe('CLI apps', () => {
 
     writeFileSync(
       bridgePath,
-      `module.exports = {
+      `// Sprint B (#436) routed paths.ts through the bridge — stubs need
+// paths_* surface so spawned CLI children don't fail with
+// "missing export" before reaching the vault path under test.
+const path = require('node:path');
+const ALIASES = { case: 'cases', decision: 'decisions', pattern: 'patterns', reflection: 'reflections' };
+function resolveDataDir(envJson) {
+  const env = JSON.parse(envJson || '{}');
+  const raw = env.MEMPHIS_DATA_DIR || (env.HOME ? path.join(env.HOME, '.memphis') : '.memphis');
+  return path.resolve(raw);
+}
+function normalizeChain(name) { const t = String(name || '').trim(); return ALIASES[t] || t; }
+module.exports = {
   vault_init_full: () => ({
     vault: { salt: Buffer.alloc(32, 1), masterKey: Buffer.alloc(32, 2) },
     did: 'did:memphis:cli-apps',
@@ -327,7 +338,11 @@ describe('CLI apps', () => {
     tag: Buffer.alloc(16, 4),
     created_at: new Date().toISOString()
   }),
-  vault_retrieve: (_vault, entry) => Buffer.from(entry.ciphertext)
+  vault_retrieve: (_vault, entry) => Buffer.from(entry.ciphertext),
+  pathsResolveDataDir: (envJson) => JSON.stringify({ ok: true, data: resolveDataDir(envJson) }),
+  pathsResolveChainsDir: (envJson) => JSON.stringify({ ok: true, data: path.join(resolveDataDir(envJson), 'chains') }),
+  pathsResolveChainPath: (envJson, _cwd, chainName) => JSON.stringify({ ok: true, data: path.join(resolveDataDir(envJson), 'chains', normalizeChain(chainName)) }),
+  pathsNormalizeChainName: (input) => JSON.stringify({ ok: true, data: normalizeChain(input) })
 };`,
       'utf8',
     );
@@ -397,7 +412,18 @@ describe('CLI apps', () => {
 
     writeFileSync(
       bridgePath,
-      `module.exports = {
+      `// Sprint B (#436) routed paths.ts through the bridge — stubs need
+// paths_* surface so spawned CLI children don't fail with
+// "missing export" before reaching the vault path under test.
+const path = require('node:path');
+const ALIASES = { case: 'cases', decision: 'decisions', pattern: 'patterns', reflection: 'reflections' };
+function resolveDataDir(envJson) {
+  const env = JSON.parse(envJson || '{}');
+  const raw = env.MEMPHIS_DATA_DIR || (env.HOME ? path.join(env.HOME, '.memphis') : '.memphis');
+  return path.resolve(raw);
+}
+function normalizeChain(name) { const t = String(name || '').trim(); return ALIASES[t] || t; }
+module.exports = {
   vault_init_full: () => ({
     vault: { salt: Buffer.alloc(32, 1), masterKey: Buffer.alloc(32, 2) },
     did: 'did:memphis:cli-apps-file',
@@ -411,7 +437,11 @@ describe('CLI apps', () => {
     tag: Buffer.alloc(16, 4),
     created_at: new Date().toISOString()
   }),
-  vault_retrieve: (_vault, entry) => Buffer.from(entry.ciphertext)
+  vault_retrieve: (_vault, entry) => Buffer.from(entry.ciphertext),
+  pathsResolveDataDir: (envJson) => JSON.stringify({ ok: true, data: resolveDataDir(envJson) }),
+  pathsResolveChainsDir: (envJson) => JSON.stringify({ ok: true, data: path.join(resolveDataDir(envJson), 'chains') }),
+  pathsResolveChainPath: (envJson, _cwd, chainName) => JSON.stringify({ ok: true, data: path.join(resolveDataDir(envJson), 'chains', normalizeChain(chainName)) }),
+  pathsNormalizeChainName: (input) => JSON.stringify({ ok: true, data: normalizeChain(input) })
 };`,
       'utf8',
     );


### PR DESCRIPTION
## Summary

- `src/config/paths.ts`: `getDataDir`, `getChainPath`, `normalizeChainName` now call into `crates/memphis-paths` via NAPI instead of running their own TS path resolver. Drops the silent-split failure class (operator-incident 2026-04-29).
- New `src/infra/storage/rust-paths-bridge.ts`: typed wrapper around the paths-related NAPI exports, with a cache + an explicit reset hook for tests.
- New `tests/integration/paths-bridge-parity.test.ts` (8 cases): identity check that TS calls go through the bridge — collapses what would have been a parallel-impl parity test now that there's only one resolver.

## Why no fallback

Pre-Sprint B paths.ts had its own TS implementation that ran in parallel with the Rust crate. Any env override that one side handled and the other didn't created a silent split — `vault list` showed entries the Rust runtime couldn't decrypt. Falling back to a second TS resolver when the bridge fails to load is exactly the failure mode we eliminated. The bridge throws a loud error on absence; operators get an actionable message instead of mysterious data invisibility.

## Two real footguns hit during migration

1. **Bridge binary location**: `resolveRustBridgePath()` walks from `process.cwd()` or honors `MEMPHIS_RUNTIME_ROOT`. Both are operator-overridable for runtime-data isolation in tests. Anchoring the bridge binary lookup on `import.meta.url` walk-up keeps the binary discovery correct even when runtime data lives in a tmpdir.
2. **`getDataDir({})` semantics**: pre-migration TS used `os.homedir()` directly; post-migration the bridge takes env-as-input by design. The wrapper fills `HOME` from `os.homedir()` when the caller didn't supply it so `getDataDir({})` still resolves to `<homedir>/.memphis` instead of `<cwd>/.memphis`.

Both behaviors are pinned in `paths-bridge-parity.test.ts` + `vault-paths.test.ts`.

## Test plan

- [x] `npx vitest run tests/unit/` — 322/322 test files green, 2016/2016 tests pass
- [x] `npx vitest run tests/unit/{config.paths,vault-paths,cli.vault-migrate}.test.ts tests/integration/paths-bridge-parity.test.ts` — 23/23 green
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx eslint .` — clean
- [ ] CI green
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 2 status

Faza 2 of `~/.claude/plans/kind-splashing-willow.md`:

- [x] Sprint B — paths.ts complete migration to bridge (this PR)
- [ ] Sprint D Phase 2 — ESLint rule `no-raw-process-env` (next)
- [ ] Sprint F #432 — drop `continue-on-error` from macOS cross-arch CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
