### PR TITLE
docs: use ollama/cogito:3b as the provider-stamp example (was minimax)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -696,7 +696,7 @@ async function startChannelGateway(container?: {
     memory,
     llm,
     // Forward the operator-visible labels so the runtime stamp on
-    // every reply names the actual upstream ("— via minimax/MiniMax-M2.7"
+    // every reply names the actual upstream (e.g. "— via ollama/cogito:3b"
     // instead of the previous fallback "— via provider/unknown" — see
     // ChatGatewayConfig docs in chat-types.ts for context).
     providerLabel: provider.name,

--- a/src/gateway/chat-types.ts
+++ b/src/gateway/chat-types.ts
@@ -157,7 +157,7 @@ export type ChatGatewayConfig = {
    * the literal string "provider" / "unknown" because the LlmClient
    * interface doesn't expose its own labels (Sprint anti-confab
    * 2026-05-04: that fallback was leaking into Telegram replies as
-   * "— via provider/unknown" instead of "— via minimax/MiniMax-M2.7").
+   * "— via provider/unknown" instead of e.g. "— via ollama/cogito:3b").
    */
   providerLabel?: string;
   modelLabel?: string;


### PR DESCRIPTION
Two-line comment swap. No runtime change — the actual stamp value is runtime-derived from `provider.name` + `provider.defaultModel()` at bootstrap, no hardcoded model names ever shipped to users. Operator preferred a local-first example matching Memphis's Ollama-first sovereignty philosophy.