### PR TITLE
fix(cognitive): align insight envelope + revive 3 P6 skipped tests

### DIFF
--- a/src/infra/cli/commands/cognitive.ts
+++ b/src/infra/cli/commands/cognitive.ts
@@ -41,8 +41,16 @@ function buildInsightSavePayload(
   topic: string | undefined,
 ): Record<string, unknown> {
   const summary = `${insights.length} insight(s) generated for ${window}${topic ? `:${topic}` : ''}`;
+  // Canonical envelope: `type` is the Rust BlockType variant accepted
+  // by the journal chain (chain-catalog: journal → ['journal','insight']),
+  // `kind` is the discriminator. The previous shape used `type:
+  // 'insight_report'` directly, which wasn't a valid BlockType and made
+  // the journal write inconsistent with categorize/reflect handlers
+  // (both already used `{type:'insight', kind:'*_report'}`). Aligned
+  // 2026-05-08 during the post-Zawoja envelope sweep.
   return {
-    type: 'insight_report',
+    type: 'insight',
+    kind: 'insight_report',
     schemaVersion: COGNITIVE_REPORT_SCHEMA_VERSION,
     source: 'cli.insights',
     content: `Insight Report: ${summary}`,

--- a/tests/integration/cli-categorize-save.e2e.test.ts
+++ b/tests/integration/cli-categorize-save.e2e.test.ts
@@ -7,12 +7,18 @@ import { describe, expect, it } from 'vitest';
 import { runCli } from '../helpers/cli.js';
 
 describe('CLI categorize save persistence e2e', () => {
-  // P6 hotfix (autopilot 2026-05-08): same block-type regression family —
-  // see cli-save-persistence.e2e. Phase 4 root-cause.
-  it.skip('writes categorize report to journal on fresh data dir', async () => {
+  // Same envelope-family revival as tests/unit/cli.categorize.test.ts —
+  // canonical shape is `{type:'insight', kind:'categorize_report', ...}`,
+  // pinned the LLM path to local-fallback so the test runs without a
+  // live provider.
+  it('writes categorize report to journal on fresh data dir', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'memphis-cli-categorize-e2e-'));
     const output = await runCli(['categorize', 'Prepare release checklist', '--json', '--save'], {
-      env: { MEMPHIS_DATA_DIR: dataDir, RUST_CHAIN_ENABLED: 'false' },
+      env: {
+        MEMPHIS_DATA_DIR: dataDir,
+        RUST_CHAIN_ENABLED: 'false',
+        DEFAULT_PROVIDER: 'local-fallback',
+      },
     });
     const parsed = JSON.parse(output) as {
       ok: boolean;
@@ -38,11 +44,13 @@ describe('CLI categorize save persistence e2e', () => {
     const latest = JSON.parse(readFileSync(join(journalDir, files.at(-1) ?? ''), 'utf8')) as {
       data?: {
         type?: string;
+        kind?: string;
         source?: string;
         report?: { suggestion?: { tags?: unknown[] } };
       };
     };
-    expect(latest.data?.type).toBe('categorize_report');
+    expect(latest.data?.type).toBe('insight');
+    expect(latest.data?.kind).toBe('categorize_report');
     expect(latest.data?.source).toBe('cli.categorize');
     expect(Array.isArray(latest.data?.report?.suggestion?.tags)).toBe(true);
   });

--- a/tests/integration/cli-insight-alias.e2e.test.ts
+++ b/tests/integration/cli-insight-alias.e2e.test.ts
@@ -49,9 +49,12 @@ describe('CLI insight alias integration', () => {
     expect(files.length).toBeGreaterThan(0);
 
     const latest = JSON.parse(readFileSync(join(journalDir, files.at(-1) ?? ''), 'utf8')) as {
-      data?: { type?: string; source?: string };
+      data?: { type?: string; kind?: string; source?: string };
     };
-    expect(latest.data?.type).toBe('insight_report');
+    // Canonical envelope: type='insight' (chain-catalog journal type),
+    // kind='insight_report' (sub-type discriminator).
+    expect(latest.data?.type).toBe('insight');
+    expect(latest.data?.kind).toBe('insight_report');
     expect(latest.data?.source).toBe('cli.insights');
   });
 });

--- a/tests/integration/cli-save-persistence.e2e.test.ts
+++ b/tests/integration/cli-save-persistence.e2e.test.ts
@@ -14,14 +14,23 @@ type SavedCliResponse = {
 };
 
 describe('CLI save persistence e2e', () => {
-  // P6 hotfix (autopilot 2026-05-08): pre-existing failure on integration —
-  // categorize handler writes block.data.type='insight' instead of
-  // 'categorize_report'; consent handler writes 'system_event' instead of
-  // 'consent.annotation'. Block-type / schema regression. Out of scope for
-  // Phase 1 hotfixes; Phase 4 root-cause investigation.
-  it.skip('persists insights, categorize, and reflections in one fresh data directory', async () => {
+  // Revival 2026-05-08 — original test was skipped because:
+  // 1. `data.type='insight_report'` assertion was the pre-canonical
+  //    shape; cognitive handlers now write `{type:'insight',
+  //    kind:'*_report'}` to match the chain-catalog journal type set.
+  // 2. The original env didn't pin a provider, so `insights` and
+  //    `reflect` failed against missing-LLM in CI.
+  //
+  // Both fixed: pin DEFAULT_PROVIDER=local-fallback so the cognitive
+  // handlers complete deterministically without a live LLM, and assert
+  // on the canonical `kind` discriminator.
+  it('persists insights, categorize, and reflections in one fresh data directory', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'memphis-cli-save-persistence-'));
-    const env = { MEMPHIS_DATA_DIR: dataDir, RUST_CHAIN_ENABLED: 'false' };
+    const env = {
+      MEMPHIS_DATA_DIR: dataDir,
+      RUST_CHAIN_ENABLED: 'false',
+      DEFAULT_PROVIDER: 'local-fallback',
+    };
 
     const insightOutput = await runCli(['insights', '--json', '--save'], { env });
     const categorizeOutput = await runCli(
@@ -63,16 +72,18 @@ describe('CLI save persistence e2e', () => {
       .sort();
     expect(files.length).toBeGreaterThanOrEqual(3);
 
-    const blockTypes = new Set(
+    // Canonical envelope: `type` is the chain-catalog BlockType variant
+    // ('insight' for the journal chain), `kind` is the report sub-type.
+    const blockKinds = new Set(
       files.map((file) => {
         const parsed = JSON.parse(readFileSync(join(journalDir, file), 'utf8')) as {
-          data?: { type?: string };
+          data?: { type?: string; kind?: string };
         };
-        return parsed.data?.type;
+        return parsed.data?.kind;
       }),
     );
-    expect(blockTypes.has('insight_report')).toBe(true);
-    expect(blockTypes.has('categorize_report')).toBe(true);
-    expect(blockTypes.has('reflection_report')).toBe(true);
+    expect(blockKinds.has('insight_report')).toBe(true);
+    expect(blockKinds.has('categorize_report')).toBe(true);
+    expect(blockKinds.has('reflection_report')).toBe(true);
   });
 });

--- a/tests/unit/cli.categorize.test.ts
+++ b/tests/unit/cli.categorize.test.ts
@@ -33,12 +33,22 @@ describe('CLI categorize', () => {
     expect(typeof parsed.suggestion.overallConfidence).toBe('number');
   });
 
-  // P6 hotfix (autopilot 2026-05-08): see cli-save-persistence.e2e — same
-  // categorize block-type regression family. Phase 4 root-cause.
-  it.skip('persists categorize report block to journal when --save is requested', async () => {
+  // Categorize handler writes the canonical envelope `{type:'insight',
+  // kind:'categorize_report', ...}` — `type` is the Rust BlockType
+  // variant (chain-catalog accepts 'insight' for journal), `kind` is the
+  // discriminator. Same envelope family as consent-mark + config writes
+  // via system_event/kind. The original test asserted the pre-refactor
+  // shape with `type:'categorize_report'`; updated to the canonical
+  // shape during the post-Zawoja revival sweep, also pinned the LLM
+  // path to local-fallback so the test runs without a live provider.
+  it('persists categorize report block to journal when --save is requested', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'memphis-cli-categorize-save-'));
     const output = await runCli(['categorize', 'Deploy hotfix for API', '--json', '--save'], {
-      env: { MEMPHIS_DATA_DIR: dataDir, RUST_CHAIN_ENABLED: 'false' },
+      env: {
+        MEMPHIS_DATA_DIR: dataDir,
+        RUST_CHAIN_ENABLED: 'false',
+        DEFAULT_PROVIDER: 'local-fallback',
+      },
     });
     const parsed = JSON.parse(output) as {
       ok: boolean;
@@ -63,12 +73,15 @@ describe('CLI categorize', () => {
     const latest = JSON.parse(readFileSync(join(journalDir, files.at(-1) ?? ''), 'utf8')) as {
       data?: {
         type?: string;
+        kind?: string;
         schemaVersion?: number;
         source?: string;
         report?: { input?: string };
       };
     };
-    expect(latest.data?.type).toBe('categorize_report');
+    // Canonical envelope: type=Rust BlockType variant, kind=sub-type.
+    expect(latest.data?.type).toBe('insight');
+    expect(latest.data?.kind).toBe('categorize_report');
     expect(latest.data?.schemaVersion).toBe(1);
     expect(latest.data?.source).toBe('cli.categorize');
     expect(latest.data?.report?.input).toBe('Deploy hotfix for API');

--- a/tests/unit/cli.insights.test.ts
+++ b/tests/unit/cli.insights.test.ts
@@ -53,12 +53,17 @@ describe('CLI insights', () => {
     const latest = JSON.parse(readFileSync(join(journalDir, files.at(-1) ?? ''), 'utf8')) as {
       data?: {
         type?: string;
+        kind?: string;
         schemaVersion?: number;
         source?: string;
         report?: { window?: string };
       };
     };
-    expect(latest.data?.type).toBe('insight_report');
+    // Canonical envelope: type='insight' (chain-catalog journal type),
+    // kind='insight_report' (sub-type discriminator). Aligned with
+    // categorize_report and reflection_report on 2026-05-08.
+    expect(latest.data?.type).toBe('insight');
+    expect(latest.data?.kind).toBe('insight_report');
     expect(latest.data?.schemaVersion).toBe(1);
     expect(latest.data?.source).toBe('cli.insights');
     expect(latest.data?.report?.window).toBe('daily');


### PR DESCRIPTION
## Summary

Two coupled changes that close out the P6 \`categorize\`-family deferral from PR #523:

**Handler alignment.** \`buildInsightSavePayload\` was the odd one out — it wrote \`data.type='insight_report'\` directly while \`categorize\` and \`reflect\` both used the canonical \`{type:'insight', kind:'*_report'}\` envelope. The chain-catalog only accepts \`'insight'\` as a journal BlockType variant, so \`'insight_report'\` was out of band. Aligned to canonical, three handlers now consistent.

**Test revivals.** Three P6 skipped tests come back with envelope alignment + a pinned \`DEFAULT_PROVIDER=local-fallback\` so cognitive handlers complete without a live LLM:

- \`tests/unit/cli.categorize.test.ts\` — categorize --save block
- \`tests/integration/cli-categorize-save.e2e.test.ts\` — categorize e2e
- \`tests/integration/cli-save-persistence.e2e.test.ts\` — insights+categorize+reflect e2e

Two adjacent tests updated to match the new envelope (not skipped, but my handler change would have broken them):
- \`tests/unit/cli.insights.test.ts\`
- \`tests/integration/cli-insight-alias.e2e.test.ts\`

8/8 across 5 files green locally.

## Behaviour change for operators

\`memphis insights --save\` previously wrote a journal block with \`data.type='insight_report'\` (no \`kind\`). Now it writes \`data.type='insight'\` + \`data.kind='insight_report'\` — same canonical shape as \`categorize\`/\`reflect\`/\`consent\`. Downstream readers that filter by \`type==='insight_report'\` (none in tree as of this PR) need to switch to \`kind==='insight_report'\`.

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – (chain-catalog accepts \`'insight'\`; no Rust change) |
| NAPI bridge | – |
| TS host | ✅ \`src/infra/cli/commands/cognitive.ts\` |
| CLI | ✅ behaviour-equivalent for operators (data fields unchanged) |
| Tauri | – |
| doctor/status | – |
| tests | ✅ 3 revived + 2 envelope updates |

## Test plan

- [ ] CI green (expect documented #270 race; covered by mitigation PR #528)
- [ ] After merge: \`memphis insights --save\` writes a block whose \`data.kind === 'insight_report'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)