### PR TITLE
fix(soul): snapshot ring + canary log on operator-curated field regression

### DIFF
--- a/src/soul/memory.ts
+++ b/src/soul/memory.ts
@@ -76,8 +76,112 @@ export function loadSoulMemory(rawEnv: NodeJS.ProcessEnv = process.env): SoulMem
   }
 }
 
+/**
+ * Snapshot ring count — keep N most recent prior versions of soul-
+ * memory.json so the operator can recover from any silent
+ * regression. ~5 KB per snapshot × 8 = 40 KB total budget on disk,
+ * negligible for the protection it buys. Rotation happens BEFORE
+ * each write, oldest gets overwritten.
+ */
+const SOUL_SNAPSHOT_RING_SIZE = 8;
+
+/**
+ * Operator-edited fields that should NEVER silently transition from
+ * non-empty → empty during a write. If a write would clear any of
+ * these, we log a canary warning so the operator sees the regression
+ * in `journalctl --user -u memphis`. The write still proceeds —
+ * this is detection, not enforcement (avoids deadlocking legitimate
+ * operator-driven clears like `memphis soul reset`).
+ *
+ * Operator session 2026-05-05 03:00 caught the data-loss vector: at
+ * 23:35 yesterday `self.personality` was edited via soul_write to
+ * "Partner Wodzu — codzienny asystent..." (forensycznie
+ * zweryfikowane). At 02:57 today the file showed original "Twór
+ * Wodzu — Memphis, sovereign AI runtime..." — restored without
+ * audit. The canary surfaces the next such overwrite immediately so
+ * we can find the writer (boot-time seed? reset path? other tool?).
+ */
+function detectOperatorFieldRegressions(prev: SoulMemory | null, next: SoulMemory): string[] {
+  if (!prev) return [];
+  const regressions: string[] = [];
+
+  const wasNonEmptyArray = (a: unknown): a is string[] => Array.isArray(a) && a.length > 0;
+  const wasNonEmptyString = (s: unknown): s is string => typeof s === 'string' && s.length > 0;
+
+  // user.* — operator-curated, NEVER auto-resets
+  for (const key of ['languages', 'preferences', 'expertise', 'integrations'] as const) {
+    if (wasNonEmptyArray(prev.user[key]) && (next.user[key] ?? []).length === 0) {
+      regressions.push(`user.${key} cleared (was ${prev.user[key].length} entries)`);
+    }
+  }
+  if (wasNonEmptyString(prev.user.name) && !wasNonEmptyString(next.user.name)) {
+    regressions.push('user.name cleared');
+  }
+
+  // self.personality + strengths/learnings/evolvedCapabilities — operator
+  // narrative, never auto-resets (reflection-loop appends to learnings,
+  // shouldn't clear)
+  if (wasNonEmptyString(prev.self.personality) && !wasNonEmptyString(next.self.personality)) {
+    regressions.push('self.personality cleared');
+  }
+  for (const key of ['strengths', 'learnings', 'evolvedCapabilities'] as const) {
+    if (wasNonEmptyArray(prev.self[key]) && (next.self[key] ?? []).length === 0) {
+      regressions.push(`self.${key} cleared (was ${prev.self[key].length} entries)`);
+    }
+  }
+
+  return regressions;
+}
+
+function rotateSnapshots(memoryPath: string): void {
+  // Pre-write snapshot ring: soul-memory.json.bak-1 (newest) →
+  // .bak-N (oldest). Rotate in reverse so we don't overwrite a
+  // file we still need to read.
+  if (!existsSync(memoryPath)) return;
+  for (let i = SOUL_SNAPSHOT_RING_SIZE - 1; i >= 1; i--) {
+    const src = `${memoryPath}.bak-${i}`;
+    const dst = `${memoryPath}.bak-${i + 1}`;
+    if (existsSync(src)) {
+      try {
+        renameSync(src, dst);
+      } catch {
+        // best-effort — ring rotation failure shouldn't block writes
+      }
+    }
+  }
+  // Current → .bak-1
+  try {
+    const content = readFileSync(memoryPath, 'utf8');
+    writeFileSync(`${memoryPath}.bak-1`, content, { mode: 0o600 });
+  } catch {
+    // best-effort
+  }
+}
+
 export function writeSoulMemory(memory: SoulMemory, rawEnv: NodeJS.ProcessEnv = process.env): void {
   const memoryPath = getSoulMemoryPath(rawEnv);
+
+  // Snapshot the prior state into a rotating ring of 8 backups
+  // BEFORE the new write. Operator can `cp soul-memory.json.bak-1
+  // soul-memory.json` to restore the immediately-prior state, or
+  // walk the ring back further. Lightweight (~5 KB × 8 = 40 KB).
+  rotateSnapshots(memoryPath);
+
+  // Canary: if this write would clear any operator-curated field
+  // that was previously non-empty, log a warning. Detection-only —
+  // the write proceeds (legitimate clears like `soul reset` exist).
+  // Operator sees the warning in `journalctl --user -u memphis` and
+  // can investigate the writer via stack trace if needed.
+  const prior = loadSoulMemory(rawEnv);
+  const regressions = detectOperatorFieldRegressions(prior, memory);
+  if (regressions.length > 0) {
+    process.stderr.write(
+      `[soul-memory canary] write would clear operator-curated field(s): ${regressions.join('; ')}. ` +
+        `Snapshot saved to ${memoryPath}.bak-1 — restore with \`cp ${memoryPath}.bak-1 ${memoryPath}\`. ` +
+        `Stack: ${new Error().stack?.split('\n').slice(2, 6).join(' → ') ?? 'n/a'}\n`,
+    );
+  }
+
   // 0600 mode + parent dir 0700 + atomic rename — see secure-file.ts.
   // soul-memory carries operator's identity narrative + memory entries;
   // group/world readability is a privacy leak, not just a hardening

--- a/tests/unit/soul-memory.test.ts
+++ b/tests/unit/soul-memory.test.ts
@@ -2,11 +2,11 @@
  * Unit tests for soul memory read, write, deep merge, and empty detection.
  */
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   emptySoulMemory,
@@ -194,6 +194,119 @@ describe('soul memory', () => {
       const second = updateSoulMemory({ user: { name: 'B' } });
       const secondTs = new Date(second.lastUpdated).getTime();
       expect(secondTs).toBeGreaterThanOrEqual(firstTs);
+    });
+  });
+
+  describe('writeSoulMemory snapshot ring (operator session 2026-05-05 03:00 data-loss vector)', () => {
+    it('creates a .bak-1 snapshot of prior state before each write', () => {
+      const memoryPath = join(dataDir, 'config', 'soul-memory.json');
+      const v1 = emptySoulMemory();
+      v1.user.name = 'Wodzu';
+      v1.user.expertise = ['Rust', 'TypeScript'];
+      writeSoulMemory(v1);
+
+      // Second write triggers snapshot of v1 → .bak-1
+      const v2 = emptySoulMemory();
+      v2.user.name = 'Wodzu';
+      v2.user.expertise = ['Rust', 'TypeScript', 'Lisp'];
+      writeSoulMemory(v2);
+
+      expect(existsSync(`${memoryPath}.bak-1`)).toBe(true);
+      const bak = JSON.parse(readFileSync(`${memoryPath}.bak-1`, 'utf8'));
+      expect(bak.user.expertise).toEqual(['Rust', 'TypeScript']);
+      // The current file has v2
+      const cur = JSON.parse(readFileSync(memoryPath, 'utf8'));
+      expect(cur.user.expertise).toEqual(['Rust', 'TypeScript', 'Lisp']);
+    });
+
+    it('rotates the ring across multiple writes (newest=.bak-1, oldest=.bak-N)', () => {
+      const memoryPath = join(dataDir, 'config', 'soul-memory.json');
+      // Write v1, v2, v3 in sequence — after the third write, .bak-1
+      // = v2, .bak-2 = v1.
+      for (const expertise of [['v1'], ['v2'], ['v3']]) {
+        const m = emptySoulMemory();
+        m.user.expertise = expertise;
+        writeSoulMemory(m);
+      }
+      const bak1 = JSON.parse(readFileSync(`${memoryPath}.bak-1`, 'utf8'));
+      const bak2 = JSON.parse(readFileSync(`${memoryPath}.bak-2`, 'utf8'));
+      expect(bak1.user.expertise).toEqual(['v2']);
+      expect(bak2.user.expertise).toEqual(['v1']);
+    });
+
+    it('canary logs to stderr when operator-curated array transitions non-empty → empty', () => {
+      const populated = emptySoulMemory();
+      populated.user.expertise = ['Rust', 'TypeScript'];
+      populated.user.integrations = ['ollama'];
+      writeSoulMemory(populated);
+
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      const cleared = emptySoulMemory();
+      cleared.user.name = populated.user.name; // preserve name
+      writeSoulMemory(cleared);
+
+      const messages = stderrSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(messages).toContain('[soul-memory canary]');
+      expect(messages).toContain('user.expertise cleared');
+      expect(messages).toContain('user.integrations cleared');
+      stderrSpy.mockRestore();
+    });
+
+    it('canary logs when self.personality regresses non-empty → empty', () => {
+      const populated = emptySoulMemory();
+      populated.self.personality = 'Partner Wodzu — codzienny asystent';
+      writeSoulMemory(populated);
+
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      const cleared = emptySoulMemory();
+      // personality reverted to undefined
+      writeSoulMemory(cleared);
+
+      const messages = stderrSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(messages).toContain('self.personality cleared');
+      stderrSpy.mockRestore();
+    });
+
+    it('canary stays silent on normal append (no regression)', () => {
+      const v1 = emptySoulMemory();
+      v1.user.expertise = ['Rust'];
+      writeSoulMemory(v1);
+
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      const v2 = emptySoulMemory();
+      v2.user.expertise = ['Rust', 'TypeScript']; // grew, didn't shrink
+      writeSoulMemory(v2);
+
+      const messages = stderrSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(messages).not.toContain('[soul-memory canary]');
+      stderrSpy.mockRestore();
+    });
+
+    it('canary message includes restore command for the operator', () => {
+      const populated = emptySoulMemory();
+      populated.user.expertise = ['important', 'data'];
+      writeSoulMemory(populated);
+
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      writeSoulMemory(emptySoulMemory());
+
+      const messages = stderrSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(messages).toContain('Snapshot saved to');
+      expect(messages).toMatch(/restore with `cp .*\.bak-1 .*soul-memory\.json`/);
+      stderrSpy.mockRestore();
+    });
+
+    it('first-ever write (no prior file) produces no snapshot and no canary', () => {
+      const memoryPath = join(dataDir, 'config', 'soul-memory.json');
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      const m = emptySoulMemory();
+      m.user.expertise = ['fresh'];
+      writeSoulMemory(m);
+
+      expect(existsSync(`${memoryPath}.bak-1`)).toBe(false);
+      const messages = stderrSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(messages).not.toContain('[soul-memory canary]');
+      stderrSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
Operator session 03:00 caught data-loss vector: self.personality edit yesterday at 23:35 was silently restored to original by 02:57. Plus user.expertise / user.integrations went from populated (block #27, 2026-04-25 seed) to empty without audit.

Two-pronged protection without needing to find the root-cause writer first:

1. **Snapshot ring** (.bak-1 newest → .bak-8 oldest) before every writeSoulMemory. ~40 KB total.
2. **Canary log** to stderr on any non-empty → empty transition of operator-curated fields. Detection-only (write proceeds), includes stack trace + restore command.

Future-proofs structural fix (append-only soul chain) — lands the safety net first.

## Test plan
- [x] 26/26 (19 existing + 7 new)
- [x] typecheck + eslint clean
- [ ] CI quality-gate green
- [ ] Operator smoke: next time bot edits personality, .bak-1 captures pre-edit state; if anything reverts, canary fires in journalctl with stack trace pointing at the writer