### PR TITLE
fix(tui): bracketed paste — multi-line copy stops triggering N submits

### DIFF
--- a/crates/memphis-tui/src/app.rs
+++ b/crates/memphis-tui/src/app.rs
@@ -649,6 +649,25 @@ impl AppState {
         }
     }
 
+    /// Append a bracketed-paste blob to the input buffer verbatim
+    /// (newlines, tabs, Unicode all preserved). The operator hits
+    /// Enter once afterwards to submit the whole paste as a single
+    /// message — without bracketed paste, every newline in the paste
+    /// fired a separate SubmitInput, producing the "active command
+    /// still running" wall the operator hit on every multi-line copy.
+    /// Help overlay swallows pastes too (so a paste while help is up
+    /// doesn't write into the buffer behind the modal).
+    pub fn handle_paste(&mut self, text: &str) {
+        if self.help_visible {
+            return;
+        }
+        self.input_buffer.push_str(text);
+        // Pastes are explicit operator intent — clear any in-progress
+        // history navigation so the next ↑ goes to "after-paste" state
+        // rather than overwriting the paste.
+        self.history_index = None;
+    }
+
     pub fn handle_key(&mut self, key: KeyEvent) -> AppAction {
         // When the help overlay is up, every key either closes it or
         // is a no-op — we DO NOT let key events leak through to chat
@@ -4820,6 +4839,40 @@ mod tests {
         );
         // Buffer untouched
         assert_eq!(app.input_buffer, "co tam, kolego?");
+    }
+
+    #[test]
+    fn paste_appends_multiline_to_input_without_submitting() {
+        // Repro of the "active command still running" wall: a 5-line
+        // copy used to fire 5 SubmitInput events. With bracketed
+        // paste, the whole blob lands in input_buffer atomically and
+        // operator decides when to send it.
+        let mut app = AppState::new(config());
+        let blob = "line one\nline two\nline three\n";
+        app.handle_paste(blob);
+        assert_eq!(app.input_buffer, blob);
+        // No history nav side-effects.
+        assert_eq!(app.history_index, None);
+    }
+
+    #[test]
+    fn paste_preserves_existing_input_buffer_prefix() {
+        // Operator typed "Co my się gapimy: " and then pasted a log
+        // dump. The paste should append, not replace.
+        let mut app = AppState::new(config());
+        app.input_buffer = "Co my się gapimy: ".to_string();
+        app.handle_paste("ERROR\nSTACK\n");
+        assert_eq!(app.input_buffer, "Co my się gapimy: ERROR\nSTACK\n");
+    }
+
+    #[test]
+    fn paste_swallowed_when_help_overlay_visible() {
+        // Help is modal — paste should NOT bleed into the buffer
+        // behind it. Operator closes help (Esc) and pastes again.
+        let mut app = AppState::new(config());
+        app.help_visible = true;
+        app.handle_paste("hidden text");
+        assert_eq!(app.input_buffer, "");
     }
 
     #[test]

--- a/crates/memphis-tui/src/main.rs
+++ b/crates/memphis-tui/src/main.rs
@@ -22,7 +22,8 @@ use config::TuiConfig;
 use crossterm::{
     cursor::{Hide, Show},
     event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, MouseEvent, MouseEventKind,
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste,
+        EnableMouseCapture, Event, MouseEvent, MouseEventKind,
     },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -82,15 +83,26 @@ impl TerminalGuard {
         setup_utf8_locale();
         enable_raw_mode()?;
         let mouse_captured = mouse_capture_enabled();
+        // Always-on bracketed paste: when the operator pastes
+        // multi-line content the terminal wraps it in CSI 200~ / 201~,
+        // and crossterm emits a single `Event::Paste(s)` instead of
+        // streaming each line as a separate Enter key event (which
+        // was triggering one chat submission per pasted line).
         if mouse_captured {
             execute!(
                 std::io::stdout(),
                 EnterAlternateScreen,
                 EnableMouseCapture,
+                EnableBracketedPaste,
                 Hide
             )?;
         } else {
-            execute!(std::io::stdout(), EnterAlternateScreen, Hide)?;
+            execute!(
+                std::io::stdout(),
+                EnterAlternateScreen,
+                EnableBracketedPaste,
+                Hide
+            )?;
         }
         Ok(Self { mouse_captured })
     }
@@ -99,6 +111,10 @@ impl TerminalGuard {
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         let _ = disable_raw_mode();
+        // Always disable bracketed paste on exit so the host shell
+        // returns to its native paste behavior. Mouse capture is
+        // toggled at runtime via F2 — release whatever is on now.
+        let _ = execute!(std::io::stdout(), DisableBracketedPaste);
         if self.mouse_captured {
             let _ = execute!(
                 std::io::stdout(),
@@ -331,6 +347,16 @@ fn main() -> ExitCode {
                     MouseEventKind::ScrollDown => renderer.scroll_down(3),
                     _ => {}
                 }
+                continue;
+            }
+
+            // Bracketed paste — terminal delivers the whole pasted
+            // blob as one event, so we can append it verbatim to the
+            // input buffer (newlines included) without each line
+            // triggering a SubmitInput. Operator hits Enter once
+            // afterwards to send the whole paste as a single message.
+            if let Event::Paste(text) = next_event {
+                app.handle_paste(&text);
                 continue;
             }
 


### PR DESCRIPTION
## Summary

Operator hit it on every paste of meaningful output (chat log, config snippet, even pasting my own response back into Memphis). Each newline in the paste fires KeyCode::Enter → SubmitInput → busy guard, N times in a row:

```
an active command is still running; wait or press Ctrl+C to cancel it
an active command is still running; wait or press Ctrl+C to cancel it
an active command is still running; wait or press Ctrl+C to cancel it
...
```

Fix: enable bracketed paste. Terminal wraps the paste in CSI 200~/201~, crossterm emits one `Event::Paste(String)` instead of streaming each line as Enter, main loop appends to input_buffer atomically.

## Test plan

- [x] 106/106 tui tests (3 new): multi-line append, prefix preservation, help-overlay swallow
- [x] cargo build --workspace clean
- [ ] CI quality-gate green
- [ ] Operator smoke: paste 30-line table → lands as one prompt, fires once on Enter