### PR TITLE
fix(ops): revive P5 cognitive-report-query x4 — kind-aware + local-fallback

### DIFF
--- a/scripts/query-cognitive-reports.mts
+++ b/scripts/query-cognitive-reports.mts
@@ -154,6 +154,7 @@ function readJournalReports(chainPath: string): ReportSummary[] {
       hash?: string;
       data?: {
         type?: string;
+        kind?: string;
         schemaVersion?: number;
         source?: string;
         report?: {
@@ -162,7 +163,14 @@ function readJournalReports(chainPath: string): ReportSummary[] {
         };
       };
     };
-    const dataType = block.data?.type;
+    // Canonical envelope: cognitive reports write `{type:'insight',
+    // kind:'*_report'}` so chain-catalog's BlockType variant ('insight')
+    // sits on `type` and the report sub-type lives on `kind`. Earlier
+    // shape used `type:'*_report'` directly; we still accept that for
+    // operators on older snapshots, so check both fields. (Aligned
+    // with handler change in src/infra/cli/commands/cognitive.ts on
+    // 2026-05-08.)
+    const dataType = block.data?.kind ?? block.data?.type;
     if (!dataType || !(dataType in REPORT_TYPE_MAP)) continue;
 
     reports.push({

--- a/tests/ops/cognitive-report-query.test.ts
+++ b/tests/ops/cognitive-report-query.test.ts
@@ -45,24 +45,30 @@ function runQuery(
 }
 
 async function seedCognitiveReports(dataDir: string): Promise<void> {
-  const env = { MEMPHIS_DATA_DIR: dataDir, RUST_CHAIN_ENABLED: 'false' };
+  // DEFAULT_PROVIDER=local-fallback lets the cognitive handlers complete
+  // deterministically without a live LLM — the in-process fallback
+  // writes the same envelope shape as the real provider path. This is
+  // what unblocked the four P5 tests (skipped during the v1.9.x
+  // autopilot when CI had no Ollama).
+  const env = {
+    MEMPHIS_DATA_DIR: dataDir,
+    RUST_CHAIN_ENABLED: 'false',
+    DEFAULT_PROVIDER: 'local-fallback',
+  };
   await runCli(['insights', '--json', '--save'], { env });
   await runCli(['categorize', 'Prepare release checklist', '--json', '--save'], { env });
   await runCli(['reflect', '--json', '--save'], { env });
 }
 
 describe('cognitive report query script', () => {
-  // Phase 1 P5 hotfix (autopilot 2026-05-08): the 4 tests that depend on
-  // `seedCognitiveReports` (which calls the live `insights`/`categorize`/
-  // `reflect` CLI handlers under no-provider conditions) fail deterministically
-  // in CI runners without an LLM available — the seeded reports never reach
-  // the journal, so query returns count=0. This was a pre-existing failure
-  // on `integration/pre-demo-2026-05-06` that gated CI for every stacked PR
-  // (#478–#499). Skipping unblocks the merge wave; the underlying contract
-  // tests (error path, invalid args) still run. Follow-up: re-enable after
-  // injecting a deterministic in-process report-writer that doesn't depend
-  // on a live provider, or after CI gains a stub Ollama server.
-  it.skip('returns latest cognitive reports as JSON for ops automation', async () => {
+  // Revival 2026-05-08 — original block was a triple problem: handlers
+  // depended on a live LLM, query script read `data.type` (which is
+  // 'insight' under canonical envelope) instead of `data.kind` (which
+  // carries the *_report sub-type), and the test env didn't pin a
+  // provider. PR #529 aligned the cognitive handlers; this revival
+  // updates the query script to read `kind` (with `type` fallback for
+  // older blocks) and pins local-fallback in seedCognitiveReports.
+  it('returns latest cognitive reports as JSON for ops automation', async () => {
     const dataDir = mkdtempSync(path.join(tmpdir(), 'memphis-cognitive-query-'));
     try {
       await seedCognitiveReports(dataDir);
@@ -102,7 +108,7 @@ describe('cognitive report query script', () => {
     }
   });
 
-  it.skip('supports type filtering for targeted triage', async () => {
+  it('supports type filtering for targeted triage', async () => {
     const dataDir = mkdtempSync(path.join(tmpdir(), 'memphis-cognitive-query-filter-'));
     try {
       await seedCognitiveReports(dataDir);
@@ -130,7 +136,7 @@ describe('cognitive report query script', () => {
     }
   });
 
-  it.skip('supports watch mode for live triage output', async () => {
+  it('supports watch mode for live triage output', async () => {
     const dataDir = mkdtempSync(path.join(tmpdir(), 'memphis-cognitive-query-watch-'));
     try {
       await seedCognitiveReports(dataDir);
@@ -147,7 +153,7 @@ describe('cognitive report query script', () => {
     }
   });
 
-  it.skip('supports ndjson watch mode for streaming integrations', async () => {
+  it('supports ndjson watch mode for streaming integrations', async () => {
     const dataDir = mkdtempSync(path.join(tmpdir(), 'memphis-cognitive-query-watch-ndjson-'));
     try {
       await seedCognitiveReports(dataDir);


### PR DESCRIPTION
## Summary

Stacked on #529 (cognitive envelope alignment). Closes the last P5 deferral from PR #523's triage.

Three coupled problems made the four tests fail:

1. **Handler depended on a live LLM.** \`seedCognitiveReports\` didn't pin a provider, so handlers fell back to whatever was in env — often nothing in CI. Fixed with \`DEFAULT_PROVIDER=local-fallback\`.
2. **Query script read \`data.type\`, not \`data.kind\`.** Under the canonical envelope landed in #529, cognitive reports use \`{type:'insight', kind:'*_report'}\`. Old script matched on \`type\` against REPORT_TYPE_MAP keyed on \`*_report\` strings → never matched. Fixed with \`kind\` first, \`type\` fallback for older snapshots.
3. **All 4 tests skipped** with a comment pointing at "no LLM in CI". With (1) and (2) fixed, both root causes vanish.

## Tests

- 4 P5 tests revived: latest-reports JSON, type filtering, watch mode, ndjson watch mode.
- 2 existing arg-validation tests unaffected.
- 6/6 green locally.

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – |
| NAPI bridge | – (no rebuild) |
| TS host | ✅ \`scripts/query-cognitive-reports.mts\` |
| CLI | – (query script is ops not CLI) |
| Tauri | – |
| doctor/status | – |
| tests | ✅ 4 revived |

## Test plan

- [ ] CI green (expect documented #270 race covered by #528)
- [ ] After merge: \`npm run -s ops:query-cognitive-reports -- --json --limit 5\` against a real data dir lists insight/categorize/reflection reports correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)