### PR TITLE
fix(stamp): provider stamp shows real labels (not 'provider/unknown')

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -695,6 +695,12 @@ async function startChannelGateway(container?: {
     adapters,
     memory,
     llm,
+    // Forward the operator-visible labels so the runtime stamp on
+    // every reply names the actual upstream ("— via minimax/MiniMax-M2.7"
+    // instead of the previous fallback "— via provider/unknown" — see
+    // ChatGatewayConfig docs in chat-types.ts for context).
+    providerLabel: provider.name,
+    modelLabel: provider.defaultModel(),
     toolExecutor,
     conversationContext: container?.conversationContextService,
     sessions: container?.operatorChatSessionRepository

--- a/src/gateway/chat-loop.ts
+++ b/src/gateway/chat-loop.ts
@@ -58,6 +58,11 @@ export async function handleMessage(
     input: message.text,
     messages: history,
     llm: config.llm,
+    // Forward operator-visible labels so resolveLlm() can stamp the
+    // reply correctly (otherwise the bare LlmClient is opaque and the
+    // stamp falls back to "provider/unknown").
+    providerLabel: config.providerLabel,
+    model: config.modelLabel,
     memory: config.memory,
     memoryUserId: conversation.actorId,
     conversationId: conversation.conversationId,

--- a/src/gateway/chat-types.ts
+++ b/src/gateway/chat-types.ts
@@ -149,6 +149,18 @@ export type ChatGatewayConfig = {
   adapters: ChannelAdapter[];
   memory: MemoryClient;
   llm: LlmClient;
+  /**
+   * Operator-visible labels for the active provider + model. Bootstrap
+   * fills these from `provider.name` / `provider.defaultModel()` so the
+   * runtime stamp ("— via {provider}/{model}") and telemetry can name
+   * the actual upstream — without these, runTurnRuntime falls back to
+   * the literal string "provider" / "unknown" because the LlmClient
+   * interface doesn't expose its own labels (Sprint anti-confab
+   * 2026-05-04: that fallback was leaking into Telegram replies as
+   * "— via provider/unknown" instead of "— via minimax/MiniMax-M2.7").
+   */
+  providerLabel?: string;
+  modelLabel?: string;
   systemPrompt?: string;
   toolExecutor?: ToolExecutor;
   loopLimits?: LoopLimits;

--- a/tests/unit/turn-runtime.test.ts
+++ b/tests/unit/turn-runtime.test.ts
@@ -197,6 +197,53 @@ describe('turn runtime', () => {
     );
   });
 
+  it('stamps real provider/model labels when using the llm: branch (no fallback to "provider/unknown")', async () => {
+    // Bug repro from operator session 2026-05-04: chat-loop wraps the
+    // active provider as a bare LlmClient, then calls runTurnRuntime
+    // with `llm: config.llm`. Pre-fix, resolveLlm() defaulted provider
+    // to the literal string "provider" and model to "unknown" — and
+    // appendProviderStamp dutifully emitted "— via provider/unknown"
+    // on every Telegram reply. Pin the path: when the caller forwards
+    // providerLabel + model alongside an opaque llm, the stamp uses
+    // those real labels.
+    const { runTurnRuntime } = await import('../../src/gateway/turn-runtime.js');
+
+    const sendReply = vi.fn(async () => undefined);
+    const llm = {
+      complete: vi.fn(async () => ({
+        content: 'assistant raw reply',
+        tool_calls: [],
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      })),
+    };
+    const memory = {
+      recall: vi.fn(async () => ({ items: [] })),
+      store: vi.fn(async () => undefined),
+      isAvailable: vi.fn(() => true),
+    };
+
+    await runTurnRuntime({
+      input: 'hello',
+      messages: [],
+      llm,
+      providerLabel: 'minimax',
+      model: 'MiniMax-M2.7',
+      memory,
+      memoryUserId: 'tg:1316033647',
+      surface: 'telegram',
+      sendReply,
+    });
+
+    await vi.waitFor(() => {
+      expect(sendReply).toHaveBeenCalled();
+    });
+    const sent = (sendReply.mock.calls[0]?.[0] ?? '') as string;
+    expect(sent).toMatch(/— via minimax\/MiniMax-M2\.7$/);
+    // Negative: the pre-fix fallback string must never reappear.
+    expect(sent).not.toContain('via provider/');
+    expect(sent).not.toContain('/unknown');
+  });
+
   it('degrades high-risk prompt injection attempts by blocking tools, recall, fetch, and durable memory writes', async () => {
     const { runTurnRuntime } = await import('../../src/gateway/turn-runtime.js');
 


### PR DESCRIPTION
## Summary

After #463 landed, operator's first Telegram reply came back footed with `— via provider/unknown` instead of `— via minimax/MiniMax-M2.7`.

**Repro chain**:
1. `providerToLlmClient(provider, defaults, { providerLabel, modelLabel })` bakes the labels into the closure.
2. `chat-loop.ts` forwards only `llm: config.llm` (the bare LlmClient — labels not exposed on the interface).
3. `resolveLlm()` takes the `options.llm` branch and falls back to literal `'provider'` / `'unknown'`.
4. `appendProviderStamp()` dutifully stamps the placeholder.

**Fix**: thread the labels through `ChatGatewayConfig` explicitly.
- `chat-types.ts`: adds optional `providerLabel` + `modelLabel` (documented).
- `chat-loop.ts`: forwards them.
- `bootstrap.ts`: passes `provider.name` + `provider.defaultModel()` on `startGateway()`.

Backwards compatible (new fields are optional).

## Test plan
- [x] `vitest run tests/unit/turn-runtime.test.ts` → 10/10 (1 new pin)
- [x] typecheck + eslint clean
- [ ] CI green
- [ ] Operator smoke: next Telegram reply ends with `— via minimax/MiniMax-M2.7`