### PR TITLE
fix(limits): Phase 1.5.3 — sweep 9 hardcoded timeouts to env-registry

### DIFF
--- a/src/cognitive/categorizer.ts
+++ b/src/cognitive/categorizer.ts
@@ -16,6 +16,7 @@ import type {
   TagSuggestion,
 } from './model-a-types.js';
 import { getPatternsByPriority } from './patterns.js';
+import { MEMPHIS_CATEGORIZER_LLM_TIMEOUT_MS } from '../config/env-registry.js';
 import { getRecentBlocks } from '../infra/storage/rust-chain-adapter.js';
 import { embedSearch } from '../infra/storage/rust-embed-adapter.js';
 import type { Block } from '../memory/chain.js';
@@ -302,9 +303,12 @@ Rules:
 
 Return ONLY the JSON array, no other text:`;
 
-      // Call LLM with timeout (max 3 seconds for classification)
+      // Phase 1.5.3: env-driven via MEMPHIS_CATEGORIZER_LLM_TIMEOUT_MS
+      // (default 1 min, was 3 s hardcode — too aggressive for cogito:3b
+      // on weaker CPUs which routinely take 4-8 s for short classifications).
+      const categorizerTimeoutMs = MEMPHIS_CATEGORIZER_LLM_TIMEOUT_MS.read(process.env);
       const timeoutPromise = new Promise<null>((_, reject) =>
-        setTimeout(() => reject(new Error('LLM classification timeout')), 3000),
+        setTimeout(() => reject(new Error('LLM classification timeout')), categorizerTimeoutMs),
       );
 
       const response = (await Promise.race([

--- a/src/gateway/media/audio-adapter.ts
+++ b/src/gateway/media/audio-adapter.ts
@@ -19,12 +19,16 @@ import { promisify } from 'node:util';
 
 
 import type { AudioTranscription } from './types.js';
-import { LOG_LEVEL, WHISPER_SERVER_URL } from '../../config/env-registry.js';
+import { LOG_LEVEL, MEMPHIS_STT_TIMEOUT_MS, WHISPER_SERVER_URL } from '../../config/env-registry.js';
 import { createPinoLogger } from '../../infra/logging/pino.js';
 
 const log = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
 
-const STT_TIMEOUT_MS = 90_000;
+// Phase 1.5.3: timeouts now env-driven via env-registry (Phase 1.5.2 added
+// the accessors). FFMPEG_TIMEOUT_MS stays hardcoded — there's no env entry
+// for it yet and 30 s is fine for typical voice clips. STT goes via the
+// MEMPHIS_STT_TIMEOUT_MS accessor (default 10 min, was 90 s hardcode).
+const STT_TIMEOUT_MS = MEMPHIS_STT_TIMEOUT_MS.read(process.env);
 const FFMPEG_TIMEOUT_MS = 30_000;
 
 const execFileAsync = promisify(execFile);

--- a/src/gateway/voice/local-piper-adapter.ts
+++ b/src/gateway/voice/local-piper-adapter.ts
@@ -17,7 +17,12 @@
  * / scripts without the chooser.
  */
 
-import { LOG_LEVEL, PIPER_SERVER_URL } from '../../config/env-registry.js';
+import {
+  LOG_LEVEL,
+  MEMPHIS_PIPER_HEALTH_TIMEOUT_MS,
+  MEMPHIS_TTS_TIMEOUT_MS,
+  PIPER_SERVER_URL,
+} from '../../config/env-registry.js';
 import { createPinoLogger } from '../../infra/logging/pino.js';
 
 const log = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
@@ -89,11 +94,10 @@ export async function textToSpeechLocal(text: string): Promise<TtsResult> {
       method: 'POST',
       headers: { 'Content-Type': 'text/plain' },
       body: text,
-      // Piper on CPU (Sandy Bridge) takes ~10-15s for 500 chars of
-      // Polish via pl_PL-gosia-medium. 15s was timing out reliably
-      // (operator session 2026-05-05 22:08, 22:14 — voice replies
-      // stopped after a few short ones). Bump to 45s for headroom.
-      signal: AbortSignal.timeout(45_000),
+      // Phase 1.5.3: env-driven via MEMPHIS_TTS_TIMEOUT_MS (default 5 min,
+      // was 45 s hardcode after the operator-session 2026-05-05 22:08/22:14
+      // bump). Long replies on Sandy Bridge can run 60+ seconds.
+      signal: AbortSignal.timeout(MEMPHIS_TTS_TIMEOUT_MS.read(process.env)),
     });
 
     if (!response.ok) {
@@ -145,7 +149,9 @@ export async function checkPiperServerHealth(): Promise<{
   try {
     const response = await fetch(piperServerSynthesizeUrl(), {
       method: 'GET',
-      signal: AbortSignal.timeout(5000),
+      // Phase 1.5.3: env-driven via MEMPHIS_PIPER_HEALTH_TIMEOUT_MS
+      // (default 30 s, was 5 s hardcode).
+      signal: AbortSignal.timeout(MEMPHIS_PIPER_HEALTH_TIMEOUT_MS.read(process.env)),
     });
     const latency = Date.now() - start;
     // 200/204 = GET supported (runbook wrapper). 405 = "POST only"

--- a/src/mcp/tools/brave-search.ts
+++ b/src/mcp/tools/brave-search.ts
@@ -18,9 +18,13 @@
  * API docs: https://api.search.brave.com/app/documentation
  */
 
+import { MEMPHIS_BRAVE_SEARCH_TIMEOUT_MS } from '../../config/env-registry.js';
+
 const BRAVE_SEARCH_ENDPOINT = 'https://api.search.brave.com/res/v1/web/search';
 const MAX_RESULTS = 20;
-const TIMEOUT_MS = 15_000;
+// Phase 1.5.3: env-driven via MEMPHIS_BRAVE_SEARCH_TIMEOUT_MS (default
+// 1 min, was 15 s hardcode).
+const TIMEOUT_MS = MEMPHIS_BRAVE_SEARCH_TIMEOUT_MS.read(process.env);
 
 export type MemphisBraveSearchInput = {
   query: string;

--- a/src/mcp/tools/build.ts
+++ b/src/mcp/tools/build.ts
@@ -27,8 +27,12 @@ export type MemphisBuildOutput = {
   error?: string;
 };
 
+import { MEMPHIS_BUILD_TIMEOUT_MS } from '../../config/env-registry.js';
+
 const MAX_OUTPUT_BYTES = 32_768;
-const TIMEOUT_MS = 300_000; // 5 min
+// Phase 1.5.3: env-driven via MEMPHIS_BUILD_TIMEOUT_MS (default 2 h, was
+// 5 min hardcode — cold full-repo Rust builds occasionally cross 1 h).
+const TIMEOUT_MS = MEMPHIS_BUILD_TIMEOUT_MS.read(process.env);
 const PROJECT_ROOT = path.join(os.homedir(), 'memphis');
 
 type ProjectType = 'node' | 'rust' | 'python' | 'unknown';

--- a/src/mcp/tools/exec.ts
+++ b/src/mcp/tools/exec.ts
@@ -1,9 +1,12 @@
 import { spawnSync } from 'node:child_process';
 
+import { MEMPHIS_EXEC_TIMEOUT_MS } from '../../config/env-registry.js';
 import { AppError } from '../../core/errors.js';
 import { enforceGatewayExecPolicy, loadGatewayExecPolicy } from '../../gateway/exec-policy.js';
 
-const EXEC_TIMEOUT_MS = 120_000;
+// Phase 1.5.3: env-driven via MEMPHIS_EXEC_TIMEOUT_MS (default 1 h, was
+// 120 s hardcode — long-running corpus builds + training need the headroom).
+const EXEC_TIMEOUT_MS = MEMPHIS_EXEC_TIMEOUT_MS.read(process.env);
 const MAX_OUTPUT_CHARS = 32_000;
 
 export type MemphisExecInput = {

--- a/src/mcp/tools/package.ts
+++ b/src/mcp/tools/package.ts
@@ -26,8 +26,12 @@ export type MemphisPackageOutput = {
   error?: string;
 };
 
+import { MEMPHIS_PACKAGE_TIMEOUT_MS } from '../../config/env-registry.js';
+
 const MAX_OUTPUT_BYTES = 32_768;
-const TIMEOUT_MS = 120_000;
+// Phase 1.5.3: env-driven via MEMPHIS_PACKAGE_TIMEOUT_MS (default 1 h,
+// was 2 min hardcode).
+const TIMEOUT_MS = MEMPHIS_PACKAGE_TIMEOUT_MS.read(process.env);
 const PROJECT_ROOT = path.join(os.homedir(), 'memphis');
 
 function buildCommand(input: MemphisPackageInput): { cmd: string; args: string[] } {

--- a/src/mcp/tools/web-fetch.ts
+++ b/src/mcp/tools/web-fetch.ts
@@ -1,10 +1,13 @@
 import { lookup } from 'node:dns/promises';
 import net from 'node:net';
 
+import { MEMPHIS_WEB_FETCH_TIMEOUT_MS } from '../../config/env-registry.js';
 import { AppError } from '../../core/errors.js';
 
 const MAX_BODY_CHARS = 4000;
-const FETCH_TIMEOUT_MS = 8000;
+// Phase 1.5.3: env-driven via MEMPHIS_WEB_FETCH_TIMEOUT_MS (default 1 min,
+// was 8 s hardcode — operator constraint cost-unconstrained).
+const FETCH_TIMEOUT_MS = MEMPHIS_WEB_FETCH_TIMEOUT_MS.read(process.env);
 const MAX_REDIRECTS = 5;
 
 export type MemphisWebFetchInput = {

--- a/src/mcp/tools/web-search.ts
+++ b/src/mcp/tools/web-search.ts
@@ -20,8 +20,12 @@ export type MemphisWebSearchOutput = {
   error?: string;
 };
 
+import { MEMPHIS_WEB_SEARCH_TIMEOUT_MS } from '../../config/env-registry.js';
+
 const MAX_RESULTS = 10;
-const TIMEOUT_MS = 15_000;
+// Phase 1.5.3: env-driven via MEMPHIS_WEB_SEARCH_TIMEOUT_MS (default
+// 1 min, was 15 s hardcode).
+const TIMEOUT_MS = MEMPHIS_WEB_SEARCH_TIMEOUT_MS.read(process.env);
 
 function parseHtmlResults(html: string): SearchResult[] {
   const results: SearchResult[] = [];


### PR DESCRIPTION
## Phase 1.5 PR 3 (autopilot)

Wires Phase 1.5.2 accessors (#505) into 9 consumer call-sites.

### Sweep
audio STT 90s→10min, piper TTS 45s→5min + health 5s→30s, web-fetch 8s→1min, brave/web-search 15s→1min, exec 120s→1h, build 300s→2h, package 120s→1h, categorizer 3s→1min.

All env-driven; defaults bigger than originals so existing tests/behaviors unchanged.

### Out of scope
send.ts/git.ts/ocr-adapter.ts/vision-adapter.ts have no env yet (short timeouts, not biting). TUI Rust handshake deferred to Phase 1.5.4.

### Verification
- ✅ tsc + eslint clean

Plan: `.claude/plans/automode-silly-pike.md` Phase 1.5 PR 3.