### PR TITLE
feat(tools): fill helpText + cliFlags for 5 more tier-0 tools (Sprint E Phase 3 batch 1)

### DIFF
--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -175,6 +175,27 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Append a decision record to the decisions chain — title, the choice taken, optional context. Decisions feed Model B inference (decision-pattern recognition) and the operator-facing audit trail. Use when the agent commits to an action that should be reviewable later, NOT for free-form thoughts (those go through memphis_journal).',
+    cliFlags: [
+      {
+        name: '--title',
+        description: 'Short label for the decision. Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--choice',
+        description: 'The decision actually taken. Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--context',
+        description: 'Optional rationale or background notes.',
+        takesValue: true,
+      },
+    ],
   },
   memphis_health: {
     name: 'memphis_health',
@@ -203,6 +224,22 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Compact runtime introspection. Surfaces the LIVE picture: active surface (mcp/cli/telegram/tui/http), effective tool tier (after surface policy + tier-3 elevation), cognitive mode (A-E), the full registered-tool list with each tool\'s availability under the current policy, active feature flags, and cross-surface tier-3 sessions. Operator capability questions ("what can you do", "co potrafisz", "show capabilities") MUST call this first — bot training data is months out of date and will confabulate. Output is JSON-shaped, safe to render to the operator verbatim.',
+    cliFlags: [
+      {
+        name: '--surface',
+        description:
+          'Override the surface name used for policy resolution (default: caller\'s surface).',
+        takesValue: true,
+      },
+      {
+        name: '--actor-id',
+        description:
+          'Actor id used for tier-3 session lookup on the resolved surface (default: "local").',
+        takesValue: true,
+      },
+    ],
   },
   memphis_slo_status: {
     name: 'memphis_slo_status',
@@ -228,6 +265,9 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Idempotent repair sweep over runtime state: chain integrity (rebuild missing index entries, drop orphans), SQLite migrations (apply any pending), derived indexes (case-index, embed-index reseed when stale). Safe to call from a healthy runtime — it is a no-op when nothing needs repair. Use after a crash, partial restore, or before the operator runs an export to be sure on-disk state is consistent.',
+    cliFlags: [],
   },
   memphis_soul_read: {
     name: 'memphis_soul_read',
@@ -240,6 +280,15 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Read the operator-private "soul memory" — the curated identity narrative that survives across sessions. Three sections: `user` (operator name, languages, preferences, expertise, integrations), `self` (agent personality, learnings, evolved capabilities), `context` (active work, recent decisions). Default `all` returns every section; pass a specific section to keep the response compact. Soul memory is privacy-sensitive: never log or echo verbatim into untrusted surfaces without redaction.',
+    cliFlags: [
+      {
+        name: '--section',
+        description: 'Which section to read: user | self | context | all (default: all).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_soul_write: {
     name: 'memphis_soul_write',
@@ -256,6 +305,9 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Deep-merge an update into the soul memory file. Three target sections (user/self/context) — only supply the keys you actually want to change; everything else stays untouched. Use to record evolved capabilities (`self.evolvedCapabilities`), update operator preferences (`user.preferences`), or refresh active work (`context.activeWork`). Writes are atomic + permission-tightened (0600). Soul memory is the long-form identity narrative — for ephemeral journal entries use memphis_journal instead.',
+    cliFlags: [],
   },
   memphis_case_append: {
     name: 'memphis_case_append',

--- a/tests/unit/tool-registry-descriptors.test.ts
+++ b/tests/unit/tool-registry-descriptors.test.ts
@@ -19,10 +19,17 @@ import { describe, expect, it } from 'vitest';
 import { TOOL_REGISTRY } from '../../src/gateway/tool-registry.js';
 
 const PROOF_SET = [
+  // Phase 1 (#429) — original 4 tier-0 tools
   'memphis_journal',
   'memphis_recall',
   'memphis_search',
   'memphis_health',
+  // Phase 3 batch 1 (this PR) — 5 more tier-0 tools
+  'memphis_decide',
+  'memphis_self_describe',
+  'memphis_repair',
+  'memphis_soul_read',
+  'memphis_soul_write',
 ] as const;
 
 describe('ToolDescriptor — Phase 1 foundation', () => {


### PR DESCRIPTION
## Summary

Sprint E Phase 1 (#429) shipped `helpText` + `cliFlags` for 4 tier-0 tools. Phase 3 fills the remaining ~35 tools so the consumer surfaces wired in Phase 2 (#439, #441, #442) show rich operator-facing text for every tool, not just the original four.

**Batch 1 — 5 most operator-visible tier-0 tools:**

| Tool | Why these 5 first |
|---|---|
| `memphis_decide` | High-traffic decision recorder; LLM needs the journal-vs-decisions distinction made explicit |
| `memphis_self_describe` | Capability introspection — explicit "MUST call before answering capability questions" instruction prevents the 2026-04-26 confabulation pattern |
| `memphis_repair` | Operator-facing diagnostic; idempotency contract documented |
| `memphis_soul_read` | Three sections (user/self/context) need explanation + privacy reminder |
| `memphis_soul_write` | Deep-merge semantics + journal-vs-soul guidance the LLM gets wrong otherwise |

`cliFlags` filled wherever the input schema has named fields (decide → `--title`/`--choice`/`--context`; self-describe → `--surface`/`--actor-id`; soul-read → `--section`). Tools whose input is structurally JSON-only (`repair`, `soul_write`) get `cliFlags: []` so the descriptor contract test still passes.

## Immediate downstream impact

The Phase 2 wiring already in flight picks up the new helpText automatically:

- **LLM system prompt** (`autoGenToolDoc` from #439) — every covered tool renders rich `PURPOSE` blocks
- **`memphis tools describe <name>`** (CLI from #441) — operator sees full helpText + Flags block
- **Telegram `/help <name>`** (from #442) — same content, mobile-friendly
- **MCP server description** — currently still hardcoded for the original 4; #439's `getToolDescription()` helper makes those routable when expanded

## Test plan

- [x] `npx vitest run tests/unit/tool-registry-descriptors.test.ts` → 21/21 (PROOF_SET expanded from 4 to 9; every contract holds)
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx eslint .` — clean
- [ ] CI green
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 3 status

- [x] Sprint E Phase 2 — system-prompt + MCP server (#439)
- [x] Sprint J — soul ↔ cognitive autonomy loop test (#440)
- [x] Sprint E Phase 2 — CLI `memphis tools describe` (#441)
- [x] Sprint E Phase 2 — Telegram `/help <tool-name>` (#442, stacked on #441)
- [x] Sprint E Phase 3 batch 1 — 5 tier-0 tools (this PR)
- [ ] Sprint E Phase 3 batch 2 — remaining ~30 tools (follow-up batches)
- [ ] Sprint E Phase 2 — TUI `?` overlay (Rust crate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
