### PR TITLE
feat(self-describe): surface recent config-changes for soul awareness

### DIFF
--- a/src/config/env-registry.ts
+++ b/src/config/env-registry.ts
@@ -263,6 +263,21 @@ export const MEMPHIS_FAULT_INJECT = defineStringAccessor({
   defaultValue: '',
 });
 
+/**
+ * Brave Search API subscription token. Used by memphis_brave_search.
+ * Free tier 2000 queries/month — get one at https://api.search.brave.com/.
+ * Vault refs ("VAULT:brave_api_key") are resolved upstream by
+ * resolveVaultSecrets() in src/infra/cli/index.ts before any tool runs.
+ * Marked secret so doctor / telemetry never log the actual key.
+ */
+export const BRAVE_API_KEY = defineStringAccessor({
+  name: 'BRAVE_API_KEY',
+  envKey: 'BRAVE_API_KEY',
+  description: 'Brave Search API subscription token (or VAULT:<key> ref)',
+  defaultValue: '',
+  isSecret: true,
+});
+
 // ── Registry surface (for doctor + telemetry) ───────────────────────────────
 
 /**
@@ -284,6 +299,7 @@ export const ENV_REGISTRY: readonly EnvAccessor<unknown>[] = [
   MEMPHIS_VAULT_PEPPER,
   MEMPHIS_SAFE_MODE,
   MEMPHIS_FAULT_INJECT,
+  BRAVE_API_KEY,
 ] as const;
 
 export interface RegistryReport {

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -243,20 +243,31 @@ this prompt.
 
 When the operator asks "did you notice my new key", "co się
 zmieniło", "what's now configured", or implies they just added
-something: don't guess. Either:
-  1. Quote a relevant \`[chain_hits]\` line tagged \`config-change\`
-     if the cognitive prelude already surfaced it, OR
-  2. Call \`memphis_recall\` with the relevant capability name (e.g.
-     "Brave Search", "telegram bot token") to find the most recent
-     config-change journal entry, OR
-  3. Call \`memphis_self_describe\` to get the current effective
-     surface state (tools / tier / features) — this is the
-     authoritative live view; trust its JSON over your own memory.
+something: don't guess. Use this ladder, picking the LOWEST cost
+option that answers the question:
 
-Do not say "I noticed you added X" unless one of those tools just
-fired and returned the evidence. If nothing surfaces, say so honestly:
-"I don't see a recent config-change for X in chains; did the command
-finish without error?" — that's the real signal the operator needs.
+  1. **Prefer \`memphis_self_describe\`** — its JSON now includes
+     a \`recentConfigChanges\` array (last 30 days, last 30 entries)
+     populated from the journal chain. Each entry has
+     \`{timestamp, capability, blockIndex, summary, tags}\`. This is
+     the authoritative live answer for "what's been wired recently"
+     — quote the matching entry's \`summary\` and cite
+     \`journal#<blockIndex>\` for trace-back.
+  2. **Quote a relevant \`[chain_hits]\` line** tagged
+     \`config-change\` if the cognitive prelude already surfaced it
+     (cheaper than another tool call when the data is already in
+     the prompt).
+  3. **Call \`memphis_recall\`** with the capability name (e.g.
+     "Brave Search", "telegram bot token", "openai") only when
+     \`recentConfigChanges\` is empty AND \`[chain_hits]\` doesn't
+     cover the question.
+
+Do not say "I noticed you added X" unless one of those paths just
+returned evidence. If \`recentConfigChanges\` is empty AND no
+chain_hits cover it AND recall returned nothing, say so honestly:
+"I don't see a recent config-change for X in chains; did the
+command finish without error?" — that's the real signal the
+operator needs.
 
 ### Memory questions — chains are the source of truth
 

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -230,6 +230,34 @@ tier, say so explicitly — "I don't have memphis_health at this tier;
 ask after /tier elevate or check the TUI status bar" — instead of
 fabricating values.
 
+### Recent operator config changes (settings awareness)
+
+The operator can change Memphis settings between turns — most often
+by adding or rotating an API key (\`memphis brave configure\`,
+\`memphis telegram configure\`, \`memphis provider add\`, etc.) or by
+flipping a feature flag. Each \`configure\`-class command writes a
+journal block tagged \`config-change\` so the bot has a way to
+notice. You DO NOT have a live capability registry that auto-updates
+between turns — what you can act on is whatever Memphis surfaces in
+this prompt.
+
+When the operator asks "did you notice my new key", "co się
+zmieniło", "what's now configured", or implies they just added
+something: don't guess. Either:
+  1. Quote a relevant \`[chain_hits]\` line tagged \`config-change\`
+     if the cognitive prelude already surfaced it, OR
+  2. Call \`memphis_recall\` with the relevant capability name (e.g.
+     "Brave Search", "telegram bot token") to find the most recent
+     config-change journal entry, OR
+  3. Call \`memphis_self_describe\` to get the current effective
+     surface state (tools / tier / features) — this is the
+     authoritative live view; trust its JSON over your own memory.
+
+Do not say "I noticed you added X" unless one of those tools just
+fired and returned the evidence. If nothing surfaces, say so honestly:
+"I don't see a recent config-change for X in chains; did the command
+finish without error?" — that's the real signal the operator needs.
+
 ### Memory questions — chains are the source of truth
 
 When the user asks about their own past — "co decydowałem o X",

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -484,6 +484,7 @@ const HAND_AUTHORED_TOOLS = new Set([
   'memphis_repair',
   'memphis_deploy',
   'memphis_web_fetch',
+  'memphis_brave_search',
   'memphis_exec',
   'memphis_loop_step',
   'memphis_soul_read',
@@ -730,6 +731,34 @@ WHEN TO USE:
 - When the user shares a URL and asks about its content
 - Fetching documentation, API specs, or public resources
 - Never for authentication endpoints or internal services
+</tool>`);
+  }
+
+  if (tools.includes('memphis_brave_search')) {
+    sections.push(`<tool name="memphis_brave_search">
+PURPOSE: Search the web via Brave Search API. Higher-quality structured
+         results than memphis_web_search (DuckDuckGo HTML scrape) when
+         the operator has set BRAVE_API_KEY.
+INPUT: { query: string, limit?: number, country?: string, search_lang?: string }
+OUTPUT: { query, results: [{title, url, description, source: 'web'|'news'}], count, error? }
+
+AUTH: Requires BRAVE_API_KEY env. Free tier 2000 queries/month at
+      https://api.search.brave.com/. Vault refs (VAULT:brave_api_key)
+      are resolved upstream. If the key is missing, the tool returns
+      an error explaining how to set it — quote that verbatim, don't
+      paraphrase.
+
+WHEN TO USE:
+- Live web facts the operator just asked about and chains don't cover
+- Discovering URLs to feed into memphis_web_fetch for full-text
+- Polish-language searches: pass country='PL' + search_lang='pl' for
+  region-localized results
+- Prefer this over memphis_web_search if BRAVE_API_KEY is available
+
+WHEN NOT TO USE:
+- For Memphis-internal knowledge (use memphis_recall / memphis_search
+  on chains)
+- When the operator can answer faster from their own knowledge base
 </tool>`);
   }
 

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -13,6 +13,7 @@ import { AppError } from '../core/errors.js';
 import { CaseChainAdapter } from '../infra/storage/case-chain-adapter.js';
 import type { SqliteEvolveSessionRepository } from '../infra/storage/sqlite/repositories/evolve-session-repository.js';
 import type { SqliteToolPermissionRepository } from '../infra/storage/sqlite/repositories/tool-permission-repository.js';
+import { runMemphisBraveSearch } from '../mcp/tools/brave-search.js';
 import { runMemphisBuild } from '../mcp/tools/build.js';
 import { runMemphisCaseAppend, runMemphisCaseQuery } from '../mcp/tools/case-entry.js';
 import { runMemphisChainQuery } from '../mcp/tools/chain-query.js';
@@ -879,6 +880,33 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       },
       async execute(input) {
         return runMemphisWebSearch(input);
+      },
+    }),
+    buildTool({
+      name: 'memphis_brave_search',
+      description: 'Search the web via Brave Search API',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Search query' },
+          limit: { type: 'number', description: 'Max results (1-20)' },
+          country: { type: 'string', description: 'ISO 3166-1 alpha-2 country code' },
+          search_lang: { type: 'string', description: 'ISO 639-1 language code' },
+        },
+        required: ['query'],
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput(args) {
+        return {
+          query: requiredString(args, 'query'),
+          limit: optionalNumber(args, 'limit'),
+          country: optionalString(args, 'country'),
+          search_lang: optionalString(args, 'search_lang'),
+        };
+      },
+      async execute(input) {
+        return runMemphisBraveSearch(input, deps.rawEnv);
       },
     }),
     buildTool({

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -938,6 +938,46 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
       },
     ],
   },
+  memphis_brave_search: {
+    name: 'memphis_brave_search',
+    tier: 2,
+    capabilities: ['network', 'read'],
+    description: 'Search the web via Brave Search API (requires BRAVE_API_KEY)',
+    inputSchema: z
+      .object({
+        query: z.string().min(1),
+        limit: z.number().int().positive().max(20).optional(),
+        country: z.string().length(2).optional(),
+        search_lang: z.string().length(2).optional(),
+        approval_request_id: z.string().optional(),
+      })
+      .strict(),
+    helpText:
+      'Brave Search API (paid tier — free 2000 queries/month at https://api.search.brave.com/). Returns up to 20 structured JSON results combining web + news. Higher quality than memphis_web_search (DuckDuckGo HTML scrape) when an API key is available; prefer this if BRAVE_API_KEY is set. Optional country (ISO-2, e.g. PL) + search_lang for region-localized results.',
+    cliFlags: [
+      {
+        name: '--query',
+        description: 'Search query. Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--limit',
+        description: 'Max results to return (cap 20).',
+        takesValue: true,
+      },
+      {
+        name: '--country',
+        description: 'ISO 3166-1 alpha-2 country code (e.g. PL, US).',
+        takesValue: true,
+      },
+      {
+        name: '--search-lang',
+        description: 'ISO 639-1 language code (e.g. pl, en).',
+        takesValue: true,
+      },
+    ],
+  },
   memphis_package: {
     name: 'memphis_package',
     tier: 2,

--- a/src/infra/cli/handlers/brave.handler.ts
+++ b/src/infra/cli/handlers/brave.handler.ts
@@ -1,0 +1,203 @@
+/**
+ * `memphis brave` CLI — dedicated UX for adding/checking the
+ * Brave Search API key.
+ *
+ * Mirrors the pattern of `memphis telegram configure` (vault-store +
+ * .env upsert + status probe). Stores the key under vault entry
+ * `brave_api_key` and writes the .env reference `BRAVE_API_KEY=
+ * VAULT:brave_api_key`. On success, journals a config-change event
+ * (`tags: ['config-change', 'brave-search']`) so the bot's chain_hits
+ * picks up "BRAVE_API_KEY was just configured" the next time the
+ * operator asks about external APIs / capabilities.
+ *
+ * Subcommands:
+ *   - `configure --key <token>`  — store + activate
+ *   - `status`                   — show key presence + API health probe
+ */
+
+import chalk from 'chalk';
+
+import type { CommandHandler } from './command-handler.js';
+import { runMemphisBraveSearch } from '../../../mcp/tools/brave-search.js';
+import { runMemphisJournal } from '../../../mcp/tools/journal.js';
+import { storeVaultSecret } from '../../../security/vault-boundary.js';
+import { upsertEnvVars } from '../../config/env-file.js';
+import type { CliContext } from '../context.js';
+import { print } from '../utils/render.js';
+
+const VAULT_KEY = 'brave_api_key';
+
+export const braveCommandHandler: CommandHandler = {
+  name: 'brave',
+  commands: ['brave'],
+  canHandle(context: CliContext): boolean {
+    return context.args.command === 'brave';
+  },
+  async handle(context: CliContext): Promise<boolean> {
+    const { subcommand } = context.args;
+    const handlers: Record<string, () => Promise<boolean>> = {
+      configure: () => handleBraveConfigure(context),
+      status: () => handleBraveStatus(context),
+    };
+    const handler = subcommand ? handlers[subcommand] : handlers.status;
+    if (!handler) {
+      throw new Error(
+        `Unknown subcommand: memphis brave ${subcommand}. Try: configure | status`,
+      );
+    }
+    return handler();
+  },
+};
+
+async function handleBraveConfigure(context: CliContext): Promise<boolean> {
+  const { json, key } = context.args as { json?: boolean; key?: string };
+
+  if (!key || key.trim().length === 0) {
+    throw new Error(
+      'memphis brave configure --key <token> required. Get a key (free 2000 q/mo) at https://api.search.brave.com/.',
+    );
+  }
+
+  const trimmed = key.trim();
+  // Brave keys begin with "BSA" and are ~32+ chars. Don't hard-fail on
+  // shape mismatch — Brave doesn't publish a stable format guarantee
+  // — just warn so the operator catches obvious paste errors.
+  const looksValid = /^BSA[A-Za-z0-9_-]{20,}$/.test(trimmed);
+  const warnings: string[] = [];
+  if (!looksValid) {
+    warnings.push(
+      'Key does not match the typical "BSA..." Brave format. Continuing — verify with `memphis brave status`.',
+    );
+  }
+
+  // Store in vault
+  storeVaultSecret(
+    VAULT_KEY,
+    trimmed,
+    { surface: 'cli', command: 'brave configure' },
+    process.env,
+  );
+
+  // Upsert .env so subsequent restarts pick up the vault reference.
+  // Using upsertEnvVars (idempotent — replaces existing line) so a
+  // re-run of `memphis brave configure` updates the key without
+  // duplicating the env entry.
+  const envUpdate = upsertEnvVars([{ key: 'BRAVE_API_KEY', value: `VAULT:${VAULT_KEY}` }]);
+
+  // Make the new key visible to the current process so the journal
+  // event below + the status probe see the resolved value, not the
+  // pre-configure state.
+  process.env.BRAVE_API_KEY = trimmed;
+
+  // Journal a config-change event so the bot's cognitive prelude
+  // picks up "BRAVE_API_KEY was set" the next time the operator
+  // asks about external APIs / capabilities. Tagged so future
+  // chain_hits queries can filter to config-change history.
+  let journaledOk = false;
+  try {
+    const journalResult = await runMemphisJournal({
+      content:
+        'Brave Search API key configured by operator. memphis_brave_search is now usable (free tier: 2000 queries/month, 1 query/sec).',
+      tags: ['config-change', 'brave-search', 'external-api'],
+      surface: 'cli',
+    });
+    journaledOk = journalResult.success;
+  } catch {
+    // Non-fatal — vault write succeeded, journal is best-effort.
+  }
+
+  const result = {
+    ok: true,
+    vaultKey: VAULT_KEY,
+    envPath: envUpdate.path,
+    envRef: 'BRAVE_API_KEY=VAULT:brave_api_key',
+    journaled: journaledOk,
+    warnings,
+    nextSteps: [
+      'Restart memphis service to load the new env: `systemctl --user restart memphis`',
+      'Or run `memphis brave status` to verify the key reaches the Brave API.',
+    ],
+  };
+
+  if (!json) {
+    console.log(chalk.green.bold('\n✓ Brave Search API configured\n'));
+    console.log(`  Vault key:  ${chalk.cyan(VAULT_KEY)}`);
+    console.log(`  Env ref:    ${chalk.cyan('BRAVE_API_KEY=VAULT:' + VAULT_KEY)}`);
+    console.log(`  .env file:  ${chalk.gray(envUpdate.path)}`);
+    console.log(
+      `  Journal:    ${
+        journaledOk
+          ? chalk.green('config-change event recorded')
+          : chalk.yellow('event NOT recorded (vault write succeeded; bot may not auto-notice the change)')
+      }`,
+    );
+    if (warnings.length > 0) {
+      for (const w of warnings) console.log(chalk.yellow(`  ⚠ ${w}`));
+    }
+    console.log('');
+    console.log(chalk.gray('  Next steps:'));
+    for (const step of result.nextSteps) {
+      console.log(chalk.gray(`    - ${step}`));
+    }
+    console.log('');
+  }
+
+  print(result, json ?? false);
+  return true;
+}
+
+async function handleBraveStatus(context: CliContext): Promise<boolean> {
+  const { json } = context.args;
+
+  const raw = process.env.BRAVE_API_KEY?.trim();
+  const configured = Boolean(raw && !raw.startsWith('VAULT:'));
+  const vaultUnresolved = Boolean(raw?.startsWith('VAULT:'));
+
+  let probe: { ok: boolean; latencyMs?: number; error?: string } | undefined;
+  if (configured) {
+    const start = Date.now();
+    const out = await runMemphisBraveSearch({ query: 'memphis-status-probe', limit: 1 }, process.env);
+    probe = {
+      ok: out.error === undefined && out.count >= 0,
+      latencyMs: Date.now() - start,
+      error: out.error,
+    };
+  }
+
+  const result = {
+    configured,
+    vaultUnresolved,
+    vaultKey: VAULT_KEY,
+    probe,
+    suggestion: !configured
+      ? vaultUnresolved
+        ? `Vault didn't expand "${raw}" — run \`memphis vault list\` to confirm the entry exists, then \`memphis brave configure --key <token>\`.`
+        : 'Run `memphis brave configure --key <token>` to set the key. Get one (free) at https://api.search.brave.com/.'
+      : probe?.ok
+        ? undefined
+        : `Brave API call failed: ${probe?.error ?? 'unknown error'}`,
+  };
+
+  if (!json) {
+    console.log(chalk.bold('\n  Brave Search API status\n'));
+    console.log(`  Key:    ${configured ? chalk.green('present') : chalk.red('not set')}`);
+    if (vaultUnresolved) {
+      console.log(`  Note:   ${chalk.yellow(`env still holds "${raw}" — vault didn't resolve`)}`);
+    }
+    if (probe) {
+      console.log(
+        `  Probe:  ${probe.ok ? chalk.green('reachable') : chalk.red('failed')} ${
+          probe.latencyMs !== undefined ? chalk.gray(`(${probe.latencyMs}ms)`) : ''
+        }`,
+      );
+      if (!probe.ok) console.log(`  Error:  ${chalk.red(probe.error ?? 'unknown')}`);
+    }
+    if (result.suggestion) {
+      console.log(chalk.gray(`\n  ${result.suggestion}`));
+    }
+    console.log('');
+  }
+
+  print(result, json ?? false);
+  return true;
+}

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -181,6 +181,11 @@ export const CLI_COMMAND_REGISTRY = [
     ),
   ),
   createCommandRegistration(
+    'brave',
+    ['brave'],
+    createLazyHandlerLoader(() => import('./handlers/brave.handler.js'), 'braveCommandHandler'),
+  ),
+  createCommandRegistration(
     'debug',
     ['debug'],
     createLazyHandlerLoader(() => import('./handlers/debug.handler.js'), 'debugCommandHandler'),

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -2047,6 +2047,38 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
     fix: kartografFix,
   });
 
