### PR TITLE
feat(cli): memphis openai configure — first-class OpenAI/Codex provider key UX

### DIFF
--- a/src/infra/cli/handlers/openai.handler.ts
+++ b/src/infra/cli/handlers/openai.handler.ts
@@ -1,0 +1,271 @@
+/**
+ * `memphis openai` CLI — dedicated UX for adding/checking the
+ * OpenAI API key (used by the openai-compatible provider).
+ *
+ * Memphis already has `OpenAICompatibleProvider` (src/providers/index.ts)
+ * — a generic adapter that talks to any /v1/chat/completions endpoint.
+ * It's wired through env vars `OPENAI_COMPATIBLE_API_BASE`,
+ * `OPENAI_COMPATIBLE_API_KEY`, `OPENAI_COMPATIBLE_MODEL`. This handler
+ * gives operators a focused command for the *OpenAI* (Codex) case
+ * specifically: stores the key in vault, populates the three env vars
+ * with sensible defaults pointing at api.openai.com, and journals a
+ * config-change event so the bot's chain_hits notices the new
+ * capability next turn.
+ *
+ * Operator's 2026-05-05 ask was about wiring Codex. OpenAI doesn't
+ * publish a public OAuth flow (Admin API is static-key only), so this
+ * is the API-key path. The default model is intentionally
+ * `gpt-5-codex` — operator can override via `--model`.
+ *
+ * Subcommands:
+ *   - `configure --key <sk-...> [--model <name>]`  — store + activate
+ *   - `status`                                     — show key + model
+ */
+
+import chalk from 'chalk';
+
+import type { CommandHandler } from './command-handler.js';
+import { runMemphisJournal } from '../../../mcp/tools/journal.js';
+import { storeVaultSecret } from '../../../security/vault-boundary.js';
+import { upsertEnvVars } from '../../config/env-file.js';
+import type { CliContext } from '../context.js';
+import { print } from '../utils/render.js';
+
+const VAULT_KEY = 'openai_api_key';
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_MODEL = 'gpt-5-codex';
+
+export const openaiCommandHandler: CommandHandler = {
+  name: 'openai',
+  commands: ['openai'],
+  canHandle(context: CliContext): boolean {
+    return context.args.command === 'openai';
+  },
+  async handle(context: CliContext): Promise<boolean> {
+    const { subcommand } = context.args;
+    const handlers: Record<string, () => Promise<boolean>> = {
+      configure: () => handleOpenAIConfigure(context),
+      status: () => handleOpenAIStatus(context),
+    };
+    const handler = subcommand ? handlers[subcommand] : handlers.status;
+    if (!handler) {
+      throw new Error(
+        `Unknown subcommand: memphis openai ${subcommand}. Try: configure | status`,
+      );
+    }
+    return handler();
+  },
+};
+
+async function handleOpenAIConfigure(context: CliContext): Promise<boolean> {
+  const { json, key, model } = context.args as {
+    json?: boolean;
+    key?: string;
+    model?: string;
+  };
+
+  if (!key || key.trim().length === 0) {
+    throw new Error(
+      'memphis openai configure --key <sk-...> required. Get a key at https://platform.openai.com/api-keys.',
+    );
+  }
+
+  const trimmed = key.trim();
+  const chosenModel = model?.trim() || DEFAULT_MODEL;
+
+  // OpenAI keys typically start with "sk-" and are 40+ chars. Soft warn
+  // on shape mismatch — OpenAI's format isn't published as a stable
+  // contract, but a paste error usually surfaces here.
+  const looksValid = /^sk-[A-Za-z0-9_-]{20,}$/.test(trimmed);
+  const warnings: string[] = [];
+  if (!looksValid) {
+    warnings.push(
+      'Key does not match the typical "sk-..." OpenAI format. Continuing — verify with `memphis openai status`.',
+    );
+  }
+
+  storeVaultSecret(
+    VAULT_KEY,
+    trimmed,
+    { surface: 'cli', command: 'openai configure' },
+    process.env,
+  );
+
+  // Memphis's openai-compatible provider reads three env vars. We point
+  // them all at OpenAI proper. If the operator was using these for
+  // DeepSeek/OpenRouter/etc, this command will overwrite that config —
+  // surface a warning so they can recover.
+  const previousBase = process.env.OPENAI_COMPATIBLE_API_BASE?.trim();
+  if (previousBase && previousBase !== DEFAULT_BASE_URL) {
+    warnings.push(
+      `OPENAI_COMPATIBLE_API_BASE was previously "${previousBase}" — this command overwrites it with ${DEFAULT_BASE_URL}. If you need that other endpoint, restore it manually after.`,
+    );
+  }
+
+  const envUpdate = upsertEnvVars([
+    { key: 'OPENAI_COMPATIBLE_API_BASE', value: DEFAULT_BASE_URL },
+    { key: 'OPENAI_COMPATIBLE_API_KEY', value: `VAULT:${VAULT_KEY}` },
+    { key: 'OPENAI_COMPATIBLE_MODEL', value: chosenModel },
+  ]);
+
+  // Make values visible to the current process.
+  process.env.OPENAI_COMPATIBLE_API_BASE = DEFAULT_BASE_URL;
+  process.env.OPENAI_COMPATIBLE_API_KEY = trimmed;
+  process.env.OPENAI_COMPATIBLE_MODEL = chosenModel;
+
+  let journaledOk = false;
+  try {
+    const journalResult = await runMemphisJournal({
+      content: `OpenAI provider configured by operator. baseUrl=${DEFAULT_BASE_URL}, model=${chosenModel}. Memphis can now route to OpenAI (Codex etc.) via the openai-compatible provider.`,
+      tags: ['config-change', 'openai', 'external-api', 'provider'],
+      surface: 'cli',
+    });
+    journaledOk = journalResult.success;
+  } catch {
+    // Non-fatal — vault + env writes succeeded, journal is best-effort.
+  }
+
+  const result = {
+    ok: true,
+    vaultKey: VAULT_KEY,
+    envPath: envUpdate.path,
+    envRefs: [
+      'OPENAI_COMPATIBLE_API_BASE=https://api.openai.com/v1',
+      'OPENAI_COMPATIBLE_API_KEY=VAULT:openai_api_key',
+      `OPENAI_COMPATIBLE_MODEL=${chosenModel}`,
+    ],
+    journaled: journaledOk,
+    warnings,
+    nextSteps: [
+      'Restart memphis service to load the new env: `systemctl --user restart memphis`',
+      'Or run `memphis openai status` to verify the key reaches OpenAI.',
+    ],
+  };
+
+  if (!json) {
+    console.log(chalk.green.bold('\n✓ OpenAI provider configured\n'));
+    console.log(`  Vault key:  ${chalk.cyan(VAULT_KEY)}`);
+    console.log(`  Base URL:   ${chalk.cyan(DEFAULT_BASE_URL)}`);
+    console.log(`  Model:      ${chalk.cyan(chosenModel)}`);
+    console.log(`  .env file:  ${chalk.gray(envUpdate.path)}`);
+    console.log(
+      `  Journal:    ${
+        journaledOk
+          ? chalk.green('config-change event recorded')
+          : chalk.yellow('event NOT recorded (vault write succeeded; bot may not auto-notice)')
+      }`,
+    );
+    if (warnings.length > 0) {
+      for (const w of warnings) console.log(chalk.yellow(`  ⚠ ${w}`));
+    }
+    console.log('');
+    console.log(chalk.gray('  Next steps:'));
+    for (const step of result.nextSteps) {
+      console.log(chalk.gray(`    - ${step}`));
+    }
+    console.log('');
+  }
+
+  print(result, json ?? false);
+  return true;
+}
+
+async function handleOpenAIStatus(context: CliContext): Promise<boolean> {
+  const { json } = context.args;
+
+  const rawKey = process.env.OPENAI_COMPATIBLE_API_KEY?.trim() ?? '';
+  const baseUrl = process.env.OPENAI_COMPATIBLE_API_BASE?.trim() ?? '';
+  const model = process.env.OPENAI_COMPATIBLE_MODEL?.trim() ?? '';
+  const configured = rawKey.length > 0 && !rawKey.startsWith('VAULT:');
+  const vaultUnresolved = rawKey.startsWith('VAULT:');
+  const targetsOpenAI = baseUrl === DEFAULT_BASE_URL;
+
+  let probe: { ok: boolean; latencyMs?: number; error?: string; modelsListed?: number } | undefined;
+  if (configured) {
+    const start = Date.now();
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 8000);
+      const response = await fetch(`${baseUrl || DEFAULT_BASE_URL}/models`, {
+        headers: {
+          Authorization: `Bearer ${rawKey}`,
+          'User-Agent': 'Memphis-Agent/1.0 (sovereign-runtime)',
+        },
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      if (response.ok) {
+        const data = (await response.json()) as { data?: unknown[] };
+        probe = {
+          ok: true,
+          latencyMs: Date.now() - start,
+          modelsListed: Array.isArray(data.data) ? data.data.length : 0,
+        };
+      } else {
+        let hint = '';
+        if (response.status === 401) hint = ' (key rejected — check it)';
+        else if (response.status === 429) hint = ' (rate-limit / quota)';
+        probe = {
+          ok: false,
+          latencyMs: Date.now() - start,
+          error: `HTTP ${response.status}${hint}`,
+        };
+      }
+    } catch (err) {
+      probe = {
+        ok: false,
+        latencyMs: Date.now() - start,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  const result = {
+    configured,
+    vaultUnresolved,
+    targetsOpenAI,
+    baseUrl: baseUrl || DEFAULT_BASE_URL,
+    model: model || '<unset>',
+    vaultKey: VAULT_KEY,
+    probe,
+    suggestion: !configured
+      ? vaultUnresolved
+        ? `Vault didn't expand "${rawKey}" — verify the entry exists (\`memphis vault list\`), then \`memphis openai configure --key <sk-...>\`.`
+        : 'Run `memphis openai configure --key <sk-...>` to set the key. Get one at https://platform.openai.com/api-keys.'
+      : !targetsOpenAI
+        ? `OPENAI_COMPATIBLE_API_BASE points at "${baseUrl}", not OpenAI proper. If that's intentional (DeepSeek / OpenRouter / local), ignore. Otherwise re-run \`memphis openai configure\` to reset to ${DEFAULT_BASE_URL}.`
+        : probe?.ok
+          ? undefined
+          : `OpenAI API call failed: ${probe?.error ?? 'unknown error'}`,
+  };
+
+  if (!json) {
+    console.log(chalk.bold('\n  OpenAI provider status\n'));
+    console.log(`  Key:    ${configured ? chalk.green('present') : chalk.red('not set')}`);
+    if (vaultUnresolved) {
+      console.log(`  Note:   ${chalk.yellow(`env still holds "${rawKey}" — vault didn't resolve`)}`);
+    }
+    console.log(
+      `  Base:   ${targetsOpenAI ? chalk.green(baseUrl || DEFAULT_BASE_URL) : chalk.yellow(baseUrl || '<unset>')}`,
+    );
+    console.log(`  Model:  ${chalk.cyan(model || '<unset>')}`);
+    if (probe) {
+      console.log(
+        `  Probe:  ${probe.ok ? chalk.green('reachable') : chalk.red('failed')} ${
+          probe.latencyMs !== undefined ? chalk.gray(`(${probe.latencyMs}ms)`) : ''
+        }`,
+      );
+      if (probe.modelsListed !== undefined) {
+        console.log(`  Models: ${chalk.gray(`${probe.modelsListed} listed`)}`);
+      }
+      if (!probe.ok) console.log(`  Error:  ${chalk.red(probe.error ?? 'unknown')}`);
+    }
+    if (result.suggestion) {
+      console.log(chalk.gray(`\n  ${result.suggestion}`));
+    }
+    console.log('');
+  }
+
+  print(result, json ?? false);
+  return true;
+}

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -181,6 +181,11 @@ export const CLI_COMMAND_REGISTRY = [
     ),
   ),
   createCommandRegistration(
+    'openai',
+    ['openai'],
+    createLazyHandlerLoader(() => import('./handlers/openai.handler.js'), 'openaiCommandHandler'),
+  ),
+  createCommandRegistration(
     'debug',
     ['debug'],
     createLazyHandlerLoader(() => import('./handlers/debug.handler.js'), 'debugCommandHandler'),

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -2047,6 +2047,39 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
     fix: kartografFix,
   });
 
+  // PR #488 — OpenAI / Codex provider visibility. Offline-only probe
+  // (env presence + shape). The live API probe lives in `memphis
+  // openai status`. Reads OPENAI_COMPATIBLE_API_KEY + _API_BASE since
+  // that's how Memphis's openai-compatible provider is wired (one set
+  // of env vars, configurable URL).
+  let openaiLevel: DoctorCheckLevel = 'pass';
+  const openaiKeyRaw = process.env.OPENAI_COMPATIBLE_API_KEY?.trim() ?? '';
+  const openaiBase = process.env.OPENAI_COMPATIBLE_API_BASE?.trim() ?? '';
+  const openaiModel = process.env.OPENAI_COMPATIBLE_MODEL?.trim() ?? '';
+  let openaiDetail = `OPENAI_COMPATIBLE_* configured (${openaiBase || 'default api.openai.com'}, model=${openaiModel || 'unset'})`;
+  let openaiFix: string | undefined;
+  if (openaiKeyRaw.length === 0) {
+    openaiLevel = 'warn';
+    openaiDetail =
+      'OPENAI_COMPATIBLE_API_KEY not set — OpenAI/Codex routing disabled. ollama / minimax / anthropic still usable.';
+    openaiFix =
+      'Run `memphis openai configure --key <sk-...> [--model gpt-5-codex]` to enable. Get a key at https://platform.openai.com/api-keys.';
+  } else if (openaiKeyRaw.startsWith('VAULT:')) {
+    openaiLevel = 'fail';
+    openaiDetail = `OPENAI_COMPATIBLE_API_KEY references "${openaiKeyRaw}" but vault didn't resolve it.`;
+    openaiFix = `Verify the vault entry exists (\`memphis vault list\`) or re-run \`memphis openai configure --key <sk-...>\`.`;
+  }
+  checks.push({
+    id: 'ta15-openai',
+    tier: 'A',
+    title: 'OpenAI / Codex provider key',
+    level: openaiLevel,
+    ok: openaiLevel === 'pass',
+    required: false,
+    detail: openaiDetail,
+    fix: openaiFix,
+  });
+
   // --post-install narrows the report to tier-1 (Core Infrastructure)
   // checks only: data dir, chains, vault, .env, systemd visibility. Provider
   // health and the higher tiers require a configured-and-running runtime,

--- a/tests/unit/openai-handler.test.ts
+++ b/tests/unit/openai-handler.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Unit tests for memphis openai configure / status CLI.
+ *
+ * Same shape as the brave-handler tests (#487) — vault, env-file,
+ * journal mocks via vi.hoisted; fetch mocked for the status probe.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  storeVaultSecret: vi.fn(),
+  upsertEnvVars: vi.fn(() => ({ path: '/tmp/.env-test', written: [] })),
+  runMemphisJournal: vi.fn(async () => ({
+    success: true,
+    memoryId: 'mem-1',
+    index: 1,
+    hash: 'abc',
+    indexed: true,
+  })),
+}));
+
+vi.mock('../../src/security/vault-boundary.js', () => ({
+  storeVaultSecret: mocks.storeVaultSecret,
+  probeVaultCipherCycle: vi.fn(),
+}));
+vi.mock('../../src/infra/config/env-file.js', () => ({
+  upsertEnvVars: mocks.upsertEnvVars,
+}));
+vi.mock('../../src/mcp/tools/journal.js', () => ({
+  runMemphisJournal: mocks.runMemphisJournal,
+}));
+
+import type { CliContext } from '../../src/infra/cli/context.js';
+import { openaiCommandHandler } from '../../src/infra/cli/handlers/openai.handler.js';
+
+const { storeVaultSecret, upsertEnvVars, runMemphisJournal } = mocks;
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function makeContext(args: Partial<CliContext['args']>): CliContext {
+  return {
+    args: {
+      command: 'openai',
+      ...args,
+    },
+  } as unknown as CliContext;
+}
+
+describe('memphis openai configure', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.OPENAI_COMPATIBLE_API_KEY;
+    delete process.env.OPENAI_COMPATIBLE_API_BASE;
+    delete process.env.OPENAI_COMPATIBLE_MODEL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('rejects configure without --key', async () => {
+    await expect(
+      openaiCommandHandler.handle(
+        makeContext({ subcommand: 'configure', json: true }),
+      ),
+    ).rejects.toThrow('--key <sk-...> required');
+  });
+
+  it('stores key in vault and writes 3 env entries on configure', async () => {
+    await openaiCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'sk-abc0123456789012345678901234567890',
+      } as Partial<CliContext['args']>),
+    );
+
+    expect(storeVaultSecret).toHaveBeenCalledWith(
+      'openai_api_key',
+      'sk-abc0123456789012345678901234567890',
+      expect.objectContaining({ surface: 'cli', command: 'openai configure' }),
+      expect.any(Object),
+    );
+    expect(upsertEnvVars).toHaveBeenCalledWith([
+      { key: 'OPENAI_COMPATIBLE_API_BASE', value: 'https://api.openai.com/v1' },
+      { key: 'OPENAI_COMPATIBLE_API_KEY', value: 'VAULT:openai_api_key' },
+      { key: 'OPENAI_COMPATIBLE_MODEL', value: 'gpt-5-codex' },
+    ]);
+  });
+
+  it('uses --model override when provided (else default gpt-5-codex)', async () => {
+    await openaiCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'sk-abc0123456789012345678901234567890',
+        model: 'gpt-4o-mini',
+      } as Partial<CliContext['args']>),
+    );
+
+    expect(upsertEnvVars).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        { key: 'OPENAI_COMPATIBLE_MODEL', value: 'gpt-4o-mini' },
+      ]),
+    );
+  });
+
+  it('writes a config-change journal event tagged for chain_hits visibility', async () => {
+    await openaiCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'sk-abc0123456789012345678901234567890',
+      } as Partial<CliContext['args']>),
+    );
+    expect(runMemphisJournal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('OpenAI provider configured'),
+        tags: expect.arrayContaining(['config-change', 'openai', 'external-api']),
+        surface: 'cli',
+      }),
+    );
+  });
+
+  it('warns and overwrites when env was already pointing at non-OpenAI baseUrl', async () => {
+    process.env.OPENAI_COMPATIBLE_API_BASE = 'https://api.deepseek.com';
+    const beforeWarnings = upsertEnvVars.mock.calls.length;
+    await openaiCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'sk-abc0123456789012345678901234567890',
+      } as Partial<CliContext['args']>),
+    );
+    // upsert still runs (overwrites unconditionally; warning surfaces in result)
+    expect(upsertEnvVars.mock.calls.length).toBe(beforeWarnings + 1);
+    // The journal entry should still fire — vault + env writes succeeded
+    expect(runMemphisJournal).toHaveBeenCalled();
+  });
+
+  it('exposes the new key + model on process.env so the same-process status sees it', async () => {
+    await openaiCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'sk-abc0123456789012345678901234567890',
+      } as Partial<CliContext['args']>),
+    );
+    expect(process.env.OPENAI_COMPATIBLE_API_KEY).toBe(
+      'sk-abc0123456789012345678901234567890',
+    );
+    expect(process.env.OPENAI_COMPATIBLE_API_BASE).toBe('https://api.openai.com/v1');
+    expect(process.env.OPENAI_COMPATIBLE_MODEL).toBe('gpt-5-codex');
+  });
+
+  it('continues even when journal write fails', async () => {
+    runMemphisJournal.mockRejectedValueOnce(new Error('chain unavailable'));
+    const ok = await openaiCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'sk-abc0123456789012345678901234567890',
+      } as Partial<CliContext['args']>),
+    );
+    expect(ok).toBe(true);
+    expect(storeVaultSecret).toHaveBeenCalled();
+  });
+});
+
+describe('memphis openai status', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.OPENAI_COMPATIBLE_API_KEY;
+    delete process.env.OPENAI_COMPATIBLE_API_BASE;
+    delete process.env.OPENAI_COMPATIBLE_MODEL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('does NOT call OpenAI when key is unset', async () => {
+    const fetchSpy = vi.fn(async () => new Response('{}', { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    await openaiCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call OpenAI when env still holds VAULT: prefix', async () => {
+    process.env.OPENAI_COMPATIBLE_API_KEY = 'VAULT:openai_api_key';
+    const fetchSpy = vi.fn(async () => new Response('{}', { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    await openaiCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('runs a /models probe with Bearer auth when key is present', async () => {
+    process.env.OPENAI_COMPATIBLE_API_KEY = 'sk-abcdef0123456789';
+    process.env.OPENAI_COMPATIBLE_API_BASE = 'https://api.openai.com/v1';
+    process.env.OPENAI_COMPATIBLE_MODEL = 'gpt-5-codex';
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: 'gpt-5-codex' }, { id: 'gpt-4o' }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await openaiCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe('https://api.openai.com/v1/models');
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer sk-abcdef0123456789');
+  });
+
+  it('annotates 401 as "key rejected"', async () => {
+    process.env.OPENAI_COMPATIBLE_API_KEY = 'sk-bad';
+    const fetchSpy = vi.fn(async () => new Response('{"error":"invalid"}', { status: 401 }));
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    // Status doesn't throw; just exercises the path
+    await openaiCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});
+
+describe('openaiCommandHandler shape', () => {
+  it('exposes name, commands, canHandle, handle', () => {
+    expect(openaiCommandHandler.name).toBe('openai');
+    expect(openaiCommandHandler.commands).toContain('openai');
+  });
+
+  it('canHandle returns true only for command="openai"', () => {
+    expect(
+      openaiCommandHandler.canHandle({ args: { command: 'openai' } } as CliContext),
+    ).toBe(true);
+    expect(
+      openaiCommandHandler.canHandle({ args: { command: 'minimax' } } as CliContext),
+    ).toBe(false);
+  });
+
+  it('rejects unknown subcommands with a helpful hint', async () => {
+    await expect(
+      openaiCommandHandler.handle(
+        makeContext({ subcommand: 'banana' } as Partial<CliContext['args']>),
+      ),
+    ).rejects.toThrow(/Unknown subcommand.*configure.*status/);
+  });
+});


### PR DESCRIPTION
## Summary

Operator's 2026-05-05 ask was wiring **Codex** (chatgpt.com/codex/cloud). OpenAI doesn't publish a public OAuth flow — Admin API is static-key only — so this is the API-key path.

Memphis already has `OpenAICompatibleProvider` (a generic /v1/chat/completions adapter), wired through `OPENAI_COMPATIBLE_API_BASE`, `_API_KEY`, `_MODEL`. This PR gives operators a **focused command for the OpenAI case specifically**: vault-stores the key, points the three env vars at api.openai.com with sensible defaults, journals a config-change event so the bot's chain_hits picks up "OpenAI wired" next turn.

## CLI

```bash
memphis openai configure --key sk-... [--model gpt-5-codex]
memphis openai status
```

`configure`:
- Default model: **`gpt-5-codex`** (operator's stated need — Codex routing)
- Stores key in vault entry `openai_api_key`
- Upserts 3 env vars (base + key ref + model)
- Soft-warns if base URL was previously a different host (DeepSeek / OpenRouter / etc — overwrite is intentional but flagged)
- Journals `tags: ['config-change', 'openai', 'external-api', 'provider']`

`status`:
- Hits `GET /v1/models` with Bearer auth
- Surfaces latency + model count + precise error (401 = "key rejected", 429 = "rate-limit / quota")

## Doctor probe `ta15-openai`

- **pass** when `OPENAI_COMPATIBLE_API_KEY` holds a literal value
- **warn** when unset (other providers still work)
- **fail** when env holds `VAULT:` prefix (vault didn't resolve)

Offline-only (env presence + shape). Live API probe in `memphis openai status`.

## Companion to #487

Same pattern as `memphis brave configure`, applied to OpenAI. The **soul-awareness** layer (system-prompt section "Recent operator config changes") that lives in #487 works for both — bot will see this PR's journal events and quote them when asked.

## Test plan

- [x] 14 new unit tests in `tests/unit/openai-handler.test.ts`:
  - configure: no-key reject / vault store / 3-env upsert / model override / journal tag / non-OpenAI-base warning / process.env exposure / journal-failure survival
  - status: missing key / vault-unresolved / Bearer probe with correct URL+auth / 401 rejection
  - shape + unknown subcommand
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)