### PR TITLE
feat(tools): /help <tool-name> in Telegram renders helpText + cliFlags (Sprint E Phase 2 cont.)

### DIFF
--- a/src/gateway/channels/telegram.ts
+++ b/src/gateway/channels/telegram.ts
@@ -15,6 +15,7 @@ import {
 } from '../../infra/config/mutability.js';
 import { envSchema } from '../../infra/config/schema.js';
 import { renderSurfaceDesignGuideText } from '../../infra/operator-guide.js';
+import { runMemphisSelfDescribe } from '../../mcp/tools/self-describe.js';
 import {
   buildTier3EnvOverride,
   getActiveTier3Session,
@@ -87,6 +88,50 @@ function setSessionTier(chatId: string, tier: 0 | 1 | 2): void {
     return;
   }
   sessionTierMap.set(chatId, { tier, expiresAt: Date.now() + TIER_TTL_MS });
+}
+
+// ─── /help <tool-name> rendering (Sprint E Phase 2) ────────────────────────
+
+/**
+ * Tool-shape consumed by `renderTelegramToolHelp`. Mirrors the
+ * `tools[]` entry from `runMemphisSelfDescribe` so the renderer can
+ * be unit-tested without spinning up a Telegram bot.
+ */
+export interface TelegramToolHelpInput {
+  name: string;
+  tier: 0 | 1 | 2 | 3;
+  description: string;
+  helpText?: string;
+  cliFlags?: ReadonlyArray<{
+    name: string;
+    alias?: string;
+    description: string;
+    required?: boolean;
+  }>;
+  featureFlag: string | null;
+}
+
+/**
+ * Format a single tool's help block for Telegram. Prefers `helpText`
+ * (rich, multi-sentence) when present; falls back to `description`.
+ * `cliFlags` rendered as a `Flags:` block when non-empty.
+ */
+export function renderTelegramToolHelp(tool: TelegramToolHelpInput): string {
+  const lines: string[] = [];
+  lines.push(`*${tool.name}* (tier ${tool.tier})`);
+  if (tool.featureFlag) lines.push(`feature flag: ${tool.featureFlag}`);
+  lines.push('');
+  lines.push(tool.helpText ?? tool.description);
+  if (tool.cliFlags && tool.cliFlags.length > 0) {
+    lines.push('');
+    lines.push('Flags:');
+    for (const flag of tool.cliFlags) {
+      const aliasSuffix = flag.alias ? ` / ${flag.alias}` : '';
+      const requiredSuffix = flag.required ? ' (required)' : '';
+      lines.push(`  ${flag.name}${aliasSuffix} — ${flag.description}${requiredSuffix}`);
+    }
+  }
+  return lines.join('\n');
 }
 
 // ─── Env override for surface policy ────────────────────────────────────────
