### PR TITLE
fix(voice): whisper server accepts both /inference and /v1/audio/transcriptions

### DIFF
--- a/scripts/voice-install.sh
+++ b/scripts/voice-install.sh
@@ -176,13 +176,21 @@ print("[whisper] ready", flush=True)
 
 class H(BaseHTTPRequestHandler):
     def do_GET(self):
-        if self.path == "/health":
+        # Liveness paths: /health for our own probe, /inference + /v1/audio/transcriptions
+        # to satisfy adapter-side GET probes (whisper.cpp clients sometimes ping
+        # the inference route to verify the server is up before POSTing).
+        if self.path in ("/health", "/inference", "/v1/audio/transcriptions"):
             self.send_response(200); self.send_header("Content-Type","application/json"); self.end_headers()
             self.wfile.write(json.dumps({"status":"ok","model":size}).encode())
         else:
             self.send_response(404); self.end_headers()
     def do_POST(self):
-        if self.path != "/v1/audio/transcriptions":
+        # Accept BOTH conventions:
+        #   /inference                        — whisper.cpp HTTP server convention
+        #                                        (Memphis local-whisper-adapter.ts uses this)
+        #   /v1/audio/transcriptions          — OpenAI / faster-whisper-server convention
+        # Body is raw audio (audio/wav from Memphis after ffmpeg transcode).
+        if self.path not in ("/inference", "/v1/audio/transcriptions"):
             self.send_response(404); self.end_headers(); return
         ln = int(self.headers.get("Content-Length","0"))
         body = self.rfile.read(ln)


### PR DESCRIPTION
## Summary

Operator's Telegram bot returned \`STT error: Whisper server error (404)\` on every voice message. Root cause: \`local-whisper-adapter.ts:79\` POSTs to \`\$WHISPER_SERVER_URL/inference\` (whisper.cpp convention), but the runbook wrapper that ships with \`scripts/voice-install.sh\` only accepts \`/v1/audio/transcriptions\` (faster-whisper-server / OpenAI convention).

Fix: the wrapper accepts both POST paths. GET probes on either also return 200 so adapter-side liveness checks stay green.

## Test plan

- [x] End-to-end on operator's box: TTS-generated WAV → POST /inference → polish transcription returned correctly
- [x] /v1/audio/transcriptions still works (backward-compat for any external client using OpenAI convention)
- [x] bash -n scripts/voice-install.sh ok
- [ ] CI quality-gate green