### PR TITLE
fix(backup): P2 hotfix — verifyAllBackups sweep + doctor drill surfacing

### DIFF
--- a/src/infra/cli/commands/backup.ts
+++ b/src/infra/cli/commands/backup.ts
@@ -728,6 +728,58 @@ export async function listBackups(options: BackupOptions = {}): Promise<{
   };
 }
 
+/**
+ * Verify every archive in the backup directory in one pass.
+ *
+ * Returns ok=false when ANY archive fails integrity checks (mismatched
+ * checksum, unsafe entries, listing failure). Used by `memphis backup list
+ * --verify` and as the data source for the doctor-v2 backup-integrity row.
+ *
+ * Phase 1.2 (P2 hotfix): the 2026-05-08 runtime diagnostic surfaced
+ * `restore-drill FAILED — backup may not be restorable` without a way for
+ * the operator to identify WHICH archive was corrupt. This sweep makes that
+ * trivial.
+ */
+export async function verifyAllBackups(options: BackupOptions = {}): Promise<{
+  ok: boolean;
+  total: number;
+  validCount: number;
+  corruptCount: number;
+  results: Array<{
+    file: string;
+    valid: boolean;
+    sizeBytes: number;
+    fileCount: number;
+    checksum: { expected?: string; actual: string };
+  }>;
+}> {
+  const listed = await listBackups(options);
+  const results: Awaited<ReturnType<typeof verifyAllBackups>>['results'] = [];
+  for (const entry of listed.backups) {
+    const verified = await verifyBackup({
+      file: entry.path,
+      backupRoot: options.backupRoot,
+      memphisRoot: options.memphisRoot,
+    });
+    results.push({
+      file: verified.file,
+      valid: verified.valid,
+      sizeBytes: verified.size,
+      fileCount: verified.fileCount,
+      checksum: verified.checksum,
+    });
+  }
+  const validCount = results.filter((r) => r.valid).length;
+  const corruptCount = results.length - validCount;
+  return {
+    ok: corruptCount === 0,
+    total: results.length,
+    validCount,
+    corruptCount,
+    results,
+  };
+}
+
 export async function verifyBackup(options: {
   file: string;
   backupRoot?: string;
@@ -961,6 +1013,35 @@ export async function handleBackupCommand(context: CliContext): Promise<boolean>
       sizeHuman: humanSize(b.size),
       staleLabel: b.stale ? chalk.yellow('STALE') : 'fresh',
     }));
