### PR TITLE
feat(security): Phase 4.3 — gate 5 handlers, close issue #278

### DIFF
--- a/src/infra/cli/commands/provider.ts
+++ b/src/infra/cli/commands/provider.ts
@@ -233,6 +233,14 @@ export async function handleProviderCommand(context: CliContext): Promise<boolea
   }
 
   if (subcommand === 'add') {
+    // Phase 4.3 (autopilot 2026-05-08): close issue #278 — provider add
+    // writes API keys via storeVaultSecret. Operator passphrase required.
+    // Use --operator-passphrase <pw> for non-interactive flows.
+    const { requireOperatorAuth } = await import('../../auth/operator-gate.js');
+    if (!(await requireOperatorAuth(undefined, process.env, context.args.operatorPassphrase))) {
+      throw new Error('Operator authentication failed.');
+    }
+
     if (!target) {
       throw new Error(
         `Provider name required: memphis provider add <${SUPPORTED_PROVIDERS.join('|')}> --api-key <key>`,

--- a/src/infra/cli/handlers/consent.handler.ts
+++ b/src/infra/cli/handlers/consent.handler.ts
@@ -45,6 +45,13 @@ export const consentCommandHandler: CommandHandler = {
  * through the normal chain-adapter path.
  */
 async function handleConsentMark(context: CliContext): Promise<boolean> {
+  // Phase 4.3 (autopilot 2026-05-08): close issue #278 — consent mark
+  // appends a consent.annotation block that overrides downstream
+  // consumer behavior. Operator passphrase required.
+  const { requireOperatorAuth } = await import('../../auth/operator-gate.js');
+  if (!(await requireOperatorAuth(undefined, process.env, context.args.operatorPassphrase))) {
+    throw new Error('Operator authentication failed.');
+  }
   const { chain, id } = context.args;
   const fromIndexRaw = context.args.fromIndex;
   const level = parseConsentLevel(context.args.level);

--- a/src/infra/cli/handlers/schedule.handler.ts
+++ b/src/infra/cli/handlers/schedule.handler.ts
@@ -20,6 +20,19 @@ export const scheduleCommandHandler: CommandHandler = {
     if (!subcommand || subcommand === 'list') {
       return handleList(context);
     }
+
+    // Phase 4.3 (autopilot 2026-05-08): close issue #278 — gate every
+    // mutating subcommand. List + help stay open (read/docs). Plan stop
+    // condition: schedule listing must NOT require auth so cron-friendly
+    // observability scripts keep working.
+    const mutatingSubs = new Set(['add', 'remove', 'enable', 'disable', 'run']);
+    if (mutatingSubs.has(subcommand)) {
+      const { requireOperatorAuth } = await import('../../auth/operator-gate.js');
+      if (!(await requireOperatorAuth(undefined, process.env, context.args.operatorPassphrase))) {
+        throw new Error('Operator authentication failed.');
+      }
+    }
+
     if (subcommand === 'add') {
       return handleAdd(context);
     }

--- a/src/infra/cli/handlers/telegram.handler.ts
+++ b/src/infra/cli/handlers/telegram.handler.ts
@@ -79,6 +79,13 @@ async function handleTelegramSend(context: CliContext): Promise<boolean> {
 }
 
 async function handleTelegramConfigure(context: CliContext): Promise<boolean> {
+  // Phase 4.3 (autopilot 2026-05-08): close issue #278 — `telegram
+  // configure` writes bot token + allowlist into the vault. Operator
+  // passphrase required. Use --operator-passphrase for non-interactive.
+  const { requireOperatorAuth } = await import('../../auth/operator-gate.js');
+  if (!(await requireOperatorAuth(undefined, process.env, context.args.operatorPassphrase))) {
+    throw new Error('Operator authentication failed.');
+  }
   const { json, botToken, allowedUserIds } = context.args;
 
   if (!botToken) {

--- a/src/infra/cli/handlers/worker.handler.ts
+++ b/src/infra/cli/handlers/worker.handler.ts
@@ -37,6 +37,12 @@ function buildRuntime(context: CliContext) {
 }
 
 async function runWorkerOnce(context: CliContext): Promise<boolean> {
+  // Phase 4.3 (autopilot 2026-05-08): close issue #278 — `worker once`
+  // mutates queue state. Operator passphrase required.
+  const { requireOperatorAuth } = await import('../../auth/operator-gate.js');
+  if (!(await requireOperatorAuth(undefined, process.env, context.args.operatorPassphrase))) {
+    throw new Error('Operator authentication failed.');
+  }
   const container = context.getContainer();
   const runner = new LocalWorkerRunner(
     {
@@ -70,6 +76,12 @@ async function runWorkerOnce(context: CliContext): Promise<boolean> {
 }
 
 async function runWorkerLoop(context: CliContext): Promise<boolean> {
+  // Phase 4.3 (autopilot 2026-05-08): close issue #278 — `worker run`
+  // continuously mutates queue state. Operator passphrase required.
+  const { requireOperatorAuth } = await import('../../auth/operator-gate.js');
+  if (!(await requireOperatorAuth(undefined, process.env, context.args.operatorPassphrase))) {
+    throw new Error('Operator authentication failed.');
+  }
   const container = context.getContainer();
   const snapshot = container.workPollingService.snapshot();
   if (!snapshot.tokenReady) {

--- a/tests/unit/consent-mark.test.ts
+++ b/tests/unit/consent-mark.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 
+// Phase 4.3: consent.handler now gates handleConsentMark via
+// requireOperatorAuth. Mock returns true so existing test scenarios
+// don't need an operator passphrase fixture.
+vi.mock('../../src/infra/auth/operator-gate.js', () => ({
+  isOperatorConfigured: vi.fn(() => true),
+  isSessionAuthorized: vi.fn(() => true),
+  authorizeSession: vi.fn(),
+  validateOperatorPassphrase: vi.fn(() => true),
+  isGatedOperation: vi.fn(() => false),
+  requireOperatorAuth: vi.fn(async () => true),
+}));
+
 vi.mock('../../src/infra/storage/rust-chain-adapter.js', () => ({
   getRecentBlocks: vi.fn(async () => [
     { index: 0, hash: 'h0' },


### PR DESCRIPTION
## Phase 4.3 (autopilot) — closes #278

Long-standing P1: 5 handlers with destructive ops remained ungated. This PR closes them all per `docs/dev/CODEBASE-TRUTH-DELTA-2026-05-08.md`.

### Gating policy
Mutating subcommands gated; reads stay open:
- **provider add** — gated (vault writes)
- **worker once / run** — gated (queue mutation)
- **telegram configure** — gated (vault writes)
- **consent mark** — gated (annotation block)
- **schedule add | remove | enable | disable | run** — gated; **list | help** open per plan stop condition

### Escape hatches
`--operator-passphrase <pw>` (per-call) + `MEMPHIS_OPERATOR_PASSPHRASE` env (non-interactive) — both preserved.

### Coverage
- Pre-PR: 7 / 60 modules gated
- Post-PR: **12 / 60 modules gated**

### Verification
- ✅ consent-mark.test.ts 5/5 pass + 1 skip (vi.mock pattern matches existing gated tests)
- ✅ tsc + eslint clean

Closes #278.

Plan: `.claude/plans/automode-silly-pike.md` Phase 4.3.