### PR TITLE
ci: drop continue-on-error from cross-arch matrix; macOS+arm64 now blocking (Sprint F #432)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,16 @@ jobs:
   # only fire on arm64 or macOS hardware before someone hits them in dev.
   # Uses GitHub-hosted free runners (ubuntu-24.04-arm + macos-latest M-chip).
   #
-  # `continue-on-error: true` — Memphis was Linux-only by accident until this
-  # matrix landed; the first push surfaced real macOS path/vault/napi lock
-  # issues. Fixing them is its own sprint. Matrix stays informational so it
-  # signals regressions without blocking merges. See `project_macos_compat_pending`
-  # memory + GitHub issue for the macOS work.
+  # 2026-05-04 (Sprint F #432): `continue-on-error` removed. Three
+  # consecutive main runs landed both arms green (Sprint S1 closed the
+  # last macOS-only regressions, S4 and v1.8.0 distribution kept them
+  # green). Matrix is now blocking on push so a regression on either
+  # arch fails the run instead of silently signalling. `fail-fast: false`
+  # keeps the other arch reporting even when one breaks, so the PR
+  # surface still tells you "macOS only" vs "arm64 only" at a glance.
   cross-arch:
     if: github.event_name == 'push'
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Drops `continue-on-error: true` from `.github/workflows/ci.yml:68`. The cross-arch matrix (`ubuntu-24.04-arm` + `macos-latest`) now blocks pushes to main if either arch fails.
- `fail-fast: false` preserved so a single-arch regression still reports the other arch's status at-a-glance.

## Why now

Three consecutive main runs landed both arms green:

| Run ID | macos-latest | ubuntu-24.04-arm |
|---|---|---|
| 25307786992 (3d5baa9) | ✅ | ✅ |
| 25307782406 (7c6c6f6) | ✅ | ✅ |
| 25307778497 (b8ee932) | ✅ | ✅ |

Sprint S1 (#375-#379) closed the last macOS-only regressions. Sprint S4 (#380-#383) and v1.8.0 distribution kept them green. The matrix has been informational-only since PR #347 landed — the safety net it added is no longer paying for itself.

## Risk + mitigation

If a macOS-flaky test emerges, this gates merges to main. The roadmap intent (Linux-canonical, macOS via build-from-source) still holds — the `cross-arch` matrix is for catching unintended cross-platform breakage, not for guaranteeing macOS-first deployment. If we hit a real macOS regression we can:

1. Quarantine the specific test with a `describe.skipIf(process.platform === 'darwin')` per-case (`Sprint F #432a`).
2. Re-add `continue-on-error: true` if the problem is structural and needs its own sprint.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` → ok
- [x] Three preceding main runs verified green via `gh run view`
- [ ] CI green on this PR (`cross-arch` is push-only so PR run won't exercise it; first push to main after merge is the proof)
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 2 status

Faza 2 of `~/.claude/plans/kind-splashing-willow.md` complete:

- [x] Sprint B — paths.ts complete migration to bridge (#436)
- [x] Sprint D Phase 2 — ESLint `no-raw-process-env` rule (#437)
- [x] Sprint F #432 — drop `continue-on-error` from macOS cross-arch (this PR)

Faza 3 next: Sprint E Phase 2 (ToolDescriptor consumers) + Sprint J (Soul ↔ Cognitive autonomy loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
