### PR TITLE
feat(voice): memphis voice install — fresh-install one-liner

### DIFF
--- a/docs/operator/voice-local-stt.md
+++ b/docs/operator/voice-local-stt.md
@@ -2,6 +2,22 @@
 
 > Sprint H PR-A • 2026-05-04 • Decision lock: `docs/dev/voice-stack-decision-2026-05-04.md`
 
+## TL;DR — fresh-install one-liner
+
+```bash
+memphis voice install
+```
+
+Idempotent: pulls faster-whisper into a venv, downloads Piper + Polish voice, writes both server scripts to `/tmp/`, starts both as background processes, prints health. Re-runs are seconds. `memphis voice install --restart` restarts; `memphis voice install --stop` stops.
+
+After it finishes:
+```bash
+echo MEMPHIS_VOICE_MODE=local >> ~/memphis/.env   # if not already pinned
+memphis voice status                              # both engines reachable
+```
+
+The rest of this document is the manual recipe + customization knobs (alternative voices, GPU↔CPU, port overrides) the one-liner abstracts away.
+
 ## Why
 
 Memphis routes Telegram voice (and any future voice surface) through `voice-service.ts`. Cloud route hits HuggingFace's `whisper-large-v3` Inference API; local route hits a host-side STT server on `WHISPER_SERVER_URL`. Local mode unblocks the offline live demo.

--- a/docs/operator/voice-local-tts.md
+++ b/docs/operator/voice-local-tts.md
@@ -2,6 +2,14 @@
 
 > Sprint H PR-B • 2026-05-04 • Decision lock: `docs/dev/voice-stack-decision-2026-05-04.md`
 
