### PR TITLE
fix(chain-adapter): enrich integrity errors with chain + block + hash fingerprints

### DIFF
--- a/src/infra/storage/chain-adapter.ts
+++ b/src/infra/storage/chain-adapter.ts
@@ -514,6 +514,16 @@ async function readAndValidateChainBlocks(
   );
 
   const blocks: ChainBlock[] = [];
+  // Pull a chain name from the directory path for diagnostic messages —
+  // without this, operators saw bare `chain integrity check failed for
+  // 00042.json: hash mismatch` and had to grep their data dir to find
+  // out which chain (journal? cases? soul?) was corrupted. Live
+  // 2026-05-08 session surfaced exactly this confusion.
+  const chainName = chainsDir.split(/[\\/]/).filter(Boolean).pop() ?? '<unknown>';
+  const formatHashFingerprint = (hash: string | undefined): string => {
+    if (!hash) return '<empty>';
+    return hash.length > 12 ? `${hash.slice(0, 8)}…${hash.slice(-4)}` : hash;
+  };
   for (const { file, block: current } of loaded) {
     const mismatch = checkBlockHashMismatch(current, crypto, file);
     if (mismatch?.mismatch) {
@@ -522,26 +532,40 @@ async function readAndValidateChainBlocks(
         // Re-check hash after repair (block was updated in place)
         current.hash = mismatch.expectedHash;
       } else {
-        throw new Error(`chain integrity check failed for ${file}: hash mismatch`);
+        throw new Error(
+          `chain '${chainName}' integrity check failed at block ${current.index} (${file}): ` +
+            `stored hash ${formatHashFingerprint(mismatch.storedHash)} ≠ ` +
+            `computed ${formatHashFingerprint(mismatch.expectedHash)}. ` +
+            `Run \`memphis repair runtime\` or set MEMPHIS_CHAIN_REPAIR_ON_MISMATCH=true to auto-heal.`,
+        );
       }
     }
 
     if (blocks.length === 0) {
       // Accept index 0 or 1 as valid genesis (Rust uses index 0, TS uses index 1)
       if (current.index !== 0 && current.index !== 1) {
-        throw new Error(`chain integrity check failed for ${file}: missing genesis block`);
+        throw new Error(
+          `chain '${chainName}' integrity check failed at block ${current.index} (${file}): ` +
+            `missing genesis block (chain must start at index 0 or 1)`,
+        );
       }
       // For index=0 genesis: prev_hash must be GENESIS_PREV_HASH
       // For index=1 genesis: prev_hash must be '' or GENESIS_PREV_HASH
       if (current.index === 0 && current.prev_hash !== GENESIS_PREV_HASH) {
-        throw new Error(`chain integrity check failed for ${file}: prev_hash mismatch`);
+        throw new Error(
+          `chain '${chainName}' integrity check failed at genesis block 0 (${file}): ` +
+            `prev_hash ${formatHashFingerprint(current.prev_hash)} ≠ expected ${formatHashFingerprint(GENESIS_PREV_HASH)}`,
+        );
       }
       if (
         current.index === 1 &&
         current.prev_hash !== '' &&
         current.prev_hash !== GENESIS_PREV_HASH
       ) {
-        throw new Error(`chain integrity check failed for ${file}: prev_hash mismatch`);
+        throw new Error(
+          `chain '${chainName}' integrity check failed at genesis block 1 (${file}): ` +
+            `prev_hash ${formatHashFingerprint(current.prev_hash)} ≠ expected '' or ${formatHashFingerprint(GENESIS_PREV_HASH)}`,
+        );
       }
       blocks.push(current);
       continue;
@@ -549,11 +573,17 @@ async function readAndValidateChainBlocks(
 
     const previous = blocks[blocks.length - 1]!;
     if (current.index !== previous.index + 1) {
-      throw new Error(`chain integrity check failed for ${file}: non-sequential index`);
+      throw new Error(
+        `chain '${chainName}' integrity check failed at block ${current.index} (${file}): ` +
+          `non-sequential index after block ${previous.index}`,
+      );
     }
 
     if (current.prev_hash !== previous.hash) {
-      throw new Error(`chain integrity check failed for ${file}: prev_hash mismatch`);
+      throw new Error(
+        `chain '${chainName}' integrity check failed at block ${current.index} (${file}): ` +
+          `prev_hash ${formatHashFingerprint(current.prev_hash)} ≠ previous block's hash ${formatHashFingerprint(previous.hash)}`,
+      );
     }
 
     blocks.push(current);

--- a/tests/unit/chain-integrity.test.ts
+++ b/tests/unit/chain-integrity.test.ts
@@ -85,7 +85,11 @@ describe('verifyChainIntegrity — tampering detection', () => {
     dataObj.content = 'tampered-content-zzz';
     writeFileSync(fullPath, JSON.stringify(original));
 
-    await expect(verifyChainIntegrity(chain)).rejects.toThrow(/hash mismatch/);
+    // Diagnostic format extended 2026-05-08 — error names the chain,
+    // block index, and includes hash fingerprints + remediation pointer.
+    await expect(verifyChainIntegrity(chain)).rejects.toThrow(
+      /integrity check failed.*stored hash.*computed/,
+    );
   });
 
   it('passes for an unmodified chain', async () => {
@@ -337,7 +341,56 @@ describe('security: chain integrity verification', () => {
     second.prev_hash = 'f'.repeat(64);
     writeFileSync(secondPath, JSON.stringify(second, null, 2), 'utf8');
 
-    await expect(verifyChainIntegrity('journal')).rejects.toThrow(/chain integrity check failed/);
+    // Diagnostic message format extended 2026-05-08 — chain name, block
+    // index, and hash fingerprints are now included so operators don't
+    // have to grep their data dir to know which chain failed.
+    // (Tampering prev_hash invalidates the stored block hash too, so
+    // the check fires at the hash-mismatch line before reaching the
+    // prev_hash-vs-previous check.)
+    await expect(verifyChainIntegrity('journal')).rejects.toThrow(
+      /chain 'journal' integrity check failed at block 2/,
+    );
+  });
+
+  it('integrity error names the chain, block index, and hash fingerprint', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'memphis-chain-msg-'));
+    process.env.HOME = home;
+
+    await appendBlock(
+      'journal',
+      { type: 'journal', content: 'first' },
+      { RUST_CHAIN_ENABLED: 'false' },
+    );
+    await appendBlock(
+      'journal',
+      { type: 'journal', content: 'second' },
+      { RUST_CHAIN_ENABLED: 'false' },
+    );
+
+    // Tamper the second block's stored hash directly so checkBlockHashMismatch
+    // returns mismatch — exercises the most common in-the-wild path
+    // (hash drift, not prev_hash drift).
+    const chainDir = join(home, '.memphis', 'chains', 'journal');
+    const secondPath = join(chainDir, '000002.json');
+    const second = JSON.parse(readFileSync(secondPath, 'utf8')) as { hash: string };
+    const tampered = 'a'.repeat(64);
+    second.hash = tampered;
+    writeFileSync(secondPath, JSON.stringify(second, null, 2), 'utf8');
+
+    let captured: Error | undefined;
+    try {
+      await verifyChainIntegrity('journal');
+    } catch (error) {
+      captured = error as Error;
+    }
+    expect(captured, 'expected verifyChainIntegrity to throw').toBeDefined();
+    const message = captured!.message;
+    expect(message).toContain("chain 'journal'");
+    expect(message).toContain('000002.json');
+    // First 8 chars of the tampered hash should appear in the message.
+    expect(message).toContain('aaaaaaaa');
+    // Pointer to the operator-facing remediation.
+    expect(message).toMatch(/MEMPHIS_CHAIN_REPAIR_ON_MISMATCH|memphis repair runtime/);
   });
 
   it('exposes CLI command: memphis chain verify', async () => {


### PR DESCRIPTION
## Summary

Live bug 2026-05-08: operator's TUI session ended with \`journal chain ma hash mismatch — coś się popsuło w integralności\`. The user-facing error from \`chain-adapter.ts\` was bare \`chain integrity check failed for 00042.json: hash mismatch\`. To diagnose, the operator had to grep the data dir to know *which chain* the file belonged to, then manually compare hashes.

The integrity *infrastructure* works correctly (auto-offer \`memphis_repair\`, audit on repair via \`system_event/chain.repair\`). This PR fixes only the diagnostic message — the weak link in the operator-debug loop.

## Fix

The message now carries:

- **Chain name** (\`'journal'\` instead of just \`00042.json\`)
- **Block index** (\`at block 42\`)
- **Hash fingerprints** for hash mismatches (8+4 hex chars — enough to grep audit logs without leaking the full hash)
- **Remediation pointer**: \`Run \\\`memphis repair runtime\\\` or set MEMPHIS_CHAIN_REPAIR_ON_MISMATCH=true to auto-heal.\`

Same enrichment across the five integrity error sites in \`readAndValidateChainBlocks\`:
- hash mismatch
- missing genesis block
- genesis prev_hash mismatch
- mid-chain prev_hash mismatch
- non-sequential index

## Tests

- New \`integrity error names the chain, block index, and hash fingerprint\` regression.
- Two existing assertions updated from \`/chain integrity check failed/\` and \`/hash mismatch/\` to the new format. Behaviour verified is unchanged; only wording is.
- 14/14 chain-integrity tests green locally.

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – (independent integrity path) |
| NAPI bridge | – |
| TS host | ✅ \`src/infra/storage/chain-adapter.ts\` |
| CLI | – (memphis chain verify uses this transitively) |
| Tauri | – |
| doctor/status | – (errors propagate via existing surface) |
| tests | ✅ 1 new + 2 updated regressions |

## Test plan

- [ ] CI green (expect documented #270 race)
- [ ] After merge: tamper a journal block, run \`memphis chain verify --chain journal\`, confirm error message contains chain name + block index + hash fingerprints + remediation pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)