### PR TITLE
feat(tools): wire helpText into system-prompt + MCP server (Sprint E Phase 2)

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -341,8 +341,14 @@ function autoGenToolDoc(name: string, meta: ToolMeta): string {
   const flag = meta.featureFlag
     ? `\nFEATURE FLAG: ${meta.featureFlag} (must be enabled for this tool to dispatch)`
     : '';
+  // Sprint E Phase 2: prefer `helpText` (rich, multi-sentence) over the
+  // one-line `description` when present. Tools without helpText still
+  // get the bare description — no regression. Once Phase 3 fills in
+  // helpText for the remaining ~35 tools, the LLM gets richer context
+  // for every tool without touching this renderer.
+  const purpose = meta.helpText ?? meta.description;
   return `<tool name="${name}">
-PURPOSE: ${meta.description}
+PURPOSE: ${purpose}
 TIER: ${tier}
 CAPABILITIES: ${caps}
 INPUT: ${shape}

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -706,6 +706,26 @@ export function getToolMeta(name: string): ToolMeta | undefined {
   return TOOL_REGISTRY[name];
 }
 
+/**
+ * Resolve the operator-facing description for a tool, preferring the
+ * richer `helpText` from Phase 1 over the one-line `description` when
+ * available. Sprint E Phase 2 (this commit) wires this into the
+ * surfaces that previously hardcoded their own strings (MCP server
+ * registration, system-prompt auto-gen, CLI/TUI/Telegram help).
+ *
+ * Falls back gracefully:
+ *   1. `helpText` (rich, multi-sentence) — populated for ~5 tools today
+ *   2. `description` (one-liner, every registered tool has it)
+ *   3. Hard-coded fallback string when name is unknown — surfaces as a
+ *      visible bug rather than empty output, so a typo in a caller
+ *      doesn't silently swallow help text.
+ */
+export function getToolDescription(name: string): string {
+  const meta = TOOL_REGISTRY[name];
+  if (!meta) return `tool "${name}" not registered`;
+  return meta.helpText ?? meta.description;
+}
+
 export function isToolEnabledByFeatureFlag(
   name: string,
   rawEnv: NodeJS.ProcessEnv = process.env,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -49,7 +49,7 @@ import { runMemphisWebFetch } from './tools/web-fetch.js';
 import { runMemphisWebSearch } from './tools/web-search.js';
 import { RollbackManager } from '../backup/rollback.js';
 import { resolveToolPolicy } from '../gateway/authorization.js';
-import { isToolEnabledByFeatureFlag } from '../gateway/tool-registry.js';
+import { getToolDescription, isToolEnabledByFeatureFlag } from '../gateway/tool-registry.js';
 import { loadConfig } from '../infra/config/env.js';
 import { CaseChainAdapter } from '../infra/storage/case-chain-adapter.js';
 import { createSqliteClient, runMigrations } from '../infra/storage/sqlite/client.js';
@@ -253,7 +253,7 @@ export function createMemphisMcpServer(
     server.registerTool(
       'memphis_journal',
       {
-        description: 'Save entries to journal chain',
+        description: getToolDescription('memphis_journal'),
         inputSchema: {
           content: z.string().min(1),
           tags: z.array(z.string()).optional(),
@@ -275,7 +275,7 @@ export function createMemphisMcpServer(
     server.registerTool(
       'memphis_recall',
       {
-        description: 'Semantic search across chains',
+        description: getToolDescription('memphis_recall'),
         inputSchema: {
           query: z.string().min(1),
           limit: z.number().int().min(1).max(50).optional(),
@@ -297,7 +297,7 @@ export function createMemphisMcpServer(
     server.registerTool(
       'memphis_search',
       {
-        description: 'Exact phrase search across indexed memory content',
+        description: getToolDescription('memphis_search'),
         inputSchema: {
           query: z.string().min(1),
           limit: z.number().int().min(1).max(50).optional(),
@@ -353,8 +353,7 @@ export function createMemphisMcpServer(
     server.registerTool(
       'memphis_health',
       {
-        description:
-          'Check Memphis runtime health (database, rust bridge, data dir, embedding provider)',
+        description: getToolDescription('memphis_health'),
         inputSchema: {
           approval_request_id: z.string().optional(),
         },

--- a/tests/unit/tool-registry-descriptors.test.ts
+++ b/tests/unit/tool-registry-descriptors.test.ts
@@ -16,7 +16,7 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { TOOL_REGISTRY } from '../../src/gateway/tool-registry.js';
+import { TOOL_REGISTRY, getToolDescription } from '../../src/gateway/tool-registry.js';
 
 const PROOF_SET = [
   'memphis_journal',
@@ -72,5 +72,34 @@ describe('ToolDescriptor — Phase 1 foundation', () => {
     for (const name of PROOF_SET) {
       expect(TOOL_REGISTRY[name].tier, `${name} should be tier 0 in proof set`).toBe(0);
     }
+  });
+});
+
+describe('getToolDescription — Sprint E Phase 2 consumer helper', () => {
+  // Wire-up for the surfaces (system-prompt, MCP server, future TUI/
+  // Telegram /help) that previously hardcoded description strings.
+  // Pin the resolution priority so a refactor doesn't silently regress
+  // the LLM-facing context.
+
+  it.each(PROOF_SET)('%s prefers helpText over description', (name) => {
+    const meta = TOOL_REGISTRY[name];
+    expect(getToolDescription(name)).toBe(meta.helpText);
+    expect(getToolDescription(name)).not.toBe(meta.description);
+  });
+
+  it('falls back to description when helpText absent', () => {
+    const noHelpText = Object.values(TOOL_REGISTRY).find(
+      (meta) => meta.helpText === undefined,
+    );
+    expect(noHelpText, 'expected at least one tool without helpText').toBeDefined();
+    expect(getToolDescription(noHelpText!.name)).toBe(noHelpText!.description);
+  });
+
+  it('returns a recognizable error string for unknown tools (not empty)', () => {
+    // Empty output would silently swallow a typo in a caller; a visible
+    // error string surfaces the bug at the surface that consumes it.
+    const result = getToolDescription('memphis_does_not_exist');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toMatch(/not registered/);
   });
 });


### PR DESCRIPTION
## Summary

Sprint E Phase 1 (#429) shipped `helpText` + `cliFlags` on `ToolMeta` and filled them in for 4 tier-0 tools (memphis_journal/recall/search/health). Phase 2 wires the **consumer surfaces** to actually read those fields instead of duplicating description strings. This first PR covers the two highest-leverage surfaces.

- **`src/gateway/system-prompt.ts:autoGenToolDoc`** — LLM `<tool>` block now uses `helpText` (multi-sentence) when present, falls back to `description` otherwise. Richer context for the LLM with zero further code changes.
- **`src/mcp/server.ts`** — 4 tool registrations route through new `getToolDescription(name)` instead of hardcoded strings. MCP introspection clients see the richer text.
- New helper `getToolDescription(name)` in `tool-registry.ts`: priority chain `helpText ?? description ?? "not registered"`. The unknown-name path returns a visible error string (not empty) so caller typos surface at the consuming surface.

## Why incrementally

Phase 2 spans 5 surfaces (system-prompt, MCP server, CLI help, TUI `?` overlay, Telegram `/help`). Shipping all 5 in one PR mixes mechanical replacements with surface-specific quirks (TUI is in Rust; CLI help is hand-authored). This PR establishes:

1. The helper (`getToolDescription`).
2. The pattern (read helpText, fall back to description, surface-test it).
3. Two of the highest-impact surfaces.

Follow-up PRs migrate CLI/TUI/Telegram one surface at a time. Phase 3 fills helpText for the remaining ~35 tools without touching consumers.

## Test plan

- [x] `npx vitest run tests/unit/tool-registry-descriptors.test.ts` → 17/17 (including 3 new `getToolDescription` cases pinning helpText preference / description fallback / unknown-tool error)
- [x] `npx vitest run tests/unit/gateway.system-prompt.test.ts tests/integration/mcp-introspection-contract.test.ts` → 30/30 (Phase 1 contract preserved)
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx eslint .` — clean
- [ ] CI green
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 3 status

Faza 3 of `~/.claude/plans/kind-splashing-willow.md` (autopilot):

- [x] Sprint E Phase 2 — ToolDescriptor consumers (this PR; 2 of 5 surfaces; first iteration)
- [ ] Sprint E Phase 2 — CLI/TUI/Telegram consumers (followup)
- [ ] Sprint E Phase 3 — fill helpText for remaining ~35 tools (followup)
- [ ] Sprint J — Soul ↔ Cognitive autonomy loop (independent of E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
