### PR TITLE
feat(cli): Phase 3.3 v1 — memphis demo plan-b record/play

### DIFF
--- a/src/infra/cli/commands/demo.ts
+++ b/src/infra/cli/commands/demo.ts
@@ -40,6 +40,15 @@ interface DemoArmedState {
   armedBy: string;
   checks: DemoCheckResult[];
   expiresHint: string;
+  /**
+   * Phase 3.2 (autopilot 2026-05-08): timestamp of the most recent
+   * `memphis demo rehearse` run. Reset to undefined when `disarm` runs
+   * or arm reinitialises. Surfaced in /v1/ops/status as
+   * `demo.lastRehearseAt`.
+   */
+  lastRehearseAt?: string;
+  lastRehearseOk?: boolean;
+  lastRehearseDurationMs?: number;
 }
 
 const DEMO_ARMED_FILENAME = 'demo-armed.json';
@@ -320,6 +329,130 @@ async function handleStatus(context: CliContext): Promise<boolean> {
   return true;
 }
 
+/**
+ * Phase 3.2 (autopilot 2026-05-08) — minimal viable rehearsal.
+ *
+ * Runs a deterministic warmup sequence that exercises Memphis's hot
+ * paths without burning a real LLM call:
+ *   - chain warm: read journal head + recent blocks
+ *   - embed warm: index probe (fast even on cold cache)
+ *   - vault warm: probe cipher cycle (no decrypt needed)
+ *   - doctor reprobe: sanity check that nothing broke since `arm`
+ *
+ * On success, stamps `lastRehearseAt` into demo-armed.json. Operator's
+ * lesson #2 from Zawoja: "Testować demo PRZED wejściem". v1 deliberately
+ * does NOT replay a recorded scenario or diff against a golden file —
+ * those are deferred to a future PR (Phase 3.2 v2). The contract
+ * shipped here is "exercise the dependencies + leave a timestamp".
+ */
+async function handleRehearse(context: CliContext): Promise<boolean> {
+  const armed = readArmedState();
+  if (!armed) {
+    if (context.args.json) {
+      print(
+        { ok: false, mode: 'demo-rehearse', error: 'demo not armed; run `memphis demo arm` first' },
+        true,
+      );
+    } else {
+      console.log(chalk.red('❌ NOT ARMED — run `memphis demo arm` first.'));
+    }
+    process.exitCode = 1;
+    return true;
+  }
+
+  const startMs = Date.now();
+  const steps: Array<{ id: string; status: 'pass' | 'fail'; detail: string }> = [];
+
+  // Step 1 — doctor reprobe (sanity since arm). Uses runDoctorChecksV2
+  // again to catch state changes since arm landed (e.g. backup deleted).
+  try {
+    const { runDoctorChecksV2 } = await import('../utils/doctor-v2.js');
+    const report = await runDoctorChecksV2({});
+    const failingRequired = report.checks.filter((c) => c.required && !c.ok);
+    steps.push({
+      id: 'doctor-reprobe',
+      status: failingRequired.length === 0 ? 'pass' : 'fail',
+      detail:
+        failingRequired.length === 0
+          ? `${report.checks.length} checks; ${report.checks.filter((c) => c.ok).length} OK`
+          : `${failingRequired.length} required check(s) failing since arm`,
+    });
+  } catch (err) {
+    steps.push({
+      id: 'doctor-reprobe',
+      status: 'fail',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Step 2 — chain warm (read journal head; first read is the slow one).
+  try {
+    const { exportChain } = await import('../../storage/chain-adapter.js');
+    const envelope = await exportChain('journal');
+    steps.push({
+      id: 'chain-warm',
+      status: 'pass',
+      detail: `journal exported (${envelope.blocks.length} block(s))`,
+    });
+  } catch (err) {
+    steps.push({
+      id: 'chain-warm',
+      status: 'fail',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Step 3 — vault probe (cipher round-trip, doesn't expose plaintext).
+  try {
+    const { probeVaultCipherCycle } = await import('../../../security/vault-boundary.js');
+    const probe = probeVaultCipherCycle({ surface: 'cli', command: 'memphis demo rehearse' });
+    steps.push({
+      id: 'vault-probe',
+      status: probe.ok ? 'pass' : 'fail',
+      detail: probe.ok ? 'cipher cycle OK' : (probe.error ?? 'unknown'),
+    });
+  } catch (err) {
+    steps.push({
+      id: 'vault-probe',
+      status: 'fail',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  const durationMs = Date.now() - startMs;
+  const failed = steps.filter((s) => s.status === 'fail');
+  const ok = failed.length === 0;
+
+  // Update demo-armed.json with rehearsal timestamp regardless of result;
+  // the timestamp is "we tried", lastRehearseOk is "did it succeed".
+  const updated: DemoArmedState = {
+    ...armed,
+    lastRehearseAt: new Date().toISOString(),
+    lastRehearseOk: ok,
+    lastRehearseDurationMs: durationMs,
+  };
+  writeArmedState(updated);
+
+  if (context.args.json) {
+    print({ ok, mode: 'demo-rehearse', steps, durationMs }, true);
+  } else {
+    console.log(chalk.bold('\nMemphis demo rehearsal\n'));
+    for (const s of steps) {
+      const sym = s.status === 'pass' ? chalk.green('✅') : chalk.red('❌');
+      console.log(`  ${sym} ${s.id.padEnd(20)} ${chalk.dim(s.detail)}`);
+    }
+    console.log('');
+    if (ok) {
+      console.log(chalk.green.bold(`✅ REHEARSAL OK (${durationMs}ms)`));
+      console.log(chalk.dim(`   lastRehearseAt = ${updated.lastRehearseAt}\n`));
+    } else {
+      console.log(chalk.red.bold(`❌ REHEARSAL FAILED — ${failed.length} step(s) failed`));
+    }
+  }
+  if (!ok) process.exitCode = 1;
+  return true;
+}
+
 async function handleDisarm(context: CliContext): Promise<boolean> {
   const cleared = clearArmedState();
   if (context.args.json) {
@@ -340,9 +473,11 @@ export async function handleDemoCommand(context: CliContext): Promise<boolean> {
       return handleStatus(context);
     case 'disarm':
       return handleDisarm(context);
+    case 'rehearse':
+      return handleRehearse(context);
     default:
       throw new Error(
-        `Unknown demo subcommand: ${sub ?? '(none)'}. Use 'arm' | 'status' | 'disarm'.`,
+        `Unknown demo subcommand: ${sub ?? '(none)'}. Use 'arm' | 'status' | 'disarm' | 'rehearse'.`,
       );
   }
 }

--- a/src/infra/cli/commands/demo.ts
+++ b/src/infra/cli/commands/demo.ts
@@ -49,6 +49,13 @@ interface DemoArmedState {
   lastRehearseAt?: string;
   lastRehearseOk?: boolean;
   lastRehearseDurationMs?: number;
+  /**
+   * Phase 3.3 (autopilot 2026-05-08): timestamp of the most recent
+   * `memphis demo plan-b record` run. Surfaced in /v1/ops/status as
+   * `demo.planBReady` (true when this is set).
+   */
+  planBRecordedAt?: string;
+  planBSnapshotPath?: string;
 }
 
 const DEMO_ARMED_FILENAME = 'demo-armed.json';
@@ -453,6 +460,162 @@ async function handleRehearse(context: CliContext): Promise<boolean> {
   return true;
 }
 
+/**
+ * Phase 3.3 (autopilot 2026-05-08) — Plan B fallback transport (v1).
+ *
+ * Operator's lesson #3 from Zawoja: "Zawsze mieć Plan B". When the
+ * live demo fails on stage, the operator needs a deterministic
+ * fallback they can show without standing in awkward silence. v1
+ * implements record + play as a simple JSON snapshot of the recent
+ * journal:
+ *
+ *   - `memphis demo plan-b record` — capture last 20 journal blocks
+ *     into data/demo-plan-b.json + stamp planBRecordedAt
+ *   - `memphis demo plan-b play` — pretty-print the snapshot with an
+ *     explicit "▶ NAGRANE WCZEŚNIEJ" banner so the audience knows it's
+ *     pre-recorded (operator's lesson #4: pokazywać że DZIAŁA, nie że
+ *     perfekcyjny — honesty about source matters)
+ *
+ * Deferred to v2: full `.mv2` container transport (Sprint G abstraction
+ * already exists at src/infra/cli/commands/export-mv2.ts; v2 wires it
+ * here for cross-machine portability).
+ */
+async function handlePlanB(context: CliContext): Promise<boolean> {
+  const target = context.args.target?.toLowerCase();
+  if (target === 'record') return handlePlanBRecord(context);
+  if (target === 'play') return handlePlanBPlay(context);
+  throw new Error(`memphis demo plan-b requires 'record' or 'play' subcommand`);
+}
+
+function getPlanBPath(): string {
+  return `${getDataDir()}/demo-plan-b.json`;
+}
+
+interface PlanBSnapshot {
+  recordedAt: string;
+  source: string;
+  blocks: Array<{ index: number; timestamp?: string; type?: string; content?: string }>;
+}
+
+async function handlePlanBRecord(context: CliContext): Promise<boolean> {
+  const armed = readArmedState();
+  if (!armed) {
+    if (context.args.json) {
+      print(
+        { ok: false, mode: 'demo-plan-b-record', error: 'demo not armed; run `memphis demo arm` first' },
+        true,
+      );
+    } else {
+      console.log(chalk.red('❌ NOT ARMED — run `memphis demo arm` first.'));
+    }
+    process.exitCode = 1;
+    return true;
+  }
+
+  let blocks: PlanBSnapshot['blocks'] = [];
+  try {
+    const { exportChain } = await import('../../storage/chain-adapter.js');
+    const envelope = await exportChain('journal');
+    blocks = envelope.blocks
+      .slice(-20)
+      .map((b) => ({
+        index: b.index,
+        timestamp: b.timestamp,
+        type: typeof b.data === 'object' && b.data !== null && 'type' in (b.data as Record<string, unknown>)
+          ? String((b.data as Record<string, unknown>).type)
+          : undefined,
+        content: typeof b.data === 'object' && b.data !== null && 'content' in (b.data as Record<string, unknown>)
+          ? String((b.data as Record<string, unknown>).content).slice(0, 500)
+          : undefined,
+      }));
+  } catch (err) {
+    if (context.args.json) {
+      print({ ok: false, mode: 'demo-plan-b-record', error: err instanceof Error ? err.message : String(err) }, true);
+    } else {
+      console.log(chalk.red(`❌ Plan-B record failed: ${err instanceof Error ? err.message : String(err)}`));
+    }
+    process.exitCode = 1;
+    return true;
+  }
+
+  const snapshot: PlanBSnapshot = {
+    recordedAt: new Date().toISOString(),
+    source: 'journal',
+    blocks,
+  };
+  const planBPath = getPlanBPath();
+  mkdirSync(dirname(planBPath), { recursive: true });
+  writeFileSync(planBPath, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8');
+
+  // Stamp into demo-armed.json so the badge in /status flips planBReady.
+  const updated: DemoArmedState = {
+    ...armed,
+    planBRecordedAt: snapshot.recordedAt,
+    planBSnapshotPath: planBPath,
+  };
+  writeArmedState(updated);
+
+  if (context.args.json) {
+    print({ ok: true, mode: 'demo-plan-b-record', snapshot: { ...snapshot, blocks: blocks.length } }, true);
+  } else {
+    console.log(chalk.green.bold('✅ PLAN-B RECORDED'));
+    console.log(chalk.dim(`   ${blocks.length} block(s) → ${planBPath}`));
+    console.log(chalk.dim(`   Use 'memphis demo plan-b play' on stage if live fails.\n`));
+  }
+  return true;
+}
+
+async function handlePlanBPlay(context: CliContext): Promise<boolean> {
+  const planBPath = getPlanBPath();
+  if (!existsSync(planBPath)) {
+    if (context.args.json) {
+      print(
+        { ok: false, mode: 'demo-plan-b-play', error: 'no Plan-B snapshot recorded' },
+        true,
+      );
+    } else {
+      console.log(chalk.red('❌ Brak Plan-B — uruchom `memphis demo plan-b record` najpierw.'));
+    }
+    process.exitCode = 1;
+    return true;
+  }
+
+  let snapshot: PlanBSnapshot;
+  try {
+    snapshot = JSON.parse(readFileSync(planBPath, 'utf8')) as PlanBSnapshot;
+  } catch (err) {
+    if (context.args.json) {
+      print(
+        { ok: false, mode: 'demo-plan-b-play', error: err instanceof Error ? err.message : String(err) },
+        true,
+      );
+    } else {
+      console.log(chalk.red(`❌ Plan-B snapshot unreadable: ${err instanceof Error ? err.message : String(err)}`));
+    }
+    process.exitCode = 1;
+    return true;
+  }
+
+  if (context.args.json) {
+    print({ ok: true, mode: 'demo-plan-b-play', stamp: 'NAGRANE WCZESNIEJ', snapshot }, true);
+    return true;
+  }
+
+  console.log('');
+  console.log(chalk.yellow.bold('  ▶ NAGRANE WCZEŚNIEJ — Plan B'));
+  console.log(chalk.dim(`    recorded ${snapshot.recordedAt} from ${snapshot.source}`));
+  console.log(chalk.dim('    (audience: this is replay, not live)'));
+  console.log('');
+  for (const b of snapshot.blocks) {
+    const ts = b.timestamp ? chalk.dim(`[${b.timestamp}]`) : '';
+    const type = b.type ? chalk.cyan(`(${b.type})`) : '';
+    const content = b.content ?? chalk.dim('(no content)');
+    console.log(`  ${ts} ${type} ${content}`);
+  }
+  console.log('');
+  return true;
+}
+
 async function handleDisarm(context: CliContext): Promise<boolean> {
   const cleared = clearArmedState();
   if (context.args.json) {
@@ -475,9 +638,11 @@ export async function handleDemoCommand(context: CliContext): Promise<boolean> {
       return handleDisarm(context);
     case 'rehearse':
       return handleRehearse(context);
+    case 'plan-b':
+      return handlePlanB(context);
     default:
       throw new Error(
-        `Unknown demo subcommand: ${sub ?? '(none)'}. Use 'arm' | 'status' | 'disarm' | 'rehearse'.`,
+        `Unknown demo subcommand: ${sub ?? '(none)'}. Use 'arm' | 'status' | 'disarm' | 'rehearse' | 'plan-b record|play'.`,
       );
   }
 }

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1329,6 +1329,58 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
         : undefined,
   });
 
+  // Phase 3.4 (autopilot 2026-05-08): Demo readiness badge — reads
+  // data/demo-armed.json written by `memphis demo arm` (Phase 3.1).
+  // Operator's lesson #2 from Zawoja: "Testować demo PRZED wejściem".
+  // Surfacing this row in doctor means the badge appears in the same
+  // health summary the operator already trusts.
+  const demoStatePath = `${memphisDir}/demo-armed.json`;
+  let demoLevel: 'pass' | 'warn' = 'pass';
+  let demoDetail: string;
+  if (!existsSync(demoStatePath)) {
+    demoLevel = 'warn';
+    demoDetail = 'NOT ARMED — run `memphis demo arm` before any live session';
+  } else {
+    try {
+      const raw = readFileSync(demoStatePath, 'utf8');
+      if (raw.trim().length === 0) {
+        demoLevel = 'warn';
+        demoDetail = 'disarmed (state file truncated by `memphis demo disarm`)';
+      } else {
+        const parsed = JSON.parse(raw) as { armedAt?: string; armedBy?: string };
+        const armedAt = parsed.armedAt ?? '?';
+        const armedBy = parsed.armedBy ?? '?';
+        const ageMs = parsed.armedAt
+          ? Date.now() - new Date(parsed.armedAt).getTime()
+          : null;
+        const ageHours = ageMs !== null ? (ageMs / 3_600_000).toFixed(1) : '?';
+        demoDetail = `ARMED ✅ at ${armedAt} by ${armedBy} (${ageHours}h ago)`;
+        // Stale arming (>24h old) drops to warn — pre-demo smoke loses
+        // signal value if it's a day old.
+        if (ageMs !== null && ageMs > 24 * 60 * 60 * 1000) {
+          demoLevel = 'warn';
+          demoDetail += ' — STALE (>24h); re-run `memphis demo arm`';
+        }
+      }
+    } catch (err) {
+      demoLevel = 'warn';
+      demoDetail = `state file unreadable: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+  checks.push({
+    id: 't5-demo-readiness',
+    tier: 5,
+    title: 'Demo readiness',
+    level: demoLevel,
+    ok: demoLevel === 'pass',
+    required: false,
+    detail: demoDetail,
+    fix:
+      demoLevel === 'warn'
+        ? 'Run `memphis demo arm` to verify the checklist + freshen the state.'
+        : undefined,
+  });
+
   // Tier 6
   const externalPlugin =
     existsSync(resolve(process.cwd(), 'external-plugin')) ||

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants, existsSync } from 'node:fs';
+import { accessSync, constants, existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 import { getAppVersion } from '../../config/paths.js';
@@ -58,6 +58,21 @@ export type HealthPayload = {
    * Always returned (zero when telemetry sink is empty / disabled).
    */
   confabulationEvents7d: number;
+  /**
+   * Phase 3.4 (autopilot 2026-05-08): demo readiness state. Populated
+   * from data/demo-armed.json which `memphis demo arm` (Phase 3.1)
+   * writes after passing the checklist. Used by monitoring scripts +
+   * the TUI status panel + future Tauri shell to render
+   * `DEMO READY ✅ / NOT ARMED ❌`. `lastRehearseAt` lands in PR 3.2,
+   * `planBReady` in PR 3.3.
+   */
+  demo: {
+    armed: boolean;
+    armedAt: string | null;
+    armedBy: string | null;
+    lastRehearseAt: string | null;
+    planBReady: boolean;
+  };
   version: string;
   uptime_seconds: number;
   /**
@@ -357,5 +372,56 @@ export async function buildHealthPayload(
       totalFailures: backupReport.state.totalFailures,
       totalDrills: backupReport.state.totalDrills,
     },
+    demo: readDemoReadinessSnapshot(rawEnv),
   };
+}
+
+/**
+ * Phase 3.4 (autopilot 2026-05-08): expose demo readiness state on
+ * /v1/ops/status so monitoring scripts (and the future Tauri shell)
+ * can render a `DEMO READY ✅ / NOT ARMED ❌` badge without parsing
+ * `data/demo-armed.json` themselves.
+ *
+ * `armed` is true iff `memphis demo arm` (Phase 3.1) succeeded and
+ * the state file has not been disarmed since. `armedAt` and
+ * `armedBy` mirror what the operator sees in `memphis demo status`.
+ *
+ * `lastRehearseAt` and `planBReady` are reserved slots for PR 3.2 and
+ * 3.3 respectively; they're null until those phases land.
+ */
+function readDemoReadinessSnapshot(rawEnv: NodeJS.ProcessEnv): {
+  armed: boolean;
+  armedAt: string | null;
+  armedBy: string | null;
+  lastRehearseAt: string | null;
+  planBReady: boolean;
+} {
+  const empty = {
+    armed: false,
+    armedAt: null,
+    armedBy: null,
+    lastRehearseAt: null,
+    planBReady: false,
+  } as const;
+  try {
+    const homeDir = rawEnv.HOME ? `${rawEnv.HOME}/.memphis` : '.';
+    const dataDir = rawEnv.MEMPHIS_DATA_DIR ?? homeDir;
+    const path = `${dataDir}/demo-armed.json`;
+    if (!existsSync(path)) return empty;
+    const raw = readFileSync(path, 'utf8');
+    if (raw.trim().length === 0) return empty; // disarmed (truncated)
+    const parsed = JSON.parse(raw) as { armedAt?: string; armedBy?: string };
+    return {
+      armed: true,
+      armedAt: parsed.armedAt ?? null,
+      armedBy: parsed.armedBy ?? null,
+      // Reserved for PR 3.2 / 3.3 — null until those land.
+      lastRehearseAt: null,
+      planBReady: false,
+    };
+  } catch {
+    // Best-effort surface — never fail the whole /status payload over
+    // a missing/malformed demo-armed.json.
+    return empty;
+  }
 }

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -410,13 +410,17 @@ function readDemoReadinessSnapshot(rawEnv: NodeJS.ProcessEnv): {
     if (!existsSync(path)) return empty;
     const raw = readFileSync(path, 'utf8');
     if (raw.trim().length === 0) return empty; // disarmed (truncated)
-    const parsed = JSON.parse(raw) as { armedAt?: string; armedBy?: string };
+    const parsed = JSON.parse(raw) as {
+      armedAt?: string;
+      armedBy?: string;
+      lastRehearseAt?: string;
+    };
     return {
       armed: true,
       armedAt: parsed.armedAt ?? null,
       armedBy: parsed.armedBy ?? null,
-      // Reserved for PR 3.2 / 3.3 — null until those land.
-      lastRehearseAt: null,
+      // Phase 3.2 populates lastRehearseAt; PR 3.3 will populate planBReady.
+      lastRehearseAt: parsed.lastRehearseAt ?? null,
       planBReady: false,
     };
   } catch {

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -414,14 +414,16 @@ function readDemoReadinessSnapshot(rawEnv: NodeJS.ProcessEnv): {
       armedAt?: string;
       armedBy?: string;
       lastRehearseAt?: string;
+      planBRecordedAt?: string;
     };
     return {
       armed: true,
       armedAt: parsed.armedAt ?? null,
       armedBy: parsed.armedBy ?? null,
-      // Phase 3.2 populates lastRehearseAt; PR 3.3 will populate planBReady.
       lastRehearseAt: parsed.lastRehearseAt ?? null,
-      planBReady: false,
+      // Phase 3.3 populates planBRecordedAt; planBReady=true means a
+      // snapshot exists and can be replayed via `demo plan-b play`.
+      planBReady: typeof parsed.planBRecordedAt === 'string' && parsed.planBRecordedAt.length > 0,
     };
   } catch {
     // Best-effort surface — never fail the whole /status payload over

--- a/tests/integration/health-demo-readiness.test.ts
+++ b/tests/integration/health-demo-readiness.test.ts
@@ -1,0 +1,85 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { AppConfig } from '../../src/infra/config/schema.js';
+import { buildHealthPayload } from '../../src/infra/http/health.js';
+
+interface TestEnv {
+  dataDir: string;
+  savedDataDir: string | undefined;
+}
+
+function setup(): TestEnv {
+  const dataDir = mkdtempSync(join(tmpdir(), 'memphis-health-demo-'));
+  const savedDataDir = process.env.MEMPHIS_DATA_DIR;
+  process.env.MEMPHIS_DATA_DIR = dataDir;
+  return { dataDir, savedDataDir };
+}
+
+function teardown(env: TestEnv): void {
+  if (env.savedDataDir === undefined) delete process.env.MEMPHIS_DATA_DIR;
+  else process.env.MEMPHIS_DATA_DIR = env.savedDataDir;
+  rmSync(env.dataDir, { recursive: true, force: true });
+}
+
+const minimalConfig = {
+  DATABASE_URL: 'file:./test.db',
+} as unknown as AppConfig;
+
+describe('Phase 3.4: /v1/ops/status demo readiness block', () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => {
+    teardown(env);
+  });
+
+  it('reports demo.armed=false when no demo-armed.json exists', async () => {
+    const payload = await buildHealthPayload(minimalConfig);
+    expect(payload.demo).toBeDefined();
+    expect(payload.demo.armed).toBe(false);
+    expect(payload.demo.armedAt).toBeNull();
+    expect(payload.demo.armedBy).toBeNull();
+    expect(payload.demo.lastRehearseAt).toBeNull();
+    expect(payload.demo.planBReady).toBe(false);
+  });
+
+  it('reports demo.armed=true when state file is present + valid', async () => {
+    mkdirSync(env.dataDir, { recursive: true });
+    writeFileSync(
+      join(env.dataDir, 'demo-armed.json'),
+      JSON.stringify({
+        armedAt: '2026-05-08T14:30:00.000Z',
+        armedBy: 'wodzu',
+        checks: [{ id: 'doctor', title: 'Doctor v2', status: 'pass', detail: 'ok' }],
+        expiresHint: 'rerun before stage',
+      }),
+      'utf8',
+    );
+    const payload = await buildHealthPayload(minimalConfig);
+    expect(payload.demo.armed).toBe(true);
+    expect(payload.demo.armedAt).toBe('2026-05-08T14:30:00.000Z');
+    expect(payload.demo.armedBy).toBe('wodzu');
+  });
+
+  it('reports demo.armed=false when state file is empty (disarmed)', async () => {
+    mkdirSync(env.dataDir, { recursive: true });
+    writeFileSync(join(env.dataDir, 'demo-armed.json'), '', 'utf8');
+    const payload = await buildHealthPayload(minimalConfig);
+    expect(payload.demo.armed).toBe(false);
+  });
+
+  it('reports demo.armed=false when state file is malformed JSON (graceful fallback)', async () => {
+    mkdirSync(env.dataDir, { recursive: true });
+    writeFileSync(join(env.dataDir, 'demo-armed.json'), 'not-json {', 'utf8');
+    const payload = await buildHealthPayload(minimalConfig);
+    // Should NOT throw — best-effort surface.
+    expect(payload.demo.armed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase 3 PR 3.3 v1 (autopilot)

Stacked on PR #509. Implements operator's **lesson #3 from Zawoja** — Plan B fallback when live fails on stage.

### What ships
- `memphis demo plan-b record` — captures last 20 journal blocks → `data/demo-plan-b.json`
- `memphis demo plan-b play` — pretty-prints with explicit `▶ NAGRANE WCZEŚNIEJ` banner (audience knows it's replay; honesty per lesson #4)
- `/v1/ops/status` `demo.planBReady=true` when snapshot exists

### Deferred to v2
- full `.mv2` container transport (Sprint G abstraction)
- HTTP serve mode (`plan-b-server.ts`)

### Phase 3 Status: ALL 4 PRs DONE
- #507 PR 3.1 demo arm
- #508 PR 3.4 status badge
- #509 PR 3.2 rehearse v1
- THIS PR 3.3 plan-b v1

### Verification
- ✅ 9/9 tests green
- ✅ tsc + eslint clean

Plan: `.claude/plans/automode-silly-pike.md` Phase 3 PR 3.3 (v1).