### PR TITLE
fix(anti-confab): persistence claims require an actual write tool call

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -146,6 +146,40 @@ from a confident-sounding fabrication. Phrases like "udało się",
 "zrobione", "skonfigurowane", "done", "enabled", "set up" are forbidden
 when the most recent tool batch returned an error.
 
+### Persistence claims require an actual write tool call (anti-confab — operator session 2026-05-05)
+
+You CANNOT claim that data was persisted unless the corresponding
+write tool was actually called in your immediately-preceding tool
+batch. Operator session 2026-05-05 02:00 caught the bot saying
+"Lądunę. Zapisane." after a profile update conversation — without
+calling \`memphis_soul_write\` even once. Soul memory on disk
+remained empty. The bot's claim was pure confabulation.
+
+Forbidden phrases when no write tool ran in this turn:
+- Polish: "zapisane", "zapisałem", "lądunę", "zapamiętane",
+  "zaktualizowane", "wpisane", "scommit'owane"
+- English: "saved", "persisted", "stored", "committed", "recorded",
+  "written", "updated"
+
+If the user describes data they want saved (preferences, identity
+facts, soul updates, journal entries, decisions), you MUST:
+  1. Call the matching write tool (\`memphis_soul_write\`,
+     \`memphis_journal\`, \`memphis_decide\`, \`memphis_case_append\`,
+     etc.) IN THIS TURN with the actual data.
+  2. Wait for its result.
+  3. Quote the result honestly — \`success: true\` → "saved";
+     \`success: false\` → "tried to save but failed: {error}".
+  4. Only then claim persistence.
+
+If you cannot call the write tool (tier blocked, tool absent, malformed
+input), say so directly: "I cannot persist this — \`memphis_soul_write\`
+is not available at the current tier" or similar. Don't pretend.
+
+The runtime audit chain records EVERY tool invocation. The operator
+can grep \`~/.memphis/chains/cases/*.json\` for the corresponding
+\`accusative\` / \`genitive\` block to verify your claim. If your turn
+emitted no such block, the operator will know you confabulated.
+
 If the runtime injects a "Tool execution surfaced errors" system message
 after a tool batch, that message is authoritative — quote the failure
 to the user verbatim, then offer next steps if any apply.

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -92,6 +92,28 @@ describe('gateway system prompt', () => {
     expect(prompt).toContain('Do not produce specific numbers');
   });
 
+  it('forbids persistence claims without an actual write tool call (anti-confab 2026-05-05)', () => {
+    // Operator session 02:00 caught bot saying "Lądunę. Zapisane." after a
+    // profile update conversation — without ever calling memphis_soul_write.
+    // Soul memory on disk remained empty (~/.memphis/config/soul-memory.json
+    // unchanged). The new guard pins forbidden phrases (Polish + English)
+    // and requires the matching write tool be called in the same turn.
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_soul_write', 'memphis_journal', 'memphis_decide'],
+    });
+
+    expect(prompt).toContain('Persistence claims require an actual write tool call');
+    expect(prompt).toContain('zapisane');
+    expect(prompt).toContain('"saved"');
+    expect(prompt).toContain('Lądunę');
+    // Specific tool names referenced as the actual write surfaces
+    expect(prompt).toContain('memphis_soul_write');
+    expect(prompt).toContain('memphis_journal');
+    expect(prompt).toContain('memphis_decide');
+    // Audit-chain reference so operator knows there's a verifiable trail
+    expect(prompt).toContain('~/.memphis/chains/cases/');
+  });
+
   it('adds instructions for preview tools when they are available', () => {
     const prompt = buildSystemPrompt({
       availableTools: ['memphis_chain_query', 'memphis_providers', 'memphis_system_info'],


### PR DESCRIPTION
Operator session 2026-05-05 02:00 caught bot saying "Lądunę. Zapisane." without ever calling memphis_soul_write. Soul memory on disk stayed empty.

Existing #463 guard covered 'tool returned error → don't claim success'. This adds the more insidious case: 'no tool called at all → still claim success'.

Forbidden phrases (PL + EN) + 4-step required protocol + audit-chain reference for operator verification.

Prompt-side fix. Structural runtime-side check (post-turn audit) would be cheaper to enforce; out of scope here.

## Test plan
- [x] vitest 29/29 (1 new)
- [ ] CI green
- [ ] Operator smoke: bot now refuses to claim 'zapisane' without actually calling soul_write