### PR TITLE
refactor(env): migrate process.env.NODE_ENV reads to env-registry accessor (Sprint D Phase 3 batch 2)

### DIFF
--- a/src/cognitive/model-c.ts
+++ b/src/cognitive/model-c.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 import { appendDurableBlock } from './durable-write.js';
 import { ChainStore, IStore } from './store.js';
 import type { DecisionContext, DecisionPattern, ModelCConfig, Prediction } from './types.js';
+import { NODE_ENV } from '../config/env-registry.js';
 import { getDataDir, getReadableChainPaths } from '../config/paths.js';
 import { createLogger } from '../infra/logging/logger.js';
 import type { Block } from '../memory/chain.js';
@@ -102,7 +103,7 @@ function resolvePatternRuntimeDir(memphisDir?: string): string | null {
   if (typeof explicit === 'string' && explicit.trim().length > 0) {
     return path.resolve(explicit);
   }
-  if (process.env.NODE_ENV === 'test') {
+  if (NODE_ENV.read(process.env) === 'test') {
     return null;
   }
   return getDataDir();

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -10,6 +10,7 @@ import {
 } from './exec-policy.js';
 import { exec, getSystemInfo } from '../agent/system.js';
 import { createAppContainer } from '../app/container.js';
+import { NODE_ENV } from '../config/env-registry.js';
 import { getAppVersion } from '../config/paths.js';
 import { AppError, toAppError } from '../core/errors.js';
 import { loadConfig as loadAppEnvConfig } from '../infra/config/env.js';
@@ -317,7 +318,7 @@ export function startGateway(config: GatewayConfig, chainsDir: string, dataDir: 
   const dangerouslyAllowExec =
     config.dangerouslyAllowExec ??
     (process.env.GATEWAY_DANGEROUSLY_ALLOW_EXEC === 'true' &&
-      process.env.NODE_ENV !== 'production');
+      NODE_ENV.read(process.env) !== 'production');
   const gw = new Gateway({ ...config, dangerouslyAllowExec }, chainsDir, dataDir);
   return gw.start();
 }

--- a/src/infra/cli/handlers/storage.handler.ts
+++ b/src/infra/cli/handlers/storage.handler.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import type { CommandHandler } from './command-handler.js';
+import { NODE_ENV } from '../../../config/env-registry.js';
 import { rebuildChainIndexes } from '../../../core/chain-index-rebuild.js';
 import { AppError } from '../../../core/errors.js';
 import { ensureSoulManifest, loadSoulManifest } from '../../../soul/manifest.js';
@@ -94,7 +95,7 @@ function ensureApplySafety(context: CliContext, execute: boolean): void {
 
   if (
     execute &&
-    process.env.NODE_ENV === 'production' &&
+    NODE_ENV.read(process.env) === 'production' &&
     profile !== 'prod-shared' &&
     profile !== 'prod-decentralized'
   ) {

--- a/src/infra/cli/index.ts
+++ b/src/infra/cli/index.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { executeCommand } from './dispatcher.js';
 import { parseCommand } from './parser.js';
 import { checkDependencies } from './utils/dependencies.js';
+import { NODE_ENV } from '../../config/env-registry.js';
 import { ensureDir, getDataDir } from '../../config/paths.js';
 import { formatCliError, toAppError } from '../../core/errors.js';
 import { resolveVaultSecrets } from '../config/vault-resolve.js';
@@ -14,7 +15,7 @@ import { healAllSensitiveFiles } from '../storage/secure-file.js';
 const FIRST_RUN_MARKER = resolve(getDataDir(), '.first-run-checks');
 
 async function runFirstRunDependencyChecks(): Promise<void> {
-  if (process.env.NODE_ENV === 'test' || process.env.MEMPHIS_SKIP_FIRST_RUN_CHECKS === '1') return;
+  if (NODE_ENV.read(process.env) === 'test' || process.env.MEMPHIS_SKIP_FIRST_RUN_CHECKS === '1') return;
   if (existsSync(FIRST_RUN_MARKER)) return;
 
   const checks = await checkDependencies({ rawEnv: process.env });

--- a/src/infra/logging/logger.ts
+++ b/src/infra/logging/logger.ts
@@ -1,3 +1,5 @@
+import { NODE_ENV } from '../../config/env-registry.js';
+
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 export type LogFormat = 'text' | 'json';
 
@@ -122,7 +124,7 @@ export function createLogger(
   // takes effect immediately without rebuilding closures.
   const state = { level, threshold: LEVEL_PRIORITY[level] };
   const quietTestLogs =
-    process.env.NODE_ENV === 'test' &&
+    NODE_ENV.read(process.env) === 'test' &&
     process.env.MEMPHIS_QUIET_TEST_LOGS === '1' &&
     write === DEFAULT_WRITE;
 

--- a/src/infra/logging/pino.ts
+++ b/src/infra/logging/pino.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import pino, { type DestinationStream, type Logger, type LoggerOptions } from 'pino';
 
 import { maybeRotateLogFile } from './log-rotation.js';
+import { NODE_ENV } from '../../config/env-registry.js';
 
 /**
  * Registry of every Pino logger created via `createPinoLogger` so that a
@@ -111,7 +112,7 @@ export function createPinoLogger(options?: LoggerOptions): Logger {
   const fileStream = getFileStream();
   const stderrStream = pino.destination({
     dest: 2,
-    sync: process.env.NODE_ENV === 'test',
+    sync: NODE_ENV.read(process.env) === 'test',
   });
   allDestinations.add(stderrStream);
 

--- a/src/infra/tui-host/commands.ts
+++ b/src/infra/tui-host/commands.ts
@@ -1,6 +1,7 @@
 import type { TuiHostCapability } from './protocol.js';
 import { createAppContainer } from '../../app/container.js';
 import { getCognitiveModeConfig, isValidCognitiveMode } from '../../cognitive/modes.js';
+import { NODE_ENV } from '../../config/env-registry.js';
 import {
   getActiveSurfacesSnapshot,
   recordSurfaceActivity,
@@ -941,7 +942,7 @@ async function maybeApplyTestDelay(
   args: Record<string, unknown> | undefined,
   signal: AbortSignal,
 ): Promise<void> {
-  if (process.env.NODE_ENV !== 'test') {
+  if (NODE_ENV.read(process.env) !== 'test') {
     return;
   }
 

--- a/src/mcp/tools/self-modify.ts
+++ b/src/mcp/tools/self-modify.ts
@@ -11,6 +11,7 @@ import { dirname, resolve } from 'node:path';
 
 import { realpathOrNearest } from './fs-permission.js';
 import { RollbackManager } from '../../backup/rollback.js';
+import { NODE_ENV } from '../../config/env-registry.js';
 import {
   commitAll,
   createBranch,
@@ -386,7 +387,7 @@ export async function runMemphisSelfModify(
       // stray process.exit() from a pending timer kills the test runner.
       const inTestRunner =
         process.env.VITEST === 'true' ||
-        process.env.NODE_ENV === 'test' ||
+        NODE_ENV.read(process.env) === 'test' ||
         process.env.MEMPHIS_DISABLE_RESTART_AFTER_EVOLVE === 'true';
       const shouldRestart =
         !inTestRunner &&


### PR DESCRIPTION
Sprint D Phase 3 batch 2 — 8 NODE_ENV call sites migrated. Pattern `process.env.NODE_ENV === 'X'` → `NODE_ENV.read(process.env) === 'X'`. cognitive tests 81/81 green. tsc clean.