### PR TITLE
feat(tools): fill helpText + cliFlags for remaining tier-0 tools (Sprint E Phase 3 batch 2)

### DIFF
--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -253,6 +253,15 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Reads telemetry spans (sourced from `~/.memphis/telemetry/`) over a rolling window and evaluates every defined SLO: tool success rate, p95 latency by tool, vault decrypt error rate, chain append throughput, embed-index health. Each SLO returns `pass | fail | unavailable` with the computed value, threshold, and sample count so the operator can see WHY the runtime is degraded, not just THAT it is. `unavailable` means the SLO has no samples in the window — usually fine for a fresh install, indicates a logging gap on a long-running runtime.',
+    cliFlags: [
+      {
+        name: '--window-days',
+        description: 'Rolling window in days (1-90, default 7).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_repair: {
     name: 'memphis_repair',
@@ -331,6 +340,9 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Append a case entry to the cases chain — Memphis\'s linguistic-case knowledge graph. Each entry is anchored on a Polish grammatical case (nominative/genitive/dative/accusative/instrumental/locative/ablative/vocative) plus role fields (actor, target, instrument, location, etc.) drawn from the operator\'s `entry` payload. Indexed in the SQLite case-index for relational queries via memphis_case_query. Use to record structured observations the embedding index can\'t capture relationally — e.g. "X delegated Y to Z".',
+    cliFlags: [],
   },
   memphis_case_query: {
     name: 'memphis_case_query',
@@ -351,6 +363,30 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Relational query over the case-index SQLite store fed by memphis_case_append. Filter by Polish case-type, by entity name, or by any role slot (actor/target/instrument/location). Returns matching case entries with their full block payloads. Prefer over memphis_recall when you need structured "who did what to whom" lookups instead of conceptual similarity.',
+    cliFlags: [
+      {
+        name: '--case-type',
+        description: 'Filter by grammatical case (nominative/genitive/dative/...).',
+        takesValue: true,
+      },
+      {
+        name: '--entity',
+        description: 'Match any role containing this entity name.',
+        takesValue: true,
+      },
+      {
+        name: '--actor',
+        description: 'Filter by actor role specifically.',
+        takesValue: true,
+      },
+      {
+        name: '--limit',
+        description: 'Max number of entries to return (default 20, cap 100).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_chain_query: {
     name: 'memphis_chain_query',
@@ -369,6 +405,40 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Direct read over a chain\'s block log with simple filters (blockType, substring `contains`, tag match). Returns raw block envelopes including hash + index + signature so the operator can audit chain integrity or pull a specific block by content. Pagination via `offset` + `limit`. Gated behind `experimental-tools` because the surface is intended for diagnostic introspection — for normal recall use memphis_recall (semantic) or memphis_search (literal).',
+    cliFlags: [
+      {
+        name: '--chain',
+        description: 'Chain name (journal, decisions, cases, ...). Omit to scan all.',
+        takesValue: true,
+      },
+      {
+        name: '--block-type',
+        description: 'Filter to one block type (journal, decision, case, ...).',
+        takesValue: true,
+      },
+      {
+        name: '--contains',
+        description: 'Literal substring match against block content/data.',
+        takesValue: true,
+      },
+      {
+        name: '--tag',
+        description: 'Match a single tag from the block\'s tags array.',
+        takesValue: true,
+      },
+      {
+        name: '--limit',
+        description: 'Max blocks (default 20, cap 100).',
+        takesValue: true,
+      },
+      {
+        name: '--offset',
+        description: 'Skip this many blocks (for pagination).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_loop_step: {
     name: 'memphis_loop_step',
@@ -396,6 +466,9 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Pure-function loop-engine step driver. Takes the current loop `state` (steps taken, tool_calls used, errors, completion flag) plus a proposed `action` (tool_call/wait/complete/error) and limits (max_steps, max_tool_calls), and returns the next allowed action — `continue`, `halt(reason)`, or `error(reason)`. This is the runtime safety boundary that prevents runaway agent loops; the cognitive layer must call it BEFORE executing the next step. JSON-shaped, deterministic, no I/O.',
+    cliFlags: [],
   },
   memphis_web_fetch: {
     name: 'memphis_web_fetch',

--- a/tests/unit/tool-registry-descriptors.test.ts
+++ b/tests/unit/tool-registry-descriptors.test.ts
@@ -24,12 +24,18 @@ const PROOF_SET = [
   'memphis_recall',
   'memphis_search',
   'memphis_health',
-  // Phase 3 batch 1 (this PR) — 5 more tier-0 tools
+  // Phase 3 batch 1 (#443) — first 5 tier-0 tools
   'memphis_decide',
   'memphis_self_describe',
   'memphis_repair',
   'memphis_soul_read',
   'memphis_soul_write',
+  // Phase 3 batch 2 (this PR) — remaining tier-0 tools
+  'memphis_slo_status',
+  'memphis_case_append',
+  'memphis_case_query',
+  'memphis_chain_query',
+  'memphis_loop_step',
 ] as const;
 
 describe('ToolDescriptor — Phase 1 foundation', () => {


### PR DESCRIPTION
## Summary

Continues Sprint E Phase 3 (#443 was batch 1). This PR fills the last 5 tier-0 tools that lacked descriptors, completing tier-0 coverage for the `helpText` + `cliFlags` contract.

| Tool | Why this batch is the right time |
|---|---|
| `memphis_slo_status` | Explains telemetry-window evaluation + the unavailable-vs-fail distinction operators get confused on |
| `memphis_case_append` | Polish grammatical-case + role-slot semantics the LLM reliably mis-explains from training data |
| `memphis_case_query` | Relational lookup contract; explicit comparison vs `memphis_recall` to prevent wrong-tool selection |
| `memphis_chain_query` | Diagnostic surface contract + `experimental-tools` flag context |
| `memphis_loop_step` | Runtime safety boundary; "must call before executing next step" is the load-bearing instruction |

`cliFlags` filled where the input schema is named-flag-friendly. Tools with structurally-JSON-only input (`case_append`, `loop_step`) get `cliFlags: []` for contract compliance.

## Stack note vs #443

#443 (batch 1) and this PR (batch 2) both expand the same `PROOF_SET` constant in `tool-registry-descriptors.test.ts`. The expansions are disjoint (different tool names) but textually adjacent. When the first of the two merges:

- The second's branch will hit a trivial textual conflict in PROOF_SET.
- Resolution is mechanical — keep both blocks under the existing comment headers.
- I'll rebase + force-push the second when the first lands; ping if you'd prefer I stack #444 on #443 directly instead.

After both merge, tier-0 coverage is complete: every tier-0 tool has helpText strictly richer than its description, and the consumer surfaces (#439 system-prompt, #441 CLI describe, #442 Telegram /help) automatically render the new content.

## Test plan

- [x] `npx vitest run tests/unit/tool-registry-descriptors.test.ts` → 21/21 (PROOF_SET expanded to 9)
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx eslint .` — clean
- [ ] CI green
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 3 status

- [x] Sprint E Phase 2 — system-prompt + MCP server (#439)
- [x] Sprint J — soul ↔ cognitive autonomy loop test (#440)
- [x] Sprint E Phase 2 — CLI `memphis tools describe` (#441)
- [x] Sprint E Phase 2 — Telegram `/help <tool-name>` (#442, stacked on #441)
- [x] Sprint E Phase 3 batch 1 — first 5 tier-0 tools (#443)
- [x] Sprint E Phase 3 batch 2 — remaining 5 tier-0 tools (this PR; tier-0 complete after both merge)
- [ ] Sprint E Phase 3 batch 3+ — tier-1 + tier-2 tools (~25 follow-up entries)
- [ ] Sprint E Phase 2 — TUI `?` overlay (Rust crate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
