### PR TITLE
fix(limits): Phase 1.5.1 — Rust↔TS parity + env-driven chat_max_tokens

### DIFF
--- a/crates/memphis-core/src/loop_engine.rs
+++ b/crates/memphis-core/src/loop_engine.rs
@@ -19,17 +19,18 @@ pub struct LoopLimits {
 
 impl Default for LoopLimits {
     fn default() -> Self {
-        // max_steps bumped 32 → 48 on 2026-05-05 after operator session
-        // hit "exceeded loop step limit" during legitimate code-spelunking
-        // exploration. 48 gives ~15 tool-call rounds without masking
-        // real runaway loops. Mirror of TS LOOP_LIMITS in
-        // src/gateway/loop-limits.ts and CHAT_MAX_STEPS_DEFAULT in
-        // crates/memphis-operator/src/chat.rs.
+        // Phase 1.5 P4 follow-up (autopilot 2026-05-08): defaults bumped per
+        // LIMITS-MATRIX-2026-05-08. Operator constraint: cost-unconstrained,
+        // limits are safety nets only. The previous values silently capped
+        // multi-day reasoning sessions far below their working budget. These
+        // mirror src/gateway/loop-limits.ts LOOP_LIMITS and the chat.rs
+        // CHAT_MAX_*_DEFAULT constants; tests/unit/loop-limits-parity.test.ts
+        // pins them all together so future drift fails CI.
         Self {
-            max_steps: 48,
-            max_tool_calls: 16,
+            max_steps: 1_000,
+            max_tool_calls: 1_024,
             max_wait_ms: 120_000,
-            max_errors: 4,
+            max_errors: 32,
         }
     }
 }

--- a/crates/memphis-operator/src/chat.rs
+++ b/crates/memphis-operator/src/chat.rs
@@ -30,17 +30,22 @@ use crate::{
 
 const DEFAULT_CHAT_SESSION_ID: &str = "primary::operator:local";
 const GENESIS_PREV_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
-const CHAT_MAX_MESSAGES_DEFAULT: usize = 40;
-// max_steps bumped 32 → 48 on 2026-05-05 after operator session in mode B
-// hit "exceeded loop step limit" during legitimate code-spelunking
-// (sequential grep / ls / find calls). 32 allowed only ~10 tool-call
-// rounds before the hard cap, too tight for exploration tasks. 48 gives
-// ~15 rounds without masking real runaway loops. Mirror of
-// src/gateway/loop-limits.ts LOOP_LIMITS.max_steps. Override via
-// MEMPHIS_CHAT_MAX_STEPS at runtime if a surface needs more.
-const CHAT_MAX_STEPS_DEFAULT: usize = 48;
-const CHAT_MAX_TOOL_CALLS_DEFAULT: usize = 16;
-const CHAT_MAX_ERRORS_DEFAULT: usize = 8;
+// Phase 1.5 P4 follow-up (autopilot 2026-05-08): the LIMITS-MATRIX audit
+// surfaced silent caps below schema. Operator constraint: limits are safety
+// nets, not budgets. Memphis must work two weeks on a single question
+// without artificial cutoff. Defaults bumped to provider-realistic values;
+// callers can still override per-task via env. Mirrors of these defaults
+// live in src/gateway/loop-limits.ts (LOOP_LIMITS) and the tests/unit/
+// loop-limits-parity.test.ts parity check; do not let them drift again.
+const CHAT_MAX_MESSAGES_DEFAULT: usize = 10_000;
+const CHAT_MAX_STEPS_DEFAULT: usize = 1_000;
+const CHAT_MAX_TOOL_CALLS_DEFAULT: usize = 1_024;
+const CHAT_MAX_ERRORS_DEFAULT: usize = 32;
+// MiniMax-M2.7 + most provider-tier models accept 32k token outputs;
+// hardcoded `Some(2048)` had been silently truncating long replies even
+// when GEN_MAX_TOKENS env was set higher (operator session 2026-05-05
+// caught HTML cut mid-stream). Now operator-overridable.
+const CHAT_MAX_TOKENS_DEFAULT: usize = 32_768;
 
 /// Read a `usize` limit from the environment, falling back to `default`.
 /// A zero or malformed value falls back so operators cannot accidentally
@@ -67,6 +72,10 @@ fn chat_max_tool_calls() -> usize {
 
 fn chat_max_errors() -> usize {
     env_limit("MEMPHIS_CHAT_MAX_ERRORS", CHAT_MAX_ERRORS_DEFAULT)
+}
+
+fn chat_max_tokens() -> usize {
+    env_limit("MEMPHIS_GEN_MAX_TOKENS", CHAT_MAX_TOKENS_DEFAULT)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -287,7 +296,9 @@ impl OperatorRuntime {
             model: model.map(ToString::to_string),
             system_prompt: Some(system_prompt),
             temperature: Some(0.7),
-            max_tokens: Some(2048),
+            // Phase 1.5: env-driven (was hardcoded Some(2048) — silently
+            // truncated long replies regardless of MEMPHIS_GEN_MAX_TOKENS).
+            max_tokens: Some(u32::try_from(chat_max_tokens()).unwrap_or(u32::MAX)),
         };
 
         let input_classification = classify_input(trimmed_prompt);

--- a/src/gateway/loop-limits.ts
+++ b/src/gateway/loop-limits.ts
@@ -20,18 +20,31 @@
 
 import type { LoopLimits } from './chat-types.js';
 
-// max_steps bumped 32 → 48 on 2026-05-05 after operator session in mode B
-// hit "exceeded loop step limit" during legitimate code-spelunking
-// (sequential grep / ls / find calls to understand a subsystem). 32
-// allowed only ~10 tool-call rounds before the hard cap, too tight for
-// exploration tasks. 48 gives ~15 rounds without masking real runaway
-// loops (a genuinely-stuck loop will hit 48 just as quickly). Override
-// via MEMPHIS_CHAT_MAX_STEPS at runtime if a surface needs more.
+// Phase 1.5 P4 follow-up (autopilot 2026-05-08): defaults bumped per
+// LIMITS-MATRIX-2026-05-08 to align with Rust enforcement and remove
+// silent caps. Operator constraint is "cost-unconstrained" — limits are
+// safety nets, not budgets. Memphis must be able to work 2 weeks on a
+// single question without artificial cutoff.
+//
+// The previous values:
+//   - max_steps=48: ~15 tool rounds before halt; too tight for deep work
+//   - max_tool_calls=64: TS said 64 but Rust enforced 16 — a silent gap
+//     that bit operator trust during code-spelunking sessions
+//   - max_errors=4: too aggressive for noisy/transient tool failures
+//
+// New values mirror Rust LoopLimits::default() in
+// crates/memphis-core/src/loop_engine.rs and the CHAT_MAX_* constants
+// in crates/memphis-operator/src/chat.rs. The parity test in
+// tests/unit/loop-limits-parity.test.ts fails CI if any of the three
+// surfaces drift again.
+//
+// Override via env at runtime (MEMPHIS_CHAT_MAX_STEPS, MEMPHIS_CHAT_MAX_TOOL_CALLS,
+// MEMPHIS_CHAT_MAX_ERRORS) when a surface or test needs different bounds.
 export const LOOP_LIMITS: Readonly<LoopLimits> = Object.freeze({
-  max_steps: 48,
-  max_tool_calls: 64,
+  max_steps: 1_000,
+  max_tool_calls: 1_024,
   max_wait_ms: 120_000,
-  max_errors: 4,
+  max_errors: 32,
 });
 
 export function formatLoopLimitsLine(): string {

--- a/tests/unit/loop-limits-parity.test.ts
+++ b/tests/unit/loop-limits-parity.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { LOOP_LIMITS } from '../../src/gateway/loop-limits.js';
+
+/**
+ * Phase 1.5 P4 follow-up (autopilot 2026-05-08):
+ *
+ * The audit in docs/dev/LIMITS-MATRIX-2026-05-08.md found three surfaces
+ * defining loop limits independently:
+ *   1. src/gateway/loop-limits.ts (LOOP_LIMITS) — TS host source
+ *   2. crates/memphis-core/src/loop_engine.rs (LoopLimits::default) — Rust core
+ *   3. crates/memphis-operator/src/chat.rs (CHAT_MAX_*_DEFAULT) — Rust operator
+ *
+ * Previously they drifted: TS said max_tool_calls=64 while Rust enforced 16.
+ * The Rust side enforces at runtime, so the TS value was misleading. Same
+ * for max_errors (TS=4 vs Rust=8).
+ *
+ * This test reads the two Rust files at test time, regex-extracts each
+ * limit, and asserts byte-for-byte equality against TS LOOP_LIMITS. If
+ * anyone changes a default in one place without updating the others, this
+ * fails CI before the drift can land. Mechanical, not philosophical —
+ * either all three move together or the test fails.
+ */
+
+const REPO_ROOT = resolve(import.meta.dirname, '../..');
+const LOOP_ENGINE_RS = resolve(REPO_ROOT, 'crates/memphis-core/src/loop_engine.rs');
+const CHAT_RS = resolve(REPO_ROOT, 'crates/memphis-operator/src/chat.rs');
+
+function readFile(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+function extractLoopEngineDefaults(): {
+  max_steps: number;
+  max_tool_calls: number;
+  max_wait_ms: number;
+  max_errors: number;
+} {
+  const content = readFile(LOOP_ENGINE_RS);
+  const block = content.match(/impl Default for LoopLimits \{[\s\S]*?Self \{([\s\S]*?)\}\s*\}\s*\}/);
+  if (!block) throw new Error('Could not locate LoopLimits::default block in loop_engine.rs');
+  const body = block[1];
+  function num(field: string): number {
+    const m = body.match(new RegExp(`${field}\\s*:\\s*([0-9_]+)`));
+    if (!m) throw new Error(`Field ${field} not found in LoopLimits::default`);
+    return Number(m[1].replace(/_/g, ''));
+  }
+  return {
+    max_steps: num('max_steps'),
+    max_tool_calls: num('max_tool_calls'),
+    max_wait_ms: num('max_wait_ms'),
+    max_errors: num('max_errors'),
+  };
+}
+
+function extractChatRsConstants(): {
+  CHAT_MAX_STEPS_DEFAULT: number;
+  CHAT_MAX_TOOL_CALLS_DEFAULT: number;
+  CHAT_MAX_ERRORS_DEFAULT: number;
+} {
+  const content = readFile(CHAT_RS);
+  function num(name: string): number {
+    const m = content.match(new RegExp(`${name}\\s*:\\s*usize\\s*=\\s*([0-9_]+)`));
+    if (!m) throw new Error(`Const ${name} not found in chat.rs`);
+    return Number(m[1].replace(/_/g, ''));
+  }
+  return {
+    CHAT_MAX_STEPS_DEFAULT: num('CHAT_MAX_STEPS_DEFAULT'),
+    CHAT_MAX_TOOL_CALLS_DEFAULT: num('CHAT_MAX_TOOL_CALLS_DEFAULT'),
+    CHAT_MAX_ERRORS_DEFAULT: num('CHAT_MAX_ERRORS_DEFAULT'),
+  };
+}
+
+describe('loop-limits parity: TS LOOP_LIMITS ≡ Rust LoopLimits::default ≡ chat.rs CHAT_MAX_*_DEFAULT', () => {
+  it('TS LOOP_LIMITS.max_steps === Rust loop_engine.rs LoopLimits::default.max_steps', () => {
+    const rust = extractLoopEngineDefaults();
+    expect(LOOP_LIMITS.max_steps).toBe(rust.max_steps);
+  });
+
+  it('TS LOOP_LIMITS.max_tool_calls === Rust loop_engine.rs LoopLimits::default.max_tool_calls', () => {
+    const rust = extractLoopEngineDefaults();
+    expect(LOOP_LIMITS.max_tool_calls).toBe(rust.max_tool_calls);
+  });
+
+  it('TS LOOP_LIMITS.max_wait_ms === Rust loop_engine.rs LoopLimits::default.max_wait_ms', () => {
+    const rust = extractLoopEngineDefaults();
+    expect(LOOP_LIMITS.max_wait_ms).toBe(rust.max_wait_ms);
+  });
+
+  it('TS LOOP_LIMITS.max_errors === Rust loop_engine.rs LoopLimits::default.max_errors', () => {
+    const rust = extractLoopEngineDefaults();
+    expect(LOOP_LIMITS.max_errors).toBe(rust.max_errors);
+  });
+
+  it('chat.rs CHAT_MAX_STEPS_DEFAULT === TS LOOP_LIMITS.max_steps', () => {
+    const chatRs = extractChatRsConstants();
+    expect(chatRs.CHAT_MAX_STEPS_DEFAULT).toBe(LOOP_LIMITS.max_steps);
+  });
+
+  it('chat.rs CHAT_MAX_TOOL_CALLS_DEFAULT === TS LOOP_LIMITS.max_tool_calls', () => {
+    const chatRs = extractChatRsConstants();
+    expect(chatRs.CHAT_MAX_TOOL_CALLS_DEFAULT).toBe(LOOP_LIMITS.max_tool_calls);
+  });
+
+  it('chat.rs CHAT_MAX_ERRORS_DEFAULT === TS LOOP_LIMITS.max_errors', () => {
+    const chatRs = extractChatRsConstants();
+    expect(chatRs.CHAT_MAX_ERRORS_DEFAULT).toBe(LOOP_LIMITS.max_errors);
+  });
+
+  it('all three sources agree post Phase 1.5 bump', () => {
+    const rust = extractLoopEngineDefaults();
+    const chatRs = extractChatRsConstants();
+    expect({
+      ts: LOOP_LIMITS,
+      rustEngine: rust,
+      chatRs: {
+        max_steps: chatRs.CHAT_MAX_STEPS_DEFAULT,
+        max_tool_calls: chatRs.CHAT_MAX_TOOL_CALLS_DEFAULT,
+        max_errors: chatRs.CHAT_MAX_ERRORS_DEFAULT,
+      },
+    }).toEqual({
+      ts: { max_steps: 1000, max_tool_calls: 1024, max_wait_ms: 120_000, max_errors: 32 },
+      rustEngine: { max_steps: 1000, max_tool_calls: 1024, max_wait_ms: 120_000, max_errors: 32 },
+      chatRs: { max_steps: 1000, max_tool_calls: 1024, max_errors: 32 },
+    });
+  });
+});

--- a/tests/unit/loop-limits.test.ts
+++ b/tests/unit/loop-limits.test.ts
@@ -6,11 +6,15 @@ import { buildSystemPrompt } from '../../src/gateway/system-prompt.js';
 
 describe('LOOP_LIMITS single source of truth', () => {
   it('exposes frozen canonical values', () => {
+    // Phase 1.5.1 (autopilot 2026-05-08): values bumped per
+    // LIMITS-MATRIX-2026-05-08 + Rust↔TS parity test. The drift-protection
+    // test in tests/unit/loop-limits-parity.test.ts cross-checks against
+    // crates/memphis-core/src/loop_engine.rs and chat.rs.
     expect(LOOP_LIMITS).toEqual({
-      max_steps: 48,
-      max_tool_calls: 64,
+      max_steps: 1_000,
+      max_tool_calls: 1_024,
       max_wait_ms: 120_000,
-      max_errors: 4,
+      max_errors: 32,
     });
     expect(Object.isFrozen(LOOP_LIMITS)).toBe(true);
   });
@@ -21,19 +25,20 @@ describe('LOOP_LIMITS single source of truth', () => {
 
   it('formatLoopLimitsLine renders every field with the canonical value', () => {
     expect(formatLoopLimitsLine()).toBe(
-      'max_steps=48, max_tool_calls=64, max_wait_ms=120000, max_errors=4',
+      `max_steps=${LOOP_LIMITS.max_steps}, max_tool_calls=${LOOP_LIMITS.max_tool_calls}, max_wait_ms=${LOOP_LIMITS.max_wait_ms}, max_errors=${LOOP_LIMITS.max_errors}`,
     );
   });
 
-  it('system prompt embeds the canonical values (not the old 16 stale default)', () => {
+  it('system prompt embeds the canonical values (not the old stale defaults)', () => {
     const prompt = buildSystemPrompt({
       availableTools: ['memphis_loop_step'],
       rustBridgeActive: true,
     });
-    expect(prompt).toContain('max_tool_calls=64');
+    expect(prompt).toContain(`max_tool_calls=${LOOP_LIMITS.max_tool_calls}`);
     expect(prompt).not.toMatch(/max_tool_calls=16/);
-    expect(prompt).toContain('max 48 steps');
-    expect(prompt).toContain('64 tool calls');
-    expect(prompt).toContain('max 4 errors allowed');
+    expect(prompt).not.toMatch(/max_tool_calls=64/);
+    expect(prompt).toContain(`max ${LOOP_LIMITS.max_steps} steps`);
+    expect(prompt).toContain(`${LOOP_LIMITS.max_tool_calls} tool calls`);
+    expect(prompt).toContain(`max ${LOOP_LIMITS.max_errors} errors allowed`);
   });
 });

--- a/tests/unit/readiness.test.ts
+++ b/tests/unit/readiness.test.ts
@@ -105,7 +105,13 @@ describe('buildReadinessReport', () => {
     expect(report.ok).toBe(true);
     expect(report.exitCode).toBe(0);
     expect(report.rows.find((r) => r.id === 'env_file')?.level).toBe('ok');
-    expect(report.rows.find((r) => r.id === 'loop_limits')?.detail).toContain('max_tool_calls=64');
+    // Phase 1.5.1 (autopilot 2026-05-08): asserts against canonical
+    // LOOP_LIMITS rather than hardcoded number, so future bumps don't
+    // require touching this test.
+    const { LOOP_LIMITS } = await import('../../src/gateway/loop-limits.js');
+    expect(report.rows.find((r) => r.id === 'loop_limits')?.detail).toContain(
+      `max_tool_calls=${LOOP_LIMITS.max_tool_calls}`,
+    );
   });
 
   it('exits 1 when a critical row fails', async () => {


### PR DESCRIPTION
## Phase 1.5 PR 1 of 4 (autopilot \`automode-silly-pike\`)

Removes the silent caps that the **LIMITS-MATRIX-2026-05-08** audit identified — three surfaces (TS LOOP_LIMITS, Rust LoopLimits::default, chat.rs CHAT_MAX_*_DEFAULT) had drifted apart, with Rust quietly enforcing 16 tool calls while TS reported 64.

### Defaults bumped
| Limit | Pre | Post |
|---|---|---|
| max_steps | 48 | **1000** |
| max_tool_calls | 16 (Rust) / 64 (TS, lie) | **1024** |
| max_errors | 4 (Rust) / 8 (chat.rs) | **32** |
| max_tokens | hardcoded Some(2048) | **env-driven via \`MEMPHIS_GEN_MAX_TOKENS\`, default 32_768** |

### Drift protection
New \`tests/unit/loop-limits-parity.test.ts\` reads both Rust files at test time, regex-extracts each constant, asserts byte-for-byte equality with TS LOOP_LIMITS. Future single-side edits fail CI.

### Cross-layer grid
| Rust | NAPI | TS | CLI | Tauri | doctor/status | tests |
|---|---|---|---|---|---|---|
| ✅ chat.rs + loop_engine | – | ✅ loop-limits | 🔧 doctor surfaces env (free) | – | 🔧 env-registry | 🧪 parity (8 cases) |

### Verification (local)
- ✅ npx vitest run tests/unit/loop-limits-parity.test.ts — 8/8
- ✅ cargo test -p memphis-core --lib loop_engine — 2/2
- ✅ cargo check -p memphis-core -p memphis-operator — clean
- ✅ npx tsc --noEmit + eslint — clean

### References
- Plan: \`.claude/plans/automode-silly-pike.md\` Phase 1.5 PR 1
- \`docs/dev/LIMITS-MATRIX-2026-05-08.md\` §1
- Memory: \`feedback_memphis_cost_unconstrained\`