### PR TITLE
refactor(env): D3 batch 4 — VAULT_PEPPER + SAFE_MODE + FAULT_INJECT → env-registry

### DIFF
--- a/src/config/env-registry.ts
+++ b/src/config/env-registry.ts
@@ -222,6 +222,47 @@ export const PIPER_SERVER_URL = defineStringAccessor({
   defaultValue: 'http://localhost:5500',
 });
 
+/**
+ * Vault encryption pepper. Combined with operator's passphrase to derive
+ * the AES-256-GCM master key. Empty default — vault MUST be initialized
+ * via `memphis init` before any vault read/write succeeds. The accessor
+ * is marked secret so doctor + telemetry don't leak the value into
+ * audit logs.
+ */
+export const MEMPHIS_VAULT_PEPPER = defineStringAccessor({
+  name: 'MEMPHIS_VAULT_PEPPER',
+  envKey: 'MEMPHIS_VAULT_PEPPER',
+  description: 'Vault encryption pepper (combined with operator passphrase)',
+  defaultValue: '',
+  isSecret: true,
+});
+
+/**
+ * Safe-mode flag. When 'true' (case-insensitive), the runtime restricts
+ * write operations: no chain mutations on degraded providers, no
+ * self-modify, no remote calls except via the fallback chain. Set by
+ * the CLI `--safe-mode` flag (see infra/cli/index.ts) or operator's
+ * `.env`.
+ */
+export const MEMPHIS_SAFE_MODE = defineStringAccessor({
+  name: 'MEMPHIS_SAFE_MODE',
+  envKey: 'MEMPHIS_SAFE_MODE',
+  description: 'Restrict writes + remote calls when "true" (case-insensitive)',
+  defaultValue: '',
+});
+
+/**
+ * Fault injection toggle for testing. Honored by task-queue-wal +
+ * a few other resilience paths. Empty / unset = off. Don't enable in
+ * production — the whole point is to surface bugs.
+ */
+export const MEMPHIS_FAULT_INJECT = defineStringAccessor({
+  name: 'MEMPHIS_FAULT_INJECT',
+  envKey: 'MEMPHIS_FAULT_INJECT',
+  description: 'Fault injection mode (testing only — leave unset in production)',
+  defaultValue: '',
+});
+
 // ── Registry surface (for doctor + telemetry) ───────────────────────────────
 
 /**
@@ -240,6 +281,9 @@ export const ENV_REGISTRY: readonly EnvAccessor<unknown>[] = [
   MEMPHIS_VOICE_MODE,
   WHISPER_SERVER_URL,
   PIPER_SERVER_URL,
+  MEMPHIS_VAULT_PEPPER,
+  MEMPHIS_SAFE_MODE,
+  MEMPHIS_FAULT_INJECT,
 ] as const;
 
 export interface RegistryReport {

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -10,7 +10,7 @@ import {
 } from './exec-policy.js';
 import { exec, getSystemInfo } from '../agent/system.js';
 import { createAppContainer } from '../app/container.js';
-import { NODE_ENV } from '../config/env-registry.js';
+import { MEMPHIS_SAFE_MODE, NODE_ENV } from '../config/env-registry.js';
 import { getAppVersion } from '../config/paths.js';
 import { AppError, toAppError } from '../core/errors.js';
 import { loadConfig as loadAppEnvConfig } from '../infra/config/env.js';
@@ -80,7 +80,7 @@ export class Gateway {
     });
 
     this.route('POST', '/exec', true, async (_req, body) => {
-      if ((process.env.MEMPHIS_SAFE_MODE ?? '').toLowerCase() === 'true') {
+      if (MEMPHIS_SAFE_MODE.read(process.env).toLowerCase() === 'true') {
         throw new AppError('PERMISSION_DENIED', 'forbidden in safe mode', 403);
       }
       const { command, cwd, timeout } = parseJsonBody<{

--- a/src/infra/cli/handlers/vault.handler.ts
+++ b/src/infra/cli/handlers/vault.handler.ts
@@ -4,6 +4,7 @@ import { emitKeypressEvents } from 'node:readline';
 import { createInterface } from 'node:readline/promises';
 
 import type { CommandHandler } from './command-handler.js';
+import { MEMPHIS_VAULT_PEPPER } from '../../../config/env-registry.js';
 import { getDataDir } from '../../../config/paths.js';
 import {
   recoverOperatorPassphrase,
@@ -482,7 +483,7 @@ async function handleVaultPepperRotate(context: CliContext): Promise<boolean> {
   process.stdout.write('outer wrapper changes. Lose the new pepper without backup\n');
   process.stdout.write('= vault unrecoverable. Back it up off-host first.\n\n');
 
-  const envOldPepper = (process.env.MEMPHIS_VAULT_PEPPER ?? '').trim();
+  const envOldPepper = MEMPHIS_VAULT_PEPPER.read(process.env).trim();
   let oldPepper = envOldPepper;
   if (!oldPepper) {
     oldPepper = await promptHidden('Current pepper');

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -21,6 +21,7 @@ import YAML from 'yaml';
 
 import { checkDependencies } from './dependencies.js';
 import {
+  MEMPHIS_VAULT_PEPPER,
   MEMPHIS_VOICE_MODE,
   PIPER_SERVER_URL,
   WHISPER_SERVER_URL,
@@ -1069,7 +1070,7 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
   );
   const didPath = resolve(memphisDir, 'did.json');
   const didExists = existsSync(didPath);
-  const pepper = process.env.MEMPHIS_VAULT_PEPPER ?? '';
+  const pepper = MEMPHIS_VAULT_PEPPER.read(process.env);
   const pepperStrong = pepper.length >= 32 && /[a-z]/.test(pepper) && /[0-9]/.test(pepper);
   const queueMode = (process.env.MEMPHIS_QUEUE_MODE ?? 'financial').trim().toLowerCase();
   const queueResumePolicy = (process.env.MEMPHIS_QUEUE_RESUME_POLICY ?? 'keep')

--- a/src/infra/storage/task-queue-wal.ts
+++ b/src/infra/storage/task-queue-wal.ts
@@ -15,6 +15,8 @@ import {
 } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
+import { MEMPHIS_FAULT_INJECT } from '../../config/env-registry.js';
+
 type QueueMode = 'financial' | 'standard';
 
 export interface TaskQueueWalOptions {
@@ -115,7 +117,10 @@ export class TaskQueueWal {
     this.mode = options.mode ?? 'financial';
     this.maxWalBytes = options.maxWalBytes ?? DEFAULT_MAX_WAL_BYTES;
     this.lockTimeoutMs = options.lockTimeoutMs ?? 2000;
-    this.faultInject = options.faultInject ?? process.env.MEMPHIS_FAULT_INJECT;
+    // Accessor default = empty string when unset; preserve undefined-shape
+    // behavior for downstream comparisons by mapping '' → undefined.
+    const envFault = MEMPHIS_FAULT_INJECT.read(process.env);
+    this.faultInject = options.faultInject ?? (envFault.length > 0 ? envFault : undefined);
 
     mkdirSync(dirname(this.walPath), { recursive: true });
     this.ensureActiveWal();

--- a/src/modules/orchestration/service.ts
+++ b/src/modules/orchestration/service.ts
@@ -1,4 +1,5 @@
 import { ProviderPolicy } from './provider-policy.js';
+import { MEMPHIS_SAFE_MODE } from '../../config/env-registry.js';
 import type { LLMProvider } from '../../core/contracts/llm-provider.js';
 import { AppError } from '../../core/errors.js';
 import {
@@ -309,7 +310,7 @@ export class OrchestrationService {
   public async chat(
     input: GenerateInput & { provider?: 'auto' | ProviderName },
   ): Promise<GenerateResult> {
-    if ((process.env.MEMPHIS_SAFE_MODE ?? '').toLowerCase() === 'true') {
+    if (MEMPHIS_SAFE_MODE.read(process.env).toLowerCase() === 'true') {
       throw new AppError(
         'PERMISSION_DENIED',
         'forbidden in safe mode: generation is disabled',
@@ -452,7 +453,7 @@ export class OrchestrationService {
   public async generate(
     input: GenerateInput & { provider?: 'auto' | ProviderName },
   ): Promise<GenerateResult> {
-    if ((process.env.MEMPHIS_SAFE_MODE ?? '').toLowerCase() === 'true') {
+    if (MEMPHIS_SAFE_MODE.read(process.env).toLowerCase() === 'true') {
       throw new AppError(
         'PERMISSION_DENIED',
         'forbidden in safe mode: generation is disabled',

--- a/src/sync/trade.ts
+++ b/src/sync/trade.ts
@@ -1,6 +1,7 @@
 import { createHmac, randomUUID } from 'node:crypto';
 
 import type { Block, DID, TradeOffer } from './types.js';
+import { MEMPHIS_VAULT_PEPPER } from '../config/env-registry.js';
 import { secureCompare } from '../security/constant-time.js';
 
 export interface TradeProtocolOptions {
@@ -19,7 +20,7 @@ export class TradeProtocol {
       options.senderDid ?? (process.env.MEMPHIS_DID as DID | undefined) ?? 'did:memphis:unknown';
     this.signer = async (payload: string) => {
       if (options.signer) return Promise.resolve(options.signer(payload));
-      const key = process.env.MEMPHIS_VAULT_PEPPER;
+      const key = MEMPHIS_VAULT_PEPPER.read(process.env);
       if (!key) throw new Error('MEMPHIS_VAULT_PEPPER must be set for trade signing');
       return createHmac('sha256', key).update(payload).digest('hex');
     };


### PR DESCRIPTION
3 new accessors + 6 read-only migrations. 3 write sites stay raw.

## Test plan
- [x] tsc --noEmit clean
- [x] vitest 3/3 on safe-mode-runtime + cli.vault
- [ ] CI green