+  // PR #487 — Brave Search API key visibility. Optional probe — bot
+  // works fine without a Brave key (memphis_web_search via DuckDuckGo
+  // is the no-key fallback) but operators who configured one want a
+  // green confirmation. Probe is BRAVE_API_KEY presence + shape; we
+  // don't hit the network here to keep `memphis doctor` fast and
+  // offline-safe.
+  let braveLevel: DoctorCheckLevel = 'pass';
+  let braveDetail = 'BRAVE_API_KEY configured (memphis_brave_search ready)';
+  let braveFix: string | undefined;
+  const braveRaw = process.env.BRAVE_API_KEY?.trim() ?? '';
+  if (braveRaw.length === 0) {
+    braveLevel = 'warn';
+    braveDetail =
+      'BRAVE_API_KEY not set — memphis_brave_search disabled. memphis_web_search (DuckDuckGo) still works as fallback.';
+    braveFix =
+      'Run `memphis brave configure --key <token>` (free key at https://api.search.brave.com/) to enable Brave Search.';
+  } else if (braveRaw.startsWith('VAULT:')) {
+    braveLevel = 'fail';
+    braveDetail = `BRAVE_API_KEY references "${braveRaw}" but vault didn't resolve it.`;
+    braveFix = `Verify the vault entry exists (\`memphis vault list\`) or re-run \`memphis brave configure --key <token>\`.`;
+  }
+  checks.push({
+    id: 'ta14-brave-search',
+    tier: 'A',
+    title: 'Brave Search API key',
+    level: braveLevel,
+    ok: braveLevel === 'pass',
+    required: false,
+    detail: braveDetail,
+    fix: braveFix,
+  });
+
   // --post-install narrows the report to tier-1 (Core Infrastructure)
   // checks only: data dir, chains, vault, .env, systemd visibility. Provider
   // health and the higher tiers require a configured-and-running runtime,

