### PR TITLE
fix(provider): MiniMax M2.7 max_tokens default 32k → 2k + heuristic 'exceeds limit' wariant

### DIFF
--- a/crates/memphis-operator/src/chat.rs
+++ b/crates/memphis-operator/src/chat.rs
@@ -41,11 +41,27 @@ const CHAT_MAX_MESSAGES_DEFAULT: usize = 10_000;
 const CHAT_MAX_STEPS_DEFAULT: usize = 1_000;
 const CHAT_MAX_TOOL_CALLS_DEFAULT: usize = 1_024;
 const CHAT_MAX_ERRORS_DEFAULT: usize = 32;
-// MiniMax-M2.7 + most provider-tier models accept 32k token outputs;
-// hardcoded `Some(2048)` had been silently truncating long replies even
-// when GEN_MAX_TOKENS env was set higher (operator session 2026-05-05
-// caught HTML cut mid-stream). Now operator-overridable.
-const CHAT_MAX_TOKENS_DEFAULT: usize = 32_768;
+// History:
+//   - Pre-Phase-1.5: hardcoded `Some(2048)`, silently truncated long
+//     replies when GEN_MAX_TOKENS env was set higher (operator session
+//     2026-05-05 caught HTML cut mid-stream).
+//   - Phase 1.5.1 (PR #515-era): bumped to 32_768 under the
+//     "cost-unconstrained" mandate to stop the truncation, picking the
+//     model-spec max for MiniMax-M2.7.
+//   - 2026-05-08 evening: live operator session showed that the model
+//     spec ≠ the operator's account / endpoint allowance. Sending
+//     max_tokens=32k to MiniMax M2.7 was rejected as
+//     `bad_request_error: invalid params, context window exceeds limit
+//     (2013)` — the server's per-request output cap (after prompt is
+//     subtracted) was 2013, far below 32_768. Reverted the default to
+//     2_048 so first-time operators with conservative endpoint plans
+//     don't hit a wall on first turn; operators with beefier allowances
+//     opt up via MEMPHIS_GEN_MAX_TOKENS=N.
+//
+// Kept in lockstep with the TS-side env-registry default in
+// src/config/env-registry.ts. Self-describe surfaces the resolved value
+// + source so operators can see exactly what's in flight.
+const CHAT_MAX_TOKENS_DEFAULT: usize = 2_048;
 
 /// Read a `usize` limit from the environment, falling back to `default`.
 /// A zero or malformed value falls back so operators cannot accidentally

--- a/crates/memphis-operator/src/provider.rs
+++ b/crates/memphis-operator/src/provider.rs
@@ -2245,6 +2245,12 @@ fn has_explicit_overflow_marker(body: &str) -> bool {
         || lower.contains("prompt is too long")
         || lower.contains("tokens too high")
         || lower.contains("context window exceeded")
+        // Live MiniMax M2.7 variant observed 2026-05-08:
+        //   "bad_request_error: invalid params, context window exceeds limit (2013)"
+        // Note "exceeds" (no -ed) and the parenthesised remaining-budget
+        // figure. The earlier markers all expected past tense.
+        || lower.contains("context window exceeds")
+        || (lower.contains("invalid params") && lower.contains("exceeds limit"))
 }
 
 /// Best-effort number extraction from a context-overflow body. OpenAI and
@@ -3184,5 +3190,28 @@ mod tests {
         let (used, window) = super::parse_context_overflow_numbers(body);
         assert_eq!(window, Some(32768));
         assert_eq!(used, Some(38538));
+    }
+
+    #[test]
+    fn detects_minimax_m27_exceeds_limit_variant() {
+        // Live operator 2026-05-08: MiniMax M2.7 returns
+        //   "bad_request_error: invalid params, context window exceeds limit (2013)"
+        // which uses "exceeds" (no -ed) and pairs the parenthesised
+        // remaining-budget figure. Earlier marker list only matched the
+        // past-tense forms and missed this; live operator saw raw 400
+        // bubble through to the chat surface.
+        let body =
+            r#"{"error":{"message":"bad_request_error: invalid params, context window exceeds limit (2013)"}}"#;
+        assert!(super::is_context_overflow_body(body));
+        assert!(super::has_explicit_overflow_marker(body));
+    }
+
+    #[test]
+    fn detects_invalid_params_exceeds_limit_pattern() {
+        // Companion to the above — a body that omits "context window"
+        // but still uses MiniMax's "invalid params … exceeds limit"
+        // shape. Both clauses must be present.
+        let body = r#"{"error":{"code":40001,"message":"invalid params, max_tokens exceeds limit"}}"#;
+        assert!(super::has_explicit_overflow_marker(body));
     }
 }

