### PR TITLE
feat(tools): surface helpText + cliFlags in `memphis tools describe` (Sprint E Phase 2 cont.)

### DIFF
--- a/src/infra/cli/handlers/tools.handler.ts
+++ b/src/infra/cli/handlers/tools.handler.ts
@@ -18,11 +18,30 @@
 import type { CommandHandler } from './command-handler.js';
 import type { CliContext } from '../context.js';
 
+/**
+ * Operator-facing CLI flag descriptor mirrored from `ToolCliFlag` in
+ * `src/gateway/tool-registry.ts`. We keep a local copy of the shape
+ * (rather than importing the type) so the CLI handler doesn't pull
+ * the gateway's whole dependency graph for type info — capabilities
+ * payload is JSON over HTTP anyway.
+ */
+interface ToolCliFlagView {
+  name: string;
+  alias?: string;
+  description: string;
+  takesValue?: boolean;
+  required?: boolean;
+}
+
 interface ToolView {
   name: string;
   tier: 0 | 1 | 2 | 3;
   capabilities: string[];
   description: string;
+  /** Sprint E Phase 2: rich help when present; falls back to description. */
+  helpText?: string;
+  /** Sprint E Phase 2: declarative flag list for `describe` rendering. */
+  cliFlags?: readonly ToolCliFlagView[];
   featureFlag: string | null;
   available: boolean;
 }
@@ -210,7 +229,22 @@ async function handleToolsDescribe(context: CliContext): Promise<boolean> {
   console.log(`Feature flag: ${tool.featureFlag ?? '(none)'}`);
   console.log(`Available:    ${tool.available ? 'yes' : 'no'} (surface=${payload.surface})`);
   console.log('');
-  console.log(tool.description);
+  // Sprint E Phase 2: prefer rich helpText when the tool has one;
+  // fall back to the one-line description for tools that haven't
+  // been migrated yet.
+  console.log(tool.helpText ?? tool.description);
+  if (tool.cliFlags && tool.cliFlags.length > 0) {
+    console.log('');
+    console.log('Flags:');
+    // Align flag names so the descriptions form a column.
+    const colWidth = Math.max(...tool.cliFlags.map((f) => f.name.length));
+    for (const flag of tool.cliFlags) {
+      const aliasSuffix = flag.alias ? ` / ${flag.alias}` : '';
+      const requiredSuffix = flag.required ? ' (required)' : '';
+      const padded = `${flag.name}${aliasSuffix}`.padEnd(colWidth + 4);
+      console.log(`  ${padded}${flag.description}${requiredSuffix}`);
+    }
+  }
   return true;
 }
 

--- a/src/mcp/tools/self-describe.ts
+++ b/src/mcp/tools/self-describe.ts
@@ -27,7 +27,7 @@ import {
   resolveSurfacePolicy,
   type SurfacePolicy,
 } from '../../gateway/surface-policy.js';