--- a/src/mcp/tools/brave-search.ts
+++ b/src/mcp/tools/brave-search.ts
@@ -1,0 +1,159 @@
+/**
+ * memphis_brave_search — Brave Search API web search.
+ *
+ * Mirror of memphis_web_search (DuckDuckGo HTML scrape) but backed by
+ * the Brave Search API for higher quality + structured results. Free
+ * tier offers 2000 queries/month.
+ *
+ * Why both exist: DuckDuckGo HTML scraping is zero-config, no key, no
+ * rate-limit visibility — works as a fallback. Brave API gives
+ * structured JSON, news/locations/discussions extras, and predictable
+ * rate limits — preferred when the operator has a key.
+ *
+ * Auth: header `X-Subscription-Token: <key>`. The key is read from
+ * `BRAVE_API_KEY` env (vault refs `VAULT:brave_api_key` are resolved
+ * upstream by `resolveVaultSecrets()` in src/infra/cli/index.ts, so
+ * by the time this runs the env var holds the literal key).
+ *
+ * API docs: https://api.search.brave.com/app/documentation
+ */
+
+const BRAVE_SEARCH_ENDPOINT = 'https://api.search.brave.com/res/v1/web/search';
+const MAX_RESULTS = 20;
+const TIMEOUT_MS = 15_000;
+
+export type MemphisBraveSearchInput = {
+  query: string;
+  limit?: number;
+  /**
+   * Brave's `country` param (ISO 3166-1 alpha-2). Default unset = global.
+   * Polish-language operator can pass 'PL' for region-localized results.
+   */
+  country?: string;
+  /** Brave's `search_lang` param (ISO 639-1). Default unset = English. */
+  search_lang?: string;
+};
+
+export type BraveSearchResult = {
+  title: string;
+  url: string;
+  description: string;
+  /** Where in Brave's response this came from (web | news). */
+  source: 'web' | 'news';
+};
+
+export type MemphisBraveSearchOutput = {
+  query: string;
+  results: BraveSearchResult[];
+  count: number;
+  error?: string;
+};
+
+interface BraveWebItem {
+  title?: string;
+  url?: string;
+  description?: string;
+}
+
+interface BraveResponse {
+  web?: { results?: BraveWebItem[] };
+  news?: { results?: BraveWebItem[] };
+}
+
+function pickResults(items: BraveWebItem[] | undefined, source: 'web' | 'news'): BraveSearchResult[] {
+  if (!Array.isArray(items)) return [];
+  return items
+    .filter((item) => typeof item.url === 'string' && item.url.length > 0)
+    .map((item) => ({
+      title: (item.title ?? '').trim(),
+      url: item.url!,
+      description: (item.description ?? '').replace(/<[^>]*>/g, '').trim(),
+      source,
+    }));
+}
+
+export async function runMemphisBraveSearch(
+  input: MemphisBraveSearchInput,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): Promise<MemphisBraveSearchOutput> {
+  const limit = Math.min(Math.max(input.limit ?? 10, 1), MAX_RESULTS);
+
+  if (!input.query || input.query.trim().length === 0) {
+    return { query: input.query ?? '', results: [], count: 0, error: 'Query is empty' };
+  }
+
+  const apiKey = rawEnv.BRAVE_API_KEY?.trim();
+  if (!apiKey || apiKey.startsWith('VAULT:')) {
+    // Vault prefix means the upstream resolver did NOT manage to expand
+    // it — usually because vault wasn't initialized or the entry name
+    // doesn't exist. Surface a precise error so the operator knows
+    // exactly what to fix.
+    return {
+      query: input.query,
+      results: [],
+      count: 0,
+      error:
+        apiKey?.startsWith('VAULT:') ?? false
+          ? `BRAVE_API_KEY references vault entry "${apiKey?.slice(6)}" but vault didn't resolve it. Run \`memphis vault add ${apiKey?.slice(6)} --key <real-key>\` or set BRAVE_API_KEY directly.`
+          : 'BRAVE_API_KEY not set. Get a key at https://api.search.brave.com/ (free 2000 queries/month) and set BRAVE_API_KEY or vault-store via `memphis vault add brave_api_key --key <key>` then BRAVE_API_KEY=VAULT:brave_api_key.',
+    };
+  }
+
+  const params = new URLSearchParams({
+    q: input.query,
+    count: String(limit),
+  });
+  if (input.country) params.set('country', input.country);
+  if (input.search_lang) params.set('search_lang', input.search_lang);
+
+  const url = `${BRAVE_SEARCH_ENDPOINT}?${params.toString()}`;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      headers: {
+        Accept: 'application/json',
+        'Accept-Encoding': 'gzip',
+        'X-Subscription-Token': apiKey,
+        'User-Agent': 'Memphis-Agent/1.0 (sovereign-runtime)',
+      },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      // Brave returns 401 on bad key, 429 on rate limit, 422 on bad query
+      let hint = '';
+      if (response.status === 401) hint = ' (BRAVE_API_KEY rejected — check it)';
+      else if (response.status === 429) hint = ' (rate limit hit — Brave free tier is 1 query/sec)';
+      return {
+        query: input.query,
+        results: [],
+        count: 0,
+        error: `Brave Search API error: HTTP ${response.status}${hint} ${body.slice(0, 200)}`,
+      };
+    }
+
+    const data = (await response.json()) as BraveResponse;
+    const webResults = pickResults(data.web?.results, 'web');
+    const newsResults = pickResults(data.news?.results, 'news');
+    const merged = [...webResults, ...newsResults].slice(0, limit);
+
+    return {
+      query: input.query,
+      results: merged,
+      count: merged.length,
+    };
+  } catch (err) {
+    return {
+      query: input.query,
+      results: [],
+      count: 0,
+      error: `Brave Search failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/src/mcp/tools/self-describe.ts
+++ b/src/mcp/tools/self-describe.ts
@@ -29,6 +29,7 @@ import {
 } from '../../gateway/surface-policy.js';
 import { getToolMeta, getToolNames, type ToolCliFlag } from '../../gateway/tool-registry.js';
 import { listEnabledFeatureFlags } from '../../infra/features/flags.js';
+import { getRecentBlocks } from '../../infra/storage/rust-chain-adapter.js';
 import {
   getActiveTier3Session,
   listActiveTier3Sessions,
@@ -92,13 +93,106 @@ export interface MemphisSelfDescribeOutput {
     expiresAt: string;
     remainingMs: number;
   }>;
+  /**
+   * Recent operator config-change events from the journal chain
+   * (last 30 entries, last 30 days). Each `configure`-class CLI
+   * (e.g. `memphis brave configure`, `memphis openai configure`,
+   * `memphis telegram configure`) writes a journal block tagged
+   * `config-change`. This list is the live, authoritative answer to
+   * "co operator ostatnio włączył / what's been configured" — bot
+   * should read it instead of guessing or relying on chain_hits.
+   *
+   * Empty array when no config-change events exist within the
+   * window or when chain reads fail (best-effort, never throws).
+   */
+  recentConfigChanges: Array<{
+    timestamp: string;
+    /** Capability tag (e.g. 'brave-search', 'openai', 'telegram'). */
+    capability: string;
+    /** Block index for trace-back (`journal#<index>`). */
+    blockIndex: number;
+    /** First ~140 chars of the journal entry content. */
+    summary: string;
+    /** Other tags on the same block (provider/external-api/etc.). */
+    tags: string[];
+  }>;
   asOf: string;
 }
 
