### PR TITLE
fix(runtime): P3 hotfix — singleton process-lock blocks duplicate workers

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -124,15 +124,20 @@ export async function bootstrap(): Promise<void> {
     if (lock.hint) {
       process.stderr.write(`[memphis-bootstrap] ${lock.hint}\n`);
     }
-    // Release on shutdown signals — the default exit handler covers
-    // normal termination, but explicit signal handling ensures SIGTERM
-    // from systemd/pm2 also tears down cleanly.
+    // Caller-owned shutdown wiring (process-lock no longer auto-attaches
+    // process.on('exit') — that pattern crashed vitest workers). SIGTERM
+    // / SIGINT release explicitly; normal exit goes through the
+    // graceful-shutdown handler installed below which calls lock.release.
     const release = (): void => {
       lock.release();
       process.exit(0);
     };
     process.once('SIGTERM', release);
     process.once('SIGINT', release);
+    // Also release on normal process exit — single registration here
+    // (not in process-lock.ts) means tests that don't go through
+    // bootstrap don't accumulate handlers.
+    process.once('exit', () => lock.release());
   }
 
   // Then evaluate whether the prior crashes warrant a revert. If yes,

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -106,6 +106,35 @@ export async function bootstrap(): Promise<void> {
   // (tsx dev, tests) bypass bin/memphis.js and still record here.
   maybeRecordBootAttempt(process.env);
 
+  // P3 hotfix (Phase 1.3): refuse start when another Memphis runtime
+  // already holds the data dir. Without this, two `memphis serve`
+  // processes both spawn channel gateways → race conditions on chains,
+  // vault, journal. Skip when MEMPHIS_PROCESS_LOCK_DISABLE=1 is set
+  // (test isolation; not for production).
+  if (process.env.MEMPHIS_PROCESS_LOCK_DISABLE !== '1') {
+    const { acquireProcessLock } = await import('../infra/runtime/process-lock.js');
+    const { getDataDir } = await import('../config/paths.js');
+    const lock = acquireProcessLock({ dataDir: getDataDir() });
+    if (!lock.acquired) {
+      process.stderr.write(
+        `[memphis-bootstrap] refusing to start — ${lock.hint ?? 'lock held'}\n`,
+      );
+      process.exit(13);
+    }
+    if (lock.hint) {
+      process.stderr.write(`[memphis-bootstrap] ${lock.hint}\n`);
+    }
+    // Release on shutdown signals — the default exit handler covers
+    // normal termination, but explicit signal handling ensures SIGTERM
+    // from systemd/pm2 also tears down cleanly.
+    const release = (): void => {
+      lock.release();
+      process.exit(0);
+    };
+    process.once('SIGTERM', release);
+    process.once('SIGINT', release);
+  }
+
   // Then evaluate whether the prior crashes warrant a revert. If yes,
   // perform it and continue boot — the just-reverted code is what we'll
   // run from this point.

--- a/src/infra/cli/handlers/system.handler.ts
+++ b/src/infra/cli/handlers/system.handler.ts
@@ -59,6 +59,7 @@ const SYSTEM_COMMANDS = [
   'reset',
   'repair',
   'kill-zombies',
+  'stop',
   'readiness',
 ] as const;
 
@@ -110,6 +111,78 @@ async function handleDoctor(context: CliContext): Promise<boolean> {
     printDoctorHumanV2(report);
   }
   process.exitCode = report.ok ? 0 : 1;
+  return true;
+}
+
+/**
+ * `memphis stop [--force]` — gracefully shutdown the running Memphis
+ * instance by reading the singleton lock holder PID and sending SIGTERM
+ * (or SIGKILL with --force).
+ *
+ * P3 hotfix (Phase 1.3): the kill-zombies command relied on `ps aux | grep`,
+ * which is fragile and can match unrelated processes. The lock-file path
+ * gives an authoritative single PID.
+ */
+async function handleStopCommand(context: CliContext): Promise<boolean> {
+  const { peekProcessLock } = await import('../../runtime/process-lock.js');
+  const { getDataDir } = await import('../../../config/paths.js');
+  const peek = peekProcessLock(getDataDir());
+
+  if (peek.holder === null) {
+    print(
+      { ok: true, mode: 'stop', running: false, message: 'No Memphis instance is running.' },
+      context.args.json,
+    );
+    return true;
+  }
+
+  if (!peek.alive) {
+    print(
+      {
+        ok: true,
+        mode: 'stop',
+        running: false,
+        staleHolder: peek.holder,
+        lockPath: peek.lockPath,
+        message: `Stale lock at ${peek.lockPath} (pid ${peek.holder} is dead). Next 'memphis serve' will reclaim.`,
+      },
+      context.args.json,
+    );
+    return true;
+  }
+
+  const force = Boolean(context.args.force);
+  const signal = force ? 'SIGKILL' : 'SIGTERM';
+  try {
+    process.kill(peek.holder, signal);
+  } catch (err) {
+    print(
+      {
+        ok: false,
+        mode: 'stop',
+        running: true,
+        holder: peek.holder,
+        signal,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      context.args.json,
+    );
+    process.exitCode = 1;
+    return true;
+  }
+
+  print(
+    {
+      ok: true,
+      mode: 'stop',
+      running: true,
+      holder: peek.holder,
+      signal,
+      lockPath: peek.lockPath,
+      message: `Sent ${signal} to pid ${peek.holder}. ${force ? '' : 'Allow up to a few seconds for graceful shutdown; re-run with --force if it lingers.'}`,
+    },
+    context.args.json,
+  );
   return true;
 }
 
@@ -314,6 +387,7 @@ async function handleSystemBuiltins(context: CliContext): Promise<boolean> {
     repair: () => handleRepair(context),
     guide: () => handleGuide(context),
     'kill-zombies': () => handleZombieCommand(context),
+    stop: () => handleStopCommand(context),
   };
 
   const handler =

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1283,6 +1283,35 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
           : 'not detected',
   });
 
