### PR TITLE
refactor(env): D3 batch 3 — MEMPHIS_AGENT_NAME / OWNER_NAME / HOME → env-registry

### DIFF
--- a/src/infra/cli/commands/setup.ts
+++ b/src/infra/cli/commands/setup.ts
@@ -10,6 +10,7 @@ import {
   type ProviderName,
 } from './provider.js';
 import { handleTelegramSetupCommand } from './setup-telegram.js';
+import { MEMPHIS_AGENT_NAME, MEMPHIS_OWNER_NAME } from '../../../config/env-registry.js';
 import { DEFAULT_MCP_HTTP_PORT } from '../../../mcp/transport/defaults.js';
 import {
   applyFirstRunPreview,
@@ -1009,8 +1010,10 @@ async function promptFirstRunMode(
 }
 
 async function promptGuidedAnswers(rl: readline.Interface): Promise<GuidedFirstRunAnswers> {
-  const defaultAgent = process.env.MEMPHIS_AGENT_NAME?.trim() || DEFAULT_AGENT_NAME;
-  const defaultOwner = process.env.MEMPHIS_OWNER_NAME?.trim() || DEFAULT_OWNER_NAME;
+  // Accessor default matches DEFAULT_AGENT_NAME / DEFAULT_OWNER_NAME so the
+  // `|| <default>` fallback was redundant once env-registry shipped.
+  const defaultAgent = MEMPHIS_AGENT_NAME.read(process.env);
+  const defaultOwner = MEMPHIS_OWNER_NAME.read(process.env);
 
   const agentName = await promptRequired(rl, 'Agent name', defaultAgent);
   const ownerName = await promptRequired(rl, 'Operator name', defaultOwner);
@@ -1285,8 +1288,8 @@ async function runInitCommand(context: CliContext): Promise<InitCommandResult> {
             rl
               ? await promptGuidedAnswers(rl)
               : {
-                  agentName: process.env.MEMPHIS_AGENT_NAME?.trim() || DEFAULT_AGENT_NAME,
-                  ownerName: process.env.MEMPHIS_OWNER_NAME?.trim() || DEFAULT_OWNER_NAME,
+                  agentName: MEMPHIS_AGENT_NAME.read(process.env),
+                  ownerName: MEMPHIS_OWNER_NAME.read(process.env),
                   languages: ['pl', 'en'],
                   communicationStyle: 'direct, concise, auditable',
                   purpose: 'Local-first operator runtime with auditable memory',

--- a/src/infra/logging/pino.ts
+++ b/src/infra/logging/pino.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import pino, { type DestinationStream, type Logger, type LoggerOptions } from 'pino';
 
 import { maybeRotateLogFile } from './log-rotation.js';
-import { NODE_ENV } from '../../config/env-registry.js';
+import { HOME, NODE_ENV } from '../../config/env-registry.js';
 
 /**
  * Registry of every Pino logger created via `createPinoLogger` so that a
@@ -63,7 +63,10 @@ function resolveLogFilePath(): string | null {
   if (explicit === 'none') return null;
   if (explicit) return explicit;
 
-  const home = process.env.HOME ?? process.env.USERPROFILE ?? '/tmp';
+  // HOME accessor falls back to os.homedir() — on Windows this returns
+  // %USERPROFILE%, so the legacy USERPROFILE/'/tmp' fallback chain is
+  // subsumed cleanly. (sprint D3 batch 3 migration)
+  const home = HOME.read(process.env);
   const logDir = join(home, '.memphis', 'logs');
   try {
     mkdirSync(logDir, { recursive: true });

--- a/src/infra/runtime/heartbeat-watchdog.ts
+++ b/src/infra/runtime/heartbeat-watchdog.ts
@@ -9,6 +9,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { MEMPHIS_AGENT_NAME } from '../../config/env-registry.js';
 import { getConfigPath } from '../../config/paths.js';
 import { getActiveSurfacesSnapshot } from '../../core/surface-presence.js';
 import type { PulseEntry, PulseEventType } from '../../soul/types.js';
@@ -245,7 +246,7 @@ export function writePulseEvent(entry: PulseEntry): void {
 
   // Keep only the most recent entries
   const trimmed = existing.slice(-PULSE_MAX_ENTRIES);
-  const agentName = process.env.MEMPHIS_AGENT_NAME ?? 'Memphis Agent';
+  const agentName = MEMPHIS_AGENT_NAME.read(process.env);
 
   const header = [
     `# PULSE — ${agentName}`,

--- a/src/infra/runtime/scheduler.ts
+++ b/src/infra/runtime/scheduler.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from 'node:url';
 
 import { runReflectionCycle } from './reflection-loop.js';
 import { getUserServiceStatus, resolveRuntimeRoot } from './user-service.js';
+import { HOME } from '../../config/env-registry.js';
 import { getConfigPath } from '../../config/paths.js';
 import { runDeployPipeline, type DeployProfile } from '../deploy/pipeline.js';
 import { appendBlock } from '../storage/chain-adapter.js';
@@ -384,7 +385,7 @@ function runShell(script: string, cwd: string): Promise<{ success: boolean; outp
   // back to '/home/memphis' only when HOME is somehow unset (which
   // shouldn't happen on POSIX, but the fallback keeps prior behavior
   // for the dev-machine case).
-  const homeDir = process.env.HOME ?? '/home/memphis';
+  const homeDir = HOME.read(process.env);
   return new Promise((resolve) => {
     // -lc instead of -c: makes bash a login shell so it sources
     // /etc/profile + ~/.profile + ~/.bashrc, which is how the

--- a/src/infra/runtime/self-modify-revert.ts
+++ b/src/infra/runtime/self-modify-revert.ts
@@ -38,6 +38,7 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+import { HOME } from '../../config/env-registry.js';
 import { writeSecurityAudit } from '../logging/security-audit.js';
 
 export const DEFAULT_REVERT_AFTER_FAILURES = 3;
@@ -55,12 +56,12 @@ interface BootFailureRecord {
 }
 
 function markerPath(rawEnv: NodeJS.ProcessEnv = process.env): string {
-  const dataDir = rawEnv.MEMPHIS_DATA_DIR ?? join(process.env.HOME ?? '/tmp', '.memphis');
+  const dataDir = rawEnv.MEMPHIS_DATA_DIR ?? join(HOME.read(rawEnv), '.memphis');
   return join(dataDir, 'state', 'last-self-modify.json');
 }
 
 function bootFailurePath(rawEnv: NodeJS.ProcessEnv = process.env): string {
-  const dataDir = rawEnv.MEMPHIS_DATA_DIR ?? join(process.env.HOME ?? '/tmp', '.memphis');
+  const dataDir = rawEnv.MEMPHIS_DATA_DIR ?? join(HOME.read(rawEnv), '.memphis');
   return join(dataDir, 'state', 'boot-failures.json');
 }
 

--- a/src/infra/runtime/user-service.ts
+++ b/src/infra/runtime/user-service.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { dirname, join, resolve } from 'node:path';
 
 import { resolveInstallRoot } from './install-root.js';
+import { HOME } from '../../config/env-registry.js';
 
 export type UserServiceStatus = {
   name: string;
@@ -82,7 +83,7 @@ function nodeBinPath(): string {
 
 function buildPathEnv(): string {
   const nodeDir = dirname(nodeBinPath());
-  return `${nodeDir}:${process.env.HOME ?? ''}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`;
+  return `${nodeDir}:${HOME.read(process.env)}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`;
 }
 
 export function resolveServiceExecStart(runtimeRoot: string): string {

--- a/src/soul/memory.ts
+++ b/src/soul/memory.ts
@@ -16,6 +16,7 @@ import {
   type SoulMemory,
   type SoulMemoryUpdate,
 } from './types.js';
+import { MEMPHIS_AGENT_NAME } from '../config/env-registry.js';
 import { getConfigPath } from '../config/paths.js';
 import { appendBlock } from '../infra/storage/chain-adapter.js';
 import { healSensitiveFilePerms, writeSensitiveFile } from '../infra/storage/secure-file.js';
@@ -297,7 +298,7 @@ export function burnMemoryAction(id: string, rawEnv: NodeJS.ProcessEnv = process
   entry.burnedAt = new Date().toISOString();
 
   // Rewrite file with updated entry
-  const agentName = process.env.MEMPHIS_AGENT_NAME ?? 'Memphis Agent';
+  const agentName = MEMPHIS_AGENT_NAME.read(process.env);
   const header = [
     `# MEMORY — ${agentName}`,
     `Burn-After-Action Log | Threshold: ${MEMORY_ROTATION_THRESHOLD}`,
@@ -337,7 +338,7 @@ export function rotateMemoryFile(rawEnv: NodeJS.ProcessEnv = process.env): void 
   const burnedAt = new Date().toISOString();
   const archivedEntries = entries.map((e) => ({ ...e, burned: true, burnedAt }));
 
-  const agentName = process.env.MEMPHIS_AGENT_NAME ?? 'Memphis Agent';
+  const agentName = MEMPHIS_AGENT_NAME.read(process.env);
 
   const header = [
     `# MEMORY ARCHIVE — ${agentName}`,


### PR DESCRIPTION
11 raw process.env reads across 7 files migrated to typed env-registry accessors (already defined post #428).

## Test plan
- [x] tsc --noEmit clean
- [x] vitest 45/45 on related suites (setup.command, heartbeat-watchdog-detail, heartbeat-memory-check, soul-memory, soul-boot)
- [x] grep -r raw process.env reads of these vars → zero hits
- [ ] CI quality-gate green