-export function runMemphisSelfDescribe(
+/**
+ * Window for `recentConfigChanges` — entries older than this are
+ * dropped from the response. Configurable so a future env override
+ * can stretch the window for ops triage. 30 days picks up most
+ * "rotated my key last month, did Memphis pick it up?" workflows.
+ */
+const CONFIG_CHANGE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const CONFIG_CHANGE_MAX_ENTRIES = 30;
+
+interface ConfigChangeBlock {
+  data?: {
+    content?: string;
+    tags?: string[];
+    type?: string;
+  };
+  index?: number;
+  timestamp?: string;
+}
+
+function deriveCapabilityTag(tags: readonly string[]): string {
+  // Capability tag is the first tag that isn't 'config-change' or
+  // a generic role tag. Operators tag entries like
+  // ['config-change', 'brave-search', 'external-api'] — we surface
+  // 'brave-search' as the capability label.
+  const generic = new Set(['config-change', 'external-api', 'provider']);
+  for (const tag of tags) {
+    if (!generic.has(tag)) return tag;
+  }
+  return tags[0] ?? 'unknown';
+}
+
+async function readRecentConfigChanges(
+  rawEnv: NodeJS.ProcessEnv,
+): Promise<MemphisSelfDescribeOutput['recentConfigChanges']> {
+  let blocks: ConfigChangeBlock[];
+  try {
+    // Read more than we need so the tag filter has plenty to cut
+    // through — journal sees high write volume and config-change
+    // blocks are sparse.
+    blocks = (await getRecentBlocks('journal', 200, rawEnv)) as ConfigChangeBlock[];
+  } catch {
+    // Best-effort. Never throw from self-describe — operators rely
+    // on it for ground truth, and a missing config-change list is
+    // strictly less useful than a non-empty answer.
+    return [];
+  }
+
+  const cutoff = Date.now() - CONFIG_CHANGE_WINDOW_MS;
+  const out: MemphisSelfDescribeOutput['recentConfigChanges'] = [];
+  // Walk newest → oldest so the slice keeps the most recent entries.
+  for (let i = blocks.length - 1; i >= 0 && out.length < CONFIG_CHANGE_MAX_ENTRIES; i -= 1) {
+    const block = blocks[i];
+    const tags = block.data?.tags;
+    if (!Array.isArray(tags) || !tags.includes('config-change')) continue;
+
+    const ts = block.timestamp ? Date.parse(block.timestamp) : NaN;
+    if (Number.isFinite(ts) && ts < cutoff) continue;
+
+    const content = (block.data?.content ?? '').toString();
+    out.push({
+      timestamp: block.timestamp ?? new Date(0).toISOString(),
+      capability: deriveCapabilityTag(tags),
+      blockIndex: typeof block.index === 'number' ? block.index : -1,
+      summary: content.length > 140 ? `${content.slice(0, 137)}…` : content,
+      tags: [...tags],
+    });
+  }
+  return out;
+}
+
+export async function runMemphisSelfDescribe(
   input: MemphisSelfDescribeInput = {},
   rawEnv: NodeJS.ProcessEnv = process.env,
-): MemphisSelfDescribeOutput {
+): Promise<MemphisSelfDescribeOutput> {
   const surface = input.surface ?? 'mcp';
   const actorId = input.actorId ?? 'local';
   const policy = resolveSurfacePolicy(surface, rawEnv);
@@ -158,6 +252,8 @@ export function runMemphisSelfDescribe(
     remainingMs: Math.max(0, s.expiresAt - now),
   }));
 
