### PR TITLE
feat(anti-confab): provider stamp on every reply + system-prompt guards

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -157,7 +157,43 @@ flagi/tools są dostępne" / "what's available" / "show capabilities", you
 MUST call \`memphis_self_describe\` BEFORE answering. Do not enumerate
 your tools, tiers, or feature flags from memory or training data. The
 returned JSON is the source of truth for the current surface, effective
-tier, cognitive mode, and active feature flags.`;
+tier, cognitive mode, and active feature flags.
+
+### Self-identity honesty (anti-confab — operator session 2026-05-04)
+
+You DO NOT KNOW which provider or model is generating your output —
+that decision lives in the runtime cascade and is not exposed to your
+context. NEVER claim "I am running on cogito:3b" / "ja, MiniMax" /
+"Pisałem to sam (Claude)" / "via Ollama" or any analogous provenance
+statement. The runtime appends a "— via {provider}/{model}" footer
+to every reply automatically; that footer is the authoritative source
+for the operator. Your job is to answer the actual question, not to
+narrate which model is answering it.
+
+When the user asks directly "którego modelu używasz / who's actually
+generating this / what runs you", call \`memphis_self_describe\` and
+quote the \`provider\` and \`model\` fields from its JSON, prefixed with
+"per memphis_self_describe:". Never assert provider identity from
+your own intuition.
+
+Do NOT bake provenance claims ("# Model: cogito:3b") into files you
+write via \`memphis_self_modify\`. The audit chain captures which
+runtime context produced each change; embedding a guess about the
+upstream model in the file content fabricates a record. If a comment
+about provenance is genuinely useful, write "Generated via Memphis
+runtime cascade" without naming a specific model.
+
+### Status / health questions
+
+If the user asks for system status, health, chain counts, vault
+state, provider list, or any concrete number about runtime state, you
+MUST call the relevant tool (\`memphis_health\`, \`memphis_providers\`,
+\`memphis_chain_query\`, etc.) FIRST. Do not produce specific numbers
+("Bloki: 2346", "Sessions: 5", "Decisions: 2h temu") from memory or
+intuition. If the required tool is not available at the current
+tier, say so explicitly — "I don't have memphis_health at this tier;
+ask after /tier elevate or check the TUI status bar" — instead of
+fabricating values.`;
 
 // ── Auto-generated tool docs (Sprint 0.5 G1) ─────────────────────────────────
 // Memphis has 37 registered tools (see src/gateway/tool-registry.ts). We hand-

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -70,6 +70,37 @@ function generateTurnId(): string {
   return `turn-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
+/**
+ * Tag every reply with a small "— via {provider}/{model}" footer so
+ * the operator always knows which model actually generated the text.
+ * The TUI's status bar already shows the same data; Telegram and other
+ * surfaces have no equivalent, so we put it in the message body
+ * itself.
+ *
+ * Idempotent: if the model already rendered a footer (rare, defensive),
+ * we don't double-stamp. Suppressed when MEMPHIS_PROVIDER_STAMP=0.
+ */
+export function appendProviderStamp(
+  output: string,
+  provider: string,
+  model: string,
+  rawEnv: NodeJS.ProcessEnv,
+): string {
+  if (rawEnv.MEMPHIS_PROVIDER_STAMP === '0' || rawEnv.MEMPHIS_PROVIDER_STAMP === 'false') {
+    return output;
+  }
+  const trimmed = output.trimEnd();
+  // The reply normally won't already contain a stamp; this is just a
+  // belt-and-braces guard so a model that imitates the format doesn't
+  // get double-stamped.
+  if (/—\s*via\s+[^/\s]+\/[^\s]+\s*$/i.test(trimmed)) {
+    return output;
+  }
+  const provLabel = provider && provider.length > 0 ? provider : 'unknown';
+  const modelLabel = model && model.length > 0 ? model : 'unknown';
+  return `${trimmed}\n\n— via ${provLabel}/${modelLabel}`;
+}
+
 function extractFrameToolCalls(messages: ChatMessage[]): string[] {
   const names = new Set<string>();
   for (const msg of messages) {
@@ -991,15 +1022,31 @@ async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntim
       );
     }
 
+    // Provider-stamp footer — appended to every reply across every
+    // surface so the operator always knows which model actually
+    // generated the text. Sprint anti-confab 2026-05-04: bot was
+    // claiming cogito:3b authorship while MiniMax was the active
+    // provider. The TUI status bar already shows it but Telegram has
+    // no equivalent, so the answer becomes part of the message body
+    // (single source of truth, also makes the persisted history
+    // self-documenting). Disable with MEMPHIS_PROVIDER_STAMP=0 if a
+    // surface explicitly suppresses it (none today).
+    const stampedOutput = appendProviderStamp(
+      guarded.output,
+      llm.provider,
+      llm.model,
+      rawEnvWithTier3,
+    );
+
     if (options.sendReply) {
-      await options.sendReply(guarded.output);
+      await options.sendReply(stampedOutput);
     }
 
     if (options.persistSession) {
       try {
         await options.persistSession({
           userText: prepared.sessionUserText,
-          assistantReply: guarded.output,
+          assistantReply: stampedOutput,
           messages,
         });
       } catch (error) {

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -56,6 +56,42 @@ describe('gateway system prompt', () => {
     expect(prompt).not.toContain('PURPOSE: Write to the journal chain. This is your persistent memory.');
   });
 
+  it('emits the anti-confab self-identity guard (sprint 2026-05-04)', () => {
+    // Operator session 2026-05-04 caught the bot claiming "ja, cogito:3b"
+    // / "Pisałem to sam (Claude Opus)" while MiniMax was the actual
+    // provider. The system-prompt guard pins three rules:
+    //   1. NEVER claim a model/provider from intuition
+    //   2. Defer to memphis_self_describe + the runtime stamp
+    //   3. Don't bake provenance lies into self-modify content
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_self_describe', 'memphis_self_modify'],
+    });
+
+    expect(prompt).toContain('Self-identity honesty');
+    expect(prompt).toContain('You DO NOT KNOW which provider or model');
+    expect(prompt).toContain('NEVER claim');
+    expect(prompt).toContain('via {provider}/{model}');
+    expect(prompt).toContain('per memphis_self_describe:');
+    // Don't bake provenance lies into self-modify outputs.
+    // (Match across line breaks since the source-code wrapping
+    // doesn't matter to the LLM consuming the prompt.)
+    expect(prompt).toMatch(/Generated via Memphis\s+runtime cascade/);
+  });
+
+  it('emits the status-fabrication guard so the bot calls health tools instead of guessing', () => {
+    // Same operator session caught fabricated chain counts ("Bloki: 2346",
+    // "Decisions: 2h temu", "Soul: 3 zapisów") rendered without a single
+    // tool call. The system-prompt now requires a real tool call before
+    // any concrete number lands in the reply.
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_health', 'memphis_chain_query'],
+    });
+
+    expect(prompt).toContain('Status / health questions');
+    expect(prompt).toContain('memphis_health');
+    expect(prompt).toContain('Do not produce specific numbers');
+  });
+
   it('adds instructions for preview tools when they are available', () => {
     const prompt = buildSystemPrompt({
       availableTools: ['memphis_chain_query', 'memphis_providers', 'memphis_system_info'],

--- a/tests/unit/provider-stamp.test.ts
+++ b/tests/unit/provider-stamp.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Anti-confab provider stamp — sprint 2026-05-04.
+ *
+ * Bot was claiming "ja, cogito:3b" / "Pisałem to sam" while the actual
+ * provider was MiniMax. Source-of-truth fix: the runtime appends a
+ * "— via {provider}/{model}" footer to every reply across every
+ * surface so the operator (and any later auditor reading persisted
+ * sessions) sees who actually generated the text.
+ *
+ * This file pins the helper's contract:
+ *   - default ON, regardless of provider/model
+ *   - idempotent (won't double-stamp when model imitates the format)
+ *   - suppressed via MEMPHIS_PROVIDER_STAMP=0 / false
+ *   - safe against missing/empty provider or model strings
+ */
+import { describe, expect, it } from 'vitest';
+
+import { appendProviderStamp } from '../../src/gateway/turn-runtime.js';
+
+describe('appendProviderStamp', () => {
+  it('appends "— via provider/model" by default', () => {
+    const out = appendProviderStamp('Cześć!', 'minimax', 'MiniMax-M2.7', {});
+    expect(out).toBe('Cześć!\n\n— via minimax/MiniMax-M2.7');
+  });
+
+  it('preserves the original body verbatim', () => {
+    const body = '## Status\n\nBloki: 2883\nVault: 4 wpisy';
+    const out = appendProviderStamp(body, 'ollama', 'cogito:3b', {});
+    expect(out.startsWith(body)).toBe(true);
+    expect(out.endsWith('— via ollama/cogito:3b')).toBe(true);
+  });
+
+  it('trims trailing whitespace before the footer (no orphan blank lines)', () => {
+    const out = appendProviderStamp('text\n\n\n\n', 'ollama', 'cogito:3b', {});
+    // exactly one blank line between body and footer
+    expect(out).toBe('text\n\n— via ollama/cogito:3b');
+  });
+
+  it('suppresses footer when MEMPHIS_PROVIDER_STAMP=0', () => {
+    const out = appendProviderStamp('hi', 'minimax', 'MiniMax-M2.7', {
+      MEMPHIS_PROVIDER_STAMP: '0',
+    });
+    expect(out).toBe('hi');
+  });
+
+  it('suppresses footer when MEMPHIS_PROVIDER_STAMP=false', () => {
+    const out = appendProviderStamp('hi', 'minimax', 'MiniMax-M2.7', {
+      MEMPHIS_PROVIDER_STAMP: 'false',
+    });
+    expect(out).toBe('hi');
+  });
+
+  it('does not double-stamp when reply already ends with a "— via X/Y" line', () => {
+    // A pathological model that imitates the footer in its own reply
+    // shouldn't get a second one bolted on.
+    const already = 'sample reply\n\n— via somebody/something';
+    const out = appendProviderStamp(already, 'minimax', 'MiniMax-M2.7', {});
+    expect(out).toBe(already);
+  });
+
+  it('falls back to "unknown" when provider or model is empty', () => {
+    expect(appendProviderStamp('hi', '', 'M', {})).toMatch(/— via unknown\/M$/);
+    expect(appendProviderStamp('hi', 'P', '', {})).toMatch(/— via P\/unknown$/);
+    expect(appendProviderStamp('hi', '', '', {})).toMatch(/— via unknown\/unknown$/);
+  });
+});

--- a/tests/unit/turn-runtime.test.ts
+++ b/tests/unit/turn-runtime.test.ts
@@ -123,13 +123,19 @@ describe('turn runtime', () => {
       persistSession,
     });
 
+    // Sprint anti-confab 2026-05-04: every reply gets a "— via X/Y"
+    // footer appended (suppressible via MEMPHIS_PROVIDER_STAMP=0).
+    // Both sendReply and persistSession see the stamped output, so
+    // surfaces and audit history stay aligned.
     await vi.waitFor(() => {
-      expect(sendReply).toHaveBeenCalledWith('assistant raw reply');
+      expect(sendReply).toHaveBeenCalledWith(
+        expect.stringMatching(/^assistant raw reply\n\n— via .+\/.+$/),
+      );
     });
     expect(persistSession).toHaveBeenCalledWith(
       expect.objectContaining({
         userText: expect.stringContaining('<user_input>'),
-        assistantReply: 'assistant raw reply',
+        assistantReply: expect.stringMatching(/^assistant raw reply\n\n— via .+\/.+$/),
       }),
     );
 


### PR DESCRIPTION
## Summary

Operator caught the bot in two recurring confabulation patterns during a 2026-05-04 session:

1. **Provider/model claims** — bot said "Pisałem to sam (cogito:3b)" while runtime was on minimax. Even baked \`# Model: cogito:3b\` into a file written via \`memphis_self_modify\`.
2. **Status fabrication** — \`/status\` table with specific chain counts, session counts, "Decisions: 2h temu", all rendered without calling \`memphis_health\` or \`memphis_chain_query\`.

Two-pronged fix in one PR.

## Provider stamp (runtime side)

New helper \`appendProviderStamp(output, provider, model, rawEnv)\` in \`turn-runtime.ts\`. Wraps both \`sendReply\` and \`persistSession\` so every chat reply, on every surface, ends with:

\`\`\`
— via minimax/MiniMax-M2.7
\`\`\`

Telegram (which had no surface-side provider indicator) now sees it. Persisted history is self-documenting. Idempotent. Suppress with \`MEMPHIS_PROVIDER_STAMP=0\`. Semantic-memory store keeps unstamped body so recall stays clean.

## System-prompt guards (prompt side)

Two sub-sections added to \`TOOL_DISCIPLINE_PREAMBLE\`:

- **Self-identity honesty** — \"You DO NOT KNOW which provider or model is generating your output\" + reference to the runtime stamp as authoritative + prohibition on baking model claims into \`memphis_self_modify\` file content.
- **Status / health questions** — concrete numbers require a real tool call; if tool isn't available, say so explicitly.

## Test plan

- [x] \`vitest run tests/unit/provider-stamp.test.ts\` → 7/7 (new file)
- [x] \`vitest run tests/unit/gateway.system-prompt.test.ts\` → 28/28 (2 new)
- [x] \`vitest run tests/unit/turn-runtime.test.ts\` → 9/9 (existing assertion updated)
- [x] typecheck + eslint clean
- [ ] CI quality-gate green
- [ ] Operator smoke: send Telegram message, see "— via minimax/MiniMax-M2.7" footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)