+## TL;DR — fresh-install one-liner
+
+```bash
+memphis voice install
+```
+
+Pulls the Piper binary + `pl_PL-gosia-medium` voice (~80 MB) and starts the HTTP server on `:5500` alongside faster-whisper STT on `:9000`. See `voice-local-stt.md` for the full one-liner story; this runbook covers the manual recipe + customization paths only.
+
 ## Why
 
 Piper runs entirely on CPU (~80 MB), <100 ms latency, no GPU contention with STT or Kartograf. Polish voice (`pl_PL-gosia-medium.onnx`) is ONNX-backed — same runtime as Kartograf — and maintained upstream by the [rhasspy/piper](https://github.com/rhasspy/piper) project.

--- a/scripts/voice-install.sh
+++ b/scripts/voice-install.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Memphis local voice stack installer — Sprint H decision lock 2026-05-04.
+#
+#   STT  faster-whisper medium INT8 → http://127.0.0.1:9000   (CUDA, falls back to CPU)
+#   TTS  Piper pl_PL-gosia-medium   → http://127.0.0.1:5500   (CPU only, ~80 MB)
+#
+# Idempotent: safe to re-run. Skips any piece already in place. Does NOT
+# touch your `.env` — `memphis voice install` writes the env var pins
+# separately (or you set MEMPHIS_VOICE_MODE=local manually).
+#
+# One-shot use:           memphis voice install
+# Direct use:             bash scripts/voice-install.sh
+# Restart servers only:   bash scripts/voice-install.sh --restart
+# Stop servers:           bash scripts/voice-install.sh --stop
+
+set -uo pipefail
+
+VENV="${MEMPHIS_VOICE_VENV:-$HOME/.cache/whisper-server-venv}"
+PIPER_DIR="${MEMPHIS_PIPER_DIR:-$HOME/piper}"
+WHISPER_PORT="${MEMPHIS_WHISPER_PORT:-9000}"
+PIPER_PORT="${MEMPHIS_PIPER_PORT:-5500}"
+WHISPER_MODEL="${MEMPHIS_WHISPER_MODEL:-medium}"
+WHISPER_DEVICE="${MEMPHIS_WHISPER_DEVICE:-cuda}"
+WHISPER_COMPUTE="${MEMPHIS_WHISPER_COMPUTE:-int8}"
+PIPER_VOICE="${MEMPHIS_PIPER_VOICE:-pl_PL-gosia-medium}"
+WHISPER_LOG="${MEMPHIS_WHISPER_LOG:-/tmp/whisper-server.log}"
+PIPER_LOG="${MEMPHIS_PIPER_LOG:-/tmp/piper-server.log}"
+WHISPER_SCRIPT="${MEMPHIS_WHISPER_SCRIPT:-/tmp/memphis-whisper-server.py}"
+PIPER_SCRIPT="${MEMPHIS_PIPER_SCRIPT:-/tmp/memphis-piper-server.py}"
+
+step() { printf '\n\033[1;36m▸ %s\033[0m\n' "$*"; }
+ok()   { printf '\033[1;32m✓\033[0m %s\n' "$*"; }
+err()  { printf '\033[1;31m✗\033[0m %s\n' "$*"; }
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "missing prerequisite: $1"
+    echo "  Install on Debian/Ubuntu: sudo apt install -y $2"
+    exit 1
+  fi
+}
+
+stop_servers() {
+  pkill -f "$WHISPER_SCRIPT" 2>/dev/null && ok "killed whisper" || true
+  pkill -f "$PIPER_SCRIPT"   2>/dev/null && ok "killed piper"   || true
+  sleep 1
+}
+
+case "${1:-install}" in
+  --stop) stop_servers; exit 0 ;;
+  --restart|install|"") ;;
+  *) echo "usage: $0 [--restart|--stop]"; exit 1 ;;
+esac
+
+# Prerequisites ────────────────────────────────────────────────────
+step "Prerequisites"
+need python3 "python3 python3-venv"
+need curl "curl"
+need tar "tar"
+ok "python3 / curl / tar found"
+
+# 1. faster-whisper venv ───────────────────────────────────────────
+step "STT: faster-whisper venv"
+if [ ! -x "$VENV/bin/python" ]; then
+  python3 -m venv "$VENV"
+  ok "venv created at $VENV"
+else
+  ok "venv exists"
+fi
+if ! "$VENV/bin/python" -c "import faster_whisper" 2>/dev/null; then
+  "$VENV/bin/pip" install --quiet --upgrade pip
+  "$VENV/bin/pip" install --quiet faster-whisper
+  ok "faster-whisper installed"
+else
+  ok "faster-whisper already installed"
+fi
+
+# 2. STT server script ─────────────────────────────────────────────
+step "STT: server script ($WHISPER_SCRIPT)"
+cat > "$WHISPER_SCRIPT" <<PYEOF
+import sys, json, tempfile, os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from faster_whisper import WhisperModel
+
+device = os.environ.get("WHISPER_DEVICE", "$WHISPER_DEVICE")
+compute = os.environ.get("WHISPER_COMPUTE", "$WHISPER_COMPUTE")
+size = os.environ.get("WHISPER_MODEL", "$WHISPER_MODEL")
+print(f"[whisper] loading {size} {device}/{compute}...", flush=True)
+try:
+    model = WhisperModel(size, device=device, compute_type=compute)
+except Exception as e:
+    print(f"[whisper] {device}/{compute} init failed ({e}); falling back to cpu/int8", flush=True)
+    model = WhisperModel(size, device="cpu", compute_type="int8")
+print("[whisper] ready", flush=True)
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200); self.send_header("Content-Type","application/json"); self.end_headers()
+            self.wfile.write(json.dumps({"status":"ok","model":size}).encode())
+        else:
+            self.send_response(404); self.end_headers()
+    def do_POST(self):
+        if self.path != "/v1/audio/transcriptions":
+            self.send_response(404); self.end_headers(); return
+        ln = int(self.headers.get("Content-Length","0"))
+        body = self.rfile.read(ln)
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            f.write(body); path = f.name
+        try:
+            segs, info = model.transcribe(path, language="pl")
+            text = " ".join(s.text for s in segs).strip()
+            self.send_response(200); self.send_header("Content-Type","application/json"); self.end_headers()
+            self.wfile.write(json.dumps({"text": text, "language": info.language}).encode())
+        finally:
+            os.unlink(path)
+    def log_message(self, *a): pass
+
+print(f"[whisper] listening on 127.0.0.1:$WHISPER_PORT", flush=True)
+HTTPServer(("127.0.0.1", $WHISPER_PORT), H).serve_forever()
+PYEOF
+ok "wrote $WHISPER_SCRIPT"
+
+# 3. Piper binary + voice ──────────────────────────────────────────
+step "TTS: Piper binary + $PIPER_VOICE"
+mkdir -p "$PIPER_DIR/voices"
+if [ ! -x "$PIPER_DIR/piper" ]; then
+  curl -sL -o /tmp/piper.tgz \
+    https://github.com/rhasspy/piper/releases/latest/download/piper_linux_x86_64.tar.gz
+  tar xzf /tmp/piper.tgz -C "$PIPER_DIR" --strip-components=1
+  rm /tmp/piper.tgz
+  ok "piper binary installed at $PIPER_DIR/piper"
+else
+  ok "piper binary exists"
+fi
+if [ ! -f "$PIPER_DIR/voices/$PIPER_VOICE.onnx" ]; then
+  # Voice path: pl/pl_PL/gosia/medium for pl_PL-gosia-medium. Generic
+  # mapping — a different voice will need a different upstream path,
+  # so we keep $PIPER_VOICE override but document that defaulting
+  # works only for gosia. Operators wanting another voice should
+  # download manually.
+  if [ "$PIPER_VOICE" = "pl_PL-gosia-medium" ]; then
+    base="https://huggingface.co/rhasspy/piper-voices/resolve/main/pl/pl_PL/gosia/medium"
+    curl -sL -o "$PIPER_DIR/voices/$PIPER_VOICE.onnx"      "$base/$PIPER_VOICE.onnx"
+    curl -sL -o "$PIPER_DIR/voices/$PIPER_VOICE.onnx.json" "$base/$PIPER_VOICE.onnx.json"
+    ok "$PIPER_VOICE downloaded"
+  else
+    err "voice $PIPER_VOICE: auto-download only supported for pl_PL-gosia-medium"
+    echo "  Manually place $PIPER_VOICE.onnx + .onnx.json in $PIPER_DIR/voices/"
+    exit 1
+  fi
+else
+  ok "$PIPER_VOICE already present"
+fi
+
+# 4. Piper server script ───────────────────────────────────────────
+step "TTS: server script ($PIPER_SCRIPT)"
+cat > "$PIPER_SCRIPT" <<PYEOF
+import subprocess, tempfile, os, json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MODEL = os.path.expanduser('$PIPER_DIR/voices/$PIPER_VOICE.onnx')
+PIPER = os.path.expanduser('$PIPER_DIR/piper')
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/health':
+            self.send_response(200); self.send_header('Content-Type','application/json'); self.end_headers()
+            self.wfile.write(json.dumps({"status":"ok","voice":"$PIPER_VOICE"}).encode())
+        else:
+            self.send_response(404); self.end_headers()
+    def do_POST(self):
+        if not self.path.startswith('/api/tts'):
+            self.send_response(404); self.end_headers(); return
+        n = int(self.headers.get('Content-Length', '0'))
+        text = self.rfile.read(n).decode('utf-8')
+        with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as out:
+            wav_path = out.name
+        try:
+            subprocess.run(
+                [PIPER, '--model', MODEL, '--output_file', wav_path],
+                input=text.encode('utf-8'), check=True,
+                stderr=subprocess.DEVNULL,
+            )
+            with open(wav_path, 'rb') as f: audio = f.read()
+        finally:
+            try: os.unlink(wav_path)
+            except OSError: pass
+        self.send_response(200)
+        self.send_header('Content-Type', 'audio/wav')
+        self.send_header('Content-Length', str(len(audio)))
+        self.end_headers()
+        self.wfile.write(audio)
+    def log_message(self, *a): pass
+
+print('[piper] listening on 127.0.0.1:$PIPER_PORT', flush=True)
+HTTPServer(('127.0.0.1', $PIPER_PORT), H).serve_forever()
+PYEOF
+ok "wrote $PIPER_SCRIPT"
+
+# 5. (Re)start ─────────────────────────────────────────────────────
+step "Restart: stop any prior servers"
+stop_servers
+
+step "Start: nohup background"
+nohup "$VENV/bin/python" "$WHISPER_SCRIPT" > "$WHISPER_LOG" 2>&1 &
+WHISPER_PID=$!
+ok "whisper started PID=$WHISPER_PID (log: $WHISPER_LOG)"
+nohup python3 "$PIPER_SCRIPT" > "$PIPER_LOG" 2>&1 &
+PIPER_PID=$!
+ok "piper started PID=$PIPER_PID (log: $PIPER_LOG)"
+
+# 6. Verify ────────────────────────────────────────────────────────
+step "Verify: waiting for servers (whisper model load takes ~30-60s on first start)"
+for _ in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:$WHISPER_PORT/health" >/dev/null 2>&1 \
+     && curl -fsS "http://127.0.0.1:$PIPER_PORT/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+WSTAT=$(curl -fsS "http://127.0.0.1:$WHISPER_PORT/health" 2>&1 || echo DOWN)
+PSTAT=$(curl -fsS "http://127.0.0.1:$PIPER_PORT/health"   2>&1 || echo DOWN)
+echo
+[ "$WSTAT" != DOWN ] && ok "STT  $WSTAT"  || { err "STT  not responding"; tail -n 20 "$WHISPER_LOG"; }
+[ "$PSTAT" != DOWN ] && ok "TTS  $PSTAT"  || { err "TTS  not responding"; tail -n 20 "$PIPER_LOG"; }
+
+cat <<MSG
+
+────────────────────────────────────────────────────────────
+PIDs:    whisper=$WHISPER_PID  piper=$PIPER_PID
+Logs:    tail -f $WHISPER_LOG
+         tail -f $PIPER_LOG
+Restart: memphis voice install --restart
+Stop:    memphis voice install --stop
+
+Set MEMPHIS_VOICE_MODE=local in your .env (or shell), then verify:
+  memphis voice status
+────────────────────────────────────────────────────────────
+MSG