+  const recentConfigChanges = await readRecentConfigChanges(rawEnv);
+
   return {
     surface,
     surfacePolicy: policy,
@@ -176,6 +272,7 @@ export function runMemphisSelfDescribe(
     toolsRegistered,
     featureFlags: listEnabledFeatureFlags(rawEnv),
     activeTier3SessionsAcrossSurfaces: acrossSurfaces,
+    recentConfigChanges,
     asOf: new Date(now).toISOString(),
   };
 }

--- a/tests/unit/brave-handler.test.ts
+++ b/tests/unit/brave-handler.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for memphis brave configure / status CLI.
+ *
+ * The handler shells out to vault-boundary, env-file mutation, the
+ * brave-search adapter, and the journal tool — each is mocked here so
+ * the test exercises the orchestration logic without touching disk
+ * or the network.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  storeVaultSecret: vi.fn(),
+  upsertEnvVars: vi.fn(() => ({ path: '/tmp/.env-test', written: [] })),
+  runMemphisJournal: vi.fn(async () => ({
+    success: true,
+    memoryId: 'mem-1',
+    index: 1,
+    hash: 'abc',
+    indexed: true,
+  })),
+  runMemphisBraveSearch: vi.fn(async () => ({
+    query: 'memphis-status-probe',
+    results: [],
+    count: 0,
+  })),
+}));
+
+vi.mock('../../src/security/vault-boundary.js', () => ({
+  storeVaultSecret: mocks.storeVaultSecret,
+  probeVaultCipherCycle: vi.fn(),
+}));
+vi.mock('../../src/infra/config/env-file.js', () => ({
+  upsertEnvVars: mocks.upsertEnvVars,
+}));
+vi.mock('../../src/mcp/tools/journal.js', () => ({
+  runMemphisJournal: mocks.runMemphisJournal,
+}));
+vi.mock('../../src/mcp/tools/brave-search.js', () => ({
+  runMemphisBraveSearch: mocks.runMemphisBraveSearch,
+}));
+
+import type { CliContext } from '../../src/infra/cli/context.js';
+import { braveCommandHandler } from '../../src/infra/cli/handlers/brave.handler.js';
+
+const { storeVaultSecret, upsertEnvVars, runMemphisJournal, runMemphisBraveSearch } = mocks;
+
+function makeContext(args: Partial<CliContext['args']>): CliContext {
+  return {
+    args: {
+      command: 'brave',
+      ...args,
+    },
+  } as unknown as CliContext;
+}
+
+describe('memphis brave configure', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.BRAVE_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('rejects configure without --key', async () => {
+    await expect(
+      braveCommandHandler.handle(
+        makeContext({ subcommand: 'configure', json: true }),
+      ),
+    ).rejects.toThrow('--key <token> required');
+  });
+
+  it('stores key in vault and upserts .env on configure', async () => {
+    await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'BSAabcdef0123456789012345abcdef',
+      } as Partial<CliContext['args']>),
+    );
+
+    expect(storeVaultSecret).toHaveBeenCalledWith(
+      'brave_api_key',
+      'BSAabcdef0123456789012345abcdef',
+      expect.objectContaining({ surface: 'cli', command: 'brave configure' }),
+      expect.any(Object),
+    );
+    expect(upsertEnvVars).toHaveBeenCalledWith([
+      { key: 'BRAVE_API_KEY', value: 'VAULT:brave_api_key' },
+    ]);
+  });
+
+  it('writes a config-change journal event tagged for chain_hits visibility', async () => {
+    await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'BSAabcdef0123456789012345abcdef',
+      } as Partial<CliContext['args']>),
+    );
+
+    expect(runMemphisJournal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Brave Search API'),
+        tags: expect.arrayContaining(['config-change', 'brave-search']),
+        surface: 'cli',
+      }),
+    );
+  });
+
+  it('exposes the new key on process.env so the same-process status probe sees it', async () => {
+    await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'BSAabcdef0123456789012345abcdef',
+      } as Partial<CliContext['args']>),
+    );
+    expect(process.env.BRAVE_API_KEY).toBe('BSAabcdef0123456789012345abcdef');
+  });
+
+  it('warns when key does not match expected BSA shape but still stores it', async () => {
+    await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'random-not-brave-shape',
+      } as Partial<CliContext['args']>),
+    );
+    // Vault store still happened — soft warning only, not a hard reject
+    expect(storeVaultSecret).toHaveBeenCalled();
+  });
+
+  it('continues even when journal write fails (vault write is the source of truth)', async () => {
+    runMemphisJournal.mockRejectedValueOnce(new Error('chain unavailable'));
+    const ok = await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'BSAabcdef0123456789012345abcdef',
+      } as Partial<CliContext['args']>),
+    );
+    expect(ok).toBe(true);
+    expect(storeVaultSecret).toHaveBeenCalled();
+  });
+});
+
+describe('memphis brave status', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.BRAVE_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('reports key=missing + suggestion when BRAVE_API_KEY is unset', async () => {
+    await braveCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+    expect(runMemphisBraveSearch).not.toHaveBeenCalled();
+  });
+
+  it('reports vault-unresolved when env still holds VAULT: prefix', async () => {
+    process.env.BRAVE_API_KEY = 'VAULT:brave_api_key';
+    await braveCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+    // No probe (key not actually usable)
+    expect(runMemphisBraveSearch).not.toHaveBeenCalled();
+  });
+
+  it('runs a probe when key is present', async () => {
+    process.env.BRAVE_API_KEY = 'BSAabcdef0123456789012345abcdef';
+    await braveCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+    expect(runMemphisBraveSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'memphis-status-probe',
+        limit: 1,
+      }),
+      expect.any(Object),
+    );
+  });
+});
+
+describe('braveCommandHandler shape', () => {
+  it('exposes name, commands, canHandle, handle on the registry contract', () => {
+    expect(braveCommandHandler.name).toBe('brave');
+    expect(braveCommandHandler.commands).toContain('brave');
+    expect(typeof braveCommandHandler.canHandle).toBe('function');
+    expect(typeof braveCommandHandler.handle).toBe('function');
+  });
+
+  it('canHandle returns true only for command="brave"', () => {
+    expect(
+      braveCommandHandler.canHandle({ args: { command: 'brave' } } as CliContext),
+    ).toBe(true);
+    expect(
+      braveCommandHandler.canHandle({ args: { command: 'telegram' } } as CliContext),
+    ).toBe(false);
+  });
+
+  it('rejects unknown subcommands with a helpful hint', async () => {
+    await expect(
+      braveCommandHandler.handle(
+        makeContext({ subcommand: 'banana' } as Partial<CliContext['args']>),
+      ),
+    ).rejects.toThrow(/Unknown subcommand.*configure.*status/);
+  });
+});

