### PR TITLE
fix(soul): validate Mode B soul_write payloads + defensive dedupeAppend

### DIFF
--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -57,7 +57,7 @@ import { runMemphisWebSearch } from '../mcp/tools/web-search.js';
 import type { ChatToolCall, ChatToolDefinition } from '../providers/index.js';
 import { loadSoulManifest } from '../soul/manifest.js';
 import { updateSoulMemory } from '../soul/memory.js';
-import type { SoulManifest } from '../soul/types.js';
+import { soulMemoryUpdateSchema, type SoulManifest } from '../soul/types.js';
 
 export type InProcessToolExecutorDeps = {
   evolveSessionRepository?: SqliteEvolveSessionRepository;
@@ -362,9 +362,30 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
         required: ['updates'],
       },
       validateInput(args) {
-        return {
-          updates: requiredRecord(args, 'updates'),
-        };
+        // Mode B (LLM-direct via gateway tool-executor) bypasses the MCP
+        // Zod gate, so prior to this guard a model could send
+        // `{ updates: { user: { languages: "Polish" } } }` (string instead
+        // of array) or `{ updates: { context: { weirdKey: ... } } }`
+        // (extra keys), and updateSoulMemory would either silently drop
+        // the bogus fields (operator sees `memory: null` on the next read)
+        // or crash with "additions is not iterable" when dedupeAppend
+        // tried to spread a non-iterable.
+        //
+        // We mirror the MCP server schema (server.ts:989) here so both
+        // surfaces reject the same shapes the same way.
+        const updatesRaw = requiredRecord(args, 'updates');
+        const parsed = soulMemoryUpdateSchema.safeParse(updatesRaw);
+        if (!parsed.success) {
+          const issue = parsed.error.issues[0];
+          const path = issue?.path?.join('.') ?? '<root>';
+          throw new AppError(
+            'VALIDATION_ERROR',
+            `tool memphis_soul_write: invalid \`updates.${path}\`: ${issue?.message ?? 'shape mismatch'}. ` +
+              `Expected fields under user/self/context with array-of-string values for list fields.`,
+            400,
+          );
+        }
+        return { updates: parsed.data };
       },
       async execute(input) {
         return runMemphisSoulWrite(

--- a/src/soul/memory.ts
+++ b/src/soul/memory.ts
@@ -319,8 +319,28 @@ export function updateSoulMemory(
 }
 
 function dedupeAppend(existing: string[], additions: string[]): string[] {
-  const set = new Set(existing);
-  for (const item of additions) {
+  // Defensive guard — without this, a caller bypassing tool-executor's
+  // soulMemoryUpdateSchema gate (e.g., a future direct caller, or a
+  // raw JSON merge from a yet-to-be-added surface) that passes a
+  // non-array `additions` would either silently iterate a string's
+  // characters (string `"Polish"` becomes `["P","o","l","i","s","h"]`)
+  // or throw a cryptic `"additions is not iterable"` deep in the
+  // soul-write path, neither of which surfaces well to the operator.
+  // We normalise instead — wrap a stray string as a one-item array,
+  // refuse anything else with a clear error.
+  const safeExisting = Array.isArray(existing) ? existing : [];
+  let safeAdditions: string[];
+  if (Array.isArray(additions)) {
+    safeAdditions = additions.filter((item): item is string => typeof item === 'string');
+  } else if (typeof additions === 'string') {
+    safeAdditions = [additions];
+  } else {
+    throw new TypeError(
+      `soul-memory dedupeAppend: expected string[] or string, got ${typeof additions}`,
+    );
+  }
+  const set = new Set(safeExisting);
+  for (const item of safeAdditions) {
     set.add(item);
   }
   return [...set];

--- a/tests/unit/in-process-tool-executor.test.ts
+++ b/tests/unit/in-process-tool-executor.test.ts
@@ -66,4 +66,35 @@ describe('in-process tool executor', () => {
       error: 'unknown tool: memphis_system_info',
     });
   });
+
+  // Live bug 2026-05-08: a tool call from Mode B (LLM-direct) carrying a
+  // schema-violating `updates` payload would either silently drop the
+  // bogus fields (operator saw `memory: null`) or crash deep in
+  // dedupeAppend with "additions is not iterable". The validateInput
+  // gate should surface a helpful error to the caller in both cases.
+  // executeTool re-throws validation errors (see tool-executor.ts:1405),
+  // so the assertion uses `.rejects.toThrow`.
+  it('rejects memphis_soul_write with non-array list field', async () => {
+    const executor = createInProcessToolExecutor();
+    await expect(
+      executor.execute({
+        id: 'call-soul-write-bad-shape',
+        name: 'memphis_soul_write',
+        arguments: {
+          updates: { user: { languages: 'Polish' } },
+        },
+      }),
+    ).rejects.toThrow(/memphis_soul_write[\s\S]*user\.languages/);
+  });
+
+  it('rejects memphis_soul_write when updates is not an object', async () => {
+    const executor = createInProcessToolExecutor();
+    await expect(
+      executor.execute({
+        id: 'call-soul-write-not-object',
+        name: 'memphis_soul_write',
+        arguments: { updates: 'just a string' },
+      }),
+    ).rejects.toThrow(/updates must be an object/);
+  });
 });

