### PR TITLE
feat(anti-confab): search-claim guard — read tool required before claiming search

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -240,6 +240,45 @@ If the runtime injects a "Tool execution surfaced errors" system message
 after a tool batch, that message is authoritative — quote the failure
 to the user verbatim, then offer next steps if any apply.
 
+### Search/lookup claims require an actual read tool call (anti-confab)
+
+You CANNOT claim that you "searched", "checked", "scanned", "looked
+through", or "didn't find" repo / docs / chains / config UNLESS the
+corresponding read tool was actually called in your immediately-
+preceding tool batch. A confabulation pattern observed in the wild:
+operator asked "how is STT coded in Memphis", bot replied
+"Przeszukałem cały src/, nie ma żadnego modułu whisper/stt/tts" —
+without calling any tool. The files DO exist
+(\`src/gateway/voice/local-whisper-adapter.ts\` is one of them).
+Bot fabricated a "no results" answer.
+
+Forbidden phrases when no read/search tool ran in this turn:
+- Polish: "przeszukałem", "szukałem", "grepowałem", "sprawdziłem
+  kod", "nie znalazłem w kodzie", "nie ma w src/", "patrzyłem w",
+  "przeszedłem przez kod"
+- English: "I searched", "I scanned", "I grepped", "I checked the
+  source", "couldn't find in src/", "not in src/", "looked through
+  the code"
+
+When the user asks where/how something is coded — "gdzie jest
+X w kodzie", "jak Y działa wewnętrznie", "pokaż mi implementację
+Z", "czy mamy moduł {whisper|piper|...}" — you MUST first call:
+  - \`memphis_exec\` with \`grep -r <pattern> src/\`,
+    \`ls src/<dir>/\`, or \`find src/ -name "<pattern>"\` for a
+    concrete repo lookup.
+  - or \`memphis_recall\` if the question is really about prior
+    decisions / context (memory question, not file question).
+
+Only after the tool returns may you state findings. If the tool
+returned 0 results, say "grep returned 0 hits for \`<pattern>\`
+in \`src/\`" — never just "nothing exists" because that overstates
+what the tool actually proved.
+
+If \`memphis_exec\` is not available at the current tier (tier 2
+default), say so directly: "I cannot grep \`src/\` from the current
+tier; ask after \`/tier elevate\` or describe what you're looking
+for so I can recommend a chain query." Don't pretend you searched.
+
 ### Capability questions (sprint 1.3)
 
 When the user asks "what can you do" / "co potrafisz" / "jakie konfigi/

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -183,6 +183,36 @@ describe('gateway system prompt', () => {
     expect(prompt).not.toMatch(/operator session 2026-05-/);
   });
 
+  it('forbids search/lookup claims without an actual read tool call (anti-confab 2026-05-05)', () => {
+    // Operator session 12:00 caught bot in mode A saying "Przeszukałem cały
+    // src/, nie ma żadnego modułu whisper/stt/tts/speech/audio" — without
+    // calling any exec/grep tool. The files DO exist
+    // (src/gateway/voice/local-whisper-adapter.ts is one of them). Bot
+    // fabricated a "no results" answer. This guard mirrors the
+    // persistence-claim pattern: forbidden phrases when no read tool ran.
+    const prompt = buildSystemPrompt({
+      availableTools: ['memphis_exec', 'memphis_recall', 'memphis_search'],
+    });
+
+    expect(prompt).toContain('Search/lookup claims require an actual read tool call');
+    // Forbidden phrases (PL + EN) — words bot shouldn't say without
+    // an exec/grep/recall tool call in the same turn.
+    expect(prompt).toContain('"przeszukałem"');
+    expect(prompt).toContain('"szukałem"');
+    expect(prompt).toContain('"grepowałem"');
+    expect(prompt).toContain('"I searched"');
+    expect(prompt).toContain('"I grepped"');
+    // Concrete tool hint so bot learns the right tool for code questions
+    expect(prompt).toContain('grep -r <pattern> src/');
+    expect(prompt).toContain('memphis_exec');
+    expect(prompt).toContain('memphis_recall');
+    // Tier-2 fallback message — bot must say so honestly when exec blocked
+    expect(prompt).toContain('I cannot grep `src/` from the current\ntier');
+    // Negative: no operator-specific narrative leaks (multi-tenant safe)
+    expect(prompt).not.toContain('Wodzu');
+    expect(prompt).not.toContain('Marcin');
+  });
+
   it('adds instructions for preview tools when they are available', () => {
     const prompt = buildSystemPrompt({
       availableTools: ['memphis_chain_query', 'memphis_providers', 'memphis_system_info'],


### PR DESCRIPTION
## Summary

Mirrors the #473 persistence-claim pattern but for **search/lookup claims**. Closes the anti-confab gap surfaced in operator session 2026-05-05 12:00 — bot in mode A said *"Przeszukałem cały src/, nie ma żadnego modułu whisper/stt/tts"* without calling any exec/grep tool. The files exist (`src/gateway/voice/local-whisper-adapter.ts` is one of them), bot fabricated a "no results" answer.

New `TOOL_DISCIPLINE_PREAMBLE` section pins:
- Forbidden phrases (PL: *przeszukałem, szukałem, grepowałem, sprawdziłem kod, nie znalazłem w kodzie, nie ma w src/*; EN: *I searched, I scanned, I grepped, couldn't find in src/, looked through the code*)
- Concrete tool hints (`grep -r <pattern> src/`, `ls src/<dir>/`, `find src/ -name "<pattern>"`)
- Tier-2 fallback wording when `memphis_exec` is blocked
- Distinction between **file questions** (`memphis_exec`) and **memory questions** (`memphis_recall`)

## Decision

Prompt-only change, **no runtime guard** in this PR. Reasoning:
- Prompt-only = immediate behavioral lift, low blast radius
- Runtime guard in `guardModelOutput` carries false-positive risk (bot can legitimately quote `przeszukałem` from a chain hit / journal block)
- If post-deploy bot still confabulates, follow up with #478b (runtime scan) — kept as escape hatch

## Test plan

- [x] New unit test in `tests/unit/gateway.system-prompt.test.ts` — section present, forbidden phrases listed, tool hints concrete, no operator-specific narrative leaks (multi-tenant safe)
- [x] Full system-prompt suite: 31/31 pass
- [x] `tsc --noEmit` clean
- [ ] Behavioral check post-merge: ask bot in mode A *"gdzie jest STT zakodowany?"* → must call `memphis_exec` for grep, OR honestly say "I can't grep at tier 2"

🤖 Generated with [Claude Code](https://claude.com/claude-code)