### PR TITLE
fix(anti-confab): strip <think> reasoning blocks before reply hits surfaces

### DIFF
--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -71,6 +71,37 @@ function generateTurnId(): string {
 }
 
 /**
+ * Strip `<think>...</think>` reasoning blocks from a model reply before
+ * it goes to surfaces or persistence.
+ *
+ * Why: smaller / reasoning-mode-on models (cogito, qwen-thinking,
+ * deepseek-r1, etc.) emit visible <think> blocks that are great as a
+ * dev trace but pollute the operator-facing reply. Telegram operator
+ * 2026-05-04 caught the bot rendering whole 8-line "<think>The user is
+ * asking..." preambles into chat messages. The stripping happens at
+ * the gateway boundary so every surface — Telegram, TUI, MCP — gets
+ * the cleaned text + the provider stamp on top of it.
+ *
+ * Heuristic: match `<think>...</think>` (case-insensitive, multiline).
+ * Also strip a *trailing* unclosed `<think>` block (some models start
+ * thinking and forget to close before the end of the stream).
+ * Disable with MEMPHIS_THINK_FILTER=0 if a downstream operator needs
+ * the raw stream (debug builds, eval harnesses).
+ */
+export function stripThinkBlocks(output: string, rawEnv: NodeJS.ProcessEnv): string {
+  if (rawEnv.MEMPHIS_THINK_FILTER === '0' || rawEnv.MEMPHIS_THINK_FILTER === 'false') {
+    return output;
+  }
+  // Closed blocks: <think>...</think>, lazy match, multi-line.
+  let cleaned = output.replace(/<think\b[^>]*>[\s\S]*?<\/think>/gi, '');
+  // Unclosed trailing block: <think> at any position with no closing tag
+  // before the end of the message. We also eat any whitespace immediately
+  // preceding the opener so we don't leave a dangling blank line.
+  cleaned = cleaned.replace(/\s*<think\b[^>]*>[\s\S]*$/i, '');
+  return cleaned.trimStart();
+}
+
+/**
  * Tag every reply with a small "— via {provider}/{model}" footer so
  * the operator always knows which model actually generated the text.
  * The TUI's status bar already shows the same data; Telegram and other
@@ -1022,17 +1053,16 @@ async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntim
       );
     }
 
-    // Provider-stamp footer — appended to every reply across every
-    // surface so the operator always knows which model actually
-    // generated the text. Sprint anti-confab 2026-05-04: bot was
-    // claiming cogito:3b authorship while MiniMax was the active
-    // provider. The TUI status bar already shows it but Telegram has
-    // no equivalent, so the answer becomes part of the message body
-    // (single source of truth, also makes the persisted history
-    // self-documenting). Disable with MEMPHIS_PROVIDER_STAMP=0 if a
-    // surface explicitly suppresses it (none today).
+    // Two-step gateway sanitize before reply hits surfaces / persistence:
+    //   1. Strip <think>...</think> reasoning blocks (Telegram operator
+    //      2026-05-04 caught these leaking into chat messages from
+    //      cogito / qwen-thinking models).
+    //   2. Append the "— via {provider}/{model}" stamp so the operator
+    //      always knows which model generated the cleaned text.
+    // Order matters: stamp goes on the cleaned body, not the raw one.
+    const cleanedOutput = stripThinkBlocks(guarded.output, rawEnvWithTier3);
     const stampedOutput = appendProviderStamp(
-      guarded.output,
+      cleanedOutput,
       llm.provider,
       llm.model,
       rawEnvWithTier3,

--- a/tests/unit/strip-think-blocks.test.ts
+++ b/tests/unit/strip-think-blocks.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Strip <think> reasoning blocks before reply hits surfaces.
+ *
+ * Operator session 2026-05-04 hit visible "<think>The user is asking..."
+ * preambles in Telegram messages. Cogito, qwen-thinking, deepseek-r1
+ * and similar reasoning-mode models all emit these blocks; great as a
+ * dev trace, ugly in chat. Pin the gateway-side strip contract.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { stripThinkBlocks } from '../../src/gateway/turn-runtime.js';
+
+describe('stripThinkBlocks', () => {
+  it('removes a single closed <think> block', () => {
+    const out = stripThinkBlocks('<think>internal reasoning</think>actual reply', {});
+    expect(out).toBe('actual reply');
+  });
+
+  it('removes a multi-line <think> block', () => {
+    const input = `<think>
+The user is asking X.
+Let me think...
+Step 1, step 2.
+</think>
+
+## Real reply
+Body.`;
+    const out = stripThinkBlocks(input, {});
+    expect(out).toContain('## Real reply');
+    expect(out).toContain('Body.');
+    expect(out).not.toContain('internal');
+    expect(out).not.toContain('Step 1');
+    expect(out).not.toMatch(/<\/?think>/);
+  });
+
+  it('removes multiple <think> blocks', () => {
+    const out = stripThinkBlocks(
+      '<think>first</think>part one<think>second</think>part two',
+      {},
+    );
+    expect(out).toBe('part onepart two');
+  });
+
+  it('handles uppercase/mixed-case <THINK>', () => {
+    expect(stripThinkBlocks('<THINK>x</THINK>visible', {})).toBe('visible');
+    expect(stripThinkBlocks('<Think>x</Think>visible', {})).toBe('visible');
+  });
+
+  it('handles attributes on the <think> tag', () => {
+    expect(stripThinkBlocks('<think class="reason">x</think>body', {})).toBe('body');
+  });
+
+  it('strips a trailing UNCLOSED <think> block (model started thinking, never closed)', () => {
+    const input = 'visible reply\n<think>partial reasoning that never closed';
+    const out = stripThinkBlocks(input, {});
+    expect(out).toBe('visible reply');
+  });
+
+  it('preserves non-<think> markup verbatim', () => {
+    const input = '## Heading\n\n```ts\nconst x = 1;\n```\n\nText.';
+    expect(stripThinkBlocks(input, {})).toBe(input);
+  });
+
+  it('returns empty string if the whole reply is <think>', () => {
+    // Pathological case: the model emitted only reasoning. We strip to
+    // empty and leave the empty-reply guard at the channel boundary
+    // (Telegram already handles "(brak odpowiedzi — spróbuj ponownie)").
+    expect(stripThinkBlocks('<think>just thinking</think>', {})).toBe('');
+  });
+
+  it('passes output through verbatim when MEMPHIS_THINK_FILTER=0', () => {
+    const input = '<think>reasoning</think>body';
+    expect(stripThinkBlocks(input, { MEMPHIS_THINK_FILTER: '0' })).toBe(input);
+    expect(stripThinkBlocks(input, { MEMPHIS_THINK_FILTER: 'false' })).toBe(input);
+  });
+
+  it('default behavior is to strip (no env var set)', () => {
+    expect(stripThinkBlocks('<think>x</think>body', {})).toBe('body');
+  });
+
+  it('removes leading whitespace left over after stripping leading <think>', () => {
+    // Without a leading-whitespace trim, "<think>x</think>\n\nReal" would
+    // leave "\n\nReal" with two blank lines on top, looking broken in
+    // Telegram. trimStart() handles it.
+    expect(stripThinkBlocks('<think>x</think>\n\nReal', {})).toBe('Real');
+  });
+});


### PR DESCRIPTION
Operator caught `<think>The user is asking...` preambles bleeding into Telegram messages. Reasoning-mode models (cogito, qwen-thinking, deepseek-r1) emit these as dev traces; they don't belong in chat.

Single gateway-side strip step in `turn-runtime.ts` BEFORE `appendProviderStamp` — handles closed blocks (multi-line, case-insensitive, attribute-tolerant) AND unclosed trailing blocks. Suppress via `MEMPHIS_THINK_FILTER=0`.

## Test plan
- [x] 11/11 new tests
- [x] 10/10 + 7/7 existing
- [x] typecheck + eslint clean
- [ ] Operator smoke: next Telegram reply shouldn't show `<think>` even from cogito