--- a/src/infra/cli/handlers/voice.handler.ts
+++ b/src/infra/cli/handlers/voice.handler.ts
@@ -1,16 +1,26 @@
 /**
  * `memphis voice` — inspect the operator's voice stack (cloud vs
- * local routing, STT engine, TTS engine, server reachability).
+ * local routing, STT engine, TTS engine, server reachability) and
+ * one-shot install the local stack.
  *
  * Sprint H PR-C • 2026-05-04 • depends on PR-A chooser + PR-B Piper
- * adapter. Live demo prep: operator runs this BEFORE going on-stage to
- * confirm both engines are reachable and routed correctly.
+ * adapter. Live demo prep: operator runs `memphis voice install` on a
+ * fresh box, then `memphis voice status` to confirm both engines are
+ * reachable and routed correctly.
  *
  * Subcommands:
  *   memphis voice                         # alias for status
  *   memphis voice status                  # human format
  *   memphis voice status --json           # JSON format for scripting
+ *   memphis voice install                 # idempotent local-stack installer
+ *   memphis voice install --restart       # (re)start servers without re-installing
+ *   memphis voice install --stop          # stop running servers
  */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   MEMPHIS_VOICE_MODE,
@@ -149,15 +159,65 @@ function formatHuman(report: VoiceStatusReport): string {
   return lines.join('\n');
 }
 
