### PR TITLE
chore(claude): add /memphis-rebuild-rust + /memphis-hotfix skills

### DIFF
--- a/.claude/skills/memphis-hotfix/SKILL.md
+++ b/.claude/skills/memphis-hotfix/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: memphis-hotfix
+description: Drive a Memphis hotfix end-to-end with the cross-layer grid as a forcing function. Use when fixing a bug that may touch more than one layer (Rust core, NAPI bridge, TS host, CLI, Tauri, doctor/status, tests). Auto-loads the grid template, the bundled-PR Codex pattern, and the rebuild reminder.
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+# Memphis hotfix workflow
+
+Memphis spans Rust core → NAPI bridge → TS host → multiple surfaces (CLI, TUI, HTTP, MCP, Telegram). A bug that "looks Rust-only" almost always has a TS-side rendering, a doctor/status visibility hook, and a test grid. Skipping the grid is the #1 source of dead-end fixes.
+
+## Trigger conditions
+
+- Operator says "fix this" / "naprawa" / "hotfix" / a bug ticket reference
+- A live runtime issue surfaced in the chat (error message, unexpected behavior)
+- A Codex review finding that needs a code change
+
+## Inputs the assistant must collect or infer
+
+1. **Scope** — one sentence. What is broken. Quote the operator if possible.
+2. **Affected layers** — check each row of the grid below; mark `✅` (touches), `–` (no), `🔧` (transparent change like rebuild).
+3. **References** — any PR numbers, memory entries, postmortem docs that anchor the fix.
+4. **Codex round** — if this is a follow-on to an earlier fix, note the round number per `feedback_codex_bundled_hotfix`.
+
+If any of these are unclear, ask the operator before coding.
+
+## The Cross-Layer Grid (forcing function)
+
+Every Memphis hotfix MUST be evaluated against this grid. Every row gets a verdict — even `–` is a deliberate decision.
+
+| Layer | Files / responsibility | Common verdict |
+|---|---|---|
+| **Rust core** | `crates/memphis-{core,operator,vault,case-index,embed}/src/` | ✅ if behavior bug; – if rendering only |
+| **NAPI bridge** | `crates/memphis-napi/src/lib.rs`; surfacing types | 🔧 (rebuild) if Rust changed; ✅ if signature change |
+| **TS host** | `src/gateway/`, `src/cognitive/`, `src/infra/` | ✅ if envelope/error/state surfaced |
+| **CLI** | `src/infra/cli/commands/`, `src/infra/cli/handlers/` | ✅ if user-visible flag/output |
+| **Tauri** | future shell at `tauri/` (placeholder for now) | – usually; 📝 if cross-cutting |
+| **doctor / status** | `src/infra/cli/utils/doctor-v2.ts`, `src/infra/http/health.ts` | ✅ if observability hook earned |
+| **tests** | `tests/unit/`, `tests/integration/`, `tests/conformance/` | ✅ always — at minimum a regression |
+
+After implementing, paste the grid into the PR body. The exact format:
+
+```markdown
+## Cross-Layer Grid
+
+| Layer | Status |
+|---|---|
+| Rust core | ✅ <files> |
+| NAPI bridge | 🔧 rebuilt; no signature change |
+| TS host | ✅ <files> or – <reason> |
+| CLI | ✅ <files> or – <reason> |
+| Tauri | – |
+| doctor/status | ✅ <files> or – <reason> |
+| tests | ✅ <files> |
+```
+
+## Workflow
+
+### 1. State the scope, draft the grid
+
+Write 2–3 sentences describing the bug and which grid layers are in scope. Get operator confirmation if scope is ambiguous.
+
+### 2. Find the surface area
+
+Use Grep liberally. For a runtime bug, grep the user-facing error message verbatim — that lands you at the constructor site and you can walk back to the cause.
+
+### 3. Implement minimum-diff fix
+
+- One logical change per commit
+- No drive-by formatting (run `cargo fmt` only on the file you touched, and check `git diff --stat` to revert any incidental formatting cargo fmt does to other files)
+- Tests in the same crate/module as the fix when possible
+
+### 4. Build the appropriate layers
+
+- Rust changed → invoke `/memphis-rebuild-rust` skill (or `npm run build:rust`)
+- TS changed → no build needed (vitest runs source)
+- Both → build:rust first, then `tsc --noEmit` if you want type-check confirmation
+
+### 5. Test
+
+- `cargo test -p <crate>` for Rust-side tests
+- `npm test -- <pattern>` for TS-side
+- For integration tests, prefer running the single test file (`npm test -- tests/integration/<name>.test.ts`) — full suite has known races (#270)
+
+### 6. Commit
+
+Branch convention:
+- Bug → `fix/<area>-<short-handle>` (e.g. `fix/provider-context-overflow-false-positive`)
+- Codex round → `hotfix/codex-round-<N>`
+- Stacked on another PR → `fix/<area>-on-<parent-branch>` or use `--base` with stacked-PR conventions
+
+Commit footer must include:
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+If the change is Rust-side, mention the rebuild requirement in the commit body — operators pulling main without `npm run build:rust` will have stale runtime.
+
+### 7. Open the PR
+
+Title: `fix(<area>): <one-line>` — under 70 chars.
+
+Body must include:
+- `## Summary` (2–3 bullets, focus on WHY)
+- `## Tests` (what's covered, what's not)
+- `## Cross-Layer Grid` (the table from above)
+- `## Test plan` (operator-facing checklist)
+
+### 8. Codex review handling
+
+When Codex reviews land:
+- Apply with judgment per `feedback_codex_review_judgment.md` — Memphis conventions take precedence over generic suggestions
+- Bundle ALL findings from a batch into ONE follow-on PR per `feedback_codex_bundled_hotfix.md`, not one PR per finding
+- Cross-PR findings: rebase + forward via `gh pr comment` per `feedback_cross_pr_codex_handoff.md`
+
+## Anti-patterns
+
+- ❌ "It's just a Rust bug, no TS layer involved" — verify by greppinging the error string anyway
+- ❌ Skipping the doctor/status row "because the surface doesn't exist yet" — earn it now if the bug was hard to detect
+- ❌ Bundling unrelated formatting in the fix commit — split it
+- ❌ Force-pushing to main, ever — feature branches with `--force-with-lease` only
+- ❌ `--no-verify` to skip hooks — fix the hook failure instead
+
+## Reference memories
+
+- `feedback_cross_layer_coverage.md` — the grid origin
+- `feedback_codex_bundled_hotfix.md` — bundled PR pattern
+- `feedback_codex_review_judgment.md` — when to push back
+- `feedback_truth_before_refactor.md` — produce CODEBASE-TRUTH-DELTA before larger refactors
+- `feedback_napi_rebuild_after_rust_changes.md` — paired with /memphis-rebuild-rust
+- `feedback_force_push_rules.md` — main vs feature branches

--- a/.claude/skills/memphis-rebuild-rust/SKILL.md
+++ b/.claude/skills/memphis-rebuild-rust/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: memphis-rebuild-rust
+description: Rebuild Memphis NAPI binary after Rust crate changes and verify the runtime will see the new code. Use whenever crates/memphis-{core,operator,napi,vault,tui,case-index,embed}/ source has been modified.
+allowed-tools: Bash, Read
+paths:
+  - "crates/**/*.rs"
+  - "crates/**/Cargo.toml"
+---
+
+# Rebuild NAPI binary after Rust crate changes
+
+The TS host loads the compiled `crates/memphis-napi/index.node` at module-load time and ESM caches it. Rust source edits are silent until the binary is rebuilt — this is the #1 source of "I changed the code but Memphis still behaves the old way" reports.
+
+## When to run this skill
+
+Trigger automatically (via the `paths:` glob) any time a `crates/**/*.rs` file is modified in the session. Trigger manually:
+
+- After `git pull` that includes Rust crate changes (CI builds artifacts upstream but local checkouts ship source-only)
+- After landing a hotfix that touched a crate
+- When the operator reports "Memphis isn't picking up my fix"
+
+## Steps
+
+### 1. Sanity-check the source/binary delta
+
+```bash
+ls -la crates/memphis-napi/index.node
+git log --format='%h %ai %s' -1 -- 'crates/**/*.rs'
+```
+
+If the latest Rust commit timestamp is **after** the binary's mtime, the runtime is stale. Proceed.
+
+### 2. Build the workspace
+
+```bash
+npm run build:rust 2>&1 | tail -10
+```
+
+Confirms no compile errors. The script (`scripts/run-rust.sh`) builds all crates in workspace and copies the NAPI shared library into `crates/memphis-napi/index.node`.
+
+### 3. Verify the binary moved
+
+```bash
+ls -la crates/memphis-napi/index.node
+```
+
+Mtime must be later than the latest Rust commit timestamp from step 1. If unchanged, the build silently failed — re-run with `--release` or check `target/debug/libmemphis_napi.so` exists.
+
+### 4. Tell the operator they need to restart
+
+The TS host process loads `.node` once at startup. A running `memphis serve` / TUI session will keep using the old binary in memory. Inform the operator:
+
+> Rebuild done. If Memphis is currently running, it needs a restart to pick up the new binary — `pkill memphis` (or close the TUI) then start fresh.
+
+### 5. Optional: run targeted tests
+
+If the change touched `provider.rs`, `chat.rs`, or `loop_engine.rs`:
+
+```bash
+cargo test -p memphis-operator --lib provider:: 2>&1 | tail -20
+cargo test -p memphis-core --lib loop_engine:: 2>&1 | tail -20
+```
+
+## Anti-patterns
+
+- **Don't** assume the binary is fresh because compilation finished. The script silently exits 0 even if the copy step is skipped — verify mtime.
+- **Don't** suggest `--release` reflexively. Debug builds are 5–10× faster to iterate; release is for tagged versions.
+- **Don't** forget restart messaging. Building without restarting = same effect as not building.
+
+## Reference memories
+
+- `feedback_napi_rebuild_after_rust_changes.md` — root-cause documentation
+- `feedback_truth_model_silent_catch.md` — same family ("what's actually running ≠ what source says")
+- `feedback_install_root_anchoring.md` — same family for path resolution


### PR DESCRIPTION
## Summary

- Add `.claude/skills/memphis-rebuild-rust/SKILL.md` — auto-loads on `crates/**/*.rs` edits, encodes the NAPI rebuild + restart procedure that prevents the "I changed Rust but Memphis still uses old code" class of bug.
- Add `.claude/skills/memphis-hotfix/SKILL.md` — drives end-to-end hotfix work with the Cross-Layer Grid as a forcing function (Rust | NAPI | TS host | CLI | Tauri | doctor | tests). Encodes branch naming, bundled-PR Codex pattern, and the canonical PR-body template.

Both skills cross-reference the underlying memory entries (`feedback_napi_rebuild_after_rust_changes`, `feedback_cross_layer_coverage`, `feedback_codex_bundled_hotfix`, etc.) so future sessions stay consistent.

Origin: post-v1.9.2 research synthesis 2026-05-08 — operator asked "co Claude Code może zasugerować by skuteczniej programować Memphis". First two of six moves in `feedback_claude_code_optimization_for_memphis.md`.

## Why this beats memory alone

Memory entries fade between sessions and require recall. Skills auto-load deterministically (`paths:` glob for the rebuild skill, explicit `/memphis-hotfix` invocation for the hotfix skill). The grid is no longer "remember to check" — it's a template every PR body inherits.

## Test plan

- [ ] Trigger the rebuild skill: edit any `crates/**/*.rs` file, observe Claude proposing `npm run build:rust`
- [ ] Trigger the hotfix skill: type `/memphis-hotfix` in a fresh session, confirm grid template is inlined
- [ ] Verify skills don't break existing CLI parsing (no shell metachar issues in YAML frontmatter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)