--- a/tests/unit/soul-memory.test.ts
+++ b/tests/unit/soul-memory.test.ts
@@ -309,4 +309,36 @@ describe('soul memory', () => {
       stderrSpy.mockRestore();
     });
   });
+
+  // Live bug 2026-05-08 — direct callers of updateSoulMemory (reflection-loop,
+  // onboarding, seed) bypass MCP/tool-executor schema validation, so the
+  // function itself needs defensive normalisation against the same shapes
+  // that crashed Mode B in the wild ("additions is not iterable" deep in
+  // dedupeAppend).
+  describe('updateSoulMemory defensive normalisation', () => {
+    it('coerces a stray string into a one-item array (silent recovery)', () => {
+      const merged = updateSoulMemory({
+        // @ts-expect-error — runtime caller may bypass TS types
+        user: { languages: 'Polish' },
+      });
+      expect(merged.user.languages).toEqual(['Polish']);
+    });
+
+    it('throws TypeError when an additions field is a non-iterable object', () => {
+      expect(() =>
+        updateSoulMemory({
+          // @ts-expect-error — runtime caller may bypass TS types
+          user: { preferences: { foo: 'bar' } },
+        }),
+      ).toThrow(TypeError);
+    });
+
+    it('drops non-string entries from an array additions field', () => {
+      const merged = updateSoulMemory({
+        // @ts-expect-error — runtime caller may bypass TS types
+        user: { expertise: ['Rust', 42, null, 'Go'] },
+      });
+      expect(merged.user.expertise).toEqual(['Rust', 'Go']);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Live bug 2026-05-08 — TUI Mode B soul_write returned `{ memory: null }` and threw \`additions is not iterable\`. Two coupled gaps:

1. **Mode B bypass.** The in-process tool-executor only required \`updates\` to be a record; the MCP server has a strict Zod schema but Mode B (LLM-direct via gateway) skips MCP entirely. So the model could send \`{ updates: { user: { languages: \"Polish\" } } }\` (string vs array) or \`{ updates: { context: { weirdKey: ... } } }\` (extra keys), and \`updateSoulMemory\` would either silently drop the bogus fields (operator sees \`memory: null\`) or crash deep in \`dedupeAppend\`.
2. **\`dedupeAppend\` undefended.** A direct caller of \`updateSoulMemory\` (reflection-loop, onboarding, seed) bypassing the tool-executor gate could still hit the cryptic crash.

## Fix

- Wire the existing \`soulMemoryUpdateSchema\` into \`tool-executor.ts\` \`validateInput\`, mirroring the MCP server gate. Bad shapes throw \`VALIDATION_ERROR\` naming the offending path (\`updates.user.languages\`).
- \`dedupeAppend\` normalises a stray string into a one-item array (silent recovery for the most common LLM mistake), throws a clear \`TypeError\` for non-iterable objects, and filters non-string entries out of arrays (\`[42, \"Rust\", null]\` → \`[\"Rust\"]\`).

## Tests

- \`tests/unit/in-process-tool-executor.test.ts\` — 2 new regressions (non-array list field rejected with helpful message; non-object \`updates\` rejected).
- \`tests/unit/soul-memory.test.ts\` — 3 new regressions covering string→array coercion, non-iterable throws, mixed-type filtering.
- 35/35 passing locally.

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – |
| NAPI bridge | – (no rebuild) |
| TS host | ✅ \`src/gateway/tool-executor.ts\`, \`src/soul/memory.ts\` |
| CLI | – (transitive via gate) |
| Tauri | – |
| doctor/status | – |
| tests | ✅ 5 new regressions |

## Test plan

- [ ] CI green (expect documented #270 vitest race)
- [ ] After merge: rebuild + restart Memphis, retry soul_write with bad shape — operator should see helpful error instead of \`memory: null\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)