--- a/src/config/env-registry.ts
+++ b/src/config/env-registry.ts
@@ -474,8 +474,24 @@ export const MEMPHIS_GEN_TIMEOUT_MS = defineNumberAccessor({
 export const MEMPHIS_GEN_MAX_TOKENS = defineNumberAccessor({
   name: 'MEMPHIS_GEN_MAX_TOKENS',
   envKey: 'MEMPHIS_GEN_MAX_TOKENS',
-  description: 'Per-request output tokens. Default 32768, sanity-rail max 1MB.',
-  defaultValue: 32_768,
+  description:
+    'Per-request output tokens. Default 2048 (pre-Phase-1.5 safe value); operator opts higher via env if their provider endpoint supports it. Sanity-rail max 1MB.',
+  // Phase 1.5.1 set this to 32_768 under the "cost-unconstrained" mandate
+  // — the model spec said 32k+ output was supported. Live operator
+  // session 2026-05-08 caught the gap: MiniMax M2.7 endpoint operator
+  // uses imposes a server-side per-request output cap that's much smaller
+  // (the rejection says "context window exceeds limit (2013)" — i.e. the
+  // remaining context after prompt is ~2013 tokens, and our 32768
+  // max_tokens parameter overshoots that).
+  //
+  // Conservative default 2048 mirrors the pre-Phase-1.5 hardcoded value
+  // that worked across providers without rejection. Operators with
+  // beefier endpoint allowances can opt up via the env var:
+  //   MEMPHIS_GEN_MAX_TOKENS=8192 memphis chat ...
+  // The schema cap stays at 1MB for the upper-end providers (Anthropic
+  // 64k, OpenRouter 100k, etc) so the env-driven opt-up isn't artificially
+  // constrained here.
+  defaultValue: 2_048,
   min: 1,
   max: 1_048_576,
 });


### PR DESCRIPTION
## Summary

Two coupled regressions caught in live operator session 2026-05-08:

1. **MiniMax M2.7 rejects max_tokens=32k.** Phase 1.5.1 bumped MEMPHIS_GEN_MAX_TOKENS default 2048 → 32768 under "cost-unconstrained" mandate. Live chat surfaced `bad_request_error: invalid params, context window exceeds limit (2013)` — server-imposed per-request output cap is account-dependent, far below model spec. Every `> status` etc. failed.

2. **Heuristic missed "exceeds" (present tense).** PR #521's marker list only covered past-tense forms ("exceeded", "too long"). MiniMax uses present tense — "exceeds limit" — so heuristic dropped through to raw 400 instead of friendly `/clear` hint.

## Fix

- `MEMPHIS_GEN_MAX_TOKENS` default reverted 32_768 → 2_048 (pre-Phase-1.5 safe value).
- `CHAT_MAX_TOKENS_DEFAULT` in chat.rs mirrored to 2_048.
- `has_explicit_overflow_marker` extended with two new recognizers: `context window exceeds` (sans -ed) + `invalid params` ∧ `exceeds limit`.
- Operators with beefier endpoint allowances opt up via env: `MEMPHIS_GEN_MAX_TOKENS=8192 memphis chat ...`

## Tests
- 39/39 provider:: tests green (2 new heuristic regressions for MiniMax variant)

## Cross-Layer Grid
| Layer | Status |
|---|---|
| Rust core | ✅ chat.rs default + provider.rs heuristic |
| NAPI | 🔧 rebuild required |
| TS host | ✅ env-registry default mirrored |
| CLI | – |
| Tauri | – |
| doctor/status | – (self-describe surfaces resolved value) |
| tests | ✅ 2 new |

## Operator note
`git pull && npm run build:rust && npm run build && restart` to pick up. See `memory/project_post_cleanup_user_testing_2026-05-08.md` for the full update + feedback test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)