--- a/tests/unit/brave-search.test.ts
+++ b/tests/unit/brave-search.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for memphis_brave_search adapter.
+ *
+ * The adapter is a thin HTTP wrapper over Brave's web search endpoint.
+ * Tests use vi-mocked global.fetch to exercise auth-key handling,
+ * error paths (missing key, vault-unresolved key, HTTP errors), and
+ * the response-shaping happy path.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runMemphisBraveSearch } from '../../src/mcp/tools/brave-search.js';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function mockFetch(
+  shape:
+    | { ok: true; status?: number; body: unknown }
+    | { ok: false; status: number; text: string },
+): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(async () => {
+    if (shape.ok) {
+      return new Response(JSON.stringify(shape.body), {
+        status: shape.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(shape.text, { status: shape.status });
+  });
+  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
+  return fn;
+}
+
+describe('runMemphisBraveSearch', () => {
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    vi.restoreAllMocks();
+  });
+
+  // ── Empty / missing input handling ───────────────────────────────────
+
+  it('returns Query is empty error for blank queries', async () => {
+    const out = await runMemphisBraveSearch({ query: '' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toBe('Query is empty');
+    expect(out.results).toHaveLength(0);
+  });
+
+  it('returns Query is empty error for whitespace-only queries', async () => {
+    const out = await runMemphisBraveSearch({ query: '   ' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toBe('Query is empty');
+  });
+
+  // ── API key resolution ───────────────────────────────────────────────
+
+  it('returns BRAVE_API_KEY-not-set error with a helpful hint when key is missing', async () => {
+    const out = await runMemphisBraveSearch({ query: 'foo' }, {});
+    expect(out.error).toContain('BRAVE_API_KEY not set');
+    expect(out.error).toContain('https://api.search.brave.com/');
+    expect(out.error).toContain('memphis vault add brave_api_key');
+  });
+
+  it('returns vault-unresolved error when env still holds VAULT: prefix at runtime', async () => {
+    const out = await runMemphisBraveSearch(
+      { query: 'foo' },
+      { BRAVE_API_KEY: 'VAULT:brave_api_key' },
+    );
+    expect(out.error).toContain('vault entry "brave_api_key"');
+    expect(out.error).toContain("vault didn't resolve");
+    expect(out.error).toContain('memphis vault add brave_api_key');
+  });
+
+  // ── HTTP error responses ─────────────────────────────────────────────
+
+  it('annotates 401 with "BRAVE_API_KEY rejected" hint', async () => {
+    mockFetch({ ok: false, status: 401, text: '{"error":"Invalid key"}' });
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'bad-key' });
+    expect(out.error).toContain('HTTP 401');
+    expect(out.error).toContain('BRAVE_API_KEY rejected');
+  });
+
+  it('annotates 429 with rate-limit hint', async () => {
+    mockFetch({ ok: false, status: 429, text: 'Too many requests' });
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toContain('HTTP 429');
+    expect(out.error).toContain('rate limit');
+  });
+
+  it('returns a generic error for other HTTP failures', async () => {
+    mockFetch({ ok: false, status: 500, text: 'server boom' });
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toContain('HTTP 500');
+    expect(out.error).not.toContain('BRAVE_API_KEY rejected');
+    expect(out.error).not.toContain('rate limit');
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────
+
+  it('parses Brave web + news results into the unified shape', async () => {
+    const fn = mockFetch({
+      ok: true,
+      body: {
+        web: {
+          results: [
+            {
+              title: 'Example domain',
+              url: 'https://example.com/',
+              description: 'Reserved for use in <strong>illustrative</strong> examples',
+            },
+            {
+              title: 'Example 2',
+              url: 'https://example.org/',
+              description: 'Another example',
+            },
+          ],
+        },
+        news: {
+          results: [
+            { title: 'Live news', url: 'https://news.example.com/', description: 'Hot off' },
+          ],
+        },
+      },
+    });
+
+    const out = await runMemphisBraveSearch(
+      { query: 'illustrative example', limit: 10 },
+      { BRAVE_API_KEY: 'sk-test' },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.count).toBe(3);
+    expect(out.results[0]).toEqual({
+      title: 'Example domain',
+      url: 'https://example.com/',
+      // <strong> stripped from description
+      description: 'Reserved for use in illustrative examples',
+      source: 'web',
+    });
+    expect(out.results[2]).toMatchObject({
+      url: 'https://news.example.com/',
+      source: 'news',
+    });
+    // Verify request shape — auth header + query params
+    const [url, init] = fn.mock.calls[0]!;
+    expect(String(url)).toContain('api.search.brave.com');
+    expect(String(url)).toContain('q=illustrative');
+    expect(String(url)).toContain('count=10');
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['X-Subscription-Token']).toBe('sk-test');
+  });
+
+  it('respects the limit parameter (caps at 20)', async () => {
+    const fn = mockFetch({ ok: true, body: { web: { results: [] } } });
+    await runMemphisBraveSearch(
+      { query: 'foo', limit: 999 },
+      { BRAVE_API_KEY: 'k' },
+    );
+    expect(String(fn.mock.calls[0]![0])).toContain('count=20');
+  });
+
+  it('uses default limit of 10 when not supplied', async () => {
+    const fn = mockFetch({ ok: true, body: { web: { results: [] } } });
+    await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(String(fn.mock.calls[0]![0])).toContain('count=10');
+  });
+
+  it('forwards country + search_lang params when provided', async () => {
+    const fn = mockFetch({ ok: true, body: { web: { results: [] } } });
+    await runMemphisBraveSearch(
+      { query: 'foo', country: 'PL', search_lang: 'pl' },
+      { BRAVE_API_KEY: 'k' },
+    );
+    const url = String(fn.mock.calls[0]![0]);
+    expect(url).toContain('country=PL');
+    expect(url).toContain('search_lang=pl');
+  });
+
+  it('returns empty results gracefully when Brave returns no web/news arrays', async () => {
+    mockFetch({ ok: true, body: {} });
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toBeUndefined();
+    expect(out.count).toBe(0);
+    expect(out.results).toHaveLength(0);
+  });
+
+  it('truncates merged results to limit (web first, news appended)', async () => {
+    mockFetch({
+      ok: true,
+      body: {
+        web: {
+          results: Array.from({ length: 8 }, (_, i) => ({
+            title: `web ${i}`,
+            url: `https://web${i}.example/`,
+            description: '',
+          })),
+        },
+        news: {
+          results: Array.from({ length: 5 }, (_, i) => ({
+            title: `news ${i}`,
+            url: `https://news${i}.example/`,
+            description: '',
+          })),
+        },
+      },
+    });
+    const out = await runMemphisBraveSearch({ query: 'foo', limit: 5 }, { BRAVE_API_KEY: 'k' });
+    expect(out.results).toHaveLength(5);
+    // All 5 are from web (truncation prefers web ordering)
+    expect(out.results.every((r) => r.source === 'web')).toBe(true);
+  });
+
+  // ── Network failures ─────────────────────────────────────────────────
+
+  it('returns Brave Search failed error on network exception', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('ENETUNREACH');
+    }) as unknown as typeof globalThis.fetch;
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toContain('Brave Search failed');
+    expect(out.error).toContain('ENETUNREACH');
+  });
+});

