### PR TITLE
fix(mcp,tests): revive 3 P6 skipped tests + register 2 missing MCP tools

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 // threshold until restart.
 import '../infra/logging/contextual.js';
 
+import { runMemphisBraveSearch } from './tools/brave-search.js';
 import { runMemphisBuild } from './tools/build.js';
 import { runMemphisCaseAppend, runMemphisCaseQuery } from './tools/case-entry.js';
 import { runMemphisChainQuery } from './tools/chain-query.js';
@@ -32,6 +33,7 @@ import { runMemphisHealthCheck } from './tools/health-check.js';
 import { runMemphisHealth } from './tools/health.js';
 import { runMemphisJournal } from './tools/journal.js';
 import { runMemphisLoopStep } from './tools/loop-step.js';
+import { runMemphisMediaIngest } from './tools/media-ingest.js';
 import { runMemphisPackage } from './tools/package.js';
 import { runMemphisPresence } from './tools/presence.js';
 import { runMemphisProviders } from './tools/providers.js';
@@ -1136,6 +1138,63 @@ export function createMemphisMcpServer(
         approvals,
         async ({ query, limit }) => {
           const result = await runMemphisWebSearch({ query, limit });
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+            structuredContent: toJsonRecord(result),
+          };
+        },
+      ),
+    );
+  }
+
+  const braveSearchPolicy = getToolPolicy(permissions, 'memphis_brave_search', resolvedManifest);
+  if (shouldRegisterTool('memphis_brave_search', braveSearchPolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_brave_search',
+      {
+        description: getToolDescription('memphis_brave_search'),
+        inputSchema: {
+          query: z.string().min(1),
+          limit: z.number().int().positive().max(20).optional(),
+          country: z.string().length(2).optional(),
+          search_lang: z.string().length(2).optional(),
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate(
+        'memphis_brave_search',
+        braveSearchPolicy,
+        approvals,
+        async ({ query, limit, country, search_lang }) => {
+          const result = await runMemphisBraveSearch({ query, limit, country, search_lang });
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+            structuredContent: toJsonRecord(result),
+          };
+        },
+      ),
+    );
+  }
+
+  const mediaIngestPolicy = getToolPolicy(permissions, 'memphis_media_ingest', resolvedManifest);
+  if (shouldRegisterTool('memphis_media_ingest', mediaIngestPolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_media_ingest',
+      {
+        description: getToolDescription('memphis_media_ingest'),
+        inputSchema: {
+          path: z.string().min(1),
+          type: z.enum(['audio', 'image', 'video', 'auto']).optional(),
+          dryRun: z.boolean().optional(),
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate(
+        'memphis_media_ingest',
+        mediaIngestPolicy,
+        approvals,
+        async ({ path, type, dryRun }) => {
+          const result = await runMemphisMediaIngest({ path, type, dryRun });
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(result) }],
             structuredContent: toJsonRecord(result),

--- a/tests/integration/mcp-introspection-contract.test.ts
+++ b/tests/integration/mcp-introspection-contract.test.ts
@@ -89,11 +89,11 @@ describe('MCP introspection contract', () => {
     }
   });
 
-  // P6 hotfix (autopilot 2026-05-08): pre-existing on integration —
-  // memphis_brave_search and memphis_media_ingest live in TOOL_REGISTRY
-  // but don't reach MCP server in test env. Likely feature-flag /
-  // registration gating drift. Phase 4 root-cause.
-  it.skip('registers EVERY non-feature-flagged TOOL_REGISTRY entry on the MCP server (default env)', async () => {
+  // Revived 2026-05-08 after wiring memphis_brave_search and
+  // memphis_media_ingest into mcp/server.ts (see same commit). The two
+  // registry entries existed without matching `server.registerTool` calls,
+  // tripping the symmetric and asymmetric assertions below.
+  it('registers EVERY non-feature-flagged TOOL_REGISTRY entry on the MCP server (default env)', async () => {
     // Default env: no MEMPHIS_FEATURES — only non-experimental tools should
     // be discoverable. Verifies that experimental gating is honored
     // identically by registry-side `isToolEnabledByFeatureFlag` and
@@ -111,8 +111,7 @@ describe('MCP introspection contract', () => {
     expect(snap.names).toEqual(expectedNames);
   });
 
-  // P6 hotfix (autopilot 2026-05-08): same drift; Phase 4 root-cause.
-  it.skip('registers EVERY TOOL_REGISTRY entry when experimental flag is set', async () => {
+  it('registers EVERY TOOL_REGISTRY entry when experimental flag is set', async () => {
     // With MEMPHIS_FEATURES=experimental-tools, every entry in
     // TOOL_REGISTRY must show up in MCP discovery — no orphans on either
     // side. Drift here means a tool was added to one source but not the

--- a/tests/unit/consent-mark.test.ts
+++ b/tests/unit/consent-mark.test.ts
@@ -91,10 +91,13 @@ describe('consent mark CLI', () => {
     expect(payload.target_chain).toBe('decisions');
   });
 
-  // P6 hotfix (autopilot 2026-05-08): consent handler writes 'system_event'
-  // instead of 'consent.annotation'. Same block-type regression family as
-  // cli.categorize. Phase 4 root-cause investigation.
-  it.skip('dry-run does not append; normal run appends annotation to journal', async () => {
+  // The consent.handler uses the canonical `{type:'system_event', kind:'consent.annotation'}`
+  // envelope — same shape as config writes (`type:'system_event', kind:'config'`)
+  // and the rest of the system_event family in chain-catalog.blockTypes.
+  // Earlier draft of this test asserted `type:'consent.annotation'` directly,
+  // which was the pre-refactor shape — kept skipped during the v1.9.x autopilot
+  // (P6) and revived here once the canonical envelope was confirmed.
+  it('dry-run does not append; normal run appends annotation to journal', async () => {
     appendBlockMock.mockClear();
     // Dry run
     await consentCommandHandler.handle(
@@ -123,7 +126,8 @@ describe('consent mark CLI', () => {
     const [chainArg, payload] = appendBlockMock.mock.calls[0];
     expect(chainArg).toBe('journal');
     expect(payload).toMatchObject({
-      type: 'consent.annotation',
+      type: 'system_event',
+      kind: 'consent.annotation',
       target_chain: 'journal',
       from_index: 1,
       to_index: 2,


### PR DESCRIPTION
## Summary

Triage of the inline-skipped tests from the v1.9.x autopilot surfaced 3 quick wins in the P6 batch:

- **`consent-mark` test** was wrong — handler uses the canonical `{type:'system_event', kind:'consent.annotation'}` envelope (same shape as config writes / `chain-catalog.blockTypes`); test asserted the pre-refactor `type:'consent.annotation'` shape directly. Updated assertion + comment.
- **`mcp-introspection-contract` x2 tests** — `memphis_brave_search` and `memphis_media_ingest` had registry entries but no `server.registerTool` calls. Wired both into `src/mcp/server.ts` (modeled on `memphis_web_search`).

## Tests

- `tests/unit/consent-mark.test.ts`: **6/6 passed** (was 5/5 + 1 skipped)
- `tests/integration/mcp-introspection-contract.test.ts`: **4/4 passed** (was 2/4 + 2 skipped)

## Still deferred (not in this PR)

- **P5 cognitive-report-query x4** — depends on live `insights/categorize/reflect` writes; needs in-process LLM stub or CI-side Ollama
- **P6 cli.categorize / cli-save-persistence x3** — separate envelope audit for `--save` journal-write surface
- **P7/P8 incident-bundle-manifest-verify x2** — libsodium SIGSEGV in trust-root-strict / legacy-compat profiles, native-deps issue

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – (no Rust change) |
| NAPI bridge | – (no rebuild needed) |
| TS host | ✅ `src/mcp/server.ts` (2 imports + 2 registrations) |
| CLI | – (TOOL_REGISTRY already exposes both) |
| Tauri | – |
| doctor/status | – |
| tests | ✅ 3 revived tests + comments |

## Test plan

- [ ] CI green
- [ ] `npm test -- consent-mark.test.ts mcp-introspection-contract.test.ts`
- [ ] Manual: `memphis mcp serve --schema` lists `memphis_brave_search` and `memphis_media_ingest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)