### PR TITLE
fix(loop): bump max_steps default 32 → 48 to handle code-spelunking exploration

### DIFF
--- a/crates/memphis-core/src/loop_engine.rs
+++ b/crates/memphis-core/src/loop_engine.rs
@@ -19,8 +19,14 @@ pub struct LoopLimits {
 
 impl Default for LoopLimits {
     fn default() -> Self {
+        // max_steps bumped 32 → 48 on 2026-05-05 after operator session
+        // hit "exceeded loop step limit" during legitimate code-spelunking
+        // exploration. 48 gives ~15 tool-call rounds without masking
+        // real runaway loops. Mirror of TS LOOP_LIMITS in
+        // src/gateway/loop-limits.ts and CHAT_MAX_STEPS_DEFAULT in
+        // crates/memphis-operator/src/chat.rs.
         Self {
-            max_steps: 32,
+            max_steps: 48,
             max_tool_calls: 16,
             max_wait_ms: 120_000,
             max_errors: 4,

--- a/crates/memphis-operator/src/chat.rs
+++ b/crates/memphis-operator/src/chat.rs
@@ -31,7 +31,14 @@ use crate::{
 const DEFAULT_CHAT_SESSION_ID: &str = "primary::operator:local";
 const GENESIS_PREV_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 const CHAT_MAX_MESSAGES_DEFAULT: usize = 40;
-const CHAT_MAX_STEPS_DEFAULT: usize = 32;
+// max_steps bumped 32 → 48 on 2026-05-05 after operator session in mode B
+// hit "exceeded loop step limit" during legitimate code-spelunking
+// (sequential grep / ls / find calls). 32 allowed only ~10 tool-call
+// rounds before the hard cap, too tight for exploration tasks. 48 gives
+// ~15 rounds without masking real runaway loops. Mirror of
+// src/gateway/loop-limits.ts LOOP_LIMITS.max_steps. Override via
+// MEMPHIS_CHAT_MAX_STEPS at runtime if a surface needs more.
+const CHAT_MAX_STEPS_DEFAULT: usize = 48;
 const CHAT_MAX_TOOL_CALLS_DEFAULT: usize = 16;
 const CHAT_MAX_ERRORS_DEFAULT: usize = 8;
 

--- a/src/gateway/loop-limits.ts
+++ b/src/gateway/loop-limits.ts
@@ -20,8 +20,15 @@
 
 import type { LoopLimits } from './chat-types.js';
 
+// max_steps bumped 32 → 48 on 2026-05-05 after operator session in mode B
+// hit "exceeded loop step limit" during legitimate code-spelunking
+// (sequential grep / ls / find calls to understand a subsystem). 32
+// allowed only ~10 tool-call rounds before the hard cap, too tight for
+// exploration tasks. 48 gives ~15 rounds without masking real runaway
+// loops (a genuinely-stuck loop will hit 48 just as quickly). Override
+// via MEMPHIS_CHAT_MAX_STEPS at runtime if a surface needs more.
 export const LOOP_LIMITS: Readonly<LoopLimits> = Object.freeze({
-  max_steps: 32,
+  max_steps: 48,
   max_tool_calls: 64,
   max_wait_ms: 120_000,
   max_errors: 4,

--- a/tests/unit/loop-limits.test.ts
+++ b/tests/unit/loop-limits.test.ts
@@ -7,7 +7,7 @@ import { buildSystemPrompt } from '../../src/gateway/system-prompt.js';
 describe('LOOP_LIMITS single source of truth', () => {
   it('exposes frozen canonical values', () => {
     expect(LOOP_LIMITS).toEqual({
-      max_steps: 32,
+      max_steps: 48,
       max_tool_calls: 64,
       max_wait_ms: 120_000,
       max_errors: 4,
@@ -21,7 +21,7 @@ describe('LOOP_LIMITS single source of truth', () => {
 
   it('formatLoopLimitsLine renders every field with the canonical value', () => {
     expect(formatLoopLimitsLine()).toBe(
-      'max_steps=32, max_tool_calls=64, max_wait_ms=120000, max_errors=4',
+      'max_steps=48, max_tool_calls=64, max_wait_ms=120000, max_errors=4',
     );
   });
 
@@ -32,7 +32,7 @@ describe('LOOP_LIMITS single source of truth', () => {
     });
     expect(prompt).toContain('max_tool_calls=64');
     expect(prompt).not.toMatch(/max_tool_calls=16/);
-    expect(prompt).toContain('max 32 steps');
+    expect(prompt).toContain('max 48 steps');
     expect(prompt).toContain('64 tool calls');
     expect(prompt).toContain('max 4 errors allowed');
   });


### PR DESCRIPTION
## Summary

Operator session 2026-05-05 in mode B hit `exceeded loop step limit` during legitimate code investigation (sequential `grep`/`ls`/`find` via `memphis_exec`). 32 allowed only ~10 tool-call rounds before the hard cap — too tight for exploration on a non-trivial codebase.

**Bump to 48** — ~15 rounds, without masking real runaway loops (a genuinely-stuck loop has unbounded growth, will hit 48 as quickly as 32). Operators who want more headroom override via `MEMPHIS_CHAT_MAX_STEPS` at runtime.

## Files (TS + Rust kept consistent — single source of truth post-2024 drift incident)

- `src/gateway/loop-limits.ts` — `LOOP_LIMITS.max_steps`
- `crates/memphis-operator/src/chat.rs` — `CHAT_MAX_STEPS_DEFAULT`
- `crates/memphis-core/src/loop_engine.rs` — `LoopLimits::default()`

## Test plan

- [x] `tests/unit/loop-limits.test.ts` — canonical-value pin updated, 4/4 pass
- [x] `cargo test -p memphis-core`: 4/4 pass
- [x] `tsc --noEmit` clean
- [ ] Behavioral check post-deploy: bot should no longer hit the limit during normal code-spelunking sessions