### PR TITLE
fix(limits): Phase 1.5.2 — schema caps + env-registry +18 limit accessors

### DIFF
--- a/src/config/env-registry.ts
+++ b/src/config/env-registry.ts
@@ -418,6 +418,185 @@ export const MINIMAX_REQUEST_TIMEOUT_MS = defineNumberAccessor({
   max: 86_400_000,
 });
 
+// ── Phase 1.5 limit-bump accessors (autopilot 2026-05-08) ──────────────────
+//
+// All defaults track LIMITS-MATRIX-2026-05-08 §4–§7. Operator constraint:
+// limits are safety nets, not budgets. Memphis must work two weeks on a
+// single question without artificial cutoff. Min/max bounds are physical
+// sanity rails — the runtime falls back to default when the env value is
+// out of range so an operator typo can't accidentally disable a limit.
+
+export const MEMPHIS_LOOP_MAX_STEPS = defineNumberAccessor({
+  name: 'MEMPHIS_LOOP_MAX_STEPS',
+  envKey: 'MEMPHIS_CHAT_MAX_STEPS',
+  description: 'Max loop steps per agent session. Default 1000.',
+  defaultValue: 1_000,
+  min: 1,
+  max: 100_000,
+});
+
+export const MEMPHIS_LOOP_MAX_TOOL_CALLS = defineNumberAccessor({
+  name: 'MEMPHIS_LOOP_MAX_TOOL_CALLS',
+  envKey: 'MEMPHIS_CHAT_MAX_TOOL_CALLS',
+  description: 'Max tool calls per agent session. Default 1024.',
+  defaultValue: 1_024,
+  min: 1,
+  max: 100_000,
+});
+
+export const MEMPHIS_LOOP_MAX_ERRORS = defineNumberAccessor({
+  name: 'MEMPHIS_LOOP_MAX_ERRORS',
+  envKey: 'MEMPHIS_CHAT_MAX_ERRORS',
+  description: 'Tolerated tool errors per agent session before halt. Default 32.',
+  defaultValue: 32,
+  min: 1,
+  max: 10_000,
+});
+
+export const MEMPHIS_CHAT_MAX_MESSAGES = defineNumberAccessor({
+  name: 'MEMPHIS_CHAT_MAX_MESSAGES',
+  envKey: 'MEMPHIS_CHAT_MAX_MESSAGES',
+  description: 'Chat history window (messages retained). Default 10000.',
+  defaultValue: 10_000,
+  min: 10,
+  max: 1_000_000,
+});
+
+export const MEMPHIS_GEN_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_GEN_TIMEOUT_MS',
+  envKey: 'GEN_TIMEOUT_MS',
+  description: 'Per-request generation timeout (ms). Default 1 h, max 24 h.',
+  defaultValue: 3_600_000,
+  min: 100,
+  max: 86_400_000,
+});
+
+export const MEMPHIS_GEN_MAX_TOKENS = defineNumberAccessor({
+  name: 'MEMPHIS_GEN_MAX_TOKENS',
+  envKey: 'MEMPHIS_GEN_MAX_TOKENS',
+  description: 'Per-request output tokens. Default 32768, sanity-rail max 1MB.',
+  defaultValue: 32_768,
+  min: 1,
+  max: 1_048_576,
+});
+
+export const MEMPHIS_STT_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_STT_TIMEOUT_MS',
+  envKey: 'MEMPHIS_STT_TIMEOUT_MS',
+  description: 'STT (Whisper) request timeout (ms). Default 10 min.',
+  defaultValue: 600_000,
+  min: 1_000,
+  max: 86_400_000,
+});
+
+export const MEMPHIS_TTS_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_TTS_TIMEOUT_MS',
+  envKey: 'MEMPHIS_TTS_TIMEOUT_MS',
+  description: 'TTS (Piper) request timeout (ms). Default 5 min.',
+  defaultValue: 300_000,
+  min: 1_000,
+  max: 86_400_000,
+});
+
+export const MEMPHIS_PIPER_HEALTH_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_PIPER_HEALTH_TIMEOUT_MS',
+  envKey: 'MEMPHIS_PIPER_HEALTH_TIMEOUT_MS',
+  description: 'Piper health probe timeout (ms). Default 30 s.',
+  defaultValue: 30_000,
+  min: 100,
+  max: 600_000,
+});
+
+export const MEMPHIS_EXEC_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_EXEC_TIMEOUT_MS',
+  envKey: 'MEMPHIS_EXEC_TIMEOUT_MS',
+  description: 'memphis_exec tool timeout (ms). Default 1 h.',
+  defaultValue: 3_600_000,
+  min: 1_000,
+  max: 86_400_000,
+});
+
+export const MEMPHIS_BUILD_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_BUILD_TIMEOUT_MS',
+  envKey: 'MEMPHIS_BUILD_TIMEOUT_MS',
+  description: 'memphis_build tool timeout (ms). Default 2 h.',
+  defaultValue: 7_200_000,
+  min: 1_000,
+  max: 86_400_000,
+});
+
+export const MEMPHIS_PACKAGE_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_PACKAGE_TIMEOUT_MS',
+  envKey: 'MEMPHIS_PACKAGE_TIMEOUT_MS',
+  description: 'memphis_package (npm/cargo) tool timeout (ms). Default 1 h.',
+  defaultValue: 3_600_000,
+  min: 1_000,
+  max: 86_400_000,
+});
+
+export const MEMPHIS_WEB_FETCH_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_WEB_FETCH_TIMEOUT_MS',
+  envKey: 'MEMPHIS_WEB_FETCH_TIMEOUT_MS',
+  description: 'memphis_web_fetch tool timeout (ms). Default 1 min.',
+  defaultValue: 60_000,
+  min: 1_000,
+  max: 600_000,
+});
+
+export const MEMPHIS_BRAVE_SEARCH_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_BRAVE_SEARCH_TIMEOUT_MS',
+  envKey: 'MEMPHIS_BRAVE_SEARCH_TIMEOUT_MS',
+  description: 'memphis_brave_search tool timeout (ms). Default 1 min.',
+  defaultValue: 60_000,
+  min: 1_000,
+  max: 600_000,
+});
+
+export const MEMPHIS_WEB_SEARCH_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_WEB_SEARCH_TIMEOUT_MS',
+  envKey: 'MEMPHIS_WEB_SEARCH_TIMEOUT_MS',
+  description: 'memphis_web_search tool timeout (ms). Default 1 min.',
+  defaultValue: 60_000,
+  min: 1_000,
+  max: 600_000,
+});
+
+export const MEMPHIS_TUI_HOST_HANDSHAKE_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_TUI_HOST_HANDSHAKE_TIMEOUT_MS',
+  envKey: 'MEMPHIS_TUI_HOST_HANDSHAKE_TIMEOUT_MS',
+  description: 'TUI host handshake timeout (ms). Default 2 min.',
+  defaultValue: 120_000,
+  min: 1_000,
+  max: 600_000,
+});
+
+export const MEMPHIS_TUI_HOST_REQUEST_START_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_TUI_HOST_REQUEST_START_TIMEOUT_MS',
+  envKey: 'MEMPHIS_TUI_HOST_REQUEST_START_TIMEOUT_MS',
+  description: 'TUI host request-start timeout (ms). Default 1 min.',
+  defaultValue: 60_000,
+  min: 1_000,
+  max: 600_000,
+});
+
+export const MEMPHIS_TUI_HOST_REQUEST_IDLE_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_TUI_HOST_REQUEST_IDLE_TIMEOUT_MS',
+  envKey: 'MEMPHIS_TUI_HOST_REQUEST_IDLE_TIMEOUT_MS',
+  description: 'TUI host idle-during-request timeout (ms). Default 30 min.',
+  defaultValue: 1_800_000,
+  min: 1_000,
+  max: 86_400_000,
+});
+
+export const MEMPHIS_CATEGORIZER_LLM_TIMEOUT_MS = defineNumberAccessor({
+  name: 'MEMPHIS_CATEGORIZER_LLM_TIMEOUT_MS',
+  envKey: 'MEMPHIS_CATEGORIZER_LLM_TIMEOUT_MS',
+  description: 'Categorizer LLM call timeout (ms). Default 1 min (was 3 s legacy setTimeout).',
+  defaultValue: 60_000,
+  min: 1_000,
+  max: 600_000,
+});
+
 // ── Registry surface (for doctor + telemetry) ───────────────────────────────
 
 /**
@@ -448,6 +627,25 @@ export const ENV_REGISTRY: readonly EnvAccessor<unknown>[] = [
   MEMPHIS_SYNC_PEERS,
   MEMPHIS_SYNC_ACCEPT_UNSIGNED,
   MINIMAX_REQUEST_TIMEOUT_MS,
+  MEMPHIS_LOOP_MAX_STEPS,
+  MEMPHIS_LOOP_MAX_TOOL_CALLS,
+  MEMPHIS_LOOP_MAX_ERRORS,
+  MEMPHIS_CHAT_MAX_MESSAGES,
+  MEMPHIS_GEN_TIMEOUT_MS,
+  MEMPHIS_GEN_MAX_TOKENS,
+  MEMPHIS_STT_TIMEOUT_MS,
+  MEMPHIS_TTS_TIMEOUT_MS,
+  MEMPHIS_PIPER_HEALTH_TIMEOUT_MS,
+  MEMPHIS_EXEC_TIMEOUT_MS,
+  MEMPHIS_BUILD_TIMEOUT_MS,
+  MEMPHIS_PACKAGE_TIMEOUT_MS,
+  MEMPHIS_WEB_FETCH_TIMEOUT_MS,
+  MEMPHIS_BRAVE_SEARCH_TIMEOUT_MS,
+  MEMPHIS_WEB_SEARCH_TIMEOUT_MS,
+  MEMPHIS_TUI_HOST_HANDSHAKE_TIMEOUT_MS,
+  MEMPHIS_TUI_HOST_REQUEST_START_TIMEOUT_MS,
+  MEMPHIS_TUI_HOST_REQUEST_IDLE_TIMEOUT_MS,
+  MEMPHIS_CATEGORIZER_LLM_TIMEOUT_MS,
 ] as const;
 
 export interface RegistryReport {

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -107,8 +107,14 @@ export const envSchema = z.object({
   GLM_BASE_URL: z.string().optional(),
   LOCAL_FALLBACK_ENABLED: boolFromString.default(true),
 
-  GEN_TIMEOUT_MS: z.coerce.number().int().min(100).max(120000).default(90000),
-  GEN_MAX_TOKENS: z.coerce.number().int().min(1).max(32768).default(4096),
+  // Phase 1.5 P4 follow-up (autopilot 2026-05-08): schema caps relaxed to
+  // sanity rails per LIMITS-MATRIX-2026-05-08. Operator constraint:
+  // cost-unconstrained — limits are safety nets, not budgets. Memphis must
+  // be able to work two weeks on a single question. The new caps are
+  // physical sanity rails (24h max timeout = runaway prevention; 1MB max
+  // tokens = no provider supports more), not artificial economic limits.
+  GEN_TIMEOUT_MS: z.coerce.number().int().min(100).max(86_400_000).default(3_600_000),
+  GEN_MAX_TOKENS: z.coerce.number().int().min(1).max(1_048_576).default(32_768),
   GEN_TEMPERATURE: z.coerce.number().min(0).max(2).default(0.4),
 
   DATABASE_URL: z.string().default('file:./data/memphis.db'),


### PR DESCRIPTION
## Phase 1.5 PR 2 of 4 (autopilot \`automode-silly-pike\`)

Re-targeted onto integration directly after PR #502 (the original parent in the stack) merged. Same diff as the closed #504, just rebased.

### Schema caps relaxed (sanity rails, not budgets)
- \`GEN_TIMEOUT_MS\`: max 120k → **86_400_000 (24 h)**, default 90k → **3_600_000 (1 h)**
- \`GEN_MAX_TOKENS\`: max 32k → **1_048_576 (1 MB)**, default 4096 → **32_768**

### env-registry +18 limit accessors
Loop tunables (4) + generation (2) + media/voice (3) + MCP tools (6) + TUI host (3) — full table in commit body and \`docs/dev/LIMITS-MATRIX-2026-05-08.md\` §4–§7.

### Cross-layer grid
| Rust | NAPI | TS | CLI | Tauri | doctor/status | tests |
|---|---|---|---|---|---|---|
| – | – | ✅ schema + registry | 🔧 doctor surface auto-extends | – | ✅ inspect()×18 new | covered by parity test from #503 (merged) |

### Verification (local)
- ✅ \`npx tsc --noEmit\` — clean
- ✅ \`npx eslint <touched>\` — clean

### References
- Plan: \`.claude/plans/automode-silly-pike.md\` Phase 1.5 PR 2
- Replaces closed #504 (parent merged by squash, base ref deleted)