### PR TITLE
fix(test): align system-prompt assertions with Sprint E Phase 2 helpText

### DIFF
--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -329,10 +329,11 @@ describe('gateway system prompt', () => {
     expect(prompt).toContain('TIER: 2 — elevated');
     expect(prompt).toContain('<tool name="memphis_test">');
     expect(prompt).toContain('<tool name="memphis_self_modify">');
-    // Should surface the registry description verbatim so operators reading
-    // the prompt see authoritative metadata rather than hallucinations.
-    expect(prompt).toContain('Git operations');
-    expect(prompt).toContain('Safe self-modification with snapshot');
+    // Should surface the registry description (or richer helpText after
+    // Sprint E Phase 2) verbatim so operators reading the prompt see
+    // authoritative metadata rather than hallucinations.
+    expect(prompt).toContain('Run a git subcommand');
+    expect(prompt).toContain('supervised self-modification surface');
   });
 
   it('does not auto-gen a second block for tools that already have hand-authored docs (G1)', () => {


### PR DESCRIPTION
## Summary

Main CI is red after the Sprint E Phase 3 batch merges. Two literal-string assertions in `tests/unit/gateway.system-prompt.test.ts:328-335` pinned the old `description` strings:
- `'Git operations'` → no longer matches helpText (`'Run a git subcommand against the Memphis tree...'`)
- `'Safe self-modification with snapshot'` → no longer matches helpText (`'The supervised self-modification surface...'`)

After Sprint E Phase 2 (#439), `buildSystemPrompt` switched from `description` to `helpText` via `getToolDescription()`. The descriptions and helpText diverged once #443-#449 populated rich helpText for tier-2 tools.

Fix: update the two assertions to substrings present in the new authoritative metadata. Test intent stays the same — the registry source-of-truth must reach the prompt — only the exact phrase tracked changes.

## Test plan

- [x] `npx vitest run tests/unit/gateway.system-prompt.test.ts` → 26/26 pass
- [x] `npx vitest run tests/unit/tool-registry-descriptors.test.ts` → 107/107 pass
- [ ] CI quality-gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)