### PR TITLE
chore: revert accidental commit of operator-draft crons

### DIFF
--- a/crons/przypomnienie-kierunek-rozwoju.sh
+++ b/crons/przypomnienie-kierunek-rozwoju.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# schedule: 0 10 * * *
-set -euo pipefail
-
-echo "Memphis reminder: Wodzu chciał pogadać o kierunku rozwoju. Okazalo sie ze duzo sie wydarzylo ostatnio."

--- a/crons/spac.sh
+++ b/crons/spac.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# schedule: 30 23 * * *
-set -euo pipefail
-
-curl -s "https://api.telegram.org/bot8669740630:AAFhkP0iwylkbm5hYnwCOk3tKhwfXxbHX00/sendMessage" \
-  -d "chat_id=1316033647" \
-  -d "text=Hej Wodzu! 23:30 - czas iść spać! 🌙" \
-  -d "parse_mode=HTML"


### PR DESCRIPTION
Removes `crons/spac.sh` and `crons/przypomnienie-kierunek-rozwoju.sh` accidentally staged in #460. They are Wodzu's deferred Sprint G operator-decision drafts and should not be on main without his explicit signal.