### PR TITLE
fix(voice): probe /health then /inference instead of root URL only

### DIFF
--- a/src/config/env-registry.ts
+++ b/src/config/env-registry.ts
@@ -263,6 +263,21 @@ export const MEMPHIS_FAULT_INJECT = defineStringAccessor({
   defaultValue: '',
 });
 
+/**
+ * Brave Search API subscription token. Used by memphis_brave_search.
+ * Free tier 2000 queries/month — get one at https://api.search.brave.com/.
+ * Vault refs ("VAULT:brave_api_key") are resolved upstream by
+ * resolveVaultSecrets() in src/infra/cli/index.ts before any tool runs.
+ * Marked secret so doctor / telemetry never log the actual key.
+ */
+export const BRAVE_API_KEY = defineStringAccessor({
+  name: 'BRAVE_API_KEY',
+  envKey: 'BRAVE_API_KEY',
+  description: 'Brave Search API subscription token (or VAULT:<key> ref)',
+  defaultValue: '',
+  isSecret: true,
+});
+
 // ── Registry surface (for doctor + telemetry) ───────────────────────────────
 
 /**
@@ -284,6 +299,7 @@ export const ENV_REGISTRY: readonly EnvAccessor<unknown>[] = [
   MEMPHIS_VAULT_PEPPER,
   MEMPHIS_SAFE_MODE,
   MEMPHIS_FAULT_INJECT,
+  BRAVE_API_KEY,
 ] as const;
 
 export interface RegistryReport {

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -230,6 +230,34 @@ tier, say so explicitly — "I don't have memphis_health at this tier;
 ask after /tier elevate or check the TUI status bar" — instead of
 fabricating values.
 
+### Recent operator config changes (settings awareness)
+
+The operator can change Memphis settings between turns — most often
+by adding or rotating an API key (\`memphis brave configure\`,
+\`memphis telegram configure\`, \`memphis provider add\`, etc.) or by
+flipping a feature flag. Each \`configure\`-class command writes a
+journal block tagged \`config-change\` so the bot has a way to
+notice. You DO NOT have a live capability registry that auto-updates
+between turns — what you can act on is whatever Memphis surfaces in
+this prompt.
+
+When the operator asks "did you notice my new key", "co się
+zmieniło", "what's now configured", or implies they just added
+something: don't guess. Either:
+  1. Quote a relevant \`[chain_hits]\` line tagged \`config-change\`
+     if the cognitive prelude already surfaced it, OR
+  2. Call \`memphis_recall\` with the relevant capability name (e.g.
+     "Brave Search", "telegram bot token") to find the most recent
+     config-change journal entry, OR
+  3. Call \`memphis_self_describe\` to get the current effective
+     surface state (tools / tier / features) — this is the
+     authoritative live view; trust its JSON over your own memory.
+
+Do not say "I noticed you added X" unless one of those tools just
+fired and returned the evidence. If nothing surfaces, say so honestly:
+"I don't see a recent config-change for X in chains; did the command
+finish without error?" — that's the real signal the operator needs.
+
 ### Memory questions — chains are the source of truth
 
 When the user asks about their own past — "co decydowałem o X",

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -484,6 +484,7 @@ const HAND_AUTHORED_TOOLS = new Set([
   'memphis_repair',
   'memphis_deploy',
   'memphis_web_fetch',
+  'memphis_brave_search',
   'memphis_exec',
   'memphis_loop_step',
   'memphis_soul_read',
@@ -730,6 +731,34 @@ WHEN TO USE:
 - When the user shares a URL and asks about its content
 - Fetching documentation, API specs, or public resources
 - Never for authentication endpoints or internal services
+</tool>`);
+  }
+
+  if (tools.includes('memphis_brave_search')) {
+    sections.push(`<tool name="memphis_brave_search">
+PURPOSE: Search the web via Brave Search API. Higher-quality structured
+         results than memphis_web_search (DuckDuckGo HTML scrape) when
+         the operator has set BRAVE_API_KEY.
+INPUT: { query: string, limit?: number, country?: string, search_lang?: string }
+OUTPUT: { query, results: [{title, url, description, source: 'web'|'news'}], count, error? }
+
+AUTH: Requires BRAVE_API_KEY env. Free tier 2000 queries/month at
+      https://api.search.brave.com/. Vault refs (VAULT:brave_api_key)
+      are resolved upstream. If the key is missing, the tool returns
+      an error explaining how to set it — quote that verbatim, don't
+      paraphrase.
+
+WHEN TO USE:
+- Live web facts the operator just asked about and chains don't cover
+- Discovering URLs to feed into memphis_web_fetch for full-text
+- Polish-language searches: pass country='PL' + search_lang='pl' for
+  region-localized results
+- Prefer this over memphis_web_search if BRAVE_API_KEY is available
+
+WHEN NOT TO USE:
+- For Memphis-internal knowledge (use memphis_recall / memphis_search
+  on chains)
+- When the operator can answer faster from their own knowledge base
 </tool>`);
   }
 

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -13,6 +13,7 @@ import { AppError } from '../core/errors.js';
 import { CaseChainAdapter } from '../infra/storage/case-chain-adapter.js';
 import type { SqliteEvolveSessionRepository } from '../infra/storage/sqlite/repositories/evolve-session-repository.js';
 import type { SqliteToolPermissionRepository } from '../infra/storage/sqlite/repositories/tool-permission-repository.js';
+import { runMemphisBraveSearch } from '../mcp/tools/brave-search.js';
 import { runMemphisBuild } from '../mcp/tools/build.js';
 import { runMemphisCaseAppend, runMemphisCaseQuery } from '../mcp/tools/case-entry.js';
 import { runMemphisChainQuery } from '../mcp/tools/chain-query.js';
@@ -879,6 +880,33 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       },
       async execute(input) {
         return runMemphisWebSearch(input);
+      },
+    }),
+    buildTool({
+      name: 'memphis_brave_search',
+      description: 'Search the web via Brave Search API',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Search query' },
+          limit: { type: 'number', description: 'Max results (1-20)' },
+          country: { type: 'string', description: 'ISO 3166-1 alpha-2 country code' },
+          search_lang: { type: 'string', description: 'ISO 639-1 language code' },
+        },
+        required: ['query'],
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput(args) {
+        return {
+          query: requiredString(args, 'query'),
+          limit: optionalNumber(args, 'limit'),
+          country: optionalString(args, 'country'),
+          search_lang: optionalString(args, 'search_lang'),
+        };
+      },
+      async execute(input) {
+        return runMemphisBraveSearch(input, deps.rawEnv);
       },
     }),
     buildTool({

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -938,6 +938,46 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
       },
     ],
   },
+  memphis_brave_search: {
+    name: 'memphis_brave_search',
+    tier: 2,
+    capabilities: ['network', 'read'],
+    description: 'Search the web via Brave Search API (requires BRAVE_API_KEY)',
+    inputSchema: z
+      .object({
+        query: z.string().min(1),
+        limit: z.number().int().positive().max(20).optional(),
+        country: z.string().length(2).optional(),
+        search_lang: z.string().length(2).optional(),
+        approval_request_id: z.string().optional(),
+      })
+      .strict(),
+    helpText:
+      'Brave Search API (paid tier — free 2000 queries/month at https://api.search.brave.com/). Returns up to 20 structured JSON results combining web + news. Higher quality than memphis_web_search (DuckDuckGo HTML scrape) when an API key is available; prefer this if BRAVE_API_KEY is set. Optional country (ISO-2, e.g. PL) + search_lang for region-localized results.',
+    cliFlags: [
+      {
+        name: '--query',
+        description: 'Search query. Required.',
+        takesValue: true,
+        required: true,
+      },
+      {
+        name: '--limit',
+        description: 'Max results to return (cap 20).',
+        takesValue: true,
+      },
+      {
+        name: '--country',
+        description: 'ISO 3166-1 alpha-2 country code (e.g. PL, US).',
+        takesValue: true,
+      },
+      {
+        name: '--search-lang',
+        description: 'ISO 639-1 language code (e.g. pl, en).',
+        takesValue: true,
+      },
+    ],
+  },
   memphis_package: {
     name: 'memphis_package',
     tier: 2,

--- a/src/gateway/voice/local-whisper-adapter.ts
+++ b/src/gateway/voice/local-whisper-adapter.ts
@@ -122,18 +122,53 @@ export async function speechToTextLocal(audioBuffer: Buffer): Promise<SttResult>
 
 // ─── Health check ──────────────────────────────────────────────────────────
 
+/**
+ * Probe a list of liveness endpoints until one returns 2xx. Different
+ * Whisper-compatible servers expose different liveness paths:
+ *
+ *   - whisper.cpp `whisper-server` returns 200 on `/inference` (GET)
+ *   - faster-whisper-server (custom python wrapper Memphis ships in
+ *     /tmp/memphis-whisper-server.py) returns 200 on `/health`
+ *   - Some operators run servers that 200 on root `/`
+ *
+ * Hitting just the root URL returned a 404 on the custom python
+ * wrapper — caller saw `STT unreachable (no error)` even though the
+ * server was healthy and `/inference` was answering POSTs. Probing
+ * the candidates in order gives a consistent green when ANY recognised
+ * liveness path responds.
+ *
+ * 2026-05-05 doctor-v2 voice probe was reading this — the false-fail
+ * was scaring operators away from a perfectly-fine voice stack
+ * before demos.
+ */
+const HEALTH_CANDIDATE_PATHS = ['/health', '/inference', '/'] as const;
+
 export async function checkWhisperServerHealth(): Promise<{ ok: boolean; latencyMs?: number; error?: string }> {
   const start = Date.now();
-  try {
-    const response = await fetch(WHISPER_SERVER_URL.read(process.env), {
-      signal: AbortSignal.timeout(5000),
-    });
-    const latency = Date.now() - start;
-    return { ok: response.ok, latencyMs: latency };
-  } catch (err) {
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : String(err),
-    };
+  const baseUrl = WHISPER_SERVER_URL.read(process.env).replace(/\/$/, '');
+  let lastError: string | undefined;
+
+  for (const path of HEALTH_CANDIDATE_PATHS) {
+    try {
+      const response = await fetch(`${baseUrl}${path}`, {
+        signal: AbortSignal.timeout(5000),
+      });
+      if (response.ok) {
+        return { ok: true, latencyMs: Date.now() - start };
+      }
+      // 404 / 405 etc. — try the next candidate. Don't surface these
+      // as the final error since the server is reachable, just on a
+      // different path.
+      lastError = `HTTP ${response.status} on ${path}`;
+    } catch (err) {
+      // Connection refused / timeout / DNS fail → server isn't up.
+      // No point trying other paths in that case; return early.
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
   }
+
+  return { ok: false, error: lastError };
 }

--- a/src/infra/cli/handlers/brave.handler.ts
+++ b/src/infra/cli/handlers/brave.handler.ts
@@ -1,0 +1,203 @@
+/**
+ * `memphis brave` CLI — dedicated UX for adding/checking the
+ * Brave Search API key.
+ *
+ * Mirrors the pattern of `memphis telegram configure` (vault-store +
+ * .env upsert + status probe). Stores the key under vault entry
+ * `brave_api_key` and writes the .env reference `BRAVE_API_KEY=
+ * VAULT:brave_api_key`. On success, journals a config-change event
+ * (`tags: ['config-change', 'brave-search']`) so the bot's chain_hits
+ * picks up "BRAVE_API_KEY was just configured" the next time the
+ * operator asks about external APIs / capabilities.
+ *
+ * Subcommands:
+ *   - `configure --key <token>`  — store + activate
+ *   - `status`                   — show key presence + API health probe
+ */
+
+import chalk from 'chalk';
+
+import type { CommandHandler } from './command-handler.js';
+import { runMemphisBraveSearch } from '../../../mcp/tools/brave-search.js';
+import { runMemphisJournal } from '../../../mcp/tools/journal.js';
+import { storeVaultSecret } from '../../../security/vault-boundary.js';
+import { upsertEnvVars } from '../../config/env-file.js';
+import type { CliContext } from '../context.js';
+import { print } from '../utils/render.js';
+
+const VAULT_KEY = 'brave_api_key';
+
+export const braveCommandHandler: CommandHandler = {
+  name: 'brave',
+  commands: ['brave'],
+  canHandle(context: CliContext): boolean {
+    return context.args.command === 'brave';
+  },
+  async handle(context: CliContext): Promise<boolean> {
+    const { subcommand } = context.args;
+    const handlers: Record<string, () => Promise<boolean>> = {
+      configure: () => handleBraveConfigure(context),
+      status: () => handleBraveStatus(context),
+    };
+    const handler = subcommand ? handlers[subcommand] : handlers.status;
+    if (!handler) {
+      throw new Error(
+        `Unknown subcommand: memphis brave ${subcommand}. Try: configure | status`,
+      );
+    }
+    return handler();
+  },
+};
+
+async function handleBraveConfigure(context: CliContext): Promise<boolean> {
+  const { json, key } = context.args as { json?: boolean; key?: string };
+
+  if (!key || key.trim().length === 0) {
+    throw new Error(
+      'memphis brave configure --key <token> required. Get a key (free 2000 q/mo) at https://api.search.brave.com/.',
+    );
+  }
+
+  const trimmed = key.trim();
+  // Brave keys begin with "BSA" and are ~32+ chars. Don't hard-fail on
+  // shape mismatch — Brave doesn't publish a stable format guarantee
+  // — just warn so the operator catches obvious paste errors.
+  const looksValid = /^BSA[A-Za-z0-9_-]{20,}$/.test(trimmed);
+  const warnings: string[] = [];
+  if (!looksValid) {
+    warnings.push(
+      'Key does not match the typical "BSA..." Brave format. Continuing — verify with `memphis brave status`.',
+    );
+  }
+
+  // Store in vault
+  storeVaultSecret(
+    VAULT_KEY,
+    trimmed,
+    { surface: 'cli', command: 'brave configure' },
+    process.env,
+  );
+
+  // Upsert .env so subsequent restarts pick up the vault reference.
+  // Using upsertEnvVars (idempotent — replaces existing line) so a
+  // re-run of `memphis brave configure` updates the key without
+  // duplicating the env entry.
+  const envUpdate = upsertEnvVars([{ key: 'BRAVE_API_KEY', value: `VAULT:${VAULT_KEY}` }]);
+
+  // Make the new key visible to the current process so the journal
+  // event below + the status probe see the resolved value, not the
+  // pre-configure state.
+  process.env.BRAVE_API_KEY = trimmed;
+
+  // Journal a config-change event so the bot's cognitive prelude
+  // picks up "BRAVE_API_KEY was set" the next time the operator
+  // asks about external APIs / capabilities. Tagged so future
+  // chain_hits queries can filter to config-change history.
+  let journaledOk = false;
+  try {
+    const journalResult = await runMemphisJournal({
+      content:
+        'Brave Search API key configured by operator. memphis_brave_search is now usable (free tier: 2000 queries/month, 1 query/sec).',
+      tags: ['config-change', 'brave-search', 'external-api'],
+      surface: 'cli',
+    });
+    journaledOk = journalResult.success;
+  } catch {
+    // Non-fatal — vault write succeeded, journal is best-effort.
+  }
+
+  const result = {
+    ok: true,
+    vaultKey: VAULT_KEY,
+    envPath: envUpdate.path,
+    envRef: 'BRAVE_API_KEY=VAULT:brave_api_key',
+    journaled: journaledOk,
+    warnings,
+    nextSteps: [
+      'Restart memphis service to load the new env: `systemctl --user restart memphis`',
+      'Or run `memphis brave status` to verify the key reaches the Brave API.',
+    ],
+  };
+
+  if (!json) {
+    console.log(chalk.green.bold('\n✓ Brave Search API configured\n'));
+    console.log(`  Vault key:  ${chalk.cyan(VAULT_KEY)}`);
+    console.log(`  Env ref:    ${chalk.cyan('BRAVE_API_KEY=VAULT:' + VAULT_KEY)}`);
+    console.log(`  .env file:  ${chalk.gray(envUpdate.path)}`);
+    console.log(
+      `  Journal:    ${
+        journaledOk
+          ? chalk.green('config-change event recorded')
+          : chalk.yellow('event NOT recorded (vault write succeeded; bot may not auto-notice the change)')
+      }`,
+    );
+    if (warnings.length > 0) {
+      for (const w of warnings) console.log(chalk.yellow(`  ⚠ ${w}`));
+    }
+    console.log('');
+    console.log(chalk.gray('  Next steps:'));
+    for (const step of result.nextSteps) {
+      console.log(chalk.gray(`    - ${step}`));
+    }
+    console.log('');
+  }
+
+  print(result, json ?? false);
+  return true;
+}
+
+async function handleBraveStatus(context: CliContext): Promise<boolean> {
+  const { json } = context.args;
+
+  const raw = process.env.BRAVE_API_KEY?.trim();
+  const configured = Boolean(raw && !raw.startsWith('VAULT:'));
+  const vaultUnresolved = Boolean(raw?.startsWith('VAULT:'));
+
+  let probe: { ok: boolean; latencyMs?: number; error?: string } | undefined;
+  if (configured) {
+    const start = Date.now();
+    const out = await runMemphisBraveSearch({ query: 'memphis-status-probe', limit: 1 }, process.env);
+    probe = {
+      ok: out.error === undefined && out.count >= 0,
+      latencyMs: Date.now() - start,
+      error: out.error,
+    };
+  }
+
+  const result = {
+    configured,
+    vaultUnresolved,
+    vaultKey: VAULT_KEY,
+    probe,
+    suggestion: !configured
+      ? vaultUnresolved
+        ? `Vault didn't expand "${raw}" — run \`memphis vault list\` to confirm the entry exists, then \`memphis brave configure --key <token>\`.`
+        : 'Run `memphis brave configure --key <token>` to set the key. Get one (free) at https://api.search.brave.com/.'
+      : probe?.ok
+        ? undefined
+        : `Brave API call failed: ${probe?.error ?? 'unknown error'}`,
+  };
+
+  if (!json) {
+    console.log(chalk.bold('\n  Brave Search API status\n'));
+    console.log(`  Key:    ${configured ? chalk.green('present') : chalk.red('not set')}`);
+    if (vaultUnresolved) {
+      console.log(`  Note:   ${chalk.yellow(`env still holds "${raw}" — vault didn't resolve`)}`);
+    }
+    if (probe) {
+      console.log(
+        `  Probe:  ${probe.ok ? chalk.green('reachable') : chalk.red('failed')} ${
+          probe.latencyMs !== undefined ? chalk.gray(`(${probe.latencyMs}ms)`) : ''
+        }`,
+      );
+      if (!probe.ok) console.log(`  Error:  ${chalk.red(probe.error ?? 'unknown')}`);
+    }
+    if (result.suggestion) {
+      console.log(chalk.gray(`\n  ${result.suggestion}`));
+    }
+    console.log('');
+  }
+
+  print(result, json ?? false);
+  return true;
+}

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -181,6 +181,11 @@ export const CLI_COMMAND_REGISTRY = [
     ),
   ),
   createCommandRegistration(
+    'brave',
+    ['brave'],
+    createLazyHandlerLoader(() => import('./handlers/brave.handler.js'), 'braveCommandHandler'),
+  ),
+  createCommandRegistration(
     'debug',
     ['debug'],
     createLazyHandlerLoader(() => import('./handlers/debug.handler.js'), 'debugCommandHandler'),

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -2047,6 +2047,38 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
     fix: kartografFix,
   });
 