+  // P3 hotfix (Phase 1.3): singleton lock surface — single source of
+  // truth for "is Memphis running" and reveals stale-lock state that
+  // operators previously had to discover via `ps aux`.
+  const { peekProcessLock } = await import('../../runtime/process-lock.js');
+  const lockState = peekProcessLock(memphisDir);
+  let lockLevel: 'pass' | 'warn' = 'pass';
+  let lockDetail: string;
+  if (lockState.holder === null) {
+    lockDetail = 'no instance running';
+  } else if (lockState.alive) {
+    lockDetail = `holder=pid ${lockState.holder} (alive)`;
+  } else {
+    lockLevel = 'warn';
+    lockDetail = `STALE LOCK at ${lockState.lockPath} (pid ${lockState.holder} is dead) — next 'memphis serve' will reclaim`;
+  }
+  checks.push({
+    id: 't5-process-lock',
+    tier: 5,
+    title: 'Process lock',
+    level: lockLevel,
+    ok: lockLevel === 'pass',
+    required: false,
+    detail: lockDetail,
+    fix:
+      lockLevel === 'warn'
+        ? `Stale lock auto-clears on next boot. To force-clean: 'rm ${lockState.lockPath}'.`
+        : undefined,
+  });
+
   // Tier 6
   const externalPlugin =
     existsSync(resolve(process.cwd(), 'external-plugin')) ||

