### PR TITLE
refactor(env): migrate process.env.LOG_LEVEL reads to env-registry accessor (Sprint D Phase 3 batch 1)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 
 import { createAppContainer } from './container.js';
 import { getCognitiveModeConfig } from '../cognitive/modes.js';
+import { LOG_LEVEL } from '../config/env-registry.js';
 import { getAppVersion } from '../config/paths.js';
 import { AppError, errorTemplates } from '../core/errors.js';
 import { formatSurfaceStatusLines, getActiveSurfacesSnapshot } from '../core/surface-presence.js';
@@ -484,7 +485,7 @@ export async function bootstrap(): Promise<void> {
   recordBootSuccess(process.env);
 }
 
-const bootstrapLog = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+const bootstrapLog = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 
 export function resolveBootstrapEnvPath(rawEnv: NodeJS.ProcessEnv = process.env): string {
   // Route through the shared `resolveDotEnvPath` so bootstrap reads

--- a/src/gateway/chat-loop.ts
+++ b/src/gateway/chat-loop.ts
@@ -19,10 +19,11 @@ import type {
 } from './chat-types.js';
 import { deriveConversationContext } from './conversation-identity.js';
 import { runTurnRuntime } from './turn-runtime.js';
+import { LOG_LEVEL } from '../config/env-registry.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
 import type { ChatMessage } from '../providers/index.js';
 
-const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+const log = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 
 // ─── Session fallback ───────────────────────────────────────────
 

--- a/src/gateway/cognitive-runtime.ts
+++ b/src/gateway/cognitive-runtime.ts
@@ -7,11 +7,12 @@ import {
   shouldUseTestIsolatedCognitiveState,
 } from '../cognitive/runtime-support.js';
 import type { DecisionContext, Prediction } from '../cognitive/types.js';
+import { LOG_LEVEL } from '../config/env-registry.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
 import { searchExactMemory, type ExactSearchOutput } from '../infra/memory/exact-search.js';
 import type { Block } from '../memory/chain.js';
 
-const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+const log = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 const COGNITIVE_STOP_WORDS = new Set([
   'about',
   'again',

--- a/src/gateway/session-store.ts
+++ b/src/gateway/session-store.ts
@@ -2,10 +2,11 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { SessionMetadata, SessionStore } from './chat-types.js';
+import { LOG_LEVEL } from '../config/env-registry.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
 import type { ChatMessage } from '../providers/index.js';
 
-const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+const log = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 const SESSION_DEPTH = 10;
 
 type SerializedSession = {

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -39,6 +39,7 @@ import {
   type FrameTurn,
 } from '../cognitive/frame-buffer.js';
 import { applyCognitiveMode, type CognitiveModeContribution } from '../cognitive/mode-dispatch.js';
+import { LOG_LEVEL } from '../config/env-registry.js';
 import { AppError } from '../core/errors.js';
 import type { RuntimeTelemetry, TokenUsage } from '../core/types.js';
 import { metrics } from '../infra/logging/metrics.js';
@@ -56,7 +57,7 @@ import {
 } from '../security/tier3-session.js';
 import { getCognitiveMode } from '../soul/manifest.js';
 
-const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+const log = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 
 function generateTurnId(): string {
   try {

--- a/src/infra/cli/index.ts
+++ b/src/infra/cli/index.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { executeCommand } from './dispatcher.js';
 import { parseCommand } from './parser.js';
 import { checkDependencies } from './utils/dependencies.js';
-import { NODE_ENV } from '../../config/env-registry.js';
+import { LOG_LEVEL, NODE_ENV } from '../../config/env-registry.js';
 import { ensureDir, getDataDir } from '../../config/paths.js';
 import { formatCliError, toAppError } from '../../core/errors.js';
 import { resolveVaultSecrets } from '../config/vault-resolve.js';
@@ -116,7 +116,7 @@ const modulePath = fileURLToPath(import.meta.url);
 // Global error handlers to prevent silent crashes
 process.on('uncaughtException', (error: Error) => {
   console.error(`[memphis] uncaught exception: ${error.message}`);
-  if (process.env.LOG_LEVEL === 'debug') {
+  if (LOG_LEVEL.read(process.env) === 'debug') {
     console.error(error.stack);
   }
   process.exit(1);
@@ -125,7 +125,7 @@ process.on('uncaughtException', (error: Error) => {
 process.on('unhandledRejection', (reason: unknown) => {
   const message = reason instanceof Error ? reason.message : String(reason);
   console.error(`[memphis] unhandled rejection: ${message}`);
-  if (process.env.LOG_LEVEL === 'debug' && reason instanceof Error) {
+  if (LOG_LEVEL.read(process.env) === 'debug' && reason instanceof Error) {
     console.error(reason.stack);
   }
   process.exit(1);

--- a/src/infra/logging/contextual.ts
+++ b/src/infra/logging/contextual.ts
@@ -18,6 +18,7 @@ import type { Logger } from 'pino';
 
 import { setAllAppLoggerLevels } from './logger.js';
 import { createPinoLogger, setAllPinoLoggerLevels } from './pino.js';
+import { LOG_LEVEL } from '../../config/env-registry.js';
 import { registerPostApplyHook } from '../config/post-apply-hooks.js';
 
 export interface LogContext {
@@ -36,7 +37,7 @@ let rootLogger: ContextLogger | null = null;
 function getRootLogger(): ContextLogger {
   if (rootLogger) return rootLogger;
   rootLogger = createPinoLogger({
-    level: process.env.LOG_LEVEL ?? 'info',
+    level: LOG_LEVEL.read(process.env),
     base: undefined,
   });
   return rootLogger;

--- a/src/infra/runtime/chain-rotation-loop.ts
+++ b/src/infra/runtime/chain-rotation-loop.ts
@@ -18,10 +18,11 @@
  * the rest.
  */
 
+import { LOG_LEVEL } from '../../config/env-registry.js';
 import { createPinoLogger } from '../logging/pino.js';
 import { rotateAllChains, type ChainRotationResult } from '../storage/chain-rotation.js';
 
-const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+const log = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 
 /** Hard floor — anything below 60s is almost certainly a misconfiguration. */
 export const MIN_INTERVAL_MS = 60_000;

--- a/src/infra/runtime/reflection-loop.ts
+++ b/src/infra/runtime/reflection-loop.ts
@@ -6,6 +6,7 @@ import { InsightGenerator } from '../../cognitive/insight-generator.js';
 import { ModelE_MetaCognitiveReflection } from '../../cognitive/model-e.js';
 import { loadCognitiveBlocks } from '../../cognitive/runtime-support.js';
 import type { Reflection } from '../../cognitive/types.js';
+import { LOG_LEVEL } from '../../config/env-registry.js';
 import { getDataDir } from '../../config/paths.js';
 import type { Block } from '../../memory/chain.js';
 import { updateSoulMemory, writeMemoryAction } from '../../soul/memory.js';
@@ -54,7 +55,7 @@ export interface ReflectionLoopOptions {
   runCycle?: () => Promise<ReflectionRunSummary>;
 }
 
-const reflectionLoopLog = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+const reflectionLoopLog = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 
 export function getReflectionLoopStatePath(_rawEnv: NodeJS.ProcessEnv = process.env): string {
   return path.join(getDataDir(_rawEnv), 'config', 'reflection-loop-state.json');

--- a/src/infra/runtime/scheduled-backup.ts
+++ b/src/infra/runtime/scheduled-backup.ts
@@ -33,10 +33,11 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { LOG_LEVEL } from '../../config/env-registry.js';
 import { createPinoLogger } from '../logging/pino.js';
 import { writeSecurityAudit } from '../logging/security-audit.js';
 
-const log = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+const log = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 
 export const DEFAULT_BACKUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
 export const MIN_BACKUP_INTERVAL_MS = 5 * 60 * 1000; // 5 min

--- a/src/sync/signature-verify.ts
+++ b/src/sync/signature-verify.ts
@@ -1,8 +1,9 @@
+import { LOG_LEVEL } from '../config/env-registry.js';
 import { createPinoLogger } from '../infra/logging/pino.js';
 import { NapiChainAdapter } from '../infra/storage/rust-chain-adapter.js';
 import type { Block } from '../memory/chain.js';
 
-const logger = createPinoLogger({ level: process.env.LOG_LEVEL ?? 'info' });
+const logger = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 
 /**
  * Verify an ed25519 signature on a peer-origin chain block.


### PR DESCRIPTION
Sprint D Phase 3 batch 1 — migrates 12 LOG_LEVEL call sites. ESLint warnings drop 195→183. tests green. Pattern: `process.env.LOG_LEVEL ?? 'info'` → `LOG_LEVEL.read(process.env)`. Two intentional non-migrations: cli/index.ts:66 (assignment for downstream raw readers, no write API on registry) and agent-runtime.ts:41 (comment text, not a read).