### PR TITLE
feat(tools): fill helpText + cliFlags for 5 high-traffic tier-2 tools (Sprint E Phase 3 batch 3)

### DIFF
--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -496,6 +496,31 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Read a file inside the Memphis install root or operator data dir. Path is normalized + path-traversal-checked against the whitelist (`/home/memphis/memphis/`, `~/.memphis/`); never escapes that boundary even with relative segments. Supports line-ranged reads (`startLine`/`endLine`) so the LLM can pull a specific block of source without dragging the whole file into context. Read-only — pair with memphis_fs_write for edits, memphis_grep for search.',
+    cliFlags: [
+      {
+        name: '--path',
+        description: 'Whitelisted path to read. Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--start-line',
+        description: 'First line to include (1-indexed).',
+        takesValue: true,
+      },
+      {
+        name: '--end-line',
+        description: 'Last line to include (inclusive).',
+        takesValue: true,
+      },
+      {
+        name: '--limit',
+        description: 'Max lines to return (cap 2000).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_grep: {
     name: 'memphis_grep',
@@ -513,6 +538,40 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Regex search across the Memphis tree. Uses ripgrep when available, falls back to GNU grep. Defaults to the Memphis install root; `--path` narrows the scan, `--glob` filters by filename pattern (e.g. `**/*.ts`). `--context` returns N lines before/after each match (operator-friendly default 0). Cap of 200 hits prevents runaway output — refine the pattern if you hit the limit.',
+    cliFlags: [
+      {
+        name: '--pattern',
+        description: 'Regex pattern. Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--path',
+        description: 'Subdirectory to scan (relative to Memphis root).',
+        takesValue: true,
+      },
+      {
+        name: '--glob',
+        description: 'Filename glob filter (e.g. `**/*.ts`).',
+        takesValue: true,
+      },
+      {
+        name: '--context',
+        description: 'Lines of context before/after each match (default 0).',
+        takesValue: true,
+      },
+      {
+        name: '--ignore-case',
+        description: 'Case-insensitive matching.',
+      },
+      {
+        name: '--limit',
+        description: 'Max matches to return (default 50, cap 200).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_glob: {
     name: 'memphis_glob',
@@ -527,6 +586,26 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'List files matching a glob (e.g. `**/*.ts`, `src/cognitive/*.ts`). Uses fd when available, GNU find otherwise. Companion to memphis_grep — use this to discover candidate files, then grep inside them. Returns paths relative to the search root. Cap of 500 — narrow `--path` if you exceed it.',
+    cliFlags: [
+      {
+        name: '--pattern',
+        description: 'Glob pattern (e.g. `**/*.ts`). Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--path',
+        description: 'Subdirectory to search (relative to Memphis root).',
+        takesValue: true,
+      },
+      {
+        name: '--limit',
+        description: 'Max paths to return (cap 500).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_git: {
     name: 'memphis_git',
@@ -540,6 +619,21 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Run a git subcommand against the Memphis tree. Pass the verb (`status`, `diff`, `log`, `add`, `commit`, etc.) as `subcommand` and any extra args as a string array. Tier-2 because mutations (commit/reset/push) need approval — read-only verbs (status/diff/log/show) execute immediately. Force-push, hard reset, hooks-skipping flags (`--no-verify`, `--no-gpg-sign`) and credential modifications stay denied even with approval; use the operator git CLI for those.',
+    cliFlags: [
+      {
+        name: '--subcommand',
+        description: 'Git verb (status, diff, log, add, commit, ...). Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--args',
+        description: 'Extra args, comma-separated (or passed via JSON in MCP).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_test: {
     name: 'memphis_test',
@@ -605,6 +699,17 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Run a shell command in the Memphis runtime context (cwd: install root, env: filtered). Tier-2 with approval-required default — operator must whitelist or one-shot approve before each call. Stdout + stderr are returned together (capped at 64KB). Use for one-off diagnostics + dev commands; tier-2 commands that mutate the filesystem prefer memphis_fs_write or memphis_git so the change is auditable. NEVER pipe secrets into commands here — the audit log captures the full argv.',
+    cliFlags: [
+      {
+        name: '--command',
+        description:
+          'Shell command to run. Quote it; spaces are literal, not argv split here. Required.',
+        takesValue: true,
+        required: true,
+      },
+    ],
   },
   memphis_self_modify: {
     name: 'memphis_self_modify',

--- a/tests/unit/tool-registry-descriptors.test.ts
+++ b/tests/unit/tool-registry-descriptors.test.ts
@@ -30,12 +30,18 @@ const PROOF_SET = [
   'memphis_repair',
   'memphis_soul_read',
   'memphis_soul_write',
-  // Phase 3 batch 2 (this PR) — remaining tier-0 tools
+  // Phase 3 batch 2 (#444) — remaining tier-0 tools
   'memphis_slo_status',
   'memphis_case_append',
   'memphis_case_query',
   'memphis_chain_query',
   'memphis_loop_step',
+  // Phase 3 batch 3 (this PR) — 5 high-traffic tier-2 tools
+  'memphis_code_read',
+  'memphis_grep',
+  'memphis_glob',
+  'memphis_git',
+  'memphis_exec',
 ] as const;
 
 describe('ToolDescriptor — Phase 1 foundation', () => {
@@ -78,12 +84,14 @@ describe('ToolDescriptor — Phase 1 foundation', () => {
     }
   });
 
-  it('proof set covers a representative tier-0 sample', () => {
+  it('proof set covers a representative sample (all members registered)', () => {
     // Drift detection: if someone narrows the proof set without expanding
-    // it, we'd lose coverage of the foundation pattern.
+    // it, we'd lose coverage of the foundation pattern. Phase 3 grows
+    // the set across tiers (was tier-0-only in Phase 1); the assertion
+    // here just guarantees every name is a real registry entry.
     expect(PROOF_SET.length).toBeGreaterThanOrEqual(4);
     for (const name of PROOF_SET) {
-      expect(TOOL_REGISTRY[name].tier, `${name} should be tier 0 in proof set`).toBe(0);
+      expect(TOOL_REGISTRY[name], `${name} should be registered`).toBeDefined();
     }
   });
 });


### PR DESCRIPTION
## Summary

Continues Sprint E Phase 3 (#443 batch 1, #444 batch 2 covered tier-0 tools). This PR moves into tier-2 territory — the tools that actually do filesystem + shell work.

| Tool | Why this batch is the right time |
|---|---|
| `memphis_code_read` | File boundary contract; whitelisted paths + line-range pull semantics LLMs reliably mis-handle |
| `memphis_grep` | ripgrep-vs-grep fallback + 200-hit cap rationale |
| `memphis_glob` | fd-vs-find fallback + companion-to-grep guidance |
| `memphis_git` | Read-vs-write tier behavior + always-denied flags (force-push, --no-verify, --no-gpg-sign) |
| `memphis_exec` | Secrets-in-argv warning, audit log surface, fs_write/git preference for auditable mutations, 64KB stdout cap |

Each tool gets cliFlags for its named-flag-friendly inputs.

## PROOF_SET evolution

Phase 1's "tier-0 sample" assertion was implicitly assuming the proof set would stay tier-0. Phase 3 grows it across tiers, so the assertion was relaxed to "every name is a registered tool" — still catches the drift case (typo, removal) but no longer rejects tier-2/3 additions.

## Stack note vs #443 / #444

This batch adds 5 distinct tool names to the same `PROOF_SET` constant. When #443 or #444 merges first, this PR will hit a textual conflict in PROOF_SET (resolution: keep all blocks under their existing comment headers). Disjoint additions, mechanical merge.

## Test plan

- [x] `npx vitest run tests/unit/tool-registry-descriptors.test.ts` → 21/21
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx eslint .` — clean
- [ ] CI green
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 3 status

- [x] Sprint E Phase 2 — system-prompt + MCP server (#439)
- [x] Sprint J — soul ↔ cognitive autonomy loop test (#440)
- [x] Sprint E Phase 2 — CLI `memphis tools describe` (#441)
- [x] Sprint E Phase 2 — Telegram `/help <tool-name>` (#442, stacked on #441)
- [x] Sprint E Phase 3 batch 1 — first 5 tier-0 tools (#443)
- [x] Sprint E Phase 3 batch 2 — last 5 tier-0 tools (#444)
- [x] Sprint E Phase 3 batch 3 — 5 high-traffic tier-2 tools (this PR)
- [ ] Sprint E Phase 3 batch 4+ — remaining ~25 tier-2 tools (memphis_test, memphis_deploy, memphis_cron, memphis_self_modify, memphis_web_fetch, etc.)
- [ ] Sprint E Phase 2 — TUI `?` overlay (Rust crate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