@@ -319,6 +364,25 @@ export function createTelegramAdapter(
       });
 
       bot.command(['start', 'help'], async (ctx) => {
+        // Sprint E Phase 2: `/help <tool-name>` renders the tool's
+        // helpText + cliFlags from the registry. Bare `/help` keeps
+        // the static command list. Operator-discoverable bridge to
+        // the same registry data CLI / system-prompt / MCP already
+        // surface.
+        const text = ctx.message?.text ?? '';
+        const arg = text.replace(/^\/(start|help)(?:@\S+)?\s*/u, '').trim();
+        if (arg.length > 0) {
+          const tools = runMemphisSelfDescribe({ surface: 'telegram' }).tools;
+          const tool = tools.find((t) => t.name === arg);
+          if (!tool) {
+            await ctx.reply(
+              `Unknown tool: ${arg}\nUse /help with no argument for the command list.`,
+            );
+            return;
+          }
+          await ctx.reply(renderTelegramToolHelp(tool));
+          return;
+        }
         await ctx.reply(
           [
             'Memphis agent online. Send a message to chat.',
@@ -334,6 +398,7 @@ export function createTelegramAdapter(
             '/config show|set|reload — show or change runtime config on the fly (tier 3 for secrets)',
             "/voice on|off|status — toggle TTS replies and view today's quota",
             '/evolve <intent> — self-modify codebase (tier 2 required, test-gated)',
+            '/help <tool-name> — describe a registered tool (e.g. /help memphis_journal)',
             '',
             'See docs/operator-handbook.md for the full operator workflow.',
           ].join('\n'),

--- a/tests/unit/telegram-help-render.test.ts
+++ b/tests/unit/telegram-help-render.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Sprint E Phase 2 — Telegram `/help <tool-name>` rendering.
+ *
+ * Pin the format the bot replies with when an operator types
+ * `/help memphis_journal` (or any registered tool name). The renderer
+ * is extracted from the bot wiring so we can assert formatting
+ * without spinning up a grammy Bot instance.
+ *
+ * Resolution priority matches the CLI `memphis tools describe` and
+ * MCP server description fields (see `getToolDescription`):
+ *   1. `helpText` (rich, multi-sentence) — preferred when present
+ *   2. `description` (one-line) — fallback for unmigrated tools
+ *
+ * `cliFlags` block rendered when non-empty; absent for tools without
+ * declarative flags.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  renderTelegramToolHelp,
+  type TelegramToolHelpInput,
+} from '../../src/gateway/channels/telegram.js';
+
+const baseTool: TelegramToolHelpInput = {
+  name: 'memphis_journal',
+  tier: 0,
+  description: 'Save entries to journal chain',
+  featureFlag: null,
+};
+
+describe('renderTelegramToolHelp', () => {
+  it('renders a header with name + tier', () => {
+    const out = renderTelegramToolHelp(baseTool);
+    expect(out).toContain('*memphis_journal*');
+    expect(out).toContain('(tier 0)');
+  });
+
+  it('prefers helpText over description when present', () => {
+    const richTool: TelegramToolHelpInput = {
+      ...baseTool,
+      helpText:
+        'Append a journal entry to the operator-private journal chain. Multi-sentence detail.',
+    };
+    const out = renderTelegramToolHelp(richTool);
+    expect(out).toContain('Multi-sentence detail');
+    // Description is the fallback path; the rich tool should NOT
+    // emit the bare description string when helpText is set.
+    expect(out).not.toMatch(/^Save entries to journal chain$/m);
+  });
+
+  it('falls back to description when helpText absent', () => {
+    const out = renderTelegramToolHelp(baseTool);
+    expect(out).toContain('Save entries to journal chain');
+  });
+
+  it('emits Flags block when cliFlags non-empty (with required marker + alias)', () => {
+    const tool: TelegramToolHelpInput = {
+      ...baseTool,
+      cliFlags: [
+        {
+          name: '--content',
+          alias: '-c',
+          description: 'Journal entry text.',
+          required: true,
+        },
+        {
+          name: '--tags',
+          description: 'Comma-separated tags.',
+        },
+      ],
+    };
+    const out = renderTelegramToolHelp(tool);
+    expect(out).toContain('Flags:');
+    expect(out).toContain('--content / -c');
+    expect(out).toContain('Journal entry text.');
+    expect(out).toContain('(required)');
+    expect(out).toContain('--tags');
+    // Optional flag has no `(required)` suffix
+    const tagsLine = out.split('\n').find((l) => l.includes('--tags'))!;
+    expect(tagsLine).not.toContain('(required)');
+  });
+
+  it('omits Flags block when cliFlags is empty or absent', () => {
+    const noFlags = renderTelegramToolHelp(baseTool);
+    expect(noFlags).not.toContain('Flags:');
+
+    const emptyFlags = renderTelegramToolHelp({ ...baseTool, cliFlags: [] });
+    expect(emptyFlags).not.toContain('Flags:');
+  });
+
+  it('shows feature flag line only when set', () => {
+    const flagged = renderTelegramToolHelp({
+      ...baseTool,
+      featureFlag: 'experimental-journal',
+    });
+    expect(flagged).toContain('feature flag: experimental-journal');
+
+    const unflagged = renderTelegramToolHelp(baseTool);
+    expect(unflagged).not.toContain('feature flag:');
+  });
+});


### PR DESCRIPTION
## Summary

Continues Sprint E Phase 2 (after #439 system-prompt+MCP, #441 CLI tools describe). This PR routes the same registry data into Telegram so operators can introspect tools from the bot UI.

- **`/help`** (no arg) — keeps the existing static command list. Adds one line documenting the new `/help <tool-name>` shape.
- **`/help <tool-name>`** — calls `runMemphisSelfDescribe({surface: 'telegram'})`, finds the matching tool, renders `helpText` (or `description` fallback) + an aligned `Flags:` block when `cliFlags` is non-empty.
- Unknown tool name → friendly error pointing at the no-arg form.

Format mirrors `memphis tools describe` (#441) so an operator who learns one surface knows the other.

## Sample output

```
*memphis_journal* (tier 0)

Append a journal entry to the operator-private journal chain.
The chain is local-only by default; entries persist across
restarts and feed cognitive Mode E (weekly reflection).

Flags:
  --content / -c — Journal entry text. (required)
  --tags — Comma-separated tags applied to the entry.
```

## Stack note

**Depends on #441** (which adds `helpText` + `cliFlags` to the `self-describe` envelope). Branched off `feat/sprint-e2-cli-tools-describe`. When #441 merges, this PR auto-rebases onto main; if GitHub auto-closes the stack (precedent: #422 after #421), I'll retarget + rebase.

## Why a separate PR

Different surface, different test approach. CLI handler tests use HTTP fixture; Telegram needs render-only coverage (the bot framework wiring isn't unit-testable cheaply). Extracted `renderTelegramToolHelp` is exported + tested in isolation — 6 cases pin header shape, helpText preference, description fallback, flag block format with required+alias markers, no-flag path, feature-flag conditional.

## Test plan

- [x] `npx vitest run tests/unit/telegram-help-render.test.ts` → 6/6
- [x] `npx tsc -p tsconfig.json --noEmit` — clean (after stacking on #441)
- [x] `npx eslint .` — clean (only pre-existing process.env warnings)
- [ ] CI green (after #441 merges)
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 3 status

Faza 3 of `~/.claude/plans/kind-splashing-willow.md`:

- [x] Sprint E Phase 2 — system-prompt + MCP server (#439)
- [x] Sprint J — soul ↔ cognitive autonomy loop test (#440)
- [x] Sprint E Phase 2 — CLI `memphis tools describe` (#441)
- [x] Sprint E Phase 2 — Telegram `/help <tool-name>` (this PR)
- [ ] Sprint E Phase 2 — TUI `?` overlay (Rust crate; separate scope)
- [ ] Sprint E Phase 3 — fill helpText for remaining ~35 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
