### PR TITLE
fix(ops): revive P7 + P8 incident-bundle verify-profile tests

### DIFF
--- a/tests/ops/incident-bundle-manifest-verify.test.ts
+++ b/tests/ops/incident-bundle-manifest-verify.test.ts
@@ -1478,12 +1478,14 @@ describe('incident manifest verifier', { timeout: 120_000 }, () => {
     expect(parsed.errors.some((item) => item.includes('manifest is encrypted'))).toBe(true);
   });
 
-  // P7 hotfix (autopilot 2026-05-08): pre-existing crash on integration —
-  // the spawn returns exit status 139 (SIGSEGV) on `exportResult.status`.
-  // Other 22 cases in this file pass; only this single trust-root-strict
-  // path crashes. Likely a sodium / signing-library segfault on the CI
-  // runner. Phase 4 root-cause investigation.
-  it.skip('supports trust-root-strict verify profile and enforces detached key-bundle provenance', async () => {
+  // Revival 2026-05-08: original SIGSEGV (status 139) was the same
+  // V8↔Rust dlclose race covered by issue #270 — the
+  // ops:export-incident-bundle subprocess transitively loads the NAPI
+  // bridge via audit/signing infrastructure, then races on V8 teardown.
+  // PR #353 added installNapiShutdownGuard for the script path; PR #528
+  // adds race tolerance. Re-enabled here to verify the guard catches
+  // the race on this specific call site too.
+  it('supports trust-root-strict verify profile and enforces detached key-bundle provenance', async () => {
     const dir = makeTempDir('memphis-incident-manifest-profile-trust-root-strict-');
     const auditPath = path.join(dir, 'security-audit.jsonl');
     const bundlePath = path.join(dir, 'incident-bundle.json');
@@ -1562,13 +1564,10 @@ describe('incident manifest verifier', { timeout: 120_000 }, () => {
     ).toBe(true);
   });
 
-  // P8 hotfix (autopilot 2026-05-08): same SIGSEGV pattern as P7
-  // (trust-root-strict). The 'legacy-compat' verify-profile spawn also
-  // exits with status 139 in CI. Both profile paths share the same
-  // signing/sodium-call sequence — likely a libsodium / native-binding
-  // segfault on the runner. Phase 4 root-cause investigation handles
-  // both at once.
-  it.skip('supports legacy-compat verify profile with non-blocking chain-link failures', async () => {
+  // Revival 2026-05-08: same family as the trust-root-strict revival
+  // above — both share the NAPI-loading subprocess path that races on
+  // V8 teardown (#270 family). Re-enabled with the same justification.
+  it('supports legacy-compat verify profile with non-blocking chain-link failures', async () => {
     const dir = makeTempDir('memphis-incident-manifest-profile-legacy-compat-');
     const auditPath = path.join(dir, 'security-audit.jsonl');
     const bundlePath = path.join(dir, 'incident-bundle.json');


### PR DESCRIPTION
## Summary

Stacked on #528 (vitest race mitigations). Closes the last two skipped tests from PR #523's triage.

Both tests were originally skipped with "exit status 139 (SIGSEGV)" attributed to a "libsodium / native-binding segfault on the CI runner". On closer look the failure is the same V8↔Rust dlclose race covered by issue #270 — \`ops:export-incident-bundle\` is one of the script-style spawns that transitively loads the NAPI bridge through audit/signing infrastructure and races on V8 teardown.

PR #353 already wired \`installNapiShutdownGuard\` for the script path; PR #528 lands race tolerance for the documented residual rate. Locally the full incident-bundle-manifest-verify suite (23 tests) runs clean in ~80s.

## Tests

- \`supports trust-root-strict verify profile and enforces detached key-bundle provenance\` — revived
- \`supports legacy-compat verify profile with non-blocking chain-link failures\` — revived
- 23/23 green locally (was 21/23 + 2 skipped)

## Why not just re-skip if CI flakes?

Keeping the tests live ensures the regression rate stays visible. If CI still hits a SIGSEGV here, the right path forward is the same Track B work that addresses script-shutdown-segv-stress, not a separate re-skip — silent skips were exactly the gap that triggered the post-Zawoja P5–P8 inventory in the first place.

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – (#270 Track B is its own scope) |
| NAPI bridge | – |
| TS host | – |
| CLI | – |
| Tauri | – |
| doctor/status | – |
| tests | ✅ 2 revived |

## Test plan

- [ ] CI green (the suite is the test plan; expect documented #270 race covered by mitigation #528)
- [ ] After merge: monitor next 5 CI runs; if SIGSEGV here recurs above the documented baseline, escalate to Track B work

🤖 Generated with [Claude Code](https://claude.com/claude-code)