### PR TITLE
fix(test): pin completion-frontier invariant in self-describe.test.ts

### DIFF
--- a/tests/unit/self-describe.test.ts
+++ b/tests/unit/self-describe.test.ts
@@ -112,17 +112,22 @@ describe('runMemphisSelfDescribe', () => {
     expect(Array.isArray(journal!.cliFlags), 'cliFlags is array when present').toBe(true);
     expect(journal!.cliFlags!.length).toBeGreaterThan(0);
 
-    // Tools without Phase 1 migration return undefined for both —
-    // surfaces fall back to description. Pin that the field stays
-    // optional rather than being coerced to empty string.
-    const unmigrated = out.tools.find(
-      (t) =>
-        !['memphis_journal', 'memphis_recall', 'memphis_search', 'memphis_health'].includes(
-          t.name,
-        ),
-    );
-    expect(unmigrated, 'expected at least one unmigrated tool').toBeDefined();
-    expect(unmigrated!.helpText).toBeUndefined();
-    expect(unmigrated!.cliFlags).toBeUndefined();
+    // Sprint E Phase 3 batch 5 closes proof-set coverage — every tool
+    // now ships helpText + cliFlags, so we can't observe the unmigrated
+    // shape organically anymore. Pin the durable invariant instead: the
+    // capabilities envelope surfaces helpText as a string (when present)
+    // and cliFlags as an array (when present), never coerced to empty
+    // string / null. The undefined-fallback path is exercised via
+    // tool-registry-descriptors.test.ts using a synthesized stripped
+    // meta — the surface contract here is what matters.
+    for (const tool of out.tools) {
+      if (tool.helpText !== undefined) {
+        expect(typeof tool.helpText, `${tool.name} helpText must be string`).toBe('string');
+        expect(tool.helpText.length, `${tool.name} helpText must be non-empty`).toBeGreaterThan(0);
+      }
+      if (tool.cliFlags !== undefined) {
+        expect(Array.isArray(tool.cliFlags), `${tool.name} cliFlags must be array`).toBe(true);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

Main CI red after #447 (Sprint E Phase 3 batch 5) closed proof-set coverage. \`tests/unit/self-describe.test.ts:125\` asserted an unmigrated tool with \`helpText === undefined\` exists; once every tool ships helpText, that assumption breaks.

Fix: replace the unmigrated-shape assertion with the durable invariant the test was meant to guard — when helpText/cliFlags are present in the capabilities envelope, they're proper string/array, not empty/null. The fallback shape (helpText absent) is covered by \`tool-registry-descriptors.test.ts\` via synthesized stripped meta.

Same pattern as #453 (system-prompt assertions). After this lands, main CI green.

## Test plan
- [x] \`npx vitest run tests/unit/self-describe.test.ts\` → 7/7
- [ ] CI quality-gate green