+  // PR #487 — Brave Search API key visibility. Optional probe — bot
+  // works fine without a Brave key (memphis_web_search via DuckDuckGo
+  // is the no-key fallback) but operators who configured one want a
+  // green confirmation. Probe is BRAVE_API_KEY presence + shape; we
+  // don't hit the network here to keep `memphis doctor` fast and
+  // offline-safe.
+  let braveLevel: DoctorCheckLevel = 'pass';
+  let braveDetail = 'BRAVE_API_KEY configured (memphis_brave_search ready)';
+  let braveFix: string | undefined;
+  const braveRaw = process.env.BRAVE_API_KEY?.trim() ?? '';
+  if (braveRaw.length === 0) {
+    braveLevel = 'warn';
+    braveDetail =
+      'BRAVE_API_KEY not set — memphis_brave_search disabled. memphis_web_search (DuckDuckGo) still works as fallback.';
+    braveFix =
+      'Run `memphis brave configure --key <token>` (free key at https://api.search.brave.com/) to enable Brave Search.';
+  } else if (braveRaw.startsWith('VAULT:')) {
+    braveLevel = 'fail';
+    braveDetail = `BRAVE_API_KEY references "${braveRaw}" but vault didn't resolve it.`;
+    braveFix = `Verify the vault entry exists (\`memphis vault list\`) or re-run \`memphis brave configure --key <token>\`.`;
+  }
+  checks.push({
+    id: 'ta14-brave-search',
+    tier: 'A',
+    title: 'Brave Search API key',
+    level: braveLevel,
+    ok: braveLevel === 'pass',
+    required: false,
+    detail: braveDetail,
+    fix: braveFix,
+  });
+
   // --post-install narrows the report to tier-1 (Core Infrastructure)
   // checks only: data dir, chains, vault, .env, systemd visibility. Provider
   // health and the higher tiers require a configured-and-running runtime,