+function resolveInstallScript(): string | undefined {
+  // Walk up from this file to the repo root and look for scripts/voice-install.sh.
+  // Works for source-tree runs (src/infra/cli/handlers/) and for built
+  // dist trees (dist/src/infra/cli/handlers/) — both land at <repo>/scripts/.
+  const here = dirname(fileURLToPath(import.meta.url));
+  for (let dir = here, prev = ''; dir !== prev; prev = dir, dir = dirname(dir)) {
+    const candidate = resolve(dir, 'scripts', 'voice-install.sh');
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+async function runInstaller(passthroughArg: string | undefined): Promise<number> {
+  const script = resolveInstallScript();
+  if (!script) {
+    process.stderr.write(
+      'memphis voice install: scripts/voice-install.sh not found in repo tree.\n' +
+        '  This usually means you are running a packaged build that omits dev scripts.\n' +
+        '  Run from a source checkout: `bash scripts/voice-install.sh`.\n',
+    );
+    return 2;
+  }
+  const args = passthroughArg ? [script, passthroughArg] : [script];
+  return new Promise<number>((res) => {
+    const child = spawn('bash', args, { stdio: 'inherit', env: process.env });
+    child.on('error', (err) => {
+      process.stderr.write(`memphis voice install: failed to launch bash: ${err.message}\n`);
+      res(2);
+    });
+    child.on('exit', (code) => res(code ?? 1));
+  });
+}
+
 async function handleVoiceCommand(context: CliContext): Promise<boolean> {
   const sub = context.args.subcommand ?? 'status';
+
+  if (sub === 'install') {
+    // The installer accepts `--restart` and `--stop` as positional
+    // mode switches. Forward the operator's intent. We only honor
+    // recognized passthroughs to avoid accidentally injecting stray
+    // CLI args into the shell script.
+    const passthrough =
+      context.argv.includes('--restart') ? '--restart'
+      : context.argv.includes('--stop') ? '--stop'
+      : undefined;
+    process.exitCode = await runInstaller(passthrough);
+    return true;
+  }
+
   if (sub !== 'status') {
     // Return `true` (handled) so the dispatcher doesn't fall through
     // to "Unknown command: voice" — the error is the bad subcommand,
     // not the bad verb. Codex P2 #433 caught the duplicate-error UX
     // mismatch with other handlers (auth, config, vault) which all
     // return true after writing usage.
-    process.stderr.write(`Unknown subcommand: voice ${sub}\nUsage: memphis voice [status] [--json]\n`);
+    process.stderr.write(
+      `Unknown subcommand: voice ${sub}\n` +
+        `Usage: memphis voice [status|install] [--json]\n`,
+    );
     process.exitCode = 2;
     return true;
   }

--- a/tests/unit/cli.voice.install.test.ts
+++ b/tests/unit/cli.voice.install.test.ts
@@ -1,0 +1,85 @@
+/**
+ * `memphis voice install` — operator one-shot installer for the local
+ * voice stack. Pins:
+ *   1. The handler shells out via `bash scripts/voice-install.sh`.
+ *   2. `--restart` and `--stop` are forwarded as positional args.
+ *   3. Other argv tokens are NOT forwarded (no shell injection of stray
+ *      flags into the installer script).
+ *
+ * Separate test file (instead of cli.voice.test.ts) because mocking
+ * node:child_process requires static vi.mock at module-load time, and
+ * cli.voice.test.ts uses vi.doMock for deferred adapter imports —
+ * mixing the two patterns wedges the runner.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const spawnCalls: Array<[string, string[]]> = [];
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn((bin: string, args: string[]) => {
+    spawnCalls.push([bin, args]);
+    return {
+      on(event: string, cb: (code: number) => void) {
+        if (event === 'exit') queueMicrotask(() => cb(0));
+        return this;
+      },
+    };
+  }),
+}));
+
+const { voiceCommandHandler } = await import('../../src/infra/cli/handlers/voice.handler.js');
+
+interface FakeContext {
+  argv: string[];
+  args: { command: string; subcommand: string };
+}
+
+function ctx(argv: string[]): FakeContext {
+  return {
+    argv,
+    args: { command: 'voice', subcommand: 'install' },
+  };
+}
+
+describe('memphis voice install', () => {
+  it('shells out to scripts/voice-install.sh via bash', async () => {
+    spawnCalls.length = 0;
+    const ok = await voiceCommandHandler.handle(ctx(['memphis', 'voice', 'install']) as never);
+    expect(ok).toBe(true);
+    expect(spawnCalls).toHaveLength(1);
+    const [bin, args] = spawnCalls[0]!;
+    expect(bin).toBe('bash');
+    expect(args[0]).toMatch(/scripts\/voice-install\.sh$/);
+    expect(args).toHaveLength(1); // no passthrough on plain install
+  });
+
+  it('forwards --restart to the installer', async () => {
+    spawnCalls.length = 0;
+    await voiceCommandHandler.handle(
+      ctx(['memphis', 'voice', 'install', '--restart']) as never,
+    );
+    const [, args] = spawnCalls[0]!;
+    expect(args).toHaveLength(2);
+    expect(args[1]).toBe('--restart');
+  });
+
+  it('forwards --stop to the installer', async () => {
+    spawnCalls.length = 0;
+    await voiceCommandHandler.handle(ctx(['memphis', 'voice', 'install', '--stop']) as never);
+    const [, args] = spawnCalls[0]!;
+    expect(args).toHaveLength(2);
+    expect(args[1]).toBe('--stop');
+  });
+
+  it('does NOT forward unrecognized flags (no shell injection)', async () => {
+    spawnCalls.length = 0;
+    await voiceCommandHandler.handle(
+      ctx(['memphis', 'voice', 'install', '--rm', '-rf', '/']) as never,
+    );
+    const [, args] = spawnCalls[0]!;
+    expect(args).toHaveLength(1);
+    expect(args).not.toContain('--rm');
+    expect(args).not.toContain('-rf');
+    expect(args).not.toContain('/');
+  });
+});

--- a/tests/unit/cli.voice.test.ts
+++ b/tests/unit/cli.voice.test.ts
@@ -31,8 +31,12 @@ let checkPiperServerHealth: ReturnType<typeof vi.fn>;
 let checkWhisperServerHealth: ReturnType<typeof vi.fn>;
 let voiceCommandHandler: { handle: (ctx: unknown) => Promise<boolean> };
 
-function buildContext(args: Record<string, unknown>): { args: Record<string, unknown> } {
+function buildContext(
+  args: Record<string, unknown>,
+  argv: string[] = [],
+): { argv: string[]; args: Record<string, unknown> } {
   return {
+    argv,
     args: { command: 'voice', subcommand: 'status', json: false, ...args },
   };
 }


### PR DESCRIPTION
## Summary

Fresh-install operators (you, on a new box) currently have to walk through `docs/operator/voice-local-stt.md` + `voice-local-tts.md` step-by-step: venv → faster-whisper install → Piper download → Polish voice → server scripts → nohup launch. Multi-line bash paste mangling makes that a footgun (we hit it twice today).

Ship `memphis voice install` — one command that does all of it, idempotently.

```bash
memphis voice install            # full install + start
memphis voice install --restart  # restart servers
memphis voice install --stop     # stop both
```

After it finishes:
```bash
echo MEMPHIS_VOICE_MODE=local >> ~/memphis/.env
memphis voice status   # both reachable
```

## What's in the PR

- `scripts/voice-install.sh` — idempotent installer. Prereq check → venv + faster-whisper → Piper binary + pl_PL-gosia-medium → server scripts → nohup launch → health probe. All paths/ports/model size are env-var overridable.
- `src/infra/cli/handlers/voice.handler.ts` — adds `install` subcommand. Walks up from `import.meta.url` to find `scripts/voice-install.sh` (works for source-tree + dist-tree). Argv passthrough is allowlisted (`--restart`, `--stop`); unknown flags are dropped — `memphis voice install --rm -rf /` cannot inject anything.
- `tests/unit/cli.voice.install.test.ts` — pins the spawn shape: bash + script path + allowlisted passthrough only.
- `tests/unit/cli.voice.test.ts` — extends `buildContext` with optional `argv`; existing 6 tests still pass.
- Runbook docs: TL;DR section pointing at `memphis voice install` at the top of both voice-local-stt.md and voice-local-tts.md.

## Test plan

- [x] `npx vitest run tests/unit/cli.voice.{test,install.test}.ts` → 10/10
- [x] `bash -n scripts/voice-install.sh` → syntax ok
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [ ] CI quality-gate green
- [ ] Operator smoke: `memphis voice install` from clean box → both engines green within ~3-5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)