### PR TITLE
feat(security): Phase 4.2 — tier-3 surface in /v1/ops/status + doctor

### DIFF
--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -1329,6 +1329,52 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
         : undefined,
   });
 
+  // Phase 4.2 (autopilot 2026-05-08): Tier-3 elevated session row.
+  // Per docs/dev/TIER3-SURFACE-AUDIT-2026-05-08.md gap #2 — operator
+  // running `memphis doctor` after elevation should see explicit
+  // confirmation; warns when a session is within 5 minutes of expiry.
+  let tier3Level: 'pass' | 'warn' = 'pass';
+  let tier3Detail: string;
+  try {
+    const { listActiveTier3Sessions } = await import('../../../security/tier3-session.js');
+    const sessions = listActiveTier3Sessions(process.env);
+    if (sessions.length === 0) {
+      tier3Detail = '0 active (default state)';
+    } else {
+      const nowMs = Date.now();
+      const fiveMinMs = 5 * 60 * 1000;
+      const expiringSoon = sessions.filter(
+        (s) => s.expiresAt - nowMs > 0 && s.expiresAt - nowMs < fiveMinMs,
+      );
+      if (expiringSoon.length > 0) {
+        tier3Level = 'warn';
+        const first = expiringSoon[0];
+        const minutesLeft = Math.max(0, Math.floor((first.expiresAt - nowMs) / 60000));
+        tier3Detail = `${sessions.length} active, ${expiringSoon.length} expiring within 5 min (${minutesLeft}m left on ${first.surface})`;
+      } else {
+        const first = sessions[0];
+        const minutesLeft = Math.max(0, Math.floor((first.expiresAt - nowMs) / 60000));
+        tier3Detail = `${sessions.length} active — surface=${first.surface}, ${minutesLeft}m left`;
+      }
+    }
+  } catch (err) {
+    tier3Level = 'warn';
+    tier3Detail = `tier3 read failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
+  checks.push({
+    id: 't5-tier3-sessions',
+    tier: 5,
+    title: 'Tier-3 sessions',
+    level: tier3Level,
+    ok: tier3Level === 'pass',
+    required: false,
+    detail: tier3Detail,
+    fix:
+      tier3Level === 'warn'
+        ? 'Re-elevate via `memphis tier elevate --tier 3 --operator-passphrase <pw>`.'
+        : undefined,
+  });
+
   // Tier 6
   const externalPlugin =
     existsSync(resolve(process.cwd(), 'external-plugin')) ||

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -139,6 +139,18 @@ export type HealthPayload = {
     totalFailures: number;
     totalDrills: number;
   };
+  /**
+   * Phase 4.2 (autopilot 2026-05-08): tier-3 elevated-session counts.
+   * Monitoring scripts use these to detect "elevated session still
+   * active" without hitting the privileged tier3/sessions detail
+   * endpoint. Operator IDs and session metadata stay behind that
+   * privileged path. Per docs/dev/TIER3-SURFACE-AUDIT-2026-05-08.md
+   * gap #1.
+   */
+  tier3: {
+    activeSessions: number;
+    expiringWithinMinutes: number;
+  };
 };
 
 function runtimeIsOperational(runtime: RuntimeHealthSnapshot): boolean {
@@ -357,5 +369,43 @@ export async function buildHealthPayload(
       totalFailures: backupReport.state.totalFailures,
       totalDrills: backupReport.state.totalDrills,
     },
+    tier3: readTier3Snapshot(rawEnv),
   };
+}
+
+/**
+ * Phase 4.2 (autopilot 2026-05-08): expose tier-3 session count on
+ * /v1/ops/status so monitoring scripts can detect "elevated session
+ * still active" without parsing the privileged /v1/ops/tier3/sessions
+ * detail endpoint. Per docs/dev/TIER3-SURFACE-AUDIT-2026-05-08.md gap #1.
+ *
+ * Returns counts only — never operator IDs or session metadata. The
+ * detail endpoint stays the privileged path.
+ */
+function readTier3Snapshot(rawEnv: NodeJS.ProcessEnv): {
+  activeSessions: number;
+  expiringWithinMinutes: number;
+} {
+  try {
+    // Dynamic import keeps tier3-session out of the health module's
+    // import graph until /status is actually called — health is on
+    // the cold path for cold-start machines.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const tier3 = require('../../security/tier3-session.js') as {
+      listActiveTier3Sessions: (env: NodeJS.ProcessEnv) => Array<{ expiresAt: number }>;
+    };
+    const sessions = tier3.listActiveTier3Sessions(rawEnv);
+    const nowMs = Date.now();
+    const fiveMinMs = 5 * 60 * 1000;
+    const expiringWithinMinutes = sessions.filter(
+      (s) => s.expiresAt - nowMs > 0 && s.expiresAt - nowMs < fiveMinMs,
+    ).length;
+    return {
+      activeSessions: sessions.length,
+      expiringWithinMinutes,
+    };
+  } catch {
+    // Best-effort; never fail the whole /status payload over tier3 read.
+    return { activeSessions: 0, expiringWithinMinutes: 0 };
+  }
 }

--- a/tests/integration/health-tier3-snapshot.test.ts
+++ b/tests/integration/health-tier3-snapshot.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AppConfig } from '../../src/infra/config/schema.js';
+import { buildHealthPayload } from '../../src/infra/http/health.js';
+
+const minimalConfig = {
+  DATABASE_URL: 'file:./test.db',
+} as unknown as AppConfig;
+
+/**
+ * Phase 4.2: /v1/ops/status surfaces a counts-only tier3 block.
+ * Detailed session list stays behind /v1/ops/tier3/sessions.
+ */
+describe('Phase 4.2: /v1/ops/status tier3 snapshot', () => {
+  it('exposes tier3.activeSessions and tier3.expiringWithinMinutes', async () => {
+    const payload = await buildHealthPayload(minimalConfig);
+    expect(payload.tier3).toBeDefined();
+    expect(typeof payload.tier3.activeSessions).toBe('number');
+    expect(typeof payload.tier3.expiringWithinMinutes).toBe('number');
+    expect(payload.tier3.activeSessions).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not leak operator IDs or session metadata in /status', async () => {
+    const payload = await buildHealthPayload(minimalConfig);
+    const json = JSON.stringify(payload.tier3);
+    // counts-only contract — no surface, actorId, sessionId, expiresAt etc.
+    expect(json).not.toMatch(/"surface"/);
+    expect(json).not.toMatch(/"actorId"/);
+    expect(json).not.toMatch(/"sessionId"/);
+    expect(json).not.toMatch(/"grantedAt"/);
+    expect(json).not.toMatch(/"expiresAt"/);
+  });
+});


### PR DESCRIPTION
## Phase 4.2 (autopilot)

Closes 2 known gaps from `docs/dev/TIER3-SURFACE-AUDIT-2026-05-08.md`:

### Gap #1 — `/v1/ops/status` missing tier-3 counts
`buildHealthPayload()` adds `tier3: { activeSessions, expiringWithinMinutes }`. Counts only — privileged data stays at `/v1/ops/tier3/sessions`.

### Gap #2 — `memphis doctor` missing tier-3 row
New `t5-tier3-sessions` check. PASS when 0 active or all >5 min left; WARN when any session expiring within 5 min.

### Privacy contract test
2nd test pins counts-only contract — no leak of surface/actorId/sessionId/grantedAt/expiresAt.

### Verification
- ✅ 2/2 tests green
- ✅ tsc + eslint clean

Plan: `.claude/plans/automode-silly-pike.md` Phase 4.2.