### PR TITLE
hotfix(codex-round-2): bundle 4 findings — narrow gates + envelope reader

### DIFF
--- a/scripts/export-incident-bundle.mts
+++ b/scripts/export-incident-bundle.mts
@@ -767,6 +767,7 @@ function readCognitiveReportSummaries(
       hash?: unknown;
       data?: {
         type?: unknown;
+        kind?: unknown;
         schemaVersion?: unknown;
         source?: unknown;
         report?: {
@@ -775,7 +776,15 @@ function readCognitiveReportSummaries(
         };
       };
     };
-    const dataType = typeof block.data?.type === 'string' ? block.data.type : null;
+    // Codex Round 1 #529 + canonical envelope alignment from PR #529
+    // (cognitive insight save). Cognitive reports use the canonical
+    // envelope `{type:'insight', kind:'*_report'}` so the chain-catalog
+    // BlockType variant ('insight') sits on `type` and the report
+    // sub-type lives on `kind`. Older blocks may still have
+    // `type:'*_report'` directly — accept both shapes (kind preferred).
+    const dataKind = typeof block.data?.kind === 'string' ? block.data.kind : null;
+    const dataTypeField = typeof block.data?.type === 'string' ? block.data.type : null;
+    const dataType = dataKind ?? dataTypeField;
     if (!dataType || !(dataType in COGNITIVE_REPORT_TYPE_MAP)) continue;
     const source = typeof block.data?.source === 'string' ? block.data.source : null;
     const generatedAt =

--- a/src/infra/runtime/napi-shutdown.ts
+++ b/src/infra/runtime/napi-shutdown.ts
@@ -104,15 +104,32 @@ function isHardExitEnabled(options: NapiShutdownOptions): boolean {
  * both events via the `cleanupRan` flag — repeating them is a no-op
  * for embed_shutdown (idempotent) but pointless for pino.
  *
- * Hard-exit honours BOTH phases when enabled. Codex Round 1 #533
- * caught the original bug: gating only on `'exit'` made `MEMPHIS_NAPI_HARD_EXIT=1`
- * ineffective for naturally-terminating scripts (Node fires `beforeExit`
- * first when the event loop drains; if our handler returned early on
- * `alreadyRan` for `'exit'`, the hard-exit branch was never reached).
- * Now: when hard-exit is enabled, we call `reallyExit` from whichever
- * event fires first (typically `beforeExit` for natural exits, `exit`
- * for explicit `process.exit(code)`). Either way the cdylib unload
- * race has no surface.
+ * Hard-exit (MEMPHIS_NAPI_HARD_EXIT=1) is honoured ONLY on the `exit`
+ * phase, never `beforeExit`. Codex Round 2 #542 caught the regression
+ * Round 1 introduced: calling `reallyExit` from `beforeExit` cuts off
+ * any subsequent `beforeExit` listener registered after our install,
+ * losing operator-registered final-state writes. Round 1 #533 (natural
+ * exits not reaching the hard-exit branch) is fixed differently: when
+ * cleanupRan is true and we're on `'exit'` with hardExit enabled, the
+ * early-return path also fires reallyExit. So:
+ *
+ *   - Natural exit path:
+ *     1. event loop drains → beforeExit fires
+ *     2. our handler: cleanup ran=false; embed_shutdown + pino flush;
+ *        eventName==='beforeExit' so SKIP reallyExit (lets other
+ *        beforeExit listeners run)
+ *     3. all beforeExit listeners drain
+ *     4. exit fires
+ *     5. our handler: cleanupRan=true; eventName==='exit' &&
+ *        hardExit → attemptReallyExit() → terminates via _exit(2)
+ *
+ *   - Explicit process.exit(code) path:
+ *     1. exit fires (no beforeExit)
+ *     2. our handler: cleanupRan=false; embed_shutdown + pino flush;
+ *        eventName==='exit' && hardExit → attemptReallyExit()
+ *
+ * Both end with reallyExit when hardExit enabled; neither cuts off
+ * other beforeExit listeners.
  */
 function buildHandler(
   bridge: BridgeModule,
@@ -121,10 +138,12 @@ function buildHandler(
   let cleanupRan = false;
   return function memphisNapiShutdownGuard(eventName: 'beforeExit' | 'exit'): void {
     if (cleanupRan) {
-      // Cleanup already ran — but if hard-exit is enabled and we're
-      // now on `'exit'` after a `'beforeExit'` that didn't terminate
-      // (rare; happens if a beforeExit listener re-armed the loop),
-      // still call reallyExit so the dlclose race has no surface.
+      // Cleanup already ran — natural-exit case: beforeExit ran our
+      // cleanup, exit follows. If hard-exit is enabled, terminate now
+      // via _exit(2) to skip the cdylib unload race. (Other exit
+      // listeners registered before us already ran in registration
+      // order; later ones are sacrificed — the trade-off documented
+      // in docs/dev/SHUTDOWN-LIFECYCLE.md Layer 2 rubric.)
       if (eventName === 'exit' && isHardExitEnabled(options)) {
         attemptReallyExit();
       }
@@ -159,22 +178,19 @@ function buildHandler(
       // operator gets the next-best signal: the not-yet-flushed log
       // lines simply don't appear, but the process exits cleanly.
     }
-    // 3. Track B: hard-exit override. When the operator opted in (via
-    //    MEMPHIS_NAPI_HARD_EXIT=1 or the explicit option), bypass the
-    //    Node runtime's normal teardown path. process.reallyExit() goes
-    //    straight to the kernel's _exit(2) syscall — no cdylib unload,
-    //    no Rust static destructors, no V8 isolate teardown that could
-    //    race with libc TLS cleanup. Steps 1+2 above already persisted
-    //    everything the operator cares about. The OS reclaims memory
-    //    and FDs at process termination regardless.
+    // 3. Track B: hard-exit override (Codex Round 2 #542 refinement).
+    //    Only honoured on `'exit'`. When this path fires from
+    //    `beforeExit`, we DO NOT call reallyExit — that would cut off
+    //    operator-registered beforeExit listeners that haven't run yet
+    //    (registered after our install land later in the listener
+    //    queue). Instead we let beforeExit drain naturally; `exit`
+    //    fires after, hits the cleanupRan-true branch above, and
+    //    THERE we call attemptReallyExit().
     //
-    //    Triggers on whichever event fires first when hard-exit is
-    //    enabled. For natural exits (event loop drains) this is
-    //    `beforeExit`; for `process.exit(code)` calls it's `exit`.
-    //    Codex Round 1 #533: original gating to `'exit'` only meant
-    //    naturally-exiting scripts never reached the hard-exit branch
-    //    because the cleanupRan flag was set in `beforeExit` first.
-    if (isHardExitEnabled(options)) {
+    //    For explicit `process.exit(code)` callers, no beforeExit
+    //    happens — exit fires directly, this branch reaches
+    //    attemptReallyExit() on first invocation, eventName==='exit'.
+    if (eventName === 'exit' && isHardExitEnabled(options)) {
       attemptReallyExit();
     }
   };

--- a/tests/integration/script-shutdown-segv-stress.test.ts
+++ b/tests/integration/script-shutdown-segv-stress.test.ts
@@ -136,34 +136,65 @@ function spawnRunner(): { code: number | null; stdout: string; stderr: string } 
 const SEGV_STRESS_MAX_TOLERATED_FAILURES =
   process.env.MEMPHIS_LEGACY_SEGV_TOLERANCE === '1' ? 1 : 0;
 
+/**
+ * Codex Round 1 #528: distinguish SEGV-shape failures from any-other
+ * failures. The threshold tolerance is meant only for the issue-#270
+ * V8↔Rust dlclose race, which always presents as `code === null`
+ * (signal kill, no exit code) or `code === 139` (128 + SIGSEGV on
+ * platforms that do report it). A child that exits with `code === 2`
+ * (bridge resolution error, e.g.) or `code === 1` (assertion failure
+ * inside the runner) is a real regression and MUST fail the suite —
+ * the SEGV tolerance must not mask those.
+ */
+function isSegvShape(code: number | null): boolean {
+  return code === null || code === 139;
+}
+
 describe.skipIf(!bridgeBuildAvailable())(
   'NAPI bridge auto-shutdown — script-style spawn ×10',
   () => {
     it('every iteration exits cleanly (no SIGSEGV from V8 teardown race)', () => {
-      const failures: Array<{ iteration: number; code: number | null; stderr: string }> = [];
+      const failures: Array<{
+        iteration: number;
+        code: number | null;
+        stderr: string;
+        segvShape: boolean;
+      }> = [];
       for (let i = 0; i < 10; i += 1) {
         const result = spawnRunner();
         if (result.code !== 0) {
-          failures.push({ iteration: i, code: result.code, stderr: result.stderr.slice(0, 400) });
+          failures.push({
+            iteration: i,
+            code: result.code,
+            stderr: result.stderr.slice(0, 400),
+            segvShape: isSegvShape(result.code),
+          });
         }
       }
-      // Always log so a regression upward is visible even when below
-      // the failure threshold. Post-Track-B the expectation is 0/10;
-      // any hit means MEMPHIS_NAPI_HARD_EXIT didn't land or the
-      // runner subprocess inheritance is broken.
+      const segvFailures = failures.filter((f) => f.segvShape);
+      const nonSegvFailures = failures.filter((f) => !f.segvShape);
+      // Always log so any failure shape is visible even when below
+      // the SEGV threshold.
       if (failures.length > 0) {
         process.stderr.write(
-          `[script-shutdown-segv-stress] ${failures.length}/10 iterations hit SIGSEGV ` +
-            `(threshold: ${SEGV_STRESS_MAX_TOLERATED_FAILURES}). ` +
-            `Track B (MEMPHIS_NAPI_HARD_EXIT) is supposed to eliminate this — ` +
-            `verify the runner inherits the env and the bridge import path triggers ` +
-            `installNapiShutdownGuard. ` +
+          `[script-shutdown-segv-stress] ${failures.length}/10 iterations failed ` +
+            `(${segvFailures.length} SEGV-shape, ${nonSegvFailures.length} other). ` +
             `Detail: ${JSON.stringify(failures, null, 2)}\n`,
         );
       }
+      // Codex Round 1 #528: non-SEGV failures (exit code 1, 2, …)
+      // ALWAYS fail the test — the SEGV tolerance must not mask
+      // bridge-resolution errors, runner-script bugs, or other
+      // regressions in the script path.
       expect(
-        failures.length,
-        `expected ≤${SEGV_STRESS_MAX_TOLERATED_FAILURES} SEGV, got ${failures.length}: ${JSON.stringify(failures, null, 2)}`,
+        nonSegvFailures,
+        `non-SEGV failures must always fail the test — got ${nonSegvFailures.length}: ${JSON.stringify(nonSegvFailures, null, 2)}`,
+      ).toEqual([]);
+      // SEGV-shape failures are tolerated up to the documented threshold
+      // (post-Track-B: 0; pre-Track-B legacy mode via env: 1).
+      expect(
+        segvFailures.length,
+        `expected ≤${SEGV_STRESS_MAX_TOLERATED_FAILURES} SEGV-shape failure(s), got ${segvFailures.length}: ${JSON.stringify(segvFailures, null, 2)}`,
       ).toBeLessThanOrEqual(SEGV_STRESS_MAX_TOLERATED_FAILURES);
     });
   },

--- a/tests/unit/napi-shutdown.test.ts
+++ b/tests/unit/napi-shutdown.test.ts
@@ -110,15 +110,12 @@ describe('installNapiShutdownGuard', () => {
       }
     }
 
-    it('calls reallyExit on beforeExit when hardExit=true (post-Codex Round 1)', () => {
-      // Codex Round 1 #533: original implementation gated reallyExit to
-      // the 'exit' event only, but Node fires `beforeExit` first when the
-      // event loop drains naturally. With cleanupRan flag set in
-      // beforeExit, the later 'exit' listener bailed early and the
-      // reallyExit branch was never reached — making
-      // MEMPHIS_NAPI_HARD_EXIT=1 ineffective for naturally-exiting
-      // scripts (the very surface it was supposed to fix). Now hard-exit
-      // honours both phases.
+    it('does NOT call reallyExit on beforeExit alone (Codex Round 2 #542 — preserve beforeExit listeners)', () => {
+      // Codex Round 2 #542: calling reallyExit from beforeExit would
+      // cut off operator-registered beforeExit listeners that haven't
+      // run yet (registered after our install land later in queue).
+      // So beforeExit only does cleanup; the 'exit' phase that fires
+      // after beforeExit drains naturally is what triggers reallyExit.
       withMockedReallyExit((reallyExit) => {
         const embedShutdown = vi.fn();
         const pinoFlush = vi.fn();
@@ -127,8 +124,32 @@ describe('installNapiShutdownGuard', () => {
           { embedShutdownFn: embedShutdown, pinoFlushFn: pinoFlush, hardExit: true },
         );
         process.emit('beforeExit', 0);
+        expect(reallyExit, 'reallyExit must NOT fire from beforeExit alone').not.toHaveBeenCalled();
+        expect(embedShutdown).toHaveBeenCalledTimes(1);
+        expect(pinoFlush).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('calls reallyExit on the natural-exit path: beforeExit then exit (Codex Round 1 #533 still fixed)', () => {
+      // This pins the natural-exit flow — beforeExit fires first
+      // (event loop drains), our cleanup runs but no reallyExit; then
+      // exit fires, cleanupRan-true branch sees hardExit and fires
+      // reallyExit. This is what makes MEMPHIS_NAPI_HARD_EXIT=1
+      // effective for one-shot scripts that exit naturally without
+      // calling process.exit() explicitly.
+      withMockedReallyExit((reallyExit) => {
+        const embedShutdown = vi.fn();
+        const pinoFlush = vi.fn();
+        installNapiShutdownGuard(
+          {},
+          { embedShutdownFn: embedShutdown, pinoFlushFn: pinoFlush, hardExit: true },
+        );
+        process.emit('beforeExit', 0);
+        expect(reallyExit).not.toHaveBeenCalled();
+        process.emit('exit', 0);
         expect(reallyExit).toHaveBeenCalledTimes(1);
         expect(reallyExit).toHaveBeenCalledWith(0);
+        // Cleanup ran exactly once across both events
         expect(embedShutdown).toHaveBeenCalledTimes(1);
         expect(pinoFlush).toHaveBeenCalledTimes(1);
       });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,19 +39,36 @@ export default defineConfig({
     //
     // Hard-exit (Track B) eliminates the dlclose race for one-shot
     // scripts but is incompatible with vitest's long-lived worker
-    // forks (calling process.reallyExit() mid-suite makes the pool
-    // surface "Worker forks emitted error" because the worker
-    // disappears before vitest's job-queue is drained). So the worker
-    // teardown path keeps relying on the partial mitigations from PR
-    // #353/#424 + Track A: race tolerance plus the gate below that
-    // swallows the post-tests pool-level unhandled error.
+    // forks. The worker teardown path keeps relying on the partial
+    // mitigations from PR #353/#424 plus the narrow `onUnhandledError`
+    // filter below.
     //
-    // The gate is narrowly justified — the failure mode is "Worker
-    // forks emitted error" surfacing AFTER all test files have
-    // reported pass/fail. Real test failures still surface through
-    // their own assertion paths. Set MEMPHIS_STRICT_VITEST_RACE=1 to
-    // disable the gate when investigating a deeper Track B path
+    // Codex Round 1 #528 caught the prior implementation gap: the
+    // earlier `dangerouslyIgnoreUnhandledErrors: true` swallowed EVERY
+    // unhandled error / rejection from the whole test run, not just
+    // the post-test worker-exit race. A test that schedules a
+    // rejected promise or crashes after its assertions could report
+    // green in CI. The narrow `onUnhandledError` callback below only
+    // suppresses the specific "Worker forks emitted error" /
+    // "Worker exited unexpectedly" signature emitted by the vitest
+    // pool when a worker fork's V8↔Rust dlclose race kills it
+    // post-tests. Anything else propagates as a hard CI failure.
+    //
+    // Set MEMPHIS_STRICT_VITEST_RACE=1 to disable even the narrow
+    // suppression when investigating a deeper Track B path
     // (e.g. NAPI v3 finalizer registration).
-    dangerouslyIgnoreUnhandledErrors: process.env.MEMPHIS_STRICT_VITEST_RACE !== '1',
+    onUnhandledError(error) {
+      if (process.env.MEMPHIS_STRICT_VITEST_RACE === '1') {
+        return true; // propagate everything in strict mode
+      }
+      const message = error?.message ?? '';
+      const isPostTestPoolRace =
+        message.includes('Worker exited unexpectedly') ||
+        message.includes('Worker forks emitted error') ||
+        message.includes('[vitest-pool]');
+      // Returning `false` suppresses this single error; everything
+      // else (return `true`) propagates as a normal CI failure.
+      return !isPostTestPoolRace;
+    },
   },
 });


### PR DESCRIPTION
Round 2 addresses 4 P2 Codex findings:

- **#542** Round 1 beforeExit-reallyExit cut off operator beforeExit listeners → exit-only hardExit; natural-exit pair (beforeExit→exit) still terminates via reallyExit
- **#528** `dangerouslyIgnoreUnhandledErrors: true` too broad → narrow `onUnhandledError` callback filters only "Worker forks emitted error" signature
- **#528** SEGV stress accepted ANY non-zero → split segv-shape (null/139) from other; non-SEGV always fails
- **#529** `scripts/export-incident-bundle.mts` reader needed kind-aware lookup → kind first, type fallback (forward-compat with older snapshots)

11/11 napi-shutdown, 1/1 script-stress, 14/14 chain-integrity, 29/29 soul-memory, 20/20 cargo embed, 39/39 cargo provider — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)