### PR TITLE
fix(prompt): anti-confab phase 4 — broaden recall before negative answer

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -279,6 +279,53 @@ default), say so directly: "I cannot grep \`src/\` from the current
 tier; ask after \`/tier elevate\` or describe what you're looking
 for so I can recommend a chain query." Don't pretend you searched.
 
+### Recall questions about operator's history — broaden the scope (anti-confab phase 4)
+
+When the operator asks about THEIR OWN past decisions, projects,
+preferences, plans, or business context — phrasings like "co wiesz
+o moich X", "what do you know about my X", "moje decyzje", "moje
+strumienie/projekty", "co ogarniamy", "what's our state on X",
+"co wybraliśmy" — you MUST search across MULTIPLE memory surfaces
+before answering. The colloquial Polish/English word "decyzje"
+(decisions) does NOT map to the literal \`decisions\` chain — that
+chain stores automated cognitive-mode shift logs, not operator
+choices.
+
+Operator's actual choices and context live across:
+- \`journal\` chain — daily entries, ad-hoc thoughts
+- \`cases\` chain — case-grammar entries (genitive: ownership,
+  accusative: learnings, dative: directions)
+- \`soul\` memory — \`memphis_soul_read\` returns user.preferences,
+  user.expertise, user.integrations, self.learnings,
+  context.activeWork, context.recentDecisions
+- \`reflections\` chain — daily/weekly reflection summaries
+- \`proactive\` chain — operator-stated goals, follow-ups
+- \`insights\` chain — generated insights
+- \`decisions\` chain — explicit \`memphis_decide\` write-throughs
+  AND auto Mode-B-shift logs (mixed signal)
+
+Required minimum tool batch BEFORE answering "I don't know" or
+"zero results" or "nie mam" or "nothing found" to a recall
+question:
+1. \`memphis_soul_read\` (section: 'all') — fast, covers identity
+2. \`memphis_recall\` with the operator's own keywords from the
+   question (e.g. "decyzje", "strumienie", "Beskid")
+3. If still empty: \`memphis_chain_query\` with \`{ chain:
+   'journal', limit: 50 }\` and same for \`cases\`, \`reflections\`
+
+Forbidden negative phrases when this batch hasn't run:
+- Polish: "nie mam żadnych", "zero", "Memphis nie zapisuje",
+  "nic nie wiem o", "muszę zaskoczyć cię", "Twoje X nie istnieje"
+- English: "I have no", "zero results", "nothing on file",
+  "Memphis doesn't track", "no record of"
+
+Only AFTER the multi-surface search comes back empty across all
+three layers may you say "I checked soul, recall, and journal/
+cases/reflections — no entries match \`<keyword>\`. Want me to
+record this as a new decision via \`memphis_decide\`?". The
+"want me to record" offer is the right next step; the absence
+itself is now grounded in actual tool output.
+
 ### Capability questions (sprint 1.3)
 
 When the user asks "what can you do" / "co potrafisz" / "jakie konfigi/

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -213,6 +213,54 @@ describe('gateway system prompt', () => {
     expect(prompt).not.toContain('Marcin');
   });
 
+  it('requires multi-surface recall before negative answer to history questions (anti-confab phase 4 2026-05-08)', () => {
+    // Live Telegram 2026-05-08 21:51: operator asked "co wiesz o moich
+    // decyzjach biznesowych?", bot searched ONLY the auto-Mode-B-shift
+    // `decisions` chain, said "zero", advised operator to call
+    // memphis_decide manually. Wrong on two axes: "decyzje" colloquially
+    // means choices/plans (lives in journal/cases/soul, not the literal
+    // decisions chain), and Memphis had access to all those surfaces
+    // but didn't recall any.
+    //
+    // The earlier anti-confab guard catches POSITIVE claims of search
+    // ("przeszukałem"). This phase-4 guard catches NEGATIVE claims of
+    // absence ("nie mam", "zero results") — same confab pattern,
+    // opposite framing.
+    const prompt = buildSystemPrompt({
+      availableTools: [
+        'memphis_recall',
+        'memphis_chain_query',
+        'memphis_soul_read',
+      ],
+    });
+
+    expect(prompt).toContain('broaden the scope (anti-confab phase 4)');
+    // The anti-conflation note: "decyzje" ≠ literal `decisions` chain
+    expect(prompt).toContain('does NOT map to the literal `decisions` chain');
+    // Multi-surface recall scope catalog
+    expect(prompt).toContain('`journal` chain');
+    expect(prompt).toContain('`soul` memory');
+    expect(prompt).toContain('`cases` chain');
+    expect(prompt).toContain('`reflections` chain');
+    // Required tool batch listed
+    expect(prompt).toContain("memphis_soul_read");
+    expect(prompt).toContain("memphis_recall");
+    expect(prompt).toContain("memphis_chain_query");
+    // Forbidden negative phrases (PL + EN)
+    expect(prompt).toContain('"nie mam żadnych"');
+    expect(prompt).toContain('"zero"');
+    expect(prompt).toContain('"Memphis nie zapisuje"');
+    expect(prompt).toContain('"I have no"');
+    expect(prompt).toContain('"Memphis doesn\'t track"');
+    // The constructive next step after honest empty result.
+    // Wraps across lines in the source — match the inner phrase that
+    // doesn't span a newline.
+    expect(prompt).toContain('record this as a new decision via');
+    // Negative: no operator-specific narrative leaks
+    expect(prompt).not.toContain('Wodzu');
+    expect(prompt).not.toContain('Marcin');
+  });
+
   it('adds instructions for preview tools when they are available', () => {
     const prompt = buildSystemPrompt({
       availableTools: ['memphis_chain_query', 'memphis_providers', 'memphis_system_info'],


### PR DESCRIPTION
Live Telegram 2026-05-08 21:51: operator asked about business decisions, Memphis searched only literal `decisions` chain (auto Mode-B-shift logs), said 'zero'. Two failures: scope too narrow (missed journal/cases/soul) + negative-claim confab not caught by #478 (which only blocks positive search verbs).

Phase 4 guard mandates multi-surface tool batch (memphis_soul_read + memphis_recall + memphis_chain_query across journal/cases/reflections) BEFORE 'I don't know' / 'zero results' / 'nie mam' answers to recall questions about operator history. Plus catalogs the colloquial-vs-literal-chain conflation pitfall.

Tests: 33/33 system-prompt tests green (1 new regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)