+    if (args.verify) {
+      // P2 hotfix: integrity sweep across every archive. Exit non-zero when
+      // any archive is corrupt so cron-based backup-watch scripts can alert.
+      const sweep = await verifyAllBackups();
+      const merged = enriched.map((b) => {
+        const v = sweep.results.find((r) => r.file === b.file);
+        return { ...b, integrity: v?.valid ?? null };
+      });
+      print(
+        {
+          ok: sweep.ok,
+          mode: 'list-verify',
+          backups: merged,
+          summary: {
+            total: sweep.total,
+            valid: sweep.validCount,
+            corrupt: sweep.corruptCount,
+          },
+          totalSize: listed.totalSize,
+          totalSizeHuman: humanSize(listed.totalSize),
+        },
+        args.json,
+      );
+      if (!sweep.ok) {
+        // Surface the corruption to shell scripts.
+        process.exitCode = 1;
+      }
+      return true;
+    }
     print(
       {
         ok: true,

--- a/src/infra/cli/parser.ts
+++ b/src/infra/cli/parser.ts
@@ -177,6 +177,7 @@ export function parseCommand(argv: string[]): CliArgs {
     list: hasBooleanFlag(flags, '--list'),
     clean: hasBooleanFlag(flags, '--clean'),
     restore: readFlagValue(flags, '--restore'),
+    verify: hasBooleanFlag(flags, '--verify'),
     keep: readNumberFlag(flags, '--keep'),
     tag: readFlagValue(flags, '--tag'),
     format: readFlagValue(flags, '--format') as CliArgs['format'],

--- a/src/infra/cli/types.ts
+++ b/src/infra/cli/types.ts
@@ -93,6 +93,8 @@ export type CliArgs = {
   list: boolean;
   clean: boolean;
   restore?: string;
+  /** `memphis backup list --verify` — sweep all archives for integrity (Phase 1.2 P2 hotfix). */
+  verify?: boolean;
   keep?: number;
   tag?: string;
   // `mv2` added for Sprint G N12 — `memphis export --format=mv2`. Other

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1256,17 +1256,34 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
     detail: daemon.staleLocks.length === 0 ? 'none' : `${daemon.staleLocks.length} stale lock(s)`,
     fix: 'Run memphis doctor --fix',
   });
+  // P2 hotfix (Phase 1.2): combine archive age + scheduled-backup drill state.
+  // The 2026-05-08 incident saw `restore-drill FAILED` reported by the
+  // scheduler without doctor surfacing it — operators only learned via
+  // unrelated TUI diagnostic. Surface drill status here as part of t5.
+  const { getScheduledBackupState } = await import('../../runtime/scheduled-backup.js');
+  const drillState = getScheduledBackupState(process.env);
+  const drillFailed = drillState.state.lastDrillOk === false;
+  let backupLevel: 'pass' | 'warn' | 'fail' = backupAgeDays <= 7 ? 'pass' : 'warn';
+  let backupDetail: string = Number.isFinite(backupAgeDays)
+    ? `${backupAgeDays.toFixed(1)} days since latest backup`
+    : 'no backups found';
+  if (drillFailed) {
+    backupLevel = 'fail';
+    backupDetail = `restore-drill FAILED: ${drillState.state.lastDrillError ?? 'unknown'} (last archive: ${drillState.state.lastSuccessFile ?? 'n/a'})`;
+  } else if (drillState.state.lastDrillOk === true) {
+    backupDetail += ` · last drill OK at ${drillState.state.lastDrillAt}`;
+  }
   checks.push({
     id: 't5-backup-status',
     tier: 5,
     title: 'Backup status',
-    level: backupAgeDays <= 7 ? 'pass' : 'warn',
-    ok: backupAgeDays <= 7,
+    level: backupLevel,
+    ok: backupLevel === 'pass',
     required: false,
-    detail: Number.isFinite(backupAgeDays)
-      ? `${backupAgeDays.toFixed(1)} days since latest backup`
-      : 'no backups found',
-    fix: 'Run memphis backup now',
+    detail: backupDetail,
+    fix: drillFailed
+      ? 'Run `memphis backup list --verify` to identify corrupt archive(s); restore from a known-good archive'
+      : 'Run memphis backup now',
   });
   checks.push({
     id: 't5-daemon',

--- a/tests/integration/backup-list-verify.test.ts
+++ b/tests/integration/backup-list-verify.test.ts
@@ -1,0 +1,154 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createBackup,
+  verifyAllBackups,
+} from '../../src/infra/cli/commands/backup.js';
+import { resetInstallRootMemoForTests } from '../../src/infra/runtime/install-root.js';
+
+interface TestEnv {
+  memphisRoot: string;
+  backupRoot: string;
+  savedRuntimeRoot: string | undefined;
+}
+
+function setup(): TestEnv {
+  const memphisRoot = mkdtempSync(join(tmpdir(), 'memphis-list-verify-'));
+  const backupRoot = join(memphisRoot, 'backups');
+  mkdirSync(join(memphisRoot, 'chains', 'journal'), { recursive: true });
+  mkdirSync(join(memphisRoot, 'vault'), { recursive: true });
+  writeFileSync(
+    join(memphisRoot, 'chains', 'journal', '000001.json'),
+    JSON.stringify({ index: 1, content: 'genesis' }),
+    'utf8',
+  );
+  writeFileSync(
+    join(memphisRoot, 'vault', 'state.json'),
+    JSON.stringify({ encryptedMasterKey: 'opaque-blob' }),
+    'utf8',
+  );
+  writeFileSync(
+    join(memphisRoot, '.env'),
+    'MEMPHIS_VAULT_PEPPER=originalPepper123456\n',
+    'utf8',
+  );
+  writeFileSync(
+    join(memphisRoot, 'package.json'),
+    JSON.stringify({ name: '@memphis-chains/memphis', version: '0.0.0-test' }),
+    'utf8',
+  );
+  mkdirSync(backupRoot, { recursive: true });
+
+  const savedRuntimeRoot = process.env.MEMPHIS_RUNTIME_ROOT;
+  process.env.MEMPHIS_RUNTIME_ROOT = memphisRoot;
+  resetInstallRootMemoForTests();
+
+  return { memphisRoot, backupRoot, savedRuntimeRoot };
+}
+
+function teardown(env: TestEnv): void {
+  if (env.savedRuntimeRoot === undefined) delete process.env.MEMPHIS_RUNTIME_ROOT;
+  else process.env.MEMPHIS_RUNTIME_ROOT = env.savedRuntimeRoot;
+  resetInstallRootMemoForTests();
+  rmSync(env.memphisRoot, { recursive: true, force: true });
+}
+
+describe('backup verify-all sweep — P2 hotfix surface', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    teardown(env);
+  });
+
+  it('reports all archives valid when none are tampered', async () => {
+    await createBackup({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      tag: 'good-1',
+      showProgress: false,
+    });
+    await createBackup({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      tag: 'good-2',
+      showProgress: false,
+    });
+
+    const sweep = await verifyAllBackups({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+    });
+    expect(sweep.ok).toBe(true);
+    expect(sweep.total).toBe(2);
+    expect(sweep.validCount).toBe(2);
+    expect(sweep.corruptCount).toBe(0);
+    expect(sweep.results.every((r) => r.valid)).toBe(true);
+  });
+
+  it('identifies a tampered archive and flags ok=false', async () => {
+    const good = await createBackup({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      tag: 'still-good',
+      showProgress: false,
+    });
+    const corrupt = await createBackup({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+      tag: 'soon-corrupt',
+      showProgress: false,
+    });
+
+    // Tamper with the archive: flip the leading byte. Checksum will mismatch.
+    const data = readFileSync(corrupt.backupPath);
+    data[0] = (data[0] ?? 0) ^ 0xff;
+    writeFileSync(corrupt.backupPath, data);
+
+    const sweep = await verifyAllBackups({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+    });
+
+    expect(sweep.ok).toBe(false);
+    expect(sweep.total).toBe(2);
+    expect(sweep.validCount).toBe(1);
+    expect(sweep.corruptCount).toBe(1);
+
+    const goodResult = sweep.results.find((r) => r.file === good.file);
+    const corruptResult = sweep.results.find((r) => r.file === corrupt.file);
+    expect(goodResult?.valid).toBe(true);
+    expect(corruptResult?.valid).toBe(false);
+    // Checksum mismatch surfaces the actual hex so the operator can
+    // cross-reference with the .sha256 sidecar.
+    expect(corruptResult?.checksum.actual).toBeTruthy();
+    expect(corruptResult?.checksum.expected).toBeTruthy();
+    expect(corruptResult?.checksum.actual).not.toEqual(corruptResult?.checksum.expected);
+  });
+
+  it('reports total=0 when backup directory is empty', async () => {
+    expect(existsSync(env.backupRoot)).toBe(true);
+    const sweep = await verifyAllBackups({
+      memphisRoot: env.memphisRoot,
+      backupRoot: env.backupRoot,
+    });
+    expect(sweep.ok).toBe(true);
+    expect(sweep.total).toBe(0);
+    expect(sweep.validCount).toBe(0);
+    expect(sweep.corruptCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Phase 1 — PR 1.2 (autopilot \`automode-silly-pike\`)

Closes the **Zawoja 2026-05-08 P2** — operator saw \`restore-drill FAILED\` in TUI diagnostic but had no way to identify WHICH archive was corrupt and \`memphis doctor\` did not surface drill-failure state.

### Changes
- **\`verifyAllBackups()\`** export in \`src/infra/cli/commands/backup.ts\` — iterates every archive, runs \`verifyBackup()\` per file, returns \`{ ok, total, validCount, corruptCount, results[] }\`
- **\`memphis backup list --verify\`** — runs the sweep, attaches per-archive \`integrity\` flag, sets \`process.exitCode=1\` if any archive corrupt (cron-watch alert path)
- **doctor-v2 t5-backup-status** — combines age + drill state. When \`getScheduledBackupState().lastDrillOk === false\`, escalates to RED with drill error reason and fix-hint pointing to \`memphis backup list --verify\`
- **\`--verify\`** boolean in CLI parser + CliArgs type

### Cross-layer grid
| Rust core | NAPI | TS host | CLI | Tauri | doctor/status | tests |
|---|---|---|---|---|---|---|
| – | – | ✅ | ✅ \`backup list --verify\` | – | ✅ Backups RED row on drill-fail | 🧪 integration |

### Tests
- \`tests/integration/backup-list-verify.test.ts\` (NEW): all-valid, tampered-archive detection (flips byte → ok=false + names corrupt file), empty-dir empty result
- Existing \`tests/integration/backup-restore-drill.test.ts\` unchanged

### Verification (local)
- ✅ \`npx vitest run tests/integration/backup-list-verify.test.ts\` — 3/3 green
- ✅ \`npx vitest run tests/integration/backup-restore-drill.test.ts\` — 5/5 green
- ✅ \`npx tsc --noEmit\` — clean
- ✅ \`npx eslint <touched files>\` — clean
- ⏳ macOS arm64 cross-arch CI — awaits CI

### References
- Plan: \`.claude/plans/automode-silly-pike.md\` Phase 1 PR 1.2
- Postmortem: \`docs/postmortems/2026-05-08-zawoja-and-runtime-state.md\` §P2
- Depends on: P5 hotfix \`e8a000f0\` (skips cognitive-report-query flakes that gate CI)