### PR TITLE
chore(eslint): warn on raw process.env.X reads outside env-registry (Sprint D Phase 2)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,6 +53,38 @@ export default [
       // Re-enable incrementally after targeted refactors.
       'max-lines-per-function': 'off',
       complexity: 'off',
+      // Sprint D Phase 2 — discourage direct `process.env.X` reads in
+      // `src/`. The env-registry (`src/config/env-registry.ts`) is the
+      // SSOT for env access; raw reads create the divergent-fallback-
+      // chain class of bug (operator sets X but Memphis can't see it).
+      //
+      // Level is `warn` initially so the ~59 existing call sites surface
+      // for incremental migration in Sprint D Phase 3 without blocking
+      // CI today. Promote to `error` once the migration is complete.
+      //
+      // The selector matches `process.env.<NAME>` (dot or bracket access).
+      // Passing `process.env` as an object reference (e.g. into the
+      // env-registry's `read(rawEnv)`) is fine — only key-level access
+      // trips the rule.
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector:
+            "MemberExpression[object.type='MemberExpression'][object.object.name='process'][object.property.name='env']",
+          message:
+            'Avoid direct `process.env.X` reads — go through `src/config/env-registry.ts`. Pass `rawEnv = process.env` and call the typed accessor (e.g. `MEMPHIS_VOICE_MODE.read(rawEnv)`).',
+        },
+      ],
+    },
+  },
+  {
+    // Allowlist: env-registry is the SSOT for env access. Schema and
+    // env-loading helpers don't read `process.env.X` today (they take
+    // `rawEnv` as an argument), so they don't need the override; if
+    // that ever changes, add them here.
+    files: ['src/config/env-registry.ts'],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
   {


### PR DESCRIPTION
## Summary

- Adds ESLint `no-restricted-syntax` rule that warns on direct `process.env.X` reads in `src/`.
- Per-file override allows `src/config/env-registry.ts` (the SSOT) to keep raw access.
- Level is `warn`, not `error`: 195 existing call sites surface as warnings; CI stays green.

## Why

Sprint D Phase 1 landed the env-registry as SSOT for env access. Direct `process.env.X` reads bypass it and re-introduce the divergent-fallback-chain class of bug that Phase 1 was created to eliminate ("operator sets X but Memphis can't see it"). This rule flags new violations at PR time so they don't accrete past Phase 3's call-site migration.

## How the rule works

- AST selector catches `process.env.X` (dot or bracket access) — both `process.env.MEMPHIS_FOO` and `process.env['MEMPHIS_FOO']`.
- Passing `process.env` as an object reference (e.g. into `MEMPHIS_VOICE_MODE.read(rawEnv)`) does NOT trigger — the selector requires the outer member access on `process.env`.
- Per-file override for `src/config/env-registry.ts` since it's the SSOT.

## Promotion path

- Phase 2 (this PR): `warn`, 0 errors, 195 warnings on main.
- Phase 3 (planned): migrate ~30+ high-traffic call sites in batched PRs.
- Phase 4: promote rule to `error` once warning count is ≤5 or zero.

## Test plan

- [x] `npx eslint .` → 0 errors, 195 warnings (rule fires across `src/`)
- [x] `npx eslint src/config/env-registry.ts --max-warnings 0` → clean (allowlist works)
- [x] Verified `process.env` passed as a reference doesn't trip the rule (default-arg pattern stays valid)
- [ ] CI green
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 2 status

Faza 2 of `~/.claude/plans/kind-splashing-willow.md`:

- [x] Sprint B — paths.ts complete migration to bridge (#436)
- [x] Sprint D Phase 2 — ESLint `no-raw-process-env` rule (this PR)
- [ ] Sprint F #432 — drop `continue-on-error` from macOS cross-arch CI matrix (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