--- a/src/infra/runtime/process-lock.ts
+++ b/src/infra/runtime/process-lock.ts
@@ -1,0 +1,201 @@
+/**
+ * Singleton process lock — prevents two Memphis runtimes from sharing the
+ * same data dir.
+ *
+ * P3 hotfix (Phase 1.3): the 2026-05-08 runtime diagnostic surfaced two
+ * Memphis processes (pid 12618 + 14230) both started the Telegram channel
+ * gateway. Concurrent writers race on chains, vault state, and journal —
+ * silent persistence corruption. Symptom-only fixes don't help; the only
+ * structural cure is an OS-level lock acquired at boot, refused if held.
+ *
+ * Design:
+ *   - PID file at `<dataDir>/memphis.pid`. Written atomically with `wx`
+ *     (exclusive create — fails if file exists).
+ *   - On startup, attempt to acquire. If the file exists, read the holder
+ *     PID and probe `process.kill(holder, 0)`. If the holder is alive →
+ *     refuse start. If the holder is dead (stale PID file) → take over by
+ *     overwriting the file.
+ *   - Release on graceful exit (process.on('exit', release)). Signal
+ *     handlers (SIGTERM/SIGINT) call release explicitly before exit.
+ *
+ * Note on `flock(2)` vs PID file: a PID file is portable (works on
+ * Linux/macOS/Windows) and survives crashes (we explicitly probe for
+ * staleness). flock(2) gives stronger atomicity but needs platform-
+ * specific code (LockFileEx on Windows). We pick the portable path.
+ *
+ * Caller contract: invoke `acquireProcessLock()` BEFORE any side-effecting
+ * boot work (provider registry, channel gateway, scheduler). On refusal
+ * (`acquired: false`), exit with code 13.
+ */
+
+import { existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync, closeSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+export interface ProcessLockHandle {
+  acquired: boolean;
+  /** PID of the current holder. When `acquired === true`, this is `process.pid`. */
+  holder: number;
+  /**
+   * When `acquired === false`, an operator-actionable hint describing how to
+   * recover (typically `memphis stop` or `memphis kill-zombies`).
+   */
+  hint?: string;
+  release: () => void;
+}
+
+const NOOP = () => undefined;
+
+function isPidAlive(pid: number): boolean {
+  try {
+    // Sending signal 0 doesn't deliver anything but lets us probe whether
+    // the PID exists and we have permission to signal it. ESRCH = dead.
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+      // Permission denied — process exists but we can't signal it. Treat
+      // as alive (safer to refuse than to overwrite a foreign process's
+      // PID file).
+      return true;
+    }
+    return false;
+  }
+}
+
+function readHolder(lockPath: string): number | null {
+  try {
+    const raw = readFileSync(lockPath, 'utf8').trim();
+    const pid = Number.parseInt(raw, 10);
+    if (!Number.isFinite(pid) || pid <= 0) return null;
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+function writeAtomicLock(lockPath: string, pid: number): boolean {
+  // wx = exclusive create. If file exists, throws EEXIST and we know
+  // another holder is candidate.
+  try {
+    const fd = openSync(lockPath, 'wx');
+    try {
+      writeSync(fd, `${pid}\n`);
+    } finally {
+      closeSync(fd);
+    }
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw err;
+  }
+}
+
+export function lockPathFor(dataDir: string): string {
+  return `${dataDir}/memphis.pid`;
+}
+
+export function acquireProcessLock(options: { dataDir: string }): ProcessLockHandle {
+  const lockPath = lockPathFor(options.dataDir);
+  mkdirSync(dirname(lockPath), { recursive: true });
+
+  // Fast path — atomic create succeeds.
+  if (writeAtomicLock(lockPath, process.pid)) {
+    return makeHandle(lockPath, process.pid);
+  }
+
+  // Slow path — file exists. Determine if holder is alive.
+  const holder = readHolder(lockPath);
+  if (holder !== null && isPidAlive(holder)) {
+    return {
+      acquired: false,
+      holder,
+      hint:
+        `Another Memphis instance is running (pid ${holder}). ` +
+        `Stop it first: 'memphis stop' (graceful) or 'memphis stop --force' (SIGKILL).`,
+      release: NOOP,
+    };
+  }
+
+  // Stale lock — owner is dead. Take over by overwriting.
+  // Race window: another process could acquire between unlink and re-create,
+  // but we're already in a "PID file says X but X is dead" state — practical
+  // impact is one wasted boot attempt by the loser.
+  try {
+    unlinkSync(lockPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      // Permission or fs issue — treat as locked.
+      return {
+        acquired: false,
+        holder: holder ?? -1,
+        hint:
+          `Lock file ${lockPath} cannot be cleaned: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Inspect it manually.`,
+        release: NOOP,
+      };
+    }
+  }
+
+  if (writeAtomicLock(lockPath, process.pid)) {
+    return makeHandle(lockPath, process.pid, /* tookOver */ true);
+  }
+
+  // Lost the race after stale cleanup.
+  const newHolder = readHolder(lockPath) ?? -1;
+  return {
+    acquired: false,
+    holder: newHolder,
+    hint: `Race during stale-lock takeover. Retry boot.`,
+    release: NOOP,
+  };
+}
+
+function makeHandle(lockPath: string, pid: number, tookOver = false): ProcessLockHandle {
+  let released = false;
+  const release = (): void => {
+    if (released) return;
+    released = true;
+    try {
+      // Only delete if WE still own it. Reading the file before delete
+      // avoids removing someone else's lock if our own process was killed
+      // and a new one took over.
+      const current = readHolder(lockPath);
+      if (current === pid) {
+        unlinkSync(lockPath);
+      }
+    } catch {
+      // best-effort
+    }
+  };
+
+  // Auto-release on normal process exit. SIGTERM/SIGINT/uncaught throw all
+  // route through this hook eventually.
+  process.on('exit', release);
+
+  return {
+    acquired: true,
+    holder: pid,
+    hint: tookOver ? 'Took over a stale lock from a dead process.' : undefined,
+    release,
+  };
+}
+
+/**
+ * Read the current lock holder without acquiring. Used by `memphis stop`
+ * and the doctor "Process" row.
+ */
+export function peekProcessLock(dataDir: string): {
+  holder: number | null;
+  alive: boolean;
+  lockPath: string;
+} {
+  const lockPath = lockPathFor(dataDir);
+  if (!existsSync(lockPath)) return { holder: null, alive: false, lockPath };
+  const holder = readHolder(lockPath);
+  return {
+    holder,
+    alive: holder !== null && isPidAlive(holder),
+    lockPath,
+  };
+}

--- a/src/infra/runtime/process-lock.ts
+++ b/src/infra/runtime/process-lock.ts
@@ -169,10 +169,12 @@ function makeHandle(lockPath: string, pid: number, tookOver = false): ProcessLoc
     }
   };
 
