### PR TITLE
feat(tools): fill helpText + cliFlags for 5 more tier-2 tools (Sprint E Phase 3 batch 4)

### DIFF
--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -481,6 +481,16 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'GET a public HTTP(S) URL and return the body (truncated to safe length). Network-capability tool — surface policy controls whether it\'s available (Telegram blocks by default; CLI/MCP allow with approval). Returns content-type + body; redirects followed up to 5 hops; 30s timeout. Use to read external docs/APIs the operator referenced; do NOT use for crawling — narrow targets only.',
+    cliFlags: [
+      {
+        name: '--url',
+        description: 'Absolute http(s) URL. Required.',
+        takesValue: true,
+        required: true,
+      },
+    ],
   },
   memphis_code_read: {
     name: 'memphis_code_read',
@@ -647,6 +657,20 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Run a Memphis test suite. `suite` selects: `ts` (vitest), `rust` (cargo test --workspace), `lint` (eslint), `typecheck` (tsc --noEmit), or `all` (sequential). `filter` narrows vitest test names; pass through to cargo via env. Output is captured (capped) and the exit code is the result. Use to gate self-modify or before deploy — pair with memphis_deploy for the full preflight.',
+    cliFlags: [
+      {
+        name: '--suite',
+        description: 'Suite to run: all | ts | rust | lint | typecheck (default: all).',
+        takesValue: true,
+      },
+      {
+        name: '--filter',
+        description: 'Test-name filter (vitest -t, cargo test pattern).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_deploy: {
     name: 'memphis_deploy',
@@ -668,6 +692,48 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Three-mode deploy orchestrator. `action: run` snapshots state, builds, deploys (per profile), then runs the health probe + post-checks; rolls back automatically on failure. `action: health` runs the health probe alone (e.g. against an external service). `action: rollback` reverts to a prior snapshot (`rollbackIndex` selects which; default = most recent). Profiles: `local-service` (systemd unit), `build-only` (no deploy), `custom` (operator-supplied build/deploy commands). `dryRun` simulates without touching anything.',
+    cliFlags: [
+      {
+        name: '--action',
+        description: 'run | health | rollback (default: run).',
+        takesValue: true,
+      },
+      {
+        name: '--profile',
+        description: 'local-service | build-only | custom.',
+        takesValue: true,
+      },
+      {
+        name: '--build-command',
+        description: 'Override build step (custom profile).',
+        takesValue: true,
+      },
+      {
+        name: '--deploy-command',
+        description: 'Override deploy step (custom profile).',
+        takesValue: true,
+      },
+      {
+        name: '--health-url',
+        description: 'URL to probe for post-deploy health check.',
+        takesValue: true,
+      },
+      {
+        name: '--test-suite',
+        description: 'Suite to run as preflight (default: all).',
+        takesValue: true,
+      },
+      {
+        name: '--deep',
+        description: 'Run deeper post-deploy verification (slower).',
+      },
+      {
+        name: '--dry-run',
+        description: 'Show what would happen without mutating anything.',
+      },
+    ],
   },
   memphis_cron: {
     name: 'memphis_cron',
@@ -687,6 +753,47 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'Manage Memphis-internal scheduled tasks (NOT crontab — these run inside the runtime, audited via the system chain). Four task types: `shell` (operator script), `reflection` (cognitive Mode E periodic run), `git-pull-build` (refresh + rebuild), `http` (poll an endpoint). `list` shows current schedule; `add` registers a new task with cron-pattern + handler; `remove` deletes by id; `enable`/`disable` toggle without removing.',
+    cliFlags: [
+      {
+        name: '--action',
+        description: 'list | add | remove | enable | disable. Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--cron',
+        description:
+          'Cron expression (5-field, e.g. `0 9 * * 1-5`). Required for add.',
+        takesValue: true,
+      },
+      {
+        name: '--name',
+        description: 'Operator-friendly task name.',
+        takesValue: true,
+      },
+      {
+        name: '--task-type',
+        description: 'shell | reflection | git-pull-build | http.',
+        takesValue: true,
+      },
+      {
+        name: '--script',
+        description: 'Shell script body (for task-type=shell).',
+        takesValue: true,
+      },
+      {
+        name: '--url',
+        description: 'Target URL (for task-type=http).',
+        takesValue: true,
+      },
+      {
+        name: '--task-id',
+        description: 'Task id (for remove/enable/disable).',
+        takesValue: true,
+      },
+    ],
   },
   memphis_exec: {
     name: 'memphis_exec',
@@ -725,6 +832,9 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
         approval_request_id: z.string().optional(),
       })
       .strict(),
+    helpText:
+      'The supervised self-modification surface. Takes an `intent` (one-line description for audit), a `files` array (paths to modify), and a `changes` map (path → new content). Pipeline: (1) snapshot the current tree to `~/.memphis/backups/`, (2) apply changes on an isolated branch, (3) run the test gate (typecheck + lint + vitest). On gate failure: auto-rollback to the snapshot. On gate pass: present the diff for operator approval. Tier-2 with passphrase requirement — never bypass the test gate even for "trivial" edits. The audit chain records every attempt regardless of outcome.',
+    cliFlags: [],
   },
   memphis_fs_write: {
     name: 'memphis_fs_write',

--- a/tests/unit/tool-registry-descriptors.test.ts
+++ b/tests/unit/tool-registry-descriptors.test.ts
@@ -36,12 +36,18 @@ const PROOF_SET = [
   'memphis_case_query',
   'memphis_chain_query',
   'memphis_loop_step',
-  // Phase 3 batch 3 (this PR) — 5 high-traffic tier-2 tools
+  // Phase 3 batch 3 (#445) — 5 high-traffic tier-2 tools
   'memphis_code_read',
   'memphis_grep',
   'memphis_glob',
   'memphis_git',
   'memphis_exec',
+  // Phase 3 batch 4 (this PR) — 5 more tier-2 tools
+  'memphis_web_fetch',
+  'memphis_test',
+  'memphis_deploy',
+  'memphis_cron',
+  'memphis_self_modify',
 ] as const;
 
 describe('ToolDescriptor — Phase 1 foundation', () => {


### PR DESCRIPTION
## Summary

Continues Sprint E Phase 3 (#443/#444 tier-0; #445 first tier-2 batch). Five more tier-2 tools — the operator-facing automation surface.

| Tool | Why this batch is the right time |
|---|---|
| `memphis_web_fetch` | Network-capability gate; redirect/timeout contracts; explicit "narrow targets only" guidance |
| `memphis_test` | Suite picker semantics + filter pass-through + pair-with-deploy guidance |
| `memphis_deploy` | Three-mode action dispatcher (run/health/rollback) + profile differences + dry-run safety |
| `memphis_cron` | Memphis-internal scheduler vs OS crontab distinction + 4 task types |
| `memphis_self_modify` | Supervised pipeline (snapshot → branch → test gate → approval) + auto-rollback contract |

cliFlags filled per schema. `memphis_self_modify` gets `cliFlags: []` — its input is structurally JSON-only (intent + files array + changes map; no clean named-flag mapping).

## Stack note vs prior Phase 3 batches

This batch adds 5 distinct tool names + relaxes the same "tier-0 sample" assertion that #445 already changed. When #443/#444/#445 merges first, this PR hits a textual conflict in `PROOF_SET` (mechanical resolution) plus a duplicate of the relaxed assertion (idempotent — keep one copy).

## Test plan

- [x] `npx vitest run tests/unit/tool-registry-descriptors.test.ts` → 21/21
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx eslint .` — clean
- [ ] CI green
- [ ] Codex review (15 min silence after CI green = exit per memory protocol)

## Faza 3 status

- [x] Sprint E Phase 2 — system-prompt + MCP server (#439)
- [x] Sprint J — soul ↔ cognitive autonomy loop test (#440)
- [x] Sprint E Phase 2 — CLI `memphis tools describe` (#441)
- [x] Sprint E Phase 2 — Telegram `/help <tool-name>` (#442)
- [x] Sprint E Phase 3 batch 1 — first 5 tier-0 tools (#443)
- [x] Sprint E Phase 3 batch 2 — last 5 tier-0 tools (#444)
- [x] Sprint E Phase 3 batch 3 — code_read/grep/glob/git/exec (#445)
- [x] Sprint E Phase 3 batch 4 — web_fetch/test/deploy/cron/self_modify (this PR)
- [ ] Sprint E Phase 3 batch 5+ — remaining tier-2 tools (memphis_fs_write, memphis_fs_ops, memphis_package, memphis_repair, memphis_db, memphis_build, memphis_restart, memphis_health_check, memphis_presence, memphis_providers, memphis_system_info, etc.)
- [ ] Sprint E Phase 2 — TUI `?` overlay (Rust crate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