--- a/tests/unit/self-describe.test.ts
+++ b/tests/unit/self-describe.test.ts
@@ -19,8 +19,8 @@ afterEach(() => {
 });
 
 describe('runMemphisSelfDescribe', () => {
-  it('returns surface, policy, cognitive mode, tools and registered count for default surface', () => {
-    const out = runMemphisSelfDescribe({}, { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv);
+  it('returns surface, policy, cognitive mode, tools and registered count for default surface', async () => {
+    const out = await runMemphisSelfDescribe({}, { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv);
 
     expect(out.surface).toBe('mcp');
     expect(typeof out.surfacePolicy.maxToolTier).toBe('number');
@@ -31,8 +31,8 @@ describe('runMemphisSelfDescribe', () => {
     expect(out.tools.some((t) => t.name === 'memphis_self_describe')).toBe(true);
   });
 
-  it('marks tools as available iff their tier is <= surface policy maxToolTier', () => {
-    const out = runMemphisSelfDescribe(
+  it('marks tools as available iff their tier is <= surface policy maxToolTier', async () => {
+    const out = await runMemphisSelfDescribe(
       { surface: 'telegram' },
       {
         MEMPHIS_DATA_DIR: '/tmp/memphis-test',
@@ -49,9 +49,9 @@ describe('runMemphisSelfDescribe', () => {
     }
   });
 
-  it('reports active tier-3 session for the resolved (surface, actorId) pair', () => {
+  it('reports active tier-3 session for the resolved (surface, actorId) pair', async () => {
     __seedTier3SessionForTests('telegram', '1316033647');
-    const out = runMemphisSelfDescribe(
+    const out = await runMemphisSelfDescribe(
       { surface: 'telegram', actorId: '1316033647' },
       { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv,
     );
@@ -63,18 +63,18 @@ describe('runMemphisSelfDescribe', () => {
     expect(out.tier3Session!.remainingMs).toBeGreaterThan(0);
   });
 
-  it('lists tier-3 sessions across surfaces in activeTier3SessionsAcrossSurfaces', () => {
+  it('lists tier-3 sessions across surfaces in activeTier3SessionsAcrossSurfaces', async () => {
     __seedTier3SessionForTests('tui', 'local');
     __seedTier3SessionForTests('telegram', '42');
-    const out = runMemphisSelfDescribe({}, { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv);
+    const out = await runMemphisSelfDescribe({}, { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv);
 
     expect(out.activeTier3SessionsAcrossSurfaces).toHaveLength(2);
     const surfaces = out.activeTier3SessionsAcrossSurfaces.map((s) => s.surface).sort();
     expect(surfaces).toEqual(['telegram', 'tui']);
   });
 
-  it('reflects MEMPHIS_FEATURES env var in featureFlags', () => {
-    const out = runMemphisSelfDescribe(
+  it('reflects MEMPHIS_FEATURES env var in featureFlags', async () => {
+    const out = await runMemphisSelfDescribe(
       {},
       {
         MEMPHIS_DATA_DIR: '/tmp/memphis-test',
@@ -84,9 +84,9 @@ describe('runMemphisSelfDescribe', () => {
     expect(out.featureFlags).toContain('experimental-tools');
   });
 
-  it('emits ISO timestamps for asOf and tier3 session timestamps', () => {
+  it('emits ISO timestamps for asOf and tier3 session timestamps', async () => {
     __seedTier3SessionForTests('cli', 'local');
-    const out = runMemphisSelfDescribe(
+    const out = await runMemphisSelfDescribe(
       { surface: 'cli', actorId: 'local' },
       { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv,
     );
@@ -95,13 +95,13 @@ describe('runMemphisSelfDescribe', () => {
     expect(out.tier3Session!.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
-  it('propagates helpText + cliFlags from tool-registry through capabilities envelope (Sprint E Phase 2)', () => {
+  it('propagates helpText + cliFlags from tool-registry through capabilities envelope (Sprint E Phase 2)', async () => {
     // Pin the wiring: tools that have helpText / cliFlags in
     // src/gateway/tool-registry.ts (Sprint E Phase 1 proof set)
     // surface those fields through `runMemphisSelfDescribe` so CLI
     // `memphis tools describe`, future TUI `?` overlay, and Telegram
     // `/help <tool>` all see the same rich text.
-    const out = runMemphisSelfDescribe(
+    const out = await runMemphisSelfDescribe(
       {},
       { MEMPHIS_DATA_DIR: '/tmp/memphis-test' } as NodeJS.ProcessEnv,
     );
@@ -128,6 +128,40 @@ describe('runMemphisSelfDescribe', () => {
       if (tool.cliFlags !== undefined) {
         expect(Array.isArray(tool.cliFlags), `${tool.name} cliFlags must be array`).toBe(true);
       }
+    }
+  });
+
+  // PR #489 — recentConfigChanges field. Pin the contract: shape is
+  // always an array (empty is fine), and when entries exist they
+  // surface capability tag + summary + ISO timestamp + block index.
+  it('returns recentConfigChanges as an array (empty when no journal blocks tagged config-change)', async () => {
+    const out = await runMemphisSelfDescribe(
+      {},
+      { MEMPHIS_DATA_DIR: '/tmp/memphis-self-describe-no-config' } as NodeJS.ProcessEnv,
+    );
+    expect(Array.isArray(out.recentConfigChanges)).toBe(true);
+    // Tmpdir has no journal chain → expect empty
+    expect(out.recentConfigChanges).toHaveLength(0);
+  });
+
+  it('shape contract for recentConfigChanges entries (tested via type — empty array is fine)', async () => {
+    // We don't seed real chain data here (would require rust adapter
+    // setup). Instead pin the field shape so future refactors don't
+    // accidentally drop properties downstream consumers (system
+    // prompt, doctor, TUI) read.
+    const out = await runMemphisSelfDescribe(
+      {},
+      { MEMPHIS_DATA_DIR: '/tmp/memphis-self-describe-shape' } as NodeJS.ProcessEnv,
+    );
+    expect(out).toHaveProperty('recentConfigChanges');
+    // TypeScript compile guarantees the shape; runtime assertion
+    // catches accidental any-typing or rename of the field.
+    for (const entry of out.recentConfigChanges) {
+      expect(typeof entry.timestamp).toBe('string');
+      expect(typeof entry.capability).toBe('string');
+      expect(typeof entry.blockIndex).toBe('number');
+      expect(typeof entry.summary).toBe('string');
+      expect(Array.isArray(entry.tags)).toBe(true);
     }
   });
 });

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -16,7 +16,8 @@ describe('tool registry', () => {
     // TOOL_REGISTRY (memphis_config_set, memphis_cognitive_mode_set).
     // S3 (sprint 2026-04-26): added memphis_self_describe (tier 0, read).
     // Track C3 (2026-04-29): added memphis_slo_status (tier 0, read).
-    expect(getToolNames()).toHaveLength(36);
+    // PR #486 (2026-05-05): added memphis_brave_search (tier 2, read+network).
+    expect(getToolNames()).toHaveLength(37);
   });
 
   it('hides experimental preview tools by default', () => {
@@ -83,9 +84,10 @@ describe('tool registry', () => {
     expect(tier1.map((t) => t.name).sort()).toEqual(['memphis_health_check'].sort());
 
     const tier2 = getToolsByTier(2);
-    expect(tier2.length).toBe(20);
+    expect(tier2.length).toBe(21);
     expect(tier2.map((t) => t.name).sort()).toEqual(
       [
+        'memphis_brave_search',
         'memphis_build',
         'memphis_code_read',
         // Codex Round 5 P1 fix (#107): added to TOOL_REGISTRY so MCP can


### PR DESCRIPTION
## Summary

Closes the soul-awareness loop started in #487. Operators flip API keys / feature flags between turns; #487's prompt section told the bot to either quote chain_hits or call memphis_recall when asked "co się zmieniło". This PR makes it **cheaper**: `memphis_self_describe` now returns a `recentConfigChanges` array so the bot reads the authoritative live state in **one tool call** instead of guessing which recall query will hit the right block.

## New output shape

```ts
recentConfigChanges: Array<{
  timestamp: string;     // ISO from journal block
  capability: string;    // 'brave-search' | 'openai' | 'telegram' | …
  blockIndex: number;    // for journal#<index> citations
  summary: string;       // first ~140 chars of content
  tags: string[];
}>
```

**Window:** last 30 days, last 30 entries. Reads journal chain via `getRecentBlocks` (best-effort — never throws; returns empty on chain read failure).

## Capability tag derivation

Operators tag entries like `['config-change', 'brave-search', 'external-api']`. Handler picks the FIRST tag that isn't a generic role label (`config-change` / `external-api` / `provider`) and surfaces it as `capability`. So `brave-search` / `openai` / `telegram` / etc. surface cleanly without each configure CLI having to format anything special.

## Async signature change

`runMemphisSelfDescribe` is now `async`. Existing callers in `tool-executor` / `mcp/server` / `http/server` already operate in async context (handlers / lambdas) so the await is trivial. Test file refactored — 7 existing tests now async, plus **2 new shape-pin tests** for `recentConfigChanges`.

## System-prompt update — ladder

The "Recent operator config changes" section (added in #487) now ladders:
1. **PREFER** `memphis_self_describe` — JSON has `recentConfigChanges`
2. Quote `[chain_hits]` when prelude already surfaced it
3. Fall back to `memphis_recall` when both are empty

Bot still must NOT say "I noticed you added X" without evidence — the anti-confab discipline from #478 stays.

## Test plan

- [x] 9/9 self-describe tests (7 async refactor + 2 new shape pins)
- [x] 30/30 gateway.system-prompt tests
- [x] `tsc --noEmit` clean
- [ ] Behavioral live: ask bot "co teraz mam skonfigurowane?" — expected to call `memphis_self_describe` and quote a `recentConfigChanges` entry with `journal#<N>` citation

🤖 Generated with [Claude Code](https://claude.com/claude-code)