### PR TITLE
fix(voice): STT 30s→90s timeout + scrub operator-narrative from system-prompt

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -146,20 +146,21 @@ from a confident-sounding fabrication. Phrases like "udało się",
 "zrobione", "skonfigurowane", "done", "enabled", "set up" are forbidden
 when the most recent tool batch returned an error.
 
-### Persistence claims require an actual write tool call (anti-confab — operator session 2026-05-05)
+### Persistence claims require an actual write tool call (anti-confab)
 
 You CANNOT claim that data was persisted unless the corresponding
 write tool was actually called in your immediately-preceding tool
-batch. Operator session 2026-05-05 02:00 caught the bot saying
-"Lądunę. Zapisane." after a profile update conversation — without
-calling \`memphis_soul_write\` even once. Soul memory on disk
-remained empty. The bot's claim was pure confabulation.
+batch. A common confabulation pattern: a chat-side conversation
+about updating profile / preferences / identity ends with "Saved."
+or "Done." while no write tool ran — and operator-curated state on
+disk remained unchanged. That's a lie regardless of intent.
 
 Forbidden phrases when no write tool ran in this turn:
-- Polish: "zapisane", "zapisałem", "lądunę", "zapamiętane",
-  "zaktualizowane", "wpisane", "scommit'owane"
+- Polish: "zapisane", "zapisałem", "ładuję", "zapamiętane",
+  "zaktualizowane", "wpisane", "scommit'owane", "zachowane",
+  "wczytane"
 - English: "saved", "persisted", "stored", "committed", "recorded",
-  "written", "updated"
+  "written", "updated", "retained", "loaded"
 
 If the user describes data they want saved (preferences, identity
 facts, soul updates, journal entries, decisions), you MUST:
@@ -193,7 +194,7 @@ your tools, tiers, or feature flags from memory or training data. The
 returned JSON is the source of truth for the current surface, effective
 tier, cognitive mode, and active feature flags.
 
-### Self-identity honesty (anti-confab — operator session 2026-05-04)
+### Self-identity honesty (anti-confab)
 
 You DO NOT KNOW which provider or model is generating your output —
 that decision lives in the runtime cascade and is not exposed to your
@@ -229,7 +230,7 @@ tier, say so explicitly — "I don't have memphis_health at this tier;
 ask after /tier elevate or check the TUI status bar" — instead of
 fabricating values.
 
-### Memory questions — chains are the source of truth (sprint 2026-05-05)
+### Memory questions — chains are the source of truth
 
 When the user asks about their own past — "co decydowałem o X",
 "kiedy zapisałem Y", "co mówiłem o Z", "jakie miałem wcześniej
@@ -242,7 +243,7 @@ plus \`[inferred_decisions]\` (Model B) and \`[predictions]\`
 chain memory, scoped to the current question.
 
 If \`[chain_hits]\` exists and seems relevant: quote the hit and
-cite the chain + index ("decisions#82 z 2026-05-05 says…"). Don't
+cite the chain + index ("journal#<N> from <date> says: …"). Don't
 paraphrase from memory.
 
 If \`[chain_hits]\` is empty OR doesn't cover what the user asks,
@@ -1190,7 +1191,7 @@ RECALL before answering. Check if you already know something before generating f
 DECIDE explicitly. When a choice is made, record it — future you needs the audit trail.
 JOURNAL selectively. Not every reply needs a journal entry. Save what matters across sessions.
 Be direct, concise, honest. If you don't know, say so — don't make things up.
-You can speak Polish naturally — Marcin is Polish.
+Match the operator's language naturally (the agent is fluent in Polish + English by default; speak whichever the operator addresses you in).
 When asked about yourself: you know your architecture, your tools, your chains. Answer truthfully.
 
 When using tools:

--- a/src/gateway/voice/local-whisper-adapter.ts
+++ b/src/gateway/voice/local-whisper-adapter.ts
@@ -80,7 +80,13 @@ export async function speechToTextLocal(audioBuffer: Buffer): Promise<SttResult>
       method: 'POST',
       headers: { 'Content-Type': 'audio/wav' },
       body: new Uint8Array(wavBuffer),
-      signal: AbortSignal.timeout(30000), // 30s timeout
+      // 90s timeout — `medium` whisper model on CPU fallback or longer
+      // recordings (>30s of audio) routinely takes >30s to transcribe;
+      // operator session 2026-05-05 hit "operation aborted due to
+      // timeout" with the 30s budget. CUDA-backed runs finish in
+      // 1-3s for normal voice notes, so 90s is generous-but-bounded
+      // — we still abort genuinely-stuck requests.
+      signal: AbortSignal.timeout(90000),
     });
 
     if (!response.ok) {

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -135,15 +135,28 @@ describe('gateway system prompt', () => {
     });
 
     expect(prompt).toContain('Persistence claims require an actual write tool call');
+    // Forbidden phrases (PL + EN) — words bot shouldn't say without
+    // a write-tool call in same turn. Generic placeholder values, no
+    // operator-specific narrative shipped.
     expect(prompt).toContain('zapisane');
+    expect(prompt).toContain('zapisałem');
+    expect(prompt).toContain('ładuję');
     expect(prompt).toContain('"saved"');
-    expect(prompt).toContain('Lądunę');
+    expect(prompt).toContain('"persisted"');
+    expect(prompt).toContain('"loaded"');
     // Specific tool names referenced as the actual write surfaces
     expect(prompt).toContain('memphis_soul_write');
     expect(prompt).toContain('memphis_journal');
     expect(prompt).toContain('memphis_decide');
     // Audit-chain reference so operator knows there's a verifiable trail
     expect(prompt).toContain('~/.memphis/chains/cases/');
+    // Negative: no operator-specific narrative leaks (multi-tenant
+    // safe — every install ships the same prompt regardless of which
+    // operator hit a confabulation incident first)
+    expect(prompt).not.toContain('Wodzu');
+    expect(prompt).not.toContain('Marcin');
+    expect(prompt).not.toContain('Lądunę');
+    expect(prompt).not.toMatch(/operator session 2026-05-/);
   });
 
   it('adds instructions for preview tools when they are available', () => {


### PR DESCRIPTION
Two related fixes for operator presentation prep:

1. **STT timeout 30s → 90s**: operator hit 'aborted due to timeout' on normal voice note; whisper-server log shows BrokenPipeError as Memphis adapter aborted mid-transcribe. CUDA-fast paths still 1-3s, but CPU/long-audio paths legitimately need >30s.

2. **Scrub operator-specific narrative from system-prompt** (multi-tenant safety): removed Wodzu/Marcin/Lądunę references + dated 'operator session 2026-05-...' headers + decisions#82 example. Forbidden-phrases list expanded with ładuję / zachowane / wczytane / retained / loaded for full PL+EN coverage.

## Test plan
- [x] 30/30 vitest (negative checks for operator-narrative leaks)
- [x] typecheck + eslint clean
- [ ] CI green
- [ ] Operator smoke: voice >30s, bot prompt no leaks