### PR TITLE
feat(status): Phase 3.4 — DEMO READY badge in /status + doctor

### DIFF
--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1329,6 +1329,58 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
         : undefined,
   });
 
+  // Phase 3.4 (autopilot 2026-05-08): Demo readiness badge — reads
+  // data/demo-armed.json written by `memphis demo arm` (Phase 3.1).
+  // Operator's lesson #2 from Zawoja: "Testować demo PRZED wejściem".
+  // Surfacing this row in doctor means the badge appears in the same
+  // health summary the operator already trusts.
+  const demoStatePath = `${memphisDir}/demo-armed.json`;
+  let demoLevel: 'pass' | 'warn' = 'pass';
+  let demoDetail: string;
+  if (!existsSync(demoStatePath)) {
+    demoLevel = 'warn';
+    demoDetail = 'NOT ARMED — run `memphis demo arm` before any live session';
+  } else {
+    try {
+      const raw = readFileSync(demoStatePath, 'utf8');
+      if (raw.trim().length === 0) {
+        demoLevel = 'warn';
+        demoDetail = 'disarmed (state file truncated by `memphis demo disarm`)';
+      } else {
+        const parsed = JSON.parse(raw) as { armedAt?: string; armedBy?: string };
+        const armedAt = parsed.armedAt ?? '?';
+        const armedBy = parsed.armedBy ?? '?';
+        const ageMs = parsed.armedAt
+          ? Date.now() - new Date(parsed.armedAt).getTime()
+          : null;
+        const ageHours = ageMs !== null ? (ageMs / 3_600_000).toFixed(1) : '?';
+        demoDetail = `ARMED ✅ at ${armedAt} by ${armedBy} (${ageHours}h ago)`;
+        // Stale arming (>24h old) drops to warn — pre-demo smoke loses
+        // signal value if it's a day old.
+        if (ageMs !== null && ageMs > 24 * 60 * 60 * 1000) {
+          demoLevel = 'warn';
+          demoDetail += ' — STALE (>24h); re-run `memphis demo arm`';
+        }
+      }
+    } catch (err) {
+      demoLevel = 'warn';
+      demoDetail = `state file unreadable: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+  checks.push({
+    id: 't5-demo-readiness',
+    tier: 5,
+    title: 'Demo readiness',
+    level: demoLevel,
+    ok: demoLevel === 'pass',
+    required: false,
+    detail: demoDetail,
+    fix:
+      demoLevel === 'warn'
+        ? 'Run `memphis demo arm` to verify the checklist + freshen the state.'
+        : undefined,
+  });
+
   // Tier 6
   const externalPlugin =
     existsSync(resolve(process.cwd(), 'external-plugin')) ||

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants, existsSync } from 'node:fs';
+import { accessSync, constants, existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 import { getAppVersion } from '../../config/paths.js';
@@ -58,6 +58,21 @@ export type HealthPayload = {
    * Always returned (zero when telemetry sink is empty / disabled).
    */
   confabulationEvents7d: number;
+  /**
+   * Phase 3.4 (autopilot 2026-05-08): demo readiness state. Populated
+   * from data/demo-armed.json which `memphis demo arm` (Phase 3.1)
+   * writes after passing the checklist. Used by monitoring scripts +
+   * the TUI status panel + future Tauri shell to render
+   * `DEMO READY ✅ / NOT ARMED ❌`. `lastRehearseAt` lands in PR 3.2,
+   * `planBReady` in PR 3.3.
+   */
+  demo: {
+    armed: boolean;
+    armedAt: string | null;
+    armedBy: string | null;
+    lastRehearseAt: string | null;
+    planBReady: boolean;
+  };
   version: string;
   uptime_seconds: number;
   /**
@@ -357,5 +372,56 @@ export async function buildHealthPayload(
       totalFailures: backupReport.state.totalFailures,
       totalDrills: backupReport.state.totalDrills,
     },
+    demo: readDemoReadinessSnapshot(rawEnv),
   };
+}
+
+/**
+ * Phase 3.4 (autopilot 2026-05-08): expose demo readiness state on
+ * /v1/ops/status so monitoring scripts (and the future Tauri shell)
+ * can render a `DEMO READY ✅ / NOT ARMED ❌` badge without parsing
+ * `data/demo-armed.json` themselves.
+ *
+ * `armed` is true iff `memphis demo arm` (Phase 3.1) succeeded and
+ * the state file has not been disarmed since. `armedAt` and
+ * `armedBy` mirror what the operator sees in `memphis demo status`.
+ *
+ * `lastRehearseAt` and `planBReady` are reserved slots for PR 3.2 and
+ * 3.3 respectively; they're null until those phases land.
+ */
+function readDemoReadinessSnapshot(rawEnv: NodeJS.ProcessEnv): {
+  armed: boolean;
+  armedAt: string | null;
+  armedBy: string | null;
+  lastRehearseAt: string | null;
+  planBReady: boolean;
+} {
+  const empty = {
+    armed: false,
+    armedAt: null,
+    armedBy: null,
+    lastRehearseAt: null,
+    planBReady: false,
+  } as const;
+  try {
+    const homeDir = rawEnv.HOME ? `${rawEnv.HOME}/.memphis` : '.';
+    const dataDir = rawEnv.MEMPHIS_DATA_DIR ?? homeDir;
+    const path = `${dataDir}/demo-armed.json`;
+    if (!existsSync(path)) return empty;
+    const raw = readFileSync(path, 'utf8');
+    if (raw.trim().length === 0) return empty; // disarmed (truncated)
+    const parsed = JSON.parse(raw) as { armedAt?: string; armedBy?: string };
+    return {
+      armed: true,
+      armedAt: parsed.armedAt ?? null,
+      armedBy: parsed.armedBy ?? null,
+      // Reserved for PR 3.2 / 3.3 — null until those land.
+      lastRehearseAt: null,
+      planBReady: false,
+    };
+  } catch {
+    // Best-effort surface — never fail the whole /status payload over
+    // a missing/malformed demo-armed.json.
+    return empty;
+  }
 }

--- a/tests/integration/health-demo-readiness.test.ts
+++ b/tests/integration/health-demo-readiness.test.ts
@@ -1,0 +1,85 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { AppConfig } from '../../src/infra/config/schema.js';
+import { buildHealthPayload } from '../../src/infra/http/health.js';
+
+interface TestEnv {
+  dataDir: string;
+  savedDataDir: string | undefined;
+}
+
+function setup(): TestEnv {
+  const dataDir = mkdtempSync(join(tmpdir(), 'memphis-health-demo-'));
+  const savedDataDir = process.env.MEMPHIS_DATA_DIR;
+  process.env.MEMPHIS_DATA_DIR = dataDir;
+  return { dataDir, savedDataDir };
+}
+
+function teardown(env: TestEnv): void {
+  if (env.savedDataDir === undefined) delete process.env.MEMPHIS_DATA_DIR;
+  else process.env.MEMPHIS_DATA_DIR = env.savedDataDir;
+  rmSync(env.dataDir, { recursive: true, force: true });
+}
+
+const minimalConfig = {
+  DATABASE_URL: 'file:./test.db',
+} as unknown as AppConfig;
+
+describe('Phase 3.4: /v1/ops/status demo readiness block', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    teardown(env);
+  });
+
+  it('reports demo.armed=false when no demo-armed.json exists', async () => {
+    const payload = await buildHealthPayload(minimalConfig);
+    expect(payload.demo).toBeDefined();
+    expect(payload.demo.armed).toBe(false);
+    expect(payload.demo.armedAt).toBeNull();
+    expect(payload.demo.armedBy).toBeNull();
+    expect(payload.demo.lastRehearseAt).toBeNull();
+    expect(payload.demo.planBReady).toBe(false);
+  });
+
+  it('reports demo.armed=true when state file is present + valid', async () => {
+    mkdirSync(env.dataDir, { recursive: true });
+    writeFileSync(
+      join(env.dataDir, 'demo-armed.json'),
+      JSON.stringify({
+        armedAt: '2026-05-08T14:30:00.000Z',
+        armedBy: 'wodzu',
+        checks: [{ id: 'doctor', title: 'Doctor v2', status: 'pass', detail: 'ok' }],
+        expiresHint: 'rerun before stage',
+      }),
+      'utf8',
+    );
+    const payload = await buildHealthPayload(minimalConfig);
+    expect(payload.demo.armed).toBe(true);
+    expect(payload.demo.armedAt).toBe('2026-05-08T14:30:00.000Z');
+    expect(payload.demo.armedBy).toBe('wodzu');
+  });
+
+  it('reports demo.armed=false when state file is empty (disarmed)', async () => {
+    mkdirSync(env.dataDir, { recursive: true });
+    writeFileSync(join(env.dataDir, 'demo-armed.json'), '', 'utf8');
+    const payload = await buildHealthPayload(minimalConfig);
+    expect(payload.demo.armed).toBe(false);
+  });
+
+  it('reports demo.armed=false when state file is malformed JSON (graceful fallback)', async () => {
+    mkdirSync(env.dataDir, { recursive: true });
+    writeFileSync(join(env.dataDir, 'demo-armed.json'), 'not-json {', 'utf8');
+    const payload = await buildHealthPayload(minimalConfig);
+    // Should NOT throw — best-effort surface.
+    expect(payload.demo.armed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase 3 PR 3.4 (autopilot \`automode-silly-pike\`)

**Stacked on PR #507** (Phase 3.1 demo arm — depends on \`data/demo-armed.json\` writer).

Surfaces demo-armed state across operator-visible channels so the Zawoja-class \"Memphis launched too late\" failure is impossible to miss.

### Changes
- \`/v1/ops/status\` payload now includes \`demo: { armed, armedAt, armedBy, lastRehearseAt, planBReady }\` block (best-effort read, never fails the whole payload)
- \`memphis doctor\` shows new \`Demo readiness\` row — WARN when not armed or stale (>24h), PASS when armed within 24h
- \`lastRehearseAt\` and \`planBReady\` slots reserved for PR 3.2 + 3.3

### Cross-layer grid
| Rust | NAPI | TS | CLI | Tauri | doctor/status | tests |
|---|---|---|---|---|---|---|
| 📝 TUI panel render in follow-up | – | ✅ health + doctor | ✅ \`memphis doctor\` row | 📝 reads \`health.demo.armed\` | ✅ both surfaces | 🧪 4 cases |

### Tests (4/4 green local)
- demo.armed=false when no state file
- demo.armed=true with valid state file
- demo.armed=false when empty (disarmed via \`demo disarm\`)
- demo.armed=false on malformed JSON (graceful fallback)

### Verification
- ✅ \`npx vitest run tests/integration/health-demo-readiness.test.ts\` 4/4
- ✅ \`npx tsc --noEmit\` clean
- ✅ \`npx eslint <touched>\` clean

### References
- Plan: \`.claude/plans/automode-silly-pike.md\` Phase 3 PR 3.4
- Stacked on #507