-import { getToolMeta, getToolNames } from '../../gateway/tool-registry.js';
+import { getToolMeta, getToolNames, type ToolCliFlag } from '../../gateway/tool-registry.js';
 import { listEnabledFeatureFlags } from '../../infra/features/flags.js';
 import {
   getActiveTier3Session,
@@ -66,6 +66,19 @@ export interface MemphisSelfDescribeOutput {
     tier: 0 | 1 | 2 | 3;
     capabilities: string[];
     description: string;
+    /**
+     * Operator-facing rich help text (Sprint E Phase 1+2). Multi-
+     * sentence detail surfaces in `memphis tools describe <name>`,
+     * TUI `?` overlay, Telegram `/help <tool>`. Optional — tools
+     * without helpText fall back to `description` at the surface.
+     */
+    helpText?: string;
+    /**
+     * Declarative CLI flag list (Sprint E Phase 1+2). When present,
+     * `memphis tools describe` renders an aligned `--flag # desc`
+     * block below the helpText. Optional — same fallback rule.
+     */
+    cliFlags?: readonly ToolCliFlag[];
     featureFlag: string | null;
     available: boolean;
   }>;
@@ -113,6 +126,14 @@ export function runMemphisSelfDescribe(
       tier: (meta?.tier ?? 0) as 0 | 1 | 2 | 3,
       capabilities: meta?.capabilities ?? [],
       description: meta?.description ?? '',
+      // Sprint E Phase 2: surface helpText + cliFlags through the
+      // capabilities envelope so `memphis tools describe` (CLI),
+      // future TUI `?` overlay, and Telegram `/help <tool>` can
+      // render the richer text without each surface re-importing
+      // tool-registry. Undefined when the tool hasn't been migrated
+      // yet — surfaces fall back to `description`.
+      helpText: meta?.helpText,
+      cliFlags: meta?.cliFlags,
       featureFlag: meta?.featureFlag ?? null,
       available,
     };

--- a/tests/unit/cli.tools.handler.test.ts
+++ b/tests/unit/cli.tools.handler.test.ts
@@ -187,6 +187,50 @@ describe('memphis tools describe', () => {
     expect(parsed.name).toBe('memphis_journal');
   });
 
+  it('renders helpText (rich) when present, plus aligned cliFlags block (Sprint E Phase 2)', async () => {
+    const payloadWithDescriptor = {
+      ...samplePayload,
+      tools: [
+        {
+          ...samplePayload.tools[0],
+          helpText:
+            'Append a journal entry to the operator-private journal chain. Multi-sentence detail.',
+          cliFlags: [
+            { name: '--content', description: 'Journal entry text.', takesValue: true, required: true },
+            { name: '--tags', description: 'Comma-separated tags.', takesValue: true },
+          ],
+        },
+        ...samplePayload.tools.slice(1),
+      ],
+    };
+    mockFetchResolve(payloadWithDescriptor);
+    await toolsCommandHandler.handle(
+      buildContext({ subcommand: 'describe', target: 'memphis_journal' }),
+    );
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    // helpText replaces the bare description for the body text
+    expect(out).toContain('Multi-sentence detail');
+    // cliFlags rendered with aligned columns + required marker
+    expect(out).toContain('Flags:');
+    expect(out).toContain('--content');
+    expect(out).toContain('(required)');
+    expect(out).toContain('--tags');
+  });
+
+  it('falls back to description when helpText is absent (unmigrated tool)', async () => {
+    mockFetchResolve(samplePayload);
+    await toolsCommandHandler.handle(
+      buildContext({ subcommand: 'describe', target: 'memphis_self_describe' }),
+    );
+
+    const out = consoleSpy.log.mock.calls.map((c) => c[0]).join('\n');
+    // No helpText on this fixture → renders description as before
+    expect(out).toContain('Runtime self-introspection');
+    // No Flags: block when cliFlags absent
+    expect(out).not.toContain('Flags:');
+  });
+
   it('errors on unknown tool name', async () => {
     mockFetchResolve(samplePayload);
     await toolsCommandHandler.handle(

--- a/tests/unit/self-describe.test.ts
+++ b/tests/unit/self-describe.test.ts
@@ -94,4 +94,35 @@ describe('runMemphisSelfDescribe', () => {
     expect(out.tier3Session!.grantedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(out.tier3Session!.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
+
+  it('propagates helpText + cliFlags from tool-registry through capabilities envelope (Sprint E Phase 2)', () => {
+    // Pin the wiring: tools that have helpText / cliFlags in
+    // src/gateway/tool-registry.ts (Sprint E Phase 1 proof set)
+    // surface those fields through `runMemphisSelfDescribe` so CLI
+    // `memphis tools describe`, future TUI `?` overlay, and Telegram
+    // `/help <tool>` all see the same rich text.
+    const out = runMemphisSelfDescribe(
+      {},
+      { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv,
+    );
+    const journal = out.tools.find((t) => t.name === 'memphis_journal');
+    expect(journal, 'memphis_journal must be in tools[]').toBeDefined();
+    expect(journal!.helpText, 'memphis_journal has Phase 1 helpText').toBeDefined();
+    expect(journal!.helpText!.length).toBeGreaterThan(journal!.description.length);
+    expect(Array.isArray(journal!.cliFlags), 'cliFlags is array when present').toBe(true);
+    expect(journal!.cliFlags!.length).toBeGreaterThan(0);
+
+    // Tools without Phase 1 migration return undefined for both —
+    // surfaces fall back to description. Pin that the field stays
+    // optional rather than being coerced to empty string.
+    const unmigrated = out.tools.find(
+      (t) =>
+        !['memphis_journal', 'memphis_recall', 'memphis_search', 'memphis_health'].includes(
+          t.name,
+        ),
+    );
+    expect(unmigrated, 'expected at least one unmigrated tool').toBeDefined();
+    expect(unmigrated!.helpText).toBeUndefined();
+    expect(unmigrated!.cliFlags).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Continues Sprint E Phase 2 wiring (started in #439 with system-prompt + MCP server). This PR routes `helpText` + `cliFlags` from the tool registry through the capabilities envelope into the CLI's `memphis tools describe <name>` output.

**Wiring chain:**

1. **`src/mcp/tools/self-describe.ts`** — `helpText` and `cliFlags` added as optional fields on the `tools[]` entry. Populated from `getToolMeta(name)`. Unmigrated tools leave both `undefined` (not empty-string coerced) so consumers can branch cleanly.
2. **`src/infra/cli/handlers/tools.handler.ts`** — `ToolView` extended with same optional fields. `describe` handler prefers `helpText` when present, falls back to `description`. Adds aligned `Flags:` block when `cliFlags` non-empty (`--name` padded to a column, `(required)` suffix, optional alias).

## Sample output

`memphis tools describe memphis_journal` now renders:

```
Tool:         memphis_journal
Tier:         0
Capabilities: write
Feature flag: (none)
Available:    yes (surface=cli)

Append a journal entry to the operator-private journal chain.
The chain is local-only by default; entries persist across
restarts and feed cognitive Mode E (weekly reflection).

Flags:
  --content     Journal entry text. Required. (required)
  --tags        Comma-separated tags applied to the entry.
```

## Why two PRs

#439 wired the LLM-facing surfaces (system-prompt + MCP description). This PR handles the operator-facing CLI inspector. Each can land independently — different files, different test surfaces, different review focus.

## Test plan

- [x] `npx vitest run tests/unit/self-describe.test.ts` → 7/7 (new: propagation pin)
- [x] `npx vitest run tests/unit/cli.tools.handler.test.ts` → 12/12 (new: helpText + flag block render, fallback when absent)
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx eslint .` — clean
- [ ] CI green
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 3 status

Faza 3 of `~/.claude/plans/kind-splashing-willow.md` (autopilot):

- [x] Sprint E Phase 2 — system-prompt + MCP server (#439)
- [x] Sprint J — soul ↔ cognitive autonomy loop test (#440)
- [x] Sprint E Phase 2 — `memphis tools describe` CLI (this PR)
- [ ] Sprint E Phase 2 — TUI `?` overlay + Telegram `/help` (followup)
- [ ] Sprint E Phase 3 — fill helpText for remaining ~35 tools (followup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
