### PR TITLE
feat(anti-confab): phase 2 — append [anti-confab note] when MEMPHIS_ANTICONFAB_ENFORCE=1

### DIFF
--- a/src/config/env-registry.ts
+++ b/src/config/env-registry.ts
@@ -263,6 +263,22 @@ export const MEMPHIS_FAULT_INJECT = defineStringAccessor({
   defaultValue: '',
 });
 
+/**
+ * Anti-confab phase 2 enforcement. When set to "1" / "true", the
+ * runtime audit appends a "[anti-confab note: …]" warning to the bot
+ * reply when a forbidden persistence/search/capability claim was
+ * detected without the matching tool call. Default off — phase 1
+ * (#482) is log-only across the audit chain. Operators flip this on
+ * once they've reviewed the security events and tuned the phrase
+ * list to match their bot's voice.
+ */
+export const MEMPHIS_ANTICONFAB_ENFORCE = defineStringAccessor({
+  name: 'MEMPHIS_ANTICONFAB_ENFORCE',
+  envKey: 'MEMPHIS_ANTICONFAB_ENFORCE',
+  description: 'Append [anti-confab note: …] to replies when audit detects a violation (default off)',
+  defaultValue: '',
+});
+
 // ── Registry surface (for doctor + telemetry) ───────────────────────────────
 
 /**
@@ -284,6 +300,7 @@ export const ENV_REGISTRY: readonly EnvAccessor<unknown>[] = [
   MEMPHIS_VAULT_PEPPER,
   MEMPHIS_SAFE_MODE,
   MEMPHIS_FAULT_INJECT,
+  MEMPHIS_ANTICONFAB_ENFORCE,
 ] as const;
 
 export interface RegistryReport {

--- a/src/gateway/anti-confab-audit.ts
+++ b/src/gateway/anti-confab-audit.ts
@@ -284,6 +284,51 @@ function findPhraseMatches(
 }
 
 /**
+ * Build a terse human-readable warning to append to a reply when
+ * detectConfabulationClaims fires AND enforcement is on. Format
+ * surfaces the category, the offending phrase, and a hint toward
+ * the right tool.
+ *
+ * Operator-facing — appears at the bottom of the bot reply (above
+ * the provider stamp). Keep it short: one line per category.
+ */
+export function buildAntiConfabWarning(violations: readonly ConfabClaimViolation[]): string {
+  if (violations.length === 0) return '';
+  // Group by category for a clean rollup. Same category multiple times
+  // (e.g. "zapisałem" + "zapisane" both fired) collapses to one line.
+  const byCategory = new Map<ConfabClaimCategory, ConfabClaimViolation[]>();
+  for (const v of violations) {
+    const list = byCategory.get(v.category);
+    if (list) list.push(v);
+    else byCategory.set(v.category, [v]);
+  }
+  const lines: string[] = ['', '[anti-confab note]'];
+  for (const [cat, items] of byCategory.entries()) {
+    const tool =
+      cat === 'persistence'
+        ? 'memphis_soul_write / memphis_journal'
+        : cat === 'search'
+          ? 'memphis_exec / memphis_recall / memphis_search'
+          : 'memphis_self_describe';
+    const phrases = Array.from(new Set(items.map((v) => `"${v.phrase}"`))).join(', ');
+    lines.push(`- ${cat} claim ${phrases} fired without a matching tool call (${tool}).`);
+  }
+  lines.push('Re-prompt explicitly if you need the action actually performed.');
+  return lines.join('\n');
+}
+
+/**
+ * Resolve the enforcement flag from the env. Strict ("1" / "true" /
+ * "yes" — case-insensitive) — anything else is off. Default off so
+ * upgrading the runtime does not surprise existing operators with
+ * new visible warnings.
+ */
+export function isAntiConfabEnforceOn(rawValue: string): boolean {
+  const v = rawValue.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+/**
  * Scan a model reply for confabulation violations. Returns the list
  * of violations (empty if all forbidden-phrase categories are either
  * absent or accompanied by a whitelisted tool call).

--- a/src/gateway/anti-confab-audit.ts
+++ b/src/gateway/anti-confab-audit.ts
@@ -74,6 +74,19 @@ const FORBIDDEN_PHRASES: Record<ConfabClaimCategory, readonly string[]> = {
     'zaktualizowane',
     'wpisane',
     'zachowane',
+    // Polish — file-creation phrases (operator session 2026-05-05
+    // 16:06 + 16:19: bot announced "Tworzę teraz plik HTML" twice
+    // before any memphis_fs_write fired — XML emit-as-text bug from
+    // #491 was the root cause, but the detector also missed the
+    // claim itself. Add the present-tense and past-tense variants
+    // so the runtime catches future file-creation confabs even when
+    // the toolcall parser layer fails again.)
+    'tworzę plik',
+    'tworzę teraz plik',
+    'utworzyłem plik',
+    'stworzyłem plik',
+    'piszę plik',
+    'zapisuję plik',
     // English
     'i saved',
     'i persisted',
@@ -82,6 +95,13 @@ const FORBIDDEN_PHRASES: Record<ConfabClaimCategory, readonly string[]> = {
     'i recorded',
     'i wrote it',
     'i updated',
+    // English — file creation
+    'creating file',
+    'creating the file',
+    "i'm creating a file",
+    "i've created a file",
+    "i've written the file",
+    'wrote the file',
   ],
   search: [
     // Polish
@@ -131,6 +151,11 @@ const WHITELISTED_TOOLS: Record<ConfabClaimCategory, readonly string[]> = {
     'memphis_self_modify',
     'memphis_capture',
     'memphis_provider_set',
+    // File-creation tools — when the bot says "Tworzę plik" AFTER
+    // calling these, that's truthful, not confab. (The persistence
+    // category covers ANY claim of writing/saving — files included.)
+    'memphis_fs_write',
+    'memphis_skills_install',
   ],
   search: [
     'memphis_recall',

--- a/src/gateway/anti-confab-audit.ts
+++ b/src/gateway/anti-confab-audit.ts
@@ -139,6 +139,13 @@ const WHITELISTED_TOOLS: Record<ConfabClaimCategory, readonly string[]> = {
     'memphis_case_query',
     'memphis_exec',
     'memphis_web_fetch',
+    // Web-search tools (#486 added memphis_brave_search; memphis_web_search
+    // is the no-key DuckDuckGo fallback). When the bot calls either and
+    // says "I searched the web for X", that's NOT confabulation — it
+    // actually did. Without these on the whitelist, a real call would
+    // false-positive as a search-claim violation.
+    'memphis_web_search',
+    'memphis_brave_search',
   ],
   capability: ['memphis_self_describe', 'memphis_providers', 'memphis_health'],
 };

--- a/src/gateway/anti-confab-audit.ts
+++ b/src/gateway/anti-confab-audit.ts
@@ -1,0 +1,284 @@
+/**
+ * Runtime audit for confabulation claims (Sprint Continue 2 phase 1).
+ *
+ * The system prompt forbids three categories of claims when no
+ * matching tool ran in the turn:
+ *
+ *   - persistence-claim (#473) — "saved", "zapisane", etc.
+ *   - search-claim (#478)      — "I searched", "przeszukałem", etc.
+ *   - capability-claim (#465)  — concrete tool/tier/flag enumerations
+ *                                without `memphis_self_describe` call
+ *
+ * Until now those rules lived only in the prompt text. Models honor
+ * them mostly, but the 2026-05-05 incidents (Lądunę confab, "Przeszukałem
+ * cały src/" confab) prove the prompt alone is insufficient — small
+ * models in concise modes (mode A) skip the discipline.
+ *
+ * This module adds the runtime side: after every turn, scan the reply
+ * for category-specific forbidden phrases and cross-reference the
+ * tool-call audit. If a forbidden phrase appears WITHOUT the matching
+ * write/read/introspect tool firing in the same turn, that's a
+ * confabulation violation — emit a runtime security event so the
+ * operator (and future training loops) can see the pattern.
+ *
+ * Phase 1 = log only. The reply is not modified or rejected. We need
+ * production telemetry across diverse turn shapes before we trust
+ * the detector to fail-closed. Phase 2 (future PR) will append a
+ * runtime warning to the reply or reject outright.
+ *
+ * ## False-positive handling
+ *
+ * A reply may legitimately contain a forbidden phrase if it's quoting
+ * a chain hit ("the journal#5 entry says: 'I searched for X'") or
+ * paraphrasing the user. The detector ignores phrases that appear
+ * inside common quotation patterns (`"…"`, `«…»`, ` — `, `: …`)
+ * to keep the false-positive rate low.
+ */
+
+import type { ChatMessage } from '../providers/index.js';
+
+export type ConfabClaimCategory = 'persistence' | 'search' | 'capability';
+
+export interface ConfabClaimViolation {
+  category: ConfabClaimCategory;
+  phrase: string;
+  /** Up to 80 chars of surrounding text for the audit log */
+  excerpt: string;
+}
+
+export interface ConfabAuditResult {
+  violations: ConfabClaimViolation[];
+}
+
+/**
+ * Forbidden phrases per category. Mirrors the system-prompt sections
+ * but kept in code so the runtime detector and the prompt stay in
+ * sync. If you update the prompt, update this list too.
+ *
+ * Phrases are matched case-insensitively as whole-word/phrase fragments.
+ * Polish diacritics are kept verbatim (matched on the same code points
+ * the model emits).
+ */
+const FORBIDDEN_PHRASES: Record<ConfabClaimCategory, readonly string[]> = {
+  persistence: [
+    // Polish — past-tense or present "I am saving" claims
+    'zapisałem',
+    'zapisaliśmy',
+    'zaktualizowałem',
+    'wpisałem',
+    'zachowałem',
+    // Polish — passive participles operators read as "done"
+    'zapisane',
+    'zapisana',
+    'zapamiętane',
+    'zaktualizowane',
+    'wpisane',
+    'zachowane',
+    // English
+    'i saved',
+    'i persisted',
+    'i stored',
+    'i committed',
+    'i recorded',
+    'i wrote it',
+    'i updated',
+  ],
+  search: [
+    // Polish
+    'przeszukałem',
+    'przeszukałam',
+    'szukałem',
+    'szukałam',
+    'grepowałem',
+    'sprawdziłem kod',
+    'sprawdziłam kod',
+    'patrzyłem w kodzie',
+    'nie znalazłem w kodzie',
+    'nie ma w src/',
+    'przeszedłem przez kod',
+    // English
+    'i searched',
+    'i scanned',
+    'i grepped',
+    'i checked the source',
+    'i looked through',
+    "couldn't find in src/",
+    'not in src/',
+  ],
+  capability: [
+    // Concrete enumerations bot should source from memphis_self_describe.
+    // We match patterns like "I have N tools" / "tier 2 grants X / Y / Z" — these
+    // are common confab shapes. Generic capability talk ("I can help you with…")
+    // is allowed.
+    'i have access to',
+    'my available tools are',
+    'my tier grants',
+  ],
+};
+
+/**
+ * Whitelisted tools per category. If ANY of these tools fired in the
+ * turn, the corresponding category's forbidden phrases are allowed
+ * (the bot earned the right to make the claim by actually doing the
+ * work).
+ */
+const WHITELISTED_TOOLS: Record<ConfabClaimCategory, readonly string[]> = {
+  persistence: [
+    'memphis_soul_write',
+    'memphis_journal',
+    'memphis_decide',
+    'memphis_case_append',
+    'memphis_self_modify',
+    'memphis_capture',
+    'memphis_provider_set',
+  ],
+  search: [
+    'memphis_recall',
+    'memphis_search',
+    'memphis_chain_query',
+    'memphis_case_query',
+    'memphis_exec',
+    'memphis_web_fetch',
+  ],
+  capability: ['memphis_self_describe', 'memphis_providers', 'memphis_health'],
+};
+
+/**
+ * Extract the set of tool names that were invoked by the assistant
+ * in this turn. Mirrors `extractFrameToolCalls` in turn-runtime.ts
+ * (kept duplicated rather than imported to avoid a circular shape).
+ */
+export function extractToolsCalled(messages: ChatMessage[]): Set<string> {
+  const names = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== 'assistant') continue;
+    const toolCalls = (msg as ChatMessage & { tool_calls?: { name?: string }[] }).tool_calls;
+    if (!Array.isArray(toolCalls)) continue;
+    for (const call of toolCalls) {
+      if (call?.name) names.add(call.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Heuristic for "this phrase looks like it's being quoted from
+ * elsewhere, not asserted by the bot itself". A claim wrapped in
+ * quotes, dashes, or appearing on its own block-line after a colon
+ * is treated as quotation and excused.
+ *
+ * The regex windows are crude on purpose — we'd rather miss a real
+ * violation than emit a false positive that erodes operator trust
+ * in the audit signal.
+ */
+function looksQuoted(haystack: string, phraseStart: number, phraseEnd: number): boolean {
+  // Slightly larger window to catch closing quotes that come after a few
+  // words of quoted material ("…says: \"I saved the password\" …")
+  const windowStart = Math.max(0, phraseStart - 64);
+  const windowEnd = Math.min(haystack.length, phraseEnd + 64);
+  const before = haystack.slice(windowStart, phraseStart);
+  const after = haystack.slice(phraseEnd, windowEnd);
+
+  // After a [chain_hits] marker the whole block is quoted-from-disk —
+  // treat anything matching as quotation regardless of inner shape.
+  if (/\[chain_hits\][\s\S]{0,400}$/u.test(haystack.slice(0, phraseStart))) return true;
+
+  // Right after a journal/case/decision entry header — citation, not bot's claim
+  if (/(?:journal|decisions?|cases?|reflections?)#\d+[\s\S]{0,80}$/u.test(before)) return true;
+
+  // Wrapping ASCII / fancy quotes around a short phrase. We look for an
+  // OPENING quote in the 64 chars before the phrase + a CLOSING quote in
+  // the 64 chars after. The window is short enough that bare quotes
+  // appearing far apart don't accidentally couple.
+  const openingQuote = /["'`«»“„«]/.test(before);
+  const closingQuote = /["'`«»”»]/.test(after);
+  if (openingQuote && closingQuote) {
+    // Plus: between the opening quote and the phrase there should not
+    // be another closing quote of the matching type — otherwise we'd be
+    // outside the quoted span. Cheap proxy: check that the substring
+    // after the LAST opening quote in `before` does not itself contain
+    // a closing quote.
+    const lastOpenIdx = Math.max(
+      before.lastIndexOf('"'),
+      before.lastIndexOf("'"),
+      before.lastIndexOf('`'),
+      before.lastIndexOf('«'),
+      before.lastIndexOf('“'),
+      before.lastIndexOf('„'),
+    );
+    if (lastOpenIdx >= 0) {
+      const tail = before.slice(lastOpenIdx + 1);
+      // If the tail between opening quote and the phrase contains a
+      // closing quote, we're outside the quoted span.
+      if (!/["'`»”]/.test(tail)) return true;
+    }
+  }
+
+  // Quote-introducer colon ("the operator said: …" or em-dash) at start
+  // of line — bot is reporting what someone said, not asserting.
+  if (/[:—]\s*"?\s*$/u.test(before) && /^[^"\n]*"\s*/u.test(after)) return true;
+
+  return false;
+}
+
+function findPhraseMatches(
+  haystack: string,
+  phrases: readonly string[],
+): { phrase: string; start: number; end: number; excerpt: string }[] {
+  const matches: { phrase: string; start: number; end: number; excerpt: string }[] = [];
+  const lower = haystack.toLowerCase();
+  for (const phrase of phrases) {
+    const needle = phrase.toLowerCase();
+    let from = 0;
+    while (true) {
+      const idx = lower.indexOf(needle, from);
+      if (idx === -1) break;
+      const end = idx + needle.length;
+      // Crude word-boundary: char before/after must not be a letter
+      const charBefore = idx > 0 ? haystack[idx - 1] : ' ';
+      const charAfter = end < haystack.length ? haystack[end] : ' ';
+      const isWordBoundaryBefore = !/[\p{L}\p{N}_]/u.test(charBefore);
+      const isWordBoundaryAfter = !/[\p{L}\p{N}_]/u.test(charAfter);
+      if (isWordBoundaryBefore && isWordBoundaryAfter) {
+        const excerptStart = Math.max(0, idx - 24);
+        const excerptEnd = Math.min(haystack.length, end + 24);
+        const excerpt = haystack.slice(excerptStart, excerptEnd).replace(/\s+/g, ' ').trim();
+        matches.push({ phrase, start: idx, end, excerpt });
+      }
+      from = end;
+    }
+  }
+  return matches;
+}
+
+/**
+ * Scan a model reply for confabulation violations. Returns the list
+ * of violations (empty if all forbidden-phrase categories are either
+ * absent or accompanied by a whitelisted tool call).
+ */
+export function detectConfabulationClaims(
+  reply: string,
+  toolsCalledInTurn: Iterable<string>,
+): ConfabAuditResult {
+  const toolSet = new Set(toolsCalledInTurn);
+  const violations: ConfabClaimViolation[] = [];
+
+  for (const category of Object.keys(FORBIDDEN_PHRASES) as ConfabClaimCategory[]) {
+    // If any whitelisted tool for this category fired, skip the whole
+    // category — the bot earned the right to make these claims.
+    const whitelistHit = WHITELISTED_TOOLS[category].some((name) => toolSet.has(name));
+    if (whitelistHit) continue;
+
+    const matches = findPhraseMatches(reply, FORBIDDEN_PHRASES[category]);
+    for (const match of matches) {
+      if (looksQuoted(reply, match.start, match.end)) continue;
+      violations.push({
+        category,
+        phrase: match.phrase,
+        excerpt: match.excerpt,
+      });
+    }
+  }
+
+  return { violations };
+}

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -1,5 +1,10 @@
 import { buildRuntimeSystemPrompt, runAgentLoop } from './agent-runtime.js';
-import { detectConfabulationClaims, extractToolsCalled } from './anti-confab-audit.js';
+import {
+  buildAntiConfabWarning,
+  detectConfabulationClaims,
+  extractToolsCalled,
+  isAntiConfabEnforceOn,
+} from './anti-confab-audit.js';
 import type { LlmClient, LoopLimits, MemoryClient, ToolExecutor } from './chat-types.js';
 import {
   prepareCognitivePrelude,
@@ -40,7 +45,7 @@ import {
   type FrameTurn,
 } from '../cognitive/frame-buffer.js';
 import { applyCognitiveMode, type CognitiveModeContribution } from '../cognitive/mode-dispatch.js';
-import { LOG_LEVEL } from '../config/env-registry.js';
+import { LOG_LEVEL, MEMPHIS_ANTICONFAB_ENFORCE } from '../config/env-registry.js';
 import { AppError } from '../core/errors.js';
 import type { RuntimeTelemetry, TokenUsage } from '../core/types.js';
 import { metrics } from '../infra/logging/metrics.js';
@@ -1027,21 +1032,21 @@ async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntim
 
     const guarded = await guardModelOutput(result.reply, options.auditSurface ?? options.surface);
 
-    // Anti-confab runtime audit (Sprint Continue 2 phase 1).
-    // Scan the reply for forbidden persistence/search/capability claims
-    // and cross-reference the tool calls that fired in this turn. If
-    // a forbidden phrase appears WITHOUT the matching whitelisted tool,
-    // emit a runtime security event so the operator (and future training
-    // signals) can see the pattern. Phase 1 is log-only — the reply is
-    // not modified or rejected. Future phase will append a runtime
-    // warning or reject outright once we have signal-vs-noise data.
+    // Anti-confab runtime audit (Sprint Continue 2).
+    // Phase 1 (#482): always log violations to the security chain.
+    // Phase 2 (#484, this PR): when MEMPHIS_ANTICONFAB_ENFORCE is on,
+    // also append a "[anti-confab note]" block to the reply so the
+    // operator sees the warning inline. Default off — operators flip
+    // it on once they've reviewed phase-1 logs and tuned the phrase
+    // list. The reply is never blocked — we surface, never silence.
+    let confabWarning = '';
     try {
       const toolsCalledInTurn = extractToolsCalled(result.messages);
       const confabAudit = detectConfabulationClaims(guarded.output, toolsCalledInTurn);
       if (confabAudit.violations.length > 0) {
         await emitRuntimeSecurityEvent({
           action: 'prompt.output.confab_claim',
-          status: 'allowed', // log-only in phase 1
+          status: 'allowed', // log-only by default; warning appended only when enforce on
           details: {
             surface: options.auditSurface ?? options.surface,
             categories: Array.from(new Set(confabAudit.violations.map((v) => v.category))),
@@ -1050,8 +1055,12 @@ async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntim
             // would bloat the audit chain.
             sampleExcerpt: confabAudit.violations[0]?.excerpt ?? '',
             samplePhrase: confabAudit.violations[0]?.phrase ?? '',
+            enforced: isAntiConfabEnforceOn(MEMPHIS_ANTICONFAB_ENFORCE.read(rawEnvWithTier3)),
           },
         });
+        if (isAntiConfabEnforceOn(MEMPHIS_ANTICONFAB_ENFORCE.read(rawEnvWithTier3))) {
+          confabWarning = buildAntiConfabWarning(confabAudit.violations);
+        }
       }
     } catch (err) {
       // Audit must never break a turn. Swallow + log; the reply still ships.
@@ -1094,8 +1103,13 @@ async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntim
     //      always knows which model generated the cleaned text.
     // Order matters: stamp goes on the cleaned body, not the raw one.
     const cleanedOutput = stripThinkBlocks(guarded.output, rawEnvWithTier3);
+    // Phase 2 anti-confab warning, when enabled: append BEFORE the
+    // provider stamp so the warning lives inside the reply body and
+    // the stamp anchors the bottom. Empty string when off / no
+    // violations — no-op concat in that case.
+    const warnedOutput = confabWarning ? `${cleanedOutput.trimEnd()}\n${confabWarning}` : cleanedOutput;
     const stampedOutput = appendProviderStamp(
-      cleanedOutput,
+      warnedOutput,
       llm.provider,
       llm.model,
       rawEnvWithTier3,

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -1,4 +1,5 @@
 import { buildRuntimeSystemPrompt, runAgentLoop } from './agent-runtime.js';
+import { detectConfabulationClaims, extractToolsCalled } from './anti-confab-audit.js';
 import type { LlmClient, LoopLimits, MemoryClient, ToolExecutor } from './chat-types.js';
 import {
   prepareCognitivePrelude,
@@ -1025,6 +1026,38 @@ async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntim
     }
 
     const guarded = await guardModelOutput(result.reply, options.auditSurface ?? options.surface);
+
+    // Anti-confab runtime audit (Sprint Continue 2 phase 1).
+    // Scan the reply for forbidden persistence/search/capability claims
+    // and cross-reference the tool calls that fired in this turn. If
+    // a forbidden phrase appears WITHOUT the matching whitelisted tool,
+    // emit a runtime security event so the operator (and future training
+    // signals) can see the pattern. Phase 1 is log-only — the reply is
+    // not modified or rejected. Future phase will append a runtime
+    // warning or reject outright once we have signal-vs-noise data.
+    try {
+      const toolsCalledInTurn = extractToolsCalled(result.messages);
+      const confabAudit = detectConfabulationClaims(guarded.output, toolsCalledInTurn);
+      if (confabAudit.violations.length > 0) {
+        await emitRuntimeSecurityEvent({
+          action: 'prompt.output.confab_claim',
+          status: 'allowed', // log-only in phase 1
+          details: {
+            surface: options.auditSurface ?? options.surface,
+            categories: Array.from(new Set(confabAudit.violations.map((v) => v.category))),
+            count: confabAudit.violations.length,
+            // First violation's excerpt is enough for triage; full list
+            // would bloat the audit chain.
+            sampleExcerpt: confabAudit.violations[0]?.excerpt ?? '',
+            samplePhrase: confabAudit.violations[0]?.phrase ?? '',
+          },
+        });
+      }
+    } catch (err) {
+      // Audit must never break a turn. Swallow + log; the reply still ships.
+      log.warn({ err }, 'anti-confab audit error');
+    }
+
     let messages = updateFinalAssistantMessage(result.messages, guarded.output);
     if (prepared.classification?.risk === 'high') {
       messages = replaceLatestUserMessage(messages, prepared.sessionUserText);

--- a/tests/unit/anti-confab-audit.test.ts
+++ b/tests/unit/anti-confab-audit.test.ts
@@ -51,6 +51,43 @@ describe('detectConfabulationClaims', () => {
     expect(result.violations).toHaveLength(0);
   });
 
+  it('flags "Tworzę plik" without memphis_fs_write (2026-05-05 incident)', () => {
+    // Operator session 2026-05-05 16:06 + 16:19: bot announced
+    // "Tworzę teraz plik HTML" twice without ever calling
+    // memphis_fs_write — XML parser bug (#491) ate the tool call,
+    // but the detector also missed the claim itself. This test pins
+    // the new forbidden phrases.
+    const result = detectConfabulationClaims(
+      'Tworzę teraz plik HTML z pełną analizą.',
+      new Set(),
+    );
+    const persistenceViolations = result.violations.filter((v) => v.category === 'persistence');
+    expect(persistenceViolations.length).toBeGreaterThanOrEqual(1);
+    // Either phrase variant counts — the test sentence contains both
+    // "tworzę plik" (substring of "tworzę teraz plik" would match first
+    // since it's the longer sequence). Either match is the right signal.
+    expect(persistenceViolations.map((v) => v.phrase)).toEqual(
+      expect.arrayContaining([expect.stringMatching(/tworzę.*plik/u)]),
+    );
+  });
+
+  it('does NOT flag "Tworzę plik" when memphis_fs_write fired (whitelist hit)', () => {
+    const result = detectConfabulationClaims(
+      'Tworzę plik HTML z analizą.',
+      new Set(['memphis_fs_write']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('flags English "creating file" without a write tool', () => {
+    const result = detectConfabulationClaims(
+      "I'm creating a file with the report.",
+      new Set(),
+    );
+    const persistenceViolations = result.violations.filter((v) => v.category === 'persistence');
+    expect(persistenceViolations.length).toBeGreaterThanOrEqual(1);
+  });
+
   // ── Search category ───────────────────────────────────────────────────
 
   it('flags "Przeszukałem cały src/" when no read tool was called', () => {

--- a/tests/unit/anti-confab-audit.test.ts
+++ b/tests/unit/anti-confab-audit.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Sprint Continue 2 phase 1 — runtime anti-confab audit.
+ *
+ * Pin the detector behavior across positive (claim+tool), violation
+ * (claim, no tool), false-positive (claim quoted from chain hit), and
+ * category-mix cases. The detector is fail-open by design (log-only),
+ * so the unit tests are the strongest guarantee its semantics stay
+ * sane as we tune phrase lists later.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  detectConfabulationClaims,
+  extractToolsCalled,
+} from '../../src/gateway/anti-confab-audit.js';
+import type { ChatMessage } from '../../src/providers/index.js';
+
+describe('detectConfabulationClaims', () => {
+  // ── Persistence category ──────────────────────────────────────────────
+
+  it('flags "zapisałem" when no write tool was called', () => {
+    const result = detectConfabulationClaims('Wszystko zapisałem.', new Set());
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].category).toBe('persistence');
+    expect(result.violations[0].phrase).toBe('zapisałem');
+  });
+
+  it('does NOT flag "zapisałem" when memphis_soul_write fired', () => {
+    const result = detectConfabulationClaims(
+      'Wszystko zapisałem.',
+      new Set(['memphis_soul_write']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('flags English "I saved" without a write tool', () => {
+    const result = detectConfabulationClaims(
+      'OK, I saved your preferences.',
+      new Set(['memphis_recall']),
+    );
+    // memphis_recall is a search tool, not a persistence tool — claim still violation
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].category).toBe('persistence');
+  });
+
+  it('skips persistence claims when memphis_journal fired (whitelist hit)', () => {
+    const result = detectConfabulationClaims(
+      'Done. Saved to journal.',
+      new Set(['memphis_journal']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  // ── Search category ───────────────────────────────────────────────────
+
+  it('flags "Przeszukałem cały src/" when no read tool was called', () => {
+    const result = detectConfabulationClaims(
+      'Przeszukałem cały src/, nie ma whisper.',
+      new Set(),
+    );
+    // Match "przeszukałem"; "nie ma w src/" is a separate phrase that
+    // also fires here — both count as violations of the same category.
+    const searchViolations = result.violations.filter((v) => v.category === 'search');
+    expect(searchViolations.length).toBeGreaterThanOrEqual(1);
+    expect(searchViolations.map((v) => v.phrase)).toContain('przeszukałem');
+  });
+
+  it('does NOT flag "Przeszukałem" when memphis_exec fired', () => {
+    const result = detectConfabulationClaims(
+      'Przeszukałem src/. Found 4 matches via grep.',
+      new Set(['memphis_exec']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('flags English "I searched" without a read tool', () => {
+    const result = detectConfabulationClaims('I searched the repo, nothing found.', new Set());
+    const searchViolations = result.violations.filter((v) => v.category === 'search');
+    expect(searchViolations).toHaveLength(1);
+    expect(searchViolations[0].phrase).toBe('i searched');
+  });
+
+  it('memphis_recall whitelists search-claim but NOT persistence-claim', () => {
+    // Mixed reply: search claim is OK (recall ran), persistence claim is not
+    // (no write tool ran).
+    const result = detectConfabulationClaims(
+      'Sprawdziłem — szukałem w pamięci. Zaktualizowałem profil.',
+      new Set(['memphis_recall']),
+    );
+    expect(result.violations.map((v) => v.category)).not.toContain('search');
+    expect(result.violations.map((v) => v.category)).toContain('persistence');
+  });
+
+  // ── Capability category ───────────────────────────────────────────────
+
+  it('flags "I have access to" without memphis_self_describe', () => {
+    const result = detectConfabulationClaims(
+      'I have access to 12 tools and 3 chains.',
+      new Set(['memphis_recall']),
+    );
+    expect(result.violations.map((v) => v.category)).toContain('capability');
+  });
+
+  it('does NOT flag capability claims when memphis_self_describe fired', () => {
+    const result = detectConfabulationClaims(
+      'My available tools are: memphis_recall, memphis_search.',
+      new Set(['memphis_self_describe']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  // ── False-positive guard: quoted text ────────────────────────────────
+
+  it('does NOT flag forbidden phrase when wrapped in ASCII quotes', () => {
+    const result = detectConfabulationClaims(
+      'The journal entry says: "I saved the password" — that was last week.',
+      new Set(),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('does NOT flag forbidden phrase appearing inside [chain_hits] context', () => {
+    const reply = [
+      '[chain_hits]',
+      '- journal#5 score=0.91 user wrote: I searched everywhere',
+      '',
+      'You asked about kitchen tools.',
+    ].join('\n');
+    const result = detectConfabulationClaims(reply, new Set());
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('does NOT flag phrase right after a journal#N citation', () => {
+    const result = detectConfabulationClaims(
+      'Per journal#42 from Tuesday: I saved the report there.',
+      new Set(),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  // ── No-violation cases ───────────────────────────────────────────────
+
+  it('returns no violations on a benign reply', () => {
+    const result = detectConfabulationClaims(
+      'Cześć, jak mogę pomóc?',
+      new Set(),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('handles empty reply gracefully', () => {
+    const result = detectConfabulationClaims('', new Set());
+    expect(result.violations).toHaveLength(0);
+  });
+
+  // ── Word-boundary discipline ─────────────────────────────────────────
+
+  it('does NOT flag the substring "saved" inside an unrelated word like "savedness"', () => {
+    // No real English word "savedness" but exercises the boundary check —
+    // "i saved" is multi-word so the boundary check fires on the start
+    // (preceding non-letter) rather than the end. The phrase still has
+    // to be a complete substring; this should not match a longer-glued
+    // sequence.
+    const result = detectConfabulationClaims('savedi savedfoo bar', new Set());
+    // The phrase "i saved" is in there ("…savedi saved…") with a
+    // letter on the right boundary ('foo') so it should NOT match.
+    expect(result.violations).toHaveLength(0);
+  });
+});
+
+describe('extractToolsCalled', () => {
+  it('returns empty set when there are no assistant tool_calls', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ];
+    expect(extractToolsCalled(messages).size).toBe(0);
+  });
+
+  it('collects tool names from assistant tool_calls across the message list', () => {
+    // extractToolsCalled reads `call.name` directly — that's the shape
+    // chat-loop history holds. The OpenAI-style nested `function.name`
+    // is normalized upstream, so the audit sees flat `{name: ...}`.
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'find foo' },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [{ name: 'memphis_search' }],
+      } as unknown as ChatMessage,
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [{ name: 'memphis_journal' }],
+      } as unknown as ChatMessage,
+    ];
+    const tools = extractToolsCalled(messages);
+    expect(tools.has('memphis_search')).toBe(true);
+    expect(tools.has('memphis_journal')).toBe(true);
+  });
+});

--- a/tests/unit/anti-confab-audit.test.ts
+++ b/tests/unit/anti-confab-audit.test.ts
@@ -80,6 +80,25 @@ describe('detectConfabulationClaims', () => {
     expect(searchViolations[0].phrase).toBe('i searched');
   });
 
+  it('memphis_brave_search whitelists web-search claims (real search happened)', () => {
+    // Bot called memphis_brave_search and reports the result honestly.
+    // Without this whitelist entry the otherwise-truthful "I searched
+    // the web" would false-positive as a search-claim violation.
+    const result = detectConfabulationClaims(
+      'I searched the web for "quantum cryptography migration plans" — nothing relevant.',
+      new Set(['memphis_brave_search']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('memphis_web_search whitelists web-search claims (DuckDuckGo fallback)', () => {
+    const result = detectConfabulationClaims(
+      'Szukałem w sieci, znalazłem 3 wyniki.',
+      new Set(['memphis_web_search']),
+    );
+    expect(result.violations).toHaveLength(0);
+  });
+
   it('memphis_recall whitelists search-claim but NOT persistence-claim', () => {
     // Mixed reply: search claim is OK (recall ran), persistence claim is not
     // (no write tool ran).

--- a/tests/unit/anti-confab-audit.test.ts
+++ b/tests/unit/anti-confab-audit.test.ts
@@ -10,8 +10,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildAntiConfabWarning,
   detectConfabulationClaims,
   extractToolsCalled,
+  isAntiConfabEnforceOn,
 } from '../../src/gateway/anti-confab-audit.js';
 import type { ChatMessage } from '../../src/providers/index.js';
 
@@ -221,6 +223,60 @@ describe('detectConfabulationClaims', () => {
     // The phrase "i saved" is in there ("…savedi saved…") with a
     // letter on the right boundary ('foo') so it should NOT match.
     expect(result.violations).toHaveLength(0);
+  });
+});
+
+describe('buildAntiConfabWarning (phase 2)', () => {
+  it('returns empty string when there are no violations', () => {
+    expect(buildAntiConfabWarning([])).toBe('');
+  });
+
+  it('renders a one-line-per-category note grouping repeated phrases', () => {
+    const warning = buildAntiConfabWarning([
+      { category: 'persistence', phrase: 'zapisałem', excerpt: 'wszystko zapisałem' },
+      { category: 'persistence', phrase: 'zapisane', excerpt: 'zapisane juz dawno' },
+      { category: 'search', phrase: 'przeszukałem', excerpt: 'przeszukałem repo' },
+    ]);
+    expect(warning).toContain('[anti-confab note]');
+    // Persistence line — both phrases collapsed into a single grouped line
+    expect(warning).toMatch(/persistence claim "zapisałem", "zapisane".*memphis_soul_write/);
+    // Search line — separate, with its own tool hint
+    expect(warning).toMatch(/search claim "przeszukałem".*memphis_exec/);
+    // Re-prompt nudge at end
+    expect(warning).toContain('Re-prompt explicitly');
+  });
+
+  it('hints memphis_self_describe for capability-category violations', () => {
+    const warning = buildAntiConfabWarning([
+      { category: 'capability', phrase: 'i have access to', excerpt: 'I have access to 12 tools' },
+    ]);
+    expect(warning).toMatch(/capability claim.*memphis_self_describe/);
+  });
+
+  it('produces output starting with a blank line so it appends cleanly to a reply', () => {
+    const warning = buildAntiConfabWarning([
+      { category: 'persistence', phrase: 'i saved', excerpt: 'I saved your settings' },
+    ]);
+    expect(warning.startsWith('\n')).toBe(true);
+  });
+});
+
+describe('isAntiConfabEnforceOn (phase 2)', () => {
+  it('treats "1" / "true" / "yes" as enabled (case-insensitive)', () => {
+    for (const v of ['1', 'true', 'TRUE', 'True', 'yes', 'Yes']) {
+      expect(isAntiConfabEnforceOn(v)).toBe(true);
+    }
+  });
+
+  it('treats anything else as disabled — empty / "0" / "false" / unset semantics', () => {
+    for (const v of ['', '0', 'false', 'FALSE', 'no', 'off', 'maybe']) {
+      expect(isAntiConfabEnforceOn(v)).toBe(false);
+    }
+  });
+
+  it('trims whitespace before testing the value', () => {
+    expect(isAntiConfabEnforceOn('  1  ')).toBe(true);
+    expect(isAntiConfabEnforceOn('  true  ')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 2 of Sprint Continue 2. Phase 1 (#482) added post-turn detector + log-only security events. This PR adds **operator-visible enforcement**: when `MEMPHIS_ANTICONFAB_ENFORCE` resolves truthy, the runtime appends an `[anti-confab note]` block to the reply describing the category, offending phrase(s), and the matching tool the bot should have called.

**Default OFF** — operators flip the env on after reviewing phase-1 logs and tuning the phrase list. The reply is never blocked; we surface, never silence.

## Stack

This PR is **stacked on #482** (`feat/anti-confab-runtime-audit`). The detector module + tests live there; this branch only adds:
- `MEMPHIS_ANTICONFAB_ENFORCE` env-registry accessor
- `buildAntiConfabWarning()` — operator-facing warning text builder
- `isAntiConfabEnforceOn()` — strict truthy parser
- Wiring in turn-runtime.ts

## Warning shape

When ENFORCE=1 and violations fire, the bot reply ends with:

```

[anti-confab note]
- persistence claim "zapisałem", "zapisane" fired without a matching tool call (memphis_soul_write / memphis_journal).
- search claim "przeszukałem" fired without a matching tool call (memphis_exec / memphis_recall / memphis_search).
Re-prompt explicitly if you need the action actually performed.

— via minimax/MiniMax-M2.7
```

## Test plan

- [x] 7 new unit tests in `tests/unit/anti-confab-audit.test.ts`:
  - `buildAntiConfabWarning` — empty input, multi-category grouping, capability hint, leading-newline shape
  - `isAntiConfabEnforceOn` — truthy ("1" / "true" / "yes" — case-insensitive), falsy ("" / "0" / "false" / "no"), whitespace trim
- [x] `tests/unit/turn-runtime.test.ts` — 10/10 still pass
- [x] `tsc --noEmit` clean
- [ ] Behavioral: set `MEMPHIS_ANTICONFAB_ENFORCE=1`, ask bot a memory question without `[chain_hits]`, observe `[anti-confab note]` in reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)