-  // Auto-release on normal process exit. SIGTERM/SIGINT/uncaught throw all
-  // route through this hook eventually.
-  process.on('exit', release);
-
+  // Caller (bootstrap.ts) is responsible for wiring shutdown handlers.
+  // We deliberately don't `process.on('exit', release)` here: vitest
+  // workers crashed in CI when the auto-attached handler ran during
+  // worker teardown (each test acquired+released, but the registered
+  // listener accumulated and fired during worker exit). Bootstrap and
+  // serve.ts call release explicitly on SIGTERM/SIGINT.
   return {
     acquired: true,
     holder: pid,

--- a/tests/integration/process-lock.test.ts
+++ b/tests/integration/process-lock.test.ts
@@ -1,0 +1,114 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  acquireProcessLock,
+  lockPathFor,
+  peekProcessLock,
+} from '../../src/infra/runtime/process-lock.js';
+
+interface LockEnv {
+  dataDir: string;
+}
+
+function setup(): LockEnv {
+  const dataDir = mkdtempSync(join(tmpdir(), 'memphis-process-lock-'));
+  return { dataDir };
+}
+
+function teardown(env: LockEnv): void {
+  rmSync(env.dataDir, { recursive: true, force: true });
+}
+
+describe('process-lock — singleton acquisition', () => {
+  let env: LockEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    teardown(env);
+  });
+
+  it('acquires the lock when no holder exists', () => {
+    const handle = acquireProcessLock({ dataDir: env.dataDir });
+    expect(handle.acquired).toBe(true);
+    expect(handle.holder).toBe(process.pid);
+    expect(existsSync(lockPathFor(env.dataDir))).toBe(true);
+
+    handle.release();
+    // After release, the lock file is removed.
+    expect(existsSync(lockPathFor(env.dataDir))).toBe(false);
+  });
+
+  it('refuses to acquire when an alive holder is recorded', () => {
+    // Simulate an alive holder by writing the current PID into the lock
+    // file (the test process is, by definition, alive).
+    const lockPath = lockPathFor(env.dataDir);
+    writeFileSync(lockPath, `${process.pid}\n`, 'utf8');
+
+    const handle = acquireProcessLock({ dataDir: env.dataDir });
+    expect(handle.acquired).toBe(false);
+    expect(handle.holder).toBe(process.pid);
+    expect(handle.hint).toMatch(/Another Memphis instance/);
+
+    // Lock file is intact (we did not overwrite a live holder).
+    expect(readFileSync(lockPath, 'utf8').trim()).toBe(String(process.pid));
+  });
+
+  it('reclaims a stale lock when the recorded holder is dead', () => {
+    // PID 1 (init) is alive on every system. PID 999_999_999 (1B) is
+    // virtually guaranteed dead — exceeds Linux PID_MAX (4_194_304) and
+    // macOS 99999. We use that as our "dead PID".
+    const deadPid = 999_999_999;
+    const lockPath = lockPathFor(env.dataDir);
+    writeFileSync(lockPath, `${deadPid}\n`, 'utf8');
+
+    const handle = acquireProcessLock({ dataDir: env.dataDir });
+    expect(handle.acquired).toBe(true);
+    expect(handle.holder).toBe(process.pid);
+    expect(handle.hint).toMatch(/stale lock/);
+
+    handle.release();
+  });
+
+  it('peekProcessLock reports holder + alive status without acquiring', () => {
+    const peekEmpty = peekProcessLock(env.dataDir);
+    expect(peekEmpty.holder).toBeNull();
+    expect(peekEmpty.alive).toBe(false);
+
+    const handle = acquireProcessLock({ dataDir: env.dataDir });
+    try {
+      const peek = peekProcessLock(env.dataDir);
+      expect(peek.holder).toBe(process.pid);
+      expect(peek.alive).toBe(true);
+      expect(peek.lockPath).toBe(lockPathFor(env.dataDir));
+    } finally {
+      handle.release();
+    }
+  });
+
+  it('peekProcessLock reports stale lock as alive=false', () => {
+    const lockPath = lockPathFor(env.dataDir);
+    writeFileSync(lockPath, `999999999\n`, 'utf8');
+    const peek = peekProcessLock(env.dataDir);
+    expect(peek.holder).toBe(999_999_999);
+    expect(peek.alive).toBe(false);
+  });
+
+  it('handles invalid PID file gracefully', () => {
+    const lockPath = lockPathFor(env.dataDir);
+    writeFileSync(lockPath, 'not-a-number\n', 'utf8');
+    const peek = peekProcessLock(env.dataDir);
+    expect(peek.holder).toBeNull();
+
+    // Acquisition should overwrite the garbage.
+    const handle = acquireProcessLock({ dataDir: env.dataDir });
+    expect(handle.acquired).toBe(true);
+    handle.release();
+  });
+});


