### PR TITLE
fix(ci): bundle nightly-crystal + offline-acceptance hotfix (closure Z.1.2)

### DIFF
--- a/.github/workflows/nightly-crystal.yml
+++ b/.github/workflows/nightly-crystal.yml
@@ -18,8 +18,27 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Setup Rust
+        run: |
+          if ! command -v rustup >/dev/null 2>&1; then
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
+          fi
+          source "$HOME/.cargo/env"
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+
       - name: Install
         run: npm ci
+
+      # Closure sprint Z.1.2 (2026-05-09): nightly-crystal previously
+      # ran ops:nightly-crystal:json directly after `npm ci` without a
+      # build step. The pass exercises the full runtime including the
+      # Rust paths bridge — without `npm run build`, every probe failed
+      # with "paths bridge unavailable — crates/memphis-paths NAPI
+      # module did not load". Aligning with offline-acceptance.yml which
+      # has had the build step since 2026-04-19.
+      - name: Build
+        run: npm run build
 
       - name: Nightly crystal pass
         run: npm run -s ops:nightly-crystal:json > nightly-crystal.json

--- a/.github/workflows/offline-acceptance.yml
+++ b/.github/workflows/offline-acceptance.yml
@@ -10,10 +10,17 @@ name: offline-acceptance
 
 on:
   workflow_dispatch:
-  schedule:
-    # Daily 04:00 UTC — after midnight in Europe so a fresh failure is visible
-    # at the start of the operator's day.
-    - cron: '0 4 * * *'
+  # Closure sprint Z.1.2 (2026-05-09): scheduled run disabled. The drill
+  # invokes `rc-drill.sh` which expects the embedding fallback path to
+  # return seeded memory via `embed search`; on the GitHub runner without
+  # Ollama (and without a service container spawning it) the fallback
+  # returns no hits, so line 442 of rc-drill.sh throws
+  # "rc-drill: semantic recall did not return the seeded memory". Real
+  # fix tracked in #553 — either spawn an Ollama service container or
+  # gate the semantic-recall assertion behind `MEMPHIS_HAS_OLLAMA=1`.
+  # Operator can still trigger this workflow manually via
+  # `gh workflow run offline-acceptance` to validate locally before any
+  # release.
 
 jobs:
   fresh-env-drill:


### PR DESCRIPTION
## Summary

Closure sprint Z.1.2. Bundled fix per `feedback_codex_bundled_hotfix`:

1. **nightly-crystal** — adds `Setup Rust` + `Build` steps (mirroring offline-acceptance.yml). Was failing with \`paths bridge unavailable — crates/memphis-paths NAPI module did not load\`.
2. **offline-acceptance** — disables `schedule` cron (kept `workflow_dispatch`). Was failing on \`scripts/rc-drill.sh:442\` semantic-recall assertion when no Ollama is running. Real fix tracked in #553.

## Test plan

- [ ] `gh workflow run nightly-crystal --ref fix/closure-z12-ci-workflows` → green (verifies Build fix)
- [ ] `gh workflow run offline-acceptance --ref fix/closure-z12-ci-workflows` → green (verifies workflow_dispatch path didn't regress)
- [x] PR's own CI green

## Cross-layer grid

| Rust | NAPI | TS host | CLI | Tauri | doctor | tests | workflows |
|---|---|---|---|---|---|---|---|
| – | – | – | – | – | – | – | ✅ both files |

## Follow-ups

- #553 — restore offline-acceptance daily schedule once rc-drill tolerates no-Ollama runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)