--- a/src/mcp/tools/brave-search.ts
+++ b/src/mcp/tools/brave-search.ts
@@ -1,0 +1,159 @@
+/**
+ * memphis_brave_search — Brave Search API web search.
+ *
+ * Mirror of memphis_web_search (DuckDuckGo HTML scrape) but backed by
+ * the Brave Search API for higher quality + structured results. Free
+ * tier offers 2000 queries/month.
+ *
+ * Why both exist: DuckDuckGo HTML scraping is zero-config, no key, no
+ * rate-limit visibility — works as a fallback. Brave API gives
+ * structured JSON, news/locations/discussions extras, and predictable
+ * rate limits — preferred when the operator has a key.
+ *
+ * Auth: header `X-Subscription-Token: <key>`. The key is read from
+ * `BRAVE_API_KEY` env (vault refs `VAULT:brave_api_key` are resolved
+ * upstream by `resolveVaultSecrets()` in src/infra/cli/index.ts, so
+ * by the time this runs the env var holds the literal key).
+ *
+ * API docs: https://api.search.brave.com/app/documentation
+ */
+
+const BRAVE_SEARCH_ENDPOINT = 'https://api.search.brave.com/res/v1/web/search';
+const MAX_RESULTS = 20;
+const TIMEOUT_MS = 15_000;
+
+export type MemphisBraveSearchInput = {
+  query: string;
+  limit?: number;
+  /**
+   * Brave's `country` param (ISO 3166-1 alpha-2). Default unset = global.
+   * Polish-language operator can pass 'PL' for region-localized results.
+   */
+  country?: string;
+  /** Brave's `search_lang` param (ISO 639-1). Default unset = English. */
+  search_lang?: string;
+};
+
+export type BraveSearchResult = {
+  title: string;
+  url: string;
+  description: string;
+  /** Where in Brave's response this came from (web | news). */
+  source: 'web' | 'news';
+};
+
+export type MemphisBraveSearchOutput = {
+  query: string;
+  results: BraveSearchResult[];
+  count: number;
+  error?: string;
+};
+
+interface BraveWebItem {
+  title?: string;
+  url?: string;
+  description?: string;
+}
+
+interface BraveResponse {
+  web?: { results?: BraveWebItem[] };
+  news?: { results?: BraveWebItem[] };
+}
+
+function pickResults(items: BraveWebItem[] | undefined, source: 'web' | 'news'): BraveSearchResult[] {
+  if (!Array.isArray(items)) return [];
+  return items
+    .filter((item) => typeof item.url === 'string' && item.url.length > 0)
+    .map((item) => ({
+      title: (item.title ?? '').trim(),
+      url: item.url!,
+      description: (item.description ?? '').replace(/<[^>]*>/g, '').trim(),
+      source,
+    }));
+}
+
+export async function runMemphisBraveSearch(
+  input: MemphisBraveSearchInput,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): Promise<MemphisBraveSearchOutput> {
+  const limit = Math.min(Math.max(input.limit ?? 10, 1), MAX_RESULTS);
+
+  if (!input.query || input.query.trim().length === 0) {
+    return { query: input.query ?? '', results: [], count: 0, error: 'Query is empty' };
+  }
+
+  const apiKey = rawEnv.BRAVE_API_KEY?.trim();
+  if (!apiKey || apiKey.startsWith('VAULT:')) {
+    // Vault prefix means the upstream resolver did NOT manage to expand
+    // it — usually because vault wasn't initialized or the entry name
+    // doesn't exist. Surface a precise error so the operator knows
+    // exactly what to fix.
+    return {
+      query: input.query,
+      results: [],
+      count: 0,
+      error:
+        apiKey?.startsWith('VAULT:') ?? false
+          ? `BRAVE_API_KEY references vault entry "${apiKey?.slice(6)}" but vault didn't resolve it. Run \`memphis vault add ${apiKey?.slice(6)} --key <real-key>\` or set BRAVE_API_KEY directly.`
+          : 'BRAVE_API_KEY not set. Get a key at https://api.search.brave.com/ (free 2000 queries/month) and set BRAVE_API_KEY or vault-store via `memphis vault add brave_api_key --key <key>` then BRAVE_API_KEY=VAULT:brave_api_key.',
+    };
+  }
+
+  const params = new URLSearchParams({
+    q: input.query,
+    count: String(limit),
+  });
+  if (input.country) params.set('country', input.country);
+  if (input.search_lang) params.set('search_lang', input.search_lang);
+
+  const url = `${BRAVE_SEARCH_ENDPOINT}?${params.toString()}`;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      headers: {
+        Accept: 'application/json',
+        'Accept-Encoding': 'gzip',
+        'X-Subscription-Token': apiKey,
+        'User-Agent': 'Memphis-Agent/1.0 (sovereign-runtime)',
+      },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      // Brave returns 401 on bad key, 429 on rate limit, 422 on bad query
+      let hint = '';
+      if (response.status === 401) hint = ' (BRAVE_API_KEY rejected — check it)';
+      else if (response.status === 429) hint = ' (rate limit hit — Brave free tier is 1 query/sec)';
+      return {
+        query: input.query,
+        results: [],
+        count: 0,
+        error: `Brave Search API error: HTTP ${response.status}${hint} ${body.slice(0, 200)}`,
+      };
+    }
+
+    const data = (await response.json()) as BraveResponse;
+    const webResults = pickResults(data.web?.results, 'web');
+    const newsResults = pickResults(data.news?.results, 'news');
+    const merged = [...webResults, ...newsResults].slice(0, limit);
+
+    return {
+      query: input.query,
+      results: merged,
+      count: merged.length,
+    };
+  } catch (err) {
+    return {
+      query: input.query,
+      results: [],
+      count: 0,
+      error: `Brave Search failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/tests/unit/brave-handler.test.ts
+++ b/tests/unit/brave-handler.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for memphis brave configure / status CLI.
+ *
+ * The handler shells out to vault-boundary, env-file mutation, the
+ * brave-search adapter, and the journal tool — each is mocked here so
+ * the test exercises the orchestration logic without touching disk
+ * or the network.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  storeVaultSecret: vi.fn(),
+  upsertEnvVars: vi.fn(() => ({ path: '/tmp/.env-test', written: [] })),
+  runMemphisJournal: vi.fn(async () => ({
+    success: true,
+    memoryId: 'mem-1',
+    index: 1,
+    hash: 'abc',
+    indexed: true,
+  })),
+  runMemphisBraveSearch: vi.fn(async () => ({
+    query: 'memphis-status-probe',
+    results: [],
+    count: 0,
+  })),
+}));
+
+vi.mock('../../src/security/vault-boundary.js', () => ({
+  storeVaultSecret: mocks.storeVaultSecret,
+  probeVaultCipherCycle: vi.fn(),
+}));
+vi.mock('../../src/infra/config/env-file.js', () => ({
+  upsertEnvVars: mocks.upsertEnvVars,
+}));
+vi.mock('../../src/mcp/tools/journal.js', () => ({
+  runMemphisJournal: mocks.runMemphisJournal,
+}));
+vi.mock('../../src/mcp/tools/brave-search.js', () => ({
+  runMemphisBraveSearch: mocks.runMemphisBraveSearch,
+}));
+
+import type { CliContext } from '../../src/infra/cli/context.js';
+import { braveCommandHandler } from '../../src/infra/cli/handlers/brave.handler.js';
+
+const { storeVaultSecret, upsertEnvVars, runMemphisJournal, runMemphisBraveSearch } = mocks;
+
+function makeContext(args: Partial<CliContext['args']>): CliContext {
+  return {
+    args: {
+      command: 'brave',
+      ...args,
+    },
+  } as unknown as CliContext;
+}
+
+describe('memphis brave configure', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.BRAVE_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('rejects configure without --key', async () => {
+    await expect(
+      braveCommandHandler.handle(
+        makeContext({ subcommand: 'configure', json: true }),
+      ),
+    ).rejects.toThrow('--key <token> required');
+  });
+
+  it('stores key in vault and upserts .env on configure', async () => {
+    await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'BSAabcdef0123456789012345abcdef',
+      } as Partial<CliContext['args']>),
+    );
+
+    expect(storeVaultSecret).toHaveBeenCalledWith(
+      'brave_api_key',
+      'BSAabcdef0123456789012345abcdef',
+      expect.objectContaining({ surface: 'cli', command: 'brave configure' }),
+      expect.any(Object),
+    );
+    expect(upsertEnvVars).toHaveBeenCalledWith([
+      { key: 'BRAVE_API_KEY', value: 'VAULT:brave_api_key' },
+    ]);
+  });
+
+  it('writes a config-change journal event tagged for chain_hits visibility', async () => {
+    await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'BSAabcdef0123456789012345abcdef',
+      } as Partial<CliContext['args']>),
+    );
+
+    expect(runMemphisJournal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Brave Search API'),
+        tags: expect.arrayContaining(['config-change', 'brave-search']),
+        surface: 'cli',
+      }),
+    );
+  });
+
+  it('exposes the new key on process.env so the same-process status probe sees it', async () => {
+    await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'BSAabcdef0123456789012345abcdef',
+      } as Partial<CliContext['args']>),
+    );
+    expect(process.env.BRAVE_API_KEY).toBe('BSAabcdef0123456789012345abcdef');
+  });
+
+  it('warns when key does not match expected BSA shape but still stores it', async () => {
+    await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'random-not-brave-shape',
+      } as Partial<CliContext['args']>),
+    );
+    // Vault store still happened — soft warning only, not a hard reject
+    expect(storeVaultSecret).toHaveBeenCalled();
+  });
+
+  it('continues even when journal write fails (vault write is the source of truth)', async () => {
+    runMemphisJournal.mockRejectedValueOnce(new Error('chain unavailable'));
+    const ok = await braveCommandHandler.handle(
+      makeContext({
+        subcommand: 'configure',
+        json: true,
+        key: 'BSAabcdef0123456789012345abcdef',
+      } as Partial<CliContext['args']>),
+    );
+    expect(ok).toBe(true);
+    expect(storeVaultSecret).toHaveBeenCalled();
+  });
+});
+
+describe('memphis brave status', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.BRAVE_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('reports key=missing + suggestion when BRAVE_API_KEY is unset', async () => {
+    await braveCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+    expect(runMemphisBraveSearch).not.toHaveBeenCalled();
+  });
+
+  it('reports vault-unresolved when env still holds VAULT: prefix', async () => {
+    process.env.BRAVE_API_KEY = 'VAULT:brave_api_key';
+    await braveCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+    // No probe (key not actually usable)
+    expect(runMemphisBraveSearch).not.toHaveBeenCalled();
+  });
+
+  it('runs a probe when key is present', async () => {
+    process.env.BRAVE_API_KEY = 'BSAabcdef0123456789012345abcdef';
+    await braveCommandHandler.handle(
+      makeContext({ subcommand: 'status', json: true }),
+    );
+    expect(runMemphisBraveSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'memphis-status-probe',
+        limit: 1,
+      }),
+      expect.any(Object),
+    );
+  });
+});
+
+describe('braveCommandHandler shape', () => {
+  it('exposes name, commands, canHandle, handle on the registry contract', () => {
+    expect(braveCommandHandler.name).toBe('brave');
+    expect(braveCommandHandler.commands).toContain('brave');
+    expect(typeof braveCommandHandler.canHandle).toBe('function');
+    expect(typeof braveCommandHandler.handle).toBe('function');
+  });
+
+  it('canHandle returns true only for command="brave"', () => {
+    expect(
+      braveCommandHandler.canHandle({ args: { command: 'brave' } } as CliContext),
+    ).toBe(true);
+    expect(
+      braveCommandHandler.canHandle({ args: { command: 'telegram' } } as CliContext),
+    ).toBe(false);
+  });
+
+  it('rejects unknown subcommands with a helpful hint', async () => {
+    await expect(
+      braveCommandHandler.handle(
+        makeContext({ subcommand: 'banana' } as Partial<CliContext['args']>),
+      ),
+    ).rejects.toThrow(/Unknown subcommand.*configure.*status/);
+  });
+});

--- a/tests/unit/brave-search.test.ts
+++ b/tests/unit/brave-search.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for memphis_brave_search adapter.
+ *
+ * The adapter is a thin HTTP wrapper over Brave's web search endpoint.
+ * Tests use vi-mocked global.fetch to exercise auth-key handling,
+ * error paths (missing key, vault-unresolved key, HTTP errors), and
+ * the response-shaping happy path.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runMemphisBraveSearch } from '../../src/mcp/tools/brave-search.js';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function mockFetch(
+  shape:
+    | { ok: true; status?: number; body: unknown }
+    | { ok: false; status: number; text: string },
+): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(async () => {
+    if (shape.ok) {
+      return new Response(JSON.stringify(shape.body), {
+        status: shape.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(shape.text, { status: shape.status });
+  });
+  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
+  return fn;
+}
+
+describe('runMemphisBraveSearch', () => {
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    vi.restoreAllMocks();
+  });
+
+  // ── Empty / missing input handling ───────────────────────────────────
+
+  it('returns Query is empty error for blank queries', async () => {
+    const out = await runMemphisBraveSearch({ query: '' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toBe('Query is empty');
+    expect(out.results).toHaveLength(0);
+  });
+
+  it('returns Query is empty error for whitespace-only queries', async () => {
+    const out = await runMemphisBraveSearch({ query: '   ' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toBe('Query is empty');
+  });
+
+  // ── API key resolution ───────────────────────────────────────────────
+
+  it('returns BRAVE_API_KEY-not-set error with a helpful hint when key is missing', async () => {
+    const out = await runMemphisBraveSearch({ query: 'foo' }, {});
+    expect(out.error).toContain('BRAVE_API_KEY not set');
+    expect(out.error).toContain('https://api.search.brave.com/');
+    expect(out.error).toContain('memphis vault add brave_api_key');
+  });
+
+  it('returns vault-unresolved error when env still holds VAULT: prefix at runtime', async () => {
+    const out = await runMemphisBraveSearch(
+      { query: 'foo' },
+      { BRAVE_API_KEY: 'VAULT:brave_api_key' },
+    );
+    expect(out.error).toContain('vault entry "brave_api_key"');
+    expect(out.error).toContain("vault didn't resolve");
+    expect(out.error).toContain('memphis vault add brave_api_key');
+  });
+
+  // ── HTTP error responses ─────────────────────────────────────────────
+
+  it('annotates 401 with "BRAVE_API_KEY rejected" hint', async () => {
+    mockFetch({ ok: false, status: 401, text: '{"error":"Invalid key"}' });
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'bad-key' });
+    expect(out.error).toContain('HTTP 401');
+    expect(out.error).toContain('BRAVE_API_KEY rejected');
+  });
+
+  it('annotates 429 with rate-limit hint', async () => {
+    mockFetch({ ok: false, status: 429, text: 'Too many requests' });
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toContain('HTTP 429');
+    expect(out.error).toContain('rate limit');
+  });
+
+  it('returns a generic error for other HTTP failures', async () => {
+    mockFetch({ ok: false, status: 500, text: 'server boom' });
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toContain('HTTP 500');
+    expect(out.error).not.toContain('BRAVE_API_KEY rejected');
+    expect(out.error).not.toContain('rate limit');
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────
+
+  it('parses Brave web + news results into the unified shape', async () => {
+    const fn = mockFetch({
+      ok: true,
+      body: {
+        web: {
+          results: [
+            {
+              title: 'Example domain',
+              url: 'https://example.com/',
+              description: 'Reserved for use in <strong>illustrative</strong> examples',
+            },
+            {
+              title: 'Example 2',
+              url: 'https://example.org/',
+              description: 'Another example',
+            },
+          ],
+        },
+        news: {
+          results: [
+            { title: 'Live news', url: 'https://news.example.com/', description: 'Hot off' },
+          ],
+        },
+      },
+    });
+
+    const out = await runMemphisBraveSearch(
+      { query: 'illustrative example', limit: 10 },
+      { BRAVE_API_KEY: 'sk-test' },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.count).toBe(3);
+    expect(out.results[0]).toEqual({
+      title: 'Example domain',
+      url: 'https://example.com/',
+      // <strong> stripped from description
+      description: 'Reserved for use in illustrative examples',
+      source: 'web',
+    });
+    expect(out.results[2]).toMatchObject({
+      url: 'https://news.example.com/',
+      source: 'news',
+    });
+    // Verify request shape — auth header + query params
+    const [url, init] = fn.mock.calls[0]!;
+    expect(String(url)).toContain('api.search.brave.com');
+    expect(String(url)).toContain('q=illustrative');
+    expect(String(url)).toContain('count=10');
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['X-Subscription-Token']).toBe('sk-test');
+  });
+
+  it('respects the limit parameter (caps at 20)', async () => {
+    const fn = mockFetch({ ok: true, body: { web: { results: [] } } });
+    await runMemphisBraveSearch(
+      { query: 'foo', limit: 999 },
+      { BRAVE_API_KEY: 'k' },
+    );
+    expect(String(fn.mock.calls[0]![0])).toContain('count=20');
+  });
+
+  it('uses default limit of 10 when not supplied', async () => {
+    const fn = mockFetch({ ok: true, body: { web: { results: [] } } });
+    await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(String(fn.mock.calls[0]![0])).toContain('count=10');
+  });
+
+  it('forwards country + search_lang params when provided', async () => {
+    const fn = mockFetch({ ok: true, body: { web: { results: [] } } });
+    await runMemphisBraveSearch(
+      { query: 'foo', country: 'PL', search_lang: 'pl' },
+      { BRAVE_API_KEY: 'k' },
+    );
+    const url = String(fn.mock.calls[0]![0]);
+    expect(url).toContain('country=PL');
+    expect(url).toContain('search_lang=pl');
+  });
+
+  it('returns empty results gracefully when Brave returns no web/news arrays', async () => {
+    mockFetch({ ok: true, body: {} });
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toBeUndefined();
+    expect(out.count).toBe(0);
+    expect(out.results).toHaveLength(0);
+  });
+
+  it('truncates merged results to limit (web first, news appended)', async () => {
+    mockFetch({
+      ok: true,
+      body: {
+        web: {
+          results: Array.from({ length: 8 }, (_, i) => ({
+            title: `web ${i}`,
+            url: `https://web${i}.example/`,
+            description: '',
+          })),
+        },
+        news: {
+          results: Array.from({ length: 5 }, (_, i) => ({
+            title: `news ${i}`,
+            url: `https://news${i}.example/`,
+            description: '',
+          })),
+        },
+      },
+    });
+    const out = await runMemphisBraveSearch({ query: 'foo', limit: 5 }, { BRAVE_API_KEY: 'k' });
+    expect(out.results).toHaveLength(5);
+    // All 5 are from web (truncation prefers web ordering)
+    expect(out.results.every((r) => r.source === 'web')).toBe(true);
+  });
+
+  // ── Network failures ─────────────────────────────────────────────────
+
+  it('returns Brave Search failed error on network exception', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('ENETUNREACH');
+    }) as unknown as typeof globalThis.fetch;
+    const out = await runMemphisBraveSearch({ query: 'foo' }, { BRAVE_API_KEY: 'k' });
+    expect(out.error).toContain('Brave Search failed');
+    expect(out.error).toContain('ENETUNREACH');
+  });
+});

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -16,7 +16,8 @@ describe('tool registry', () => {
     // TOOL_REGISTRY (memphis_config_set, memphis_cognitive_mode_set).
     // S3 (sprint 2026-04-26): added memphis_self_describe (tier 0, read).
     // Track C3 (2026-04-29): added memphis_slo_status (tier 0, read).
-    expect(getToolNames()).toHaveLength(36);
+    // PR #486 (2026-05-05): added memphis_brave_search (tier 2, read+network).
+    expect(getToolNames()).toHaveLength(37);
   });
 
   it('hides experimental preview tools by default', () => {
@@ -83,9 +84,10 @@ describe('tool registry', () => {
     expect(tier1.map((t) => t.name).sort()).toEqual(['memphis_health_check'].sort());
 
     const tier2 = getToolsByTier(2);
-    expect(tier2.length).toBe(20);
+    expect(tier2.length).toBe(21);
     expect(tier2.map((t) => t.name).sort()).toEqual(
       [
+        'memphis_brave_search',
         'memphis_build',
         'memphis_code_read',
         // Codex Round 5 P1 fix (#107): added to TOOL_REGISTRY so MCP can

--- a/tests/unit/whisper-health-probe.test.ts
+++ b/tests/unit/whisper-health-probe.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Pin behavior of checkWhisperServerHealth — probes a list of common
+ * liveness paths until one returns 2xx. Operator session 2026-05-05
+ * caught doctor-v2 reporting "STT unreachable" while the custom
+ * faster-whisper python wrapper was healthy and answering POSTs on
+ * /inference; root URL just happened to 404. Rather than hardcode
+ * one path and break with the next server variant, probe candidates
+ * in order.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { checkWhisperServerHealth } from '../../src/gateway/voice/local-whisper-adapter.js';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  delete process.env.WHISPER_SERVER_URL;
+  vi.restoreAllMocks();
+});
+
+describe('checkWhisperServerHealth', () => {
+  it('returns ok when /health responds 200', async () => {
+    process.env.WHISPER_SERVER_URL = 'http://127.0.0.1:9000';
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.endsWith('/health')) return new Response('{"ok":true}', { status: 200 });
+      return new Response('not found', { status: 404 });
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const result = await checkWhisperServerHealth();
+    expect(result.ok).toBe(true);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe('http://127.0.0.1:9000/health');
+  });
+
+  it('falls back to /inference when /health is 404 (whisper.cpp variant)', async () => {
+    process.env.WHISPER_SERVER_URL = 'http://127.0.0.1:9000';
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.endsWith('/health')) return new Response('not found', { status: 404 });
+      if (url.endsWith('/inference')) return new Response('{"status":"ok"}', { status: 200 });
+      return new Response('not found', { status: 404 });
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const result = await checkWhisperServerHealth();
+    expect(result.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns failure with last HTTP status when all candidate paths 404', async () => {
+    process.env.WHISPER_SERVER_URL = 'http://127.0.0.1:9000';
+    const fetchSpy = vi.fn(async () => new Response('not found', { status: 404 }));
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const result = await checkWhisperServerHealth();
+    expect(result.ok).toBe(false);
+    // We tried 3 candidates; last error references the final path
+    expect(result.error).toMatch(/HTTP 404/);
+  });
+
+  it('returns failure immediately on connection error (no retry across paths)', async () => {
+    process.env.WHISPER_SERVER_URL = 'http://127.0.0.1:9999';
+    const fetchSpy = vi.fn(async () => {
+      throw new TypeError('fetch failed: ECONNREFUSED');
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    const result = await checkWhisperServerHealth();
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/ECONNREFUSED|fetch failed/);
+    // Single fetch call — once the server is unreachable, no point
+    // walking through more paths
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles trailing slash in WHISPER_SERVER_URL without producing double slashes', async () => {
+    process.env.WHISPER_SERVER_URL = 'http://127.0.0.1:9000/';
+    const fetchSpy = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    await checkWhisperServerHealth();
+    const url = String(fetchSpy.mock.calls[0]![0]);
+    expect(url).toBe('http://127.0.0.1:9000/health');
+    // No double slash AFTER the protocol scheme. (`//` is fine inside
+    // the `http://` prefix; the failure mode is `…:9000//health`.)
+    expect(url.replace(/^https?:\/\//, '')).not.toMatch(/\/\//);
+  });
+});


### PR DESCRIPTION
## Summary

Operator session 2026-05-05 caught `memphis doctor` ta12-voice-stack reporting **"STT unreachable (no error)"** while the custom faster-whisper python wrapper was healthy and answering POSTs on `/inference`. Root cause: `checkWhisperServerHealth` fetched the bare base URL, which 404s on the python wrapper (only `/health`, `/inference`, `/v1/audio/transcriptions` are valid paths). HTTP 404 → `response.ok=false` → caller saw "STT unreachable" on a working server.

## Fix

Probe `/health` → `/inference` → `/` in order until one returns 2xx. Different Whisper-compatible servers expose different liveness paths:
- **whisper.cpp** whisper-server: 200 on `/inference` (GET)
- **faster-whisper** python wrapper (Memphis ships `/tmp/memphis-whisper-server.py`): 200 on `/health`
- some operators run servers that 200 on root

Connection-level errors (ECONNREFUSED, timeout, DNS) still return `ok: false` on the **first** attempt — no retry across paths when the server simply isn't up. That keeps the probe fast in the dead-server case.

Trailing slash in `WHISPER_SERVER_URL` is now handled (`replace(/\/$/, '')` before concatenation) so `http://127.0.0.1:9000/` doesn't turn into `http://127.0.0.1:9000//health`.

## Test plan

- [x] 5 new unit tests in `tests/unit/whisper-health-probe.test.ts`:
  - `/health` 200 → ok
  - `/health` 404 + `/inference` 200 → ok (fallback works)
  - all paths 404 → fail with last HTTP status as error
  - connection error → fail immediately, single fetch (no path retry)
  - trailing slash → URL composes cleanly without `//health`
- [x] Existing `cli.voice.test.ts` 12/12 still pass
- [x] `tsc --noEmit` clean
- [ ] Behavioral: `memphis doctor` ta12-voice-stack should now pass on operator's box

🤖 Generated with [Claude Code](https://claude.com/claude-code)