### PR TITLE
feat(anti-confab): runtime audit — log forbidden claims with tool-call cross-reference

### DIFF
--- a/src/gateway/anti-confab-audit.ts
+++ b/src/gateway/anti-confab-audit.ts
@@ -74,6 +74,19 @@ const FORBIDDEN_PHRASES: Record<ConfabClaimCategory, readonly string[]> = {
     'zaktualizowane',
     'wpisane',
     'zachowane',
+    // Polish — file-creation phrases (operator session 2026-05-05
+    // 16:06 + 16:19: bot announced "Tworzę teraz plik HTML" twice
+    // before any memphis_fs_write fired — XML emit-as-text bug from
+    // #491 was the root cause, but the detector also missed the
+    // claim itself. Add the present-tense and past-tense variants
+    // so the runtime catches future file-creation confabs even when
+    // the toolcall parser layer fails again.)
+    'tworzę plik',
+    'tworzę teraz plik',
+    'utworzyłem plik',
+    'stworzyłem plik',
+    'piszę plik',
+    'zapisuję plik',
     // English
     'i saved',
     'i persisted',
@@ -82,6 +95,13 @@ const FORBIDDEN_PHRASES: Record<ConfabClaimCategory, readonly string[]> = {
     'i recorded',
     'i wrote it',
     'i updated',
+    // English — file creation
+    'creating file',
+    'creating the file',
+    "i'm creating a file",
+    "i've created a file",
+    "i've written the file",
+    'wrote the file',
   ],
   search: [
     // Polish
@@ -131,6 +151,11 @@ const WHITELISTED_TOOLS: Record<ConfabClaimCategory, readonly string[]> = {
     'memphis_self_modify',
     'memphis_capture',
     'memphis_provider_set',
+    // File-creation tools — when the bot says "Tworzę plik" AFTER
+    // calling these, that's truthful, not confab. (The persistence
+    // category covers ANY claim of writing/saving — files included.)
+    'memphis_fs_write',
+    'memphis_skills_install',
   ],
   search: [
     'memphis_recall',

--- a/src/gateway/anti-confab-audit.ts
+++ b/src/gateway/anti-confab-audit.ts
@@ -139,6 +139,13 @@ const WHITELISTED_TOOLS: Record<ConfabClaimCategory, readonly string[]> = {
     'memphis_case_query',
     'memphis_exec',
     'memphis_web_fetch',
+    // Web-search tools (#486 added memphis_brave_search; memphis_web_search
+    // is the no-key DuckDuckGo fallback). When the bot calls either and
+    // says "I searched the web for X", that's NOT confabulation — it
+    // actually did. Without these on the whitelist, a real call would
+    // false-positive as a search-claim violation.
+    'memphis_web_search',
+    'memphis_brave_search',
   ],
   capability: ['memphis_self_describe', 'memphis_providers', 'memphis_health'],
 };

--- a/src/gateway/anti-confab-audit.ts
+++ b/src/gateway/anti-confab-audit.ts
@@ -1,0 +1,284 @@
+/**
+ * Runtime audit for confabulation claims (Sprint Continue 2 phase 1).
+ *
+ * The system prompt forbids three categories of claims when no
+ * matching tool ran in the turn:
+ *
+ *   - persistence-claim (#473) — "saved", "zapisane", etc.
+ *   - search-claim (#478)      — "I searched", "przeszukałem", etc.
+ *   - capability-claim (#465)  — concrete tool/tier/flag enumerations
+ *                                without `memphis_self_describe` call
+ *
+ * Until now those rules lived only in the prompt text. Models honor
+ * them mostly, but the 2026-05-05 incidents (Lądunę confab, "Przeszukałem
+ * cały src/" confab) prove the prompt alone is insufficient — small
+ * models in concise modes (mode A) skip the discipline.
+ *
+ * This module adds the runtime side: after every turn, scan the reply
+ * for category-specific forbidden phrases and cross-reference the
+ * tool-call audit. If a forbidden phrase appears WITHOUT the matching
+ * write/read/introspect tool firing in the same turn, that's a
+ * confabulation violation — emit a runtime security event so the
+ * operator (and future training loops) can see the pattern.
+ *
+ * Phase 1 = log only. The reply is not modified or rejected. We need
+ * production telemetry across diverse turn shapes before we trust
+ * the detector to fail-closed. Phase 2 (future PR) will append a
+ * runtime warning to the reply or reject outright.
+ *
+ * ## False-positive handling
+ *
+ * A reply may legitimately contain a forbidden phrase if it's quoting
+ * a chain hit ("the journal#5 entry says: 'I searched for X'") or
+ * paraphrasing the user. The detector ignores phrases that appear
+ * inside common quotation patterns (`"…"`, `«…»`, ` — `, `: …`)
+ * to keep the false-positive rate low.
+ */
+
+import type { ChatMessage } from '../providers/index.js';
+
+export type ConfabClaimCategory = 'persistence' | 'search' | 'capability';
+
+export interface ConfabClaimViolation {
+  category: ConfabClaimCategory;
+  phrase: string;
+  /** Up to 80 chars of surrounding text for the audit log */
+  excerpt: string;
+}
+
+export interface ConfabAuditResult {
+  violations: ConfabClaimViolation[];
+}
+
+/**
+ * Forbidden phrases per category. Mirrors the system-prompt sections
+ * but kept in code so the runtime detector and the prompt stay in
+ * sync. If you update the prompt, update this list too.
+ *
+ * Phrases are matched case-insensitively as whole-word/phrase fragments.
+ * Polish diacritics are kept verbatim (matched on the same code points
+ * the model emits).
+ */
+const FORBIDDEN_PHRASES: Record<ConfabClaimCategory, readonly string[]> = {
+  persistence: [
+    // Polish — past-tense or present "I am saving" claims
+    'zapisałem',
+    'zapisaliśmy',
+    'zaktualizowałem',
+    'wpisałem',
+    'zachowałem',
+    // Polish — passive participles operators read as "done"
+    'zapisane',
+    'zapisana',
+    'zapamiętane',
+    'zaktualizowane',
+    'wpisane',
+    'zachowane',
+    // English
+    'i saved',
+    'i persisted',
+    'i stored',
+    'i committed',
+    'i recorded',
+    'i wrote it',
+    'i updated',
+  ],
+  search: [
+    // Polish
+    'przeszukałem',
+    'przeszukałam',
+    'szukałem',
+    'szukałam',
+    'grepowałem',
+    'sprawdziłem kod',
+    'sprawdziłam kod',
+    'patrzyłem w kodzie',
+    'nie znalazłem w kodzie',
+    'nie ma w src/',
+    'przeszedłem przez kod',
+    // English
+    'i searched',
+    'i scanned',
+    'i grepped',
+    'i checked the source',
+    'i looked through',
+    "couldn't find in src/",
+    'not in src/',
+  ],
+  capability: [
+    // Concrete enumerations bot should source from memphis_self_describe.
+    // We match patterns like "I have N tools" / "tier 2 grants X / Y / Z" — these
+    // are common confab shapes. Generic capability talk ("I can help you with…")
+    // is allowed.
+    'i have access to',
+    'my available tools are',
+    'my tier grants',
+  ],
+};
+
+/**
+ * Whitelisted tools per category. If ANY of these tools fired in the
+ * turn, the corresponding category's forbidden phrases are allowed
+ * (the bot earned the right to make the claim by actually doing the
+ * work).
+ */
+const WHITELISTED_TOOLS: Record<ConfabClaimCategory, readonly string[]> = {
+  persistence: [
+    'memphis_soul_write',
+    'memphis_journal',
+    'memphis_decide',
+    'memphis_case_append',
+    'memphis_self_modify',
+    'memphis_capture',
+    'memphis_provider_set',
+  ],
+  search: [
+    'memphis_recall',
+    'memphis_search',
+    'memphis_chain_query',
+    'memphis_case_query',
+    'memphis_exec',
+    'memphis_web_fetch',
+  ],
+  capability: ['memphis_self_describe', 'memphis_providers', 'memphis_health'],
+};
+
+/**
+ * Extract the set of tool names that were invoked by the assistant
+ * in this turn. Mirrors `extractFrameToolCalls` in turn-runtime.ts
+ * (kept duplicated rather than imported to avoid a circular shape).
+ */
+export function extractToolsCalled(messages: ChatMessage[]): Set<string> {
+  const names = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== 'assistant') continue;
+    const toolCalls = (msg as ChatMessage & { tool_calls?: { name?: string }[] }).tool_calls;
+    if (!Array.isArray(toolCalls)) continue;
+    for (const call of toolCalls) {
+      if (call?.name) names.add(call.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Heuristic for "this phrase looks like it's being quoted from
+ * elsewhere, not asserted by the bot itself". A claim wrapped in
+ * quotes, dashes, or appearing on its own block-line after a colon
+ * is treated as quotation and excused.
+ *
+ * The regex windows are crude on purpose — we'd rather miss a real
+ * violation than emit a false positive that erodes operator trust
+ * in the audit signal.
+ */
+function looksQuoted(haystack: string, phraseStart: number, phraseEnd: number): boolean {
+  // Slightly larger window to catch closing quotes that come after a few
+  // words of quoted material ("…says: \"I saved the password\" …")
+  const windowStart = Math.max(0, phraseStart - 64);
+  const windowEnd = Math.min(haystack.length, phraseEnd + 64);
+  const before = haystack.slice(windowStart, phraseStart);
+  const after = haystack.slice(phraseEnd, windowEnd);
+
+  // After a [chain_hits] marker the whole block is quoted-from-disk —
+  // treat anything matching as quotation regardless of inner shape.
+  if (/\[chain_hits\][\s\S]{0,400}$/u.test(haystack.slice(0, phraseStart))) return true;
+
+  // Right after a journal/case/decision entry header — citation, not bot's claim
+  if (/(?:journal|decisions?|cases?|reflections?)#\d+[\s\S]{0,80}$/u.test(before)) return true;
+
+  // Wrapping ASCII / fancy quotes around a short phrase. We look for an
+  // OPENING quote in the 64 chars before the phrase + a CLOSING quote in
+  // the 64 chars after. The window is short enough that bare quotes
+  // appearing far apart don't accidentally couple.
+  const openingQuote = /["'`«»“„«]/.test(before);
+  const closingQuote = /["'`«»”»]/.test(after);
+  if (openingQuote && closingQuote) {
+    // Plus: between the opening quote and the phrase there should not
+    // be another closing quote of the matching type — otherwise we'd be
+    // outside the quoted span. Cheap proxy: check that the substring
+    // after the LAST opening quote in `before` does not itself contain
+    // a closing quote.
+    const lastOpenIdx = Math.max(
+      before.lastIndexOf('"'),
+      before.lastIndexOf("'"),
+      before.lastIndexOf('`'),
+      before.lastIndexOf('«'),
+      before.lastIndexOf('“'),
+      before.lastIndexOf('„'),
+    );
+    if (lastOpenIdx >= 0) {
+      const tail = before.slice(lastOpenIdx + 1);
+      // If the tail between opening quote and the phrase contains a
+      // closing quote, we're outside the quoted span.
+      if (!/["'`»”]/.test(tail)) return true;
+    }
+  }
+
+  // Quote-introducer colon ("the operator said: …" or em-dash) at start
+  // of line — bot is reporting what someone said, not asserting.
+  if (/[:—]\s*"?\s*$/u.test(before) && /^[^"\n]*"\s*/u.test(after)) return true;
+
+  return false;
+}
+
+function findPhraseMatches(
+  haystack: string,
+  phrases: readonly string[],
+): { phrase: string; start: number; end: number; excerpt: string }[] {
+  const matches: { phrase: string; start: number; end: number; excerpt: string }[] = [];
+  const lower = haystack.toLowerCase();
+  for (const phrase of phrases) {
+    const needle = phrase.toLowerCase();
+    let from = 0;
+    while (true) {
+      const idx = lower.indexOf(needle, from);
+      if (idx === -1) break;
+      const end = idx + needle.length;
+      // Crude word-boundary: char before/after must not be a letter
+      const charBefore = idx > 0 ? haystack[idx - 1] : ' ';
+      const charAfter = end < haystack.length ? haystack[end] : ' ';
+      const isWordBoundaryBefore = !/[\p{L}\p{N}_]/u.test(charBefore);
+      const isWordBoundaryAfter = !/[\p{L}\p{N}_]/u.test(charAfter);
+      if (isWordBoundaryBefore && isWordBoundaryAfter) {
+        const excerptStart = Math.max(0, idx - 24);
+        const excerptEnd = Math.min(haystack.length, end + 24);
+        const excerpt = haystack.slice(excerptStart, excerptEnd).replace(/\s+/g, ' ').trim();
+        matches.push({ phrase, start: idx, end, excerpt });
+      }
+      from = end;
+    }
+  }
+  return matches;
+}
+
+/**
+ * Scan a model reply for confabulation violations. Returns the list
+ * of violations (empty if all forbidden-phrase categories are either
+ * absent or accompanied by a whitelisted tool call).
+ */
+export function detectConfabulationClaims(
+  reply: string,
+  toolsCalledInTurn: Iterable<string>,
+): ConfabAuditResult {
+  const toolSet = new Set(toolsCalledInTurn);
+  const violations: ConfabClaimViolation[] = [];
+
+  for (const category of Object.keys(FORBIDDEN_PHRASES) as ConfabClaimCategory[]) {
+    // If any whitelisted tool for this category fired, skip the whole
+    // category — the bot earned the right to make these claims.
+    const whitelistHit = WHITELISTED_TOOLS[category].some((name) => toolSet.has(name));
+    if (whitelistHit) continue;
+
+    const matches = findPhraseMatches(reply, FORBIDDEN_PHRASES[category]);
+    for (const match of matches) {
+      if (looksQuoted(reply, match.start, match.end)) continue;
+      violations.push({
+        category,
+        phrase: match.phrase,
+        excerpt: match.excerpt,
+      });
+    }
+  }
+
+  return { violations };
+}

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -1,4 +1,5 @@
 import { buildRuntimeSystemPrompt, runAgentLoop } from './agent-runtime.js';
+import { detectConfabulationClaims, extractToolsCalled } from './anti-confab-audit.js';
 import type { LlmClient, LoopLimits, MemoryClient, ToolExecutor } from './chat-types.js';
 import {
   prepareCognitivePrelude,
@@ -1025,6 +1026,38 @@ async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntim
     }
 
     const guarded = await guardModelOutput(result.reply, options.auditSurface ?? options.surface);
+
+    // Anti-confab runtime audit (Sprint Continue 2 phase 1).
+    // Scan the reply for forbidden persistence/search/capability claims
+    // and cross-reference the tool calls that fired in this turn. If
+    // a forbidden phrase appears WITHOUT the matching whitelisted tool,
+    // emit a runtime security event so the operator (and future training
+    // signals) can see the pattern. Phase 1 is log-only — the reply is
+    // not modified or rejected. Future phase will append a runtime
+    // warning or reject outright once we have signal-vs-noise data.
+    try {
+      const toolsCalledInTurn = extractToolsCalled(result.messages);
+      const confabAudit = detectConfabulationClaims(guarded.output, toolsCalledInTurn);
+      if (confabAudit.violations.length > 0) {
+        await emitRuntimeSecurityEvent({
+          action: 'prompt.output.confab_claim',
+          status: 'allowed', // log-only in phase 1
+          details: {
+            surface: options.auditSurface ?? options.surface,
+            categories: Array.from(new Set(confabAudit.violations.map((v) => v.category))),
+            count: confabAudit.violations.length,
+            // First violation's excerpt is enough for triage; full list
+            // would bloat the audit chain.
+            sampleExcerpt: confabAudit.violations[0]?.excerpt ?? '',
+            samplePhrase: confabAudit.violations[0]?.phrase ?? '',
+          },
+        });
+      }
+    } catch (err) {
+      // Audit must never break a turn. Swallow + log; the reply still ships.
+      log.warn({ err }, 'anti-confab audit error');
+    }
+
     let messages = updateFinalAssistantMessage(result.messages, guarded.output);
     if (prepared.classification?.risk === 'high') {
       messages = replaceLatestUserMessage(messages, prepared.sessionUserText);

--- a/tests/unit/anti-confab-audit.test.ts
+++ b/tests/unit/anti-confab-audit.test.ts
@@ -51,6 +51,43 @@ describe('detectConfabulationClaims', () => {
     expect(result.violations).toHaveLength(0);
   });
 
+  it('flags "Tworzę plik" without memphis_fs_write (2026-05-05 incident)', () => {
+    // Operator session 2026-05-05 16:06 + 16:19: bot announced
+    // "Tworzę teraz plik HTML" twice without ever calling
+    // memphis_fs_write — XML parser bug (#491) ate the tool call,
+    // but the detector also missed the claim itself. This test pins
+    // the new forbidden phrases.
+    const result = detectConfabulationClaims(
+      'Tworzę teraz plik HTML z pełną analizą.',
+      new Set(),
+    );
+    const persistenceViolations = result.violations.filter((v) => v.category === 'persistence');
+    expect(persistenceViolations.length).toBeGreaterThanOrEqual(1);
+    // Either phrase variant counts — the test sentence contains both
+    // "tworzę plik" (substring of "tworzę teraz plik" would match first
+    // since it's the longer sequence). Either match is the right signal.
+    expect(persistenceViolations.map((v) => v.phrase)).toEqual(
+      expect.arrayContaining([expect.stringMatching(/tworzę.*plik/u)]),
+    );
+  });
+
+  it('does NOT flag "Tworzę plik" when memphis_fs_write fired (whitelist hit)', () => {
+    const result = detectConfabulationClaims(
+      'Tworzę plik HTML z analizą.',
+      new Set(['memphis_fs_write']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('flags English "creating file" without a write tool', () => {
+    const result = detectConfabulationClaims(
+      "I'm creating a file with the report.",
+      new Set(),
+    );
+    const persistenceViolations = result.violations.filter((v) => v.category === 'persistence');
+    expect(persistenceViolations.length).toBeGreaterThanOrEqual(1);
+  });
+
   // ── Search category ───────────────────────────────────────────────────
 
   it('flags "Przeszukałem cały src/" when no read tool was called', () => {

--- a/tests/unit/anti-confab-audit.test.ts
+++ b/tests/unit/anti-confab-audit.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Sprint Continue 2 phase 1 — runtime anti-confab audit.
+ *
+ * Pin the detector behavior across positive (claim+tool), violation
+ * (claim, no tool), false-positive (claim quoted from chain hit), and
+ * category-mix cases. The detector is fail-open by design (log-only),
+ * so the unit tests are the strongest guarantee its semantics stay
+ * sane as we tune phrase lists later.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  detectConfabulationClaims,
+  extractToolsCalled,
+} from '../../src/gateway/anti-confab-audit.js';
+import type { ChatMessage } from '../../src/providers/index.js';
+
+describe('detectConfabulationClaims', () => {
+  // ── Persistence category ──────────────────────────────────────────────
+
+  it('flags "zapisałem" when no write tool was called', () => {
+    const result = detectConfabulationClaims('Wszystko zapisałem.', new Set());
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].category).toBe('persistence');
+    expect(result.violations[0].phrase).toBe('zapisałem');
+  });
+
+  it('does NOT flag "zapisałem" when memphis_soul_write fired', () => {
+    const result = detectConfabulationClaims(
+      'Wszystko zapisałem.',
+      new Set(['memphis_soul_write']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('flags English "I saved" without a write tool', () => {
+    const result = detectConfabulationClaims(
+      'OK, I saved your preferences.',
+      new Set(['memphis_recall']),
+    );
+    // memphis_recall is a search tool, not a persistence tool — claim still violation
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].category).toBe('persistence');
+  });
+
+  it('skips persistence claims when memphis_journal fired (whitelist hit)', () => {
+    const result = detectConfabulationClaims(
+      'Done. Saved to journal.',
+      new Set(['memphis_journal']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  // ── Search category ───────────────────────────────────────────────────
+
+  it('flags "Przeszukałem cały src/" when no read tool was called', () => {
+    const result = detectConfabulationClaims(
+      'Przeszukałem cały src/, nie ma whisper.',
+      new Set(),
+    );
+    // Match "przeszukałem"; "nie ma w src/" is a separate phrase that
+    // also fires here — both count as violations of the same category.
+    const searchViolations = result.violations.filter((v) => v.category === 'search');
+    expect(searchViolations.length).toBeGreaterThanOrEqual(1);
+    expect(searchViolations.map((v) => v.phrase)).toContain('przeszukałem');
+  });
+
+  it('does NOT flag "Przeszukałem" when memphis_exec fired', () => {
+    const result = detectConfabulationClaims(
+      'Przeszukałem src/. Found 4 matches via grep.',
+      new Set(['memphis_exec']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('flags English "I searched" without a read tool', () => {
+    const result = detectConfabulationClaims('I searched the repo, nothing found.', new Set());
+    const searchViolations = result.violations.filter((v) => v.category === 'search');
+    expect(searchViolations).toHaveLength(1);
+    expect(searchViolations[0].phrase).toBe('i searched');
+  });
+
+  it('memphis_recall whitelists search-claim but NOT persistence-claim', () => {
+    // Mixed reply: search claim is OK (recall ran), persistence claim is not
+    // (no write tool ran).
+    const result = detectConfabulationClaims(
+      'Sprawdziłem — szukałem w pamięci. Zaktualizowałem profil.',
+      new Set(['memphis_recall']),
+    );
+    expect(result.violations.map((v) => v.category)).not.toContain('search');
+    expect(result.violations.map((v) => v.category)).toContain('persistence');
+  });
+
+  // ── Capability category ───────────────────────────────────────────────
+
+  it('flags "I have access to" without memphis_self_describe', () => {
+    const result = detectConfabulationClaims(
+      'I have access to 12 tools and 3 chains.',
+      new Set(['memphis_recall']),
+    );
+    expect(result.violations.map((v) => v.category)).toContain('capability');
+  });
+
+  it('does NOT flag capability claims when memphis_self_describe fired', () => {
+    const result = detectConfabulationClaims(
+      'My available tools are: memphis_recall, memphis_search.',
+      new Set(['memphis_self_describe']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  // ── False-positive guard: quoted text ────────────────────────────────
+
+  it('does NOT flag forbidden phrase when wrapped in ASCII quotes', () => {
+    const result = detectConfabulationClaims(
+      'The journal entry says: "I saved the password" — that was last week.',
+      new Set(),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('does NOT flag forbidden phrase appearing inside [chain_hits] context', () => {
+    const reply = [
+      '[chain_hits]',
+      '- journal#5 score=0.91 user wrote: I searched everywhere',
+      '',
+      'You asked about kitchen tools.',
+    ].join('\n');
+    const result = detectConfabulationClaims(reply, new Set());
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('does NOT flag phrase right after a journal#N citation', () => {
+    const result = detectConfabulationClaims(
+      'Per journal#42 from Tuesday: I saved the report there.',
+      new Set(),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  // ── No-violation cases ───────────────────────────────────────────────
+
+  it('returns no violations on a benign reply', () => {
+    const result = detectConfabulationClaims(
+      'Cześć, jak mogę pomóc?',
+      new Set(),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('handles empty reply gracefully', () => {
+    const result = detectConfabulationClaims('', new Set());
+    expect(result.violations).toHaveLength(0);
+  });
+
+  // ── Word-boundary discipline ─────────────────────────────────────────
+
+  it('does NOT flag the substring "saved" inside an unrelated word like "savedness"', () => {
+    // No real English word "savedness" but exercises the boundary check —
+    // "i saved" is multi-word so the boundary check fires on the start
+    // (preceding non-letter) rather than the end. The phrase still has
+    // to be a complete substring; this should not match a longer-glued
+    // sequence.
+    const result = detectConfabulationClaims('savedi savedfoo bar', new Set());
+    // The phrase "i saved" is in there ("…savedi saved…") with a
+    // letter on the right boundary ('foo') so it should NOT match.
+    expect(result.violations).toHaveLength(0);
+  });
+});
+
+describe('extractToolsCalled', () => {
+  it('returns empty set when there are no assistant tool_calls', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ];
+    expect(extractToolsCalled(messages).size).toBe(0);
+  });
+
+  it('collects tool names from assistant tool_calls across the message list', () => {
+    // extractToolsCalled reads `call.name` directly — that's the shape
+    // chat-loop history holds. The OpenAI-style nested `function.name`
+    // is normalized upstream, so the audit sees flat `{name: ...}`.
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'find foo' },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [{ name: 'memphis_search' }],
+      } as unknown as ChatMessage,
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [{ name: 'memphis_journal' }],
+      } as unknown as ChatMessage,
+    ];
+    const tools = extractToolsCalled(messages);
+    expect(tools.has('memphis_search')).toBe(true);
+    expect(tools.has('memphis_journal')).toBe(true);
+  });
+});

--- a/tests/unit/anti-confab-audit.test.ts
+++ b/tests/unit/anti-confab-audit.test.ts
@@ -80,6 +80,25 @@ describe('detectConfabulationClaims', () => {
     expect(searchViolations[0].phrase).toBe('i searched');
   });
 
+  it('memphis_brave_search whitelists web-search claims (real search happened)', () => {
+    // Bot called memphis_brave_search and reports the result honestly.
+    // Without this whitelist entry the otherwise-truthful "I searched
+    // the web" would false-positive as a search-claim violation.
+    const result = detectConfabulationClaims(
+      'I searched the web for "quantum cryptography migration plans" — nothing relevant.',
+      new Set(['memphis_brave_search']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('memphis_web_search whitelists web-search claims (DuckDuckGo fallback)', () => {
+    const result = detectConfabulationClaims(
+      'Szukałem w sieci, znalazłem 3 wyniki.',
+      new Set(['memphis_web_search']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
   it('memphis_recall whitelists search-claim but NOT persistence-claim', () => {
     // Mixed reply: search claim is OK (recall ran), persistence claim is not
     // (no write tool ran).


### PR DESCRIPTION
## Summary

Sprint Continue 2 phase 1 — adds the **runtime side** of anti-confab. Until now the guards (#473, #478, #465) lived only in the system-prompt text. The 2026-05-05 incidents (Lądunę "zapisane" without `memphis_soul_write`, "Przeszukałem cały src/" without any tool call) prove the prompt alone is insufficient for small models in concise modes.

After every turn, the post-`guardModelOutput` reply is scanned for category-specific forbidden phrases and cross-referenced against the tool calls that fired in this turn. If a forbidden phrase appears **without** the matching whitelisted tool, a runtime security event is emitted with the category, sample phrase, and 24+24-char excerpt.

**Phase 1 is log-only.** The reply is not modified or rejected. We need production signal-vs-noise data across diverse turn shapes before phase 2 promotes the detector to fail-closed.

## Architecture

`src/gateway/anti-confab-audit.ts` (new):
- `FORBIDDEN_PHRASES` per category — `persistence` | `search` | `capability`
- `WHITELISTED_TOOLS` per category — if any one fires in the turn, that category is excused
- `looksQuoted()` heuristic — scopes out `[chain_hits]` context, `journal#N` citations, ASCII/fancy-quote-wrapped phrases, `"operator said: …"` introducers. Crude on purpose — better to miss a real violation than emit a false positive that erodes operator trust.
- `extractToolsCalled()` — reads assistant `tool_calls` across the message list. Mirrors `extractFrameToolCalls()` in turn-runtime.

`src/gateway/turn-runtime.ts` (wiring): right after `guardModelOutput`, calls `detectConfabulationClaims(reply, toolsCalledInTurn)`. On any violation, emits `prompt.output.confab_claim` security event with `status: 'allowed'` (log-only). Audit failures are swallowed — the reply still ships.

## False-positive guards

The detector is paranoid about false positives. If any of these conditions hold around a matched phrase, it's excused:
- Phrase appears inside a `[chain_hits]` block
- Phrase appears within ~80 chars after a `journal#N` / `decisions#N` / `cases#N` citation
- Phrase is wrapped in ASCII/fancy quotes (`"…"`, `'…'`, `«…»`, `"…"`)
- Phrase follows a quote-introducer colon (`"operator said: …"`)

## Test plan

- [x] 18 unit tests in `tests/unit/anti-confab-audit.test.ts` — positive (claim+tool) / violation (claim, no tool) / false-positive (chain hit, journal citation, quoted text) / category-mix (recall whitelists search but not persistence) / word-boundary discipline / empty input
- [x] 2 unit tests for `extractToolsCalled`
- [x] `tests/unit/turn-runtime.test.ts` not regressed (10/10)
- [x] `tsc --noEmit` clean
- [x] `eslint` only emits pre-existing warnings (no new errors)
- [ ] Behavioral check post-merge: monitor `~/.memphis/chains/security/*.json` for `confab_claim` events over the next 24h. Tune phrase list if false-positive rate >5%.

## Phase 2 (future)

Once we have signal data, promote to fail-closed by either:
1. **Append warning** — `[anti-confab note] reply contained an unverified persistence claim with no write tool in this turn` appended to the reply
2. **Reject** — return error to caller, force the bot to retry with the proper tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)