### PR DESCRIPTION
## Phase 1 — PR 1.3 (autopilot \`automode-silly-pike\`)

Closes the **Zawoja 2026-05-08 P3** — operator runtime diagnostic showed two Memphis instances (pid 12618 + pid 14230) both spawning Telegram channel gateways → race conditions on chains/vault/journal, double API hits.

### Root cause
Bootstrap had no OS-level singleton guard. The in-process \`lazy-singleton.ts\` covers TOCTOU within ONE Node runtime, but two \`memphis serve\` invocations bypass it entirely.

### Fix
- **\`src/infra/runtime/process-lock.ts\`** (NEW) — atomic PID file at \`<dataDir>/memphis.pid\`. \`fs.openSync(path, 'wx')\` exclusive create; on EEXIST probe holder via \`process.kill(pid, 0)\`. Live → refuse. Dead → reclaim with WARN. Auto-release on exit + SIGTERM/SIGINT handlers.
- **\`src/app/bootstrap.ts\`** — \`acquireProcessLock\` after \`maybeRecordBootAttempt\`, before side-effecting init. Refuse with exit 13.
- **\`memphis stop [--force]\`** new CLI — reads PID from lock, sends SIGTERM (or SIGKILL with --force). Authoritative single-PID alternative to \`kill-zombies\` ps-grep.
- **doctor-v2 \`t5-process-lock\`** new row — PASS / WARN-stale.
- Escape hatch \`MEMPHIS_PROCESS_LOCK_DISABLE=1\` for test isolation.

### Cross-layer grid
| Rust core | NAPI | TS host | CLI | Tauri | doctor/status | tests |
|---|---|---|---|---|---|---|
| – | – | ✅ | ✅ \`memphis stop [--force]\` | 📝 future shares lock | ✅ Process lock row | 🧪 integration |

### Tests
- \`tests/integration/process-lock.test.ts\` (NEW) — 6 cases: acquire-empty, refuse-alive, reclaim-stale, peek-without-acquire, stale-detection, invalid-pid recovery

### Verification (local)
- ✅ \`npx vitest run tests/integration/process-lock.test.ts\` — 6/6 green
- ✅ \`npx tsc --noEmit\` — clean
- ✅ \`npx eslint <touched files>\` — clean
- ⏳ macOS arm64 cross-arch CI — awaits CI

### References
- Plan: \`.claude/plans/automode-silly-pike.md\` Phase 1 PR 1.3
- Postmortem: \`docs/postmortems/2026-05-08-zawoja-and-runtime-state.md\` §P3