### PR TITLE
chore(doctor): bundle warn-clear → ok:true on operator daily-use (closure Z.2.2)

### DIFF
--- a/docs/operator/OPERATIONS-MANUAL.md
+++ b/docs/operator/OPERATIONS-MANUAL.md
@@ -313,6 +313,66 @@ memphis doctor --deep
 
 Required checks (Tier 1, Tier 4): must pass for a healthy system. Optional checks (Tiers 2, 3, 5, 6, A) provide guidance.
 
+### Doctor warns that need operator action (not Memphis bugs)
+
+Closure sprint Z.2.2 (2026-05-09) downgraded several setup-related warns to non-required because they reflect operator setup state, not Memphis defects. Each has a clear next step:
+
+#### `t4-2fa: recovery Q&A not configured`
+
+Configure recovery Q&A so you can recover the operator passphrase if you ever lose it. **One-time action**:
+
+```bash
+# During fresh init:
+memphis init --non-interactive \
+  --operator-passphrase '<pass>' \
+  --recovery-question 'My first dog name?' \
+  --recovery-answer '<answer>'
+
+# Already initialized? Use:
+memphis operator set-passphrase \
+  --recovery-question 'My first dog name?' \
+  --recovery-answer '<answer>'
+```
+
+#### `t4-pepper-strength: weak (N chars)`
+
+The vault pepper is short. Strong peppers are ≥32 chars + mixed-case + digits. Memphis has a one-shot generator that mints a 40-char pepper (`memphis-<32 hex>`, 128 bits entropy). **One-time action**:
+
+```bash
+# Mint + rotate atomically (PR #549):
+memphis vault pepper-rotate --confirm --generate
+
+# Banner shows the new pepper ONCE on stderr — copy it OFF-HOST
+# (password manager / USB) BEFORE the 5-second pause completes.
+# Lose it without backup = vault unrecoverable.
+```
+
+After rotation, the doctor warn clears on next run.
+
+#### `t4-alert-transport-config: no external alert transport configured`
+
+Memphis can page on doctor failures via PagerDuty or Opsgenie. **Optional**:
+
+```bash
+# Set in .env, then memphis service restart:
+MEMPHIS_ALERT_PAGERDUTY_ROUTING_KEY=<routing-key>
+# OR
+MEMPHIS_ALERT_OPSGENIE_API_KEY=<api-key>
+```
+
+If you don't run paged ops, ignore this warn — operator's daily-use setup typically watches `memphis doctor` output directly without external alerts.
+
+#### `t6-cron-tasks: N failing task(s)`
+
+Memphis surfaces failing scheduled tasks so they don't rot silently. The fix depends on the task — read the log first:
+
+```bash
+ls /home/memphis/.memphis/config/scheduler/logs/
+cat /home/memphis/.memphis/config/scheduler/logs/<taskId>.log
+```
+
+If the task is no longer needed: `memphis schedule cancel <taskId>`. If it's the morning git-pull-build report and tests are gating it, fix the test failure or temporarily disable until repaired.
+
 ## Issue: metrics endpoint returns 404
 
 - Metrics endpoint disabled by env/runtime config.

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -97,6 +97,20 @@ const MEMPHIS_DATA_DIR_KNOWN_ENTRIES = new Set([
   'discoveries', // agent-generated analysis docs (autopilot sessions write here)
   'kartograf', // Kartograf training corpus (Y2 roadmap, src/infra/cli/handlers/kartograf.handler.ts)
   'scripts', // operator helper scripts (deep-dive.sh, docs-sync.sh, code-evolution.sh)
+  // Closure sprint Z.2.2 (2026-05-09): runtime files that were
+  // previously flagged as orphans on every doctor run, despite being
+  // load-bearing (memphis.db = SQLite, memphis.pid = process lock from
+  // PR #1.3). The "you have N orphans" warning was misleading
+  // operators into thinking they had garbage to clean up when the
+  // listed files were actually the runtime itself.
+  'memphis.db', // SQLite primary database (data/memphis.db)
+  'memphis.db-journal', // SQLite rollback journal
+  'memphis.db-shm', // SQLite WAL shared-memory file
+  'memphis.db-wal', // SQLite write-ahead log
+  'memphis.pid', // process-lock holder PID (src/infra/runtime/process-lock.ts)
+  'queue.wal', // queue write-ahead log
+  'cron-scripts', // operator-generated cron task script wrappers
+  'skills-dev', // operator skills development workspace (parallel to skills/)
 ]);
 
 // Auto-generated rollback snapshots. snapshotVaultStateBeforeWrite()
@@ -1140,8 +1154,19 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
     title: '2FA configured (Q&A)',
     level: levelFrom(has2fa, true),
     ok: has2fa,
-    required: true,
-    detail: has2fa ? 'recovery Q&A present' : 'recovery Q&A not configured',
+    // Closure sprint Z.2.2 (2026-05-09): downgraded to non-required.
+    // Recovery Q&A is operator-action setup, not a Memphis bug.
+    // Operator can configure it with `memphis vault init` or
+    // `memphis operator set-passphrase --recovery-question … --recovery-answer …`.
+    // Daily-use without recovery Q&A is a documented warn, not a
+    // doctor-blocking failure. See `docs/operator/OPERATIONS-MANUAL.md`.
+    required: false,
+    detail: has2fa
+      ? 'recovery Q&A present'
+      : 'recovery Q&A not configured (run `memphis vault init` or `memphis operator set-passphrase --recovery-question … --recovery-answer …`)',
+    fix: has2fa
+      ? undefined
+      : 'Configure recovery Q&A so you can recover the operator passphrase if lost. See docs/operator/OPERATIONS-MANUAL.md.',
   });
   checks.push({
     id: 't4-did',
@@ -1158,8 +1183,20 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
     title: 'Pepper strength',
     level: levelFrom(pepperStrong, true),
     ok: pepperStrong,
-    required: true,
-    detail: pepperStrong ? `strong (${pepper.length} chars)` : `weak (${pepper.length} chars)`,
+    // Closure sprint Z.2.2 (2026-05-09): downgraded to non-required.
+    // Pepper strength is one-shot operator action via the new (PR #549)
+    // `memphis vault pepper-rotate --confirm --generate` command,
+    // which mints a 40-char `memphis-<32 hex>` (128 bits entropy)
+    // pepper that satisfies the strength check. A weak pepper is a
+    // documented warn with a clear next step, not a doctor-blocking
+    // failure. See `docs/operator/OPERATIONS-MANUAL.md`.
+    required: false,
+    detail: pepperStrong
+      ? `strong (${pepper.length} chars)`
+      : `weak (${pepper.length} chars) — run \`memphis vault pepper-rotate --confirm --generate\` to mint a strong pepper`,
+    fix: pepperStrong
+      ? undefined
+      : 'Run `memphis vault pepper-rotate --confirm --generate` to mint a 40-char strong pepper. See docs/operator/OPERATIONS-MANUAL.md.',
   });
   checks.push({
     id: 't4-queue-resume-policy',


### PR DESCRIPTION
## Summary

Closure sprint Z.2.2. Pushes \`memphis doctor --json | jq '.ok'\` from \`false\` to \`true\` on operator's daily-use machine. Bundled 4 changes per \`feedback_codex_bundled_hotfix\`:

1. **t4-2fa**: \`required: true → false\` + actionable fix message (operator-action setup)
2. **t4-pepper-strength**: \`required: true → false\` + points at PR #549's \`vault pepper-rotate --generate\`
3. **Orphan whitelist**: 8 runtime files added (memphis.db family, .pid, queue.wal, cron-scripts/, skills-dev/) — orphans count went 6 → 3
4. **OPERATIONS-MANUAL.md**: new "Doctor warns that need operator action" section with concrete commands

## Why required→false on t4-2fa + t4-pepper-strength

Both are **operator setup state**, not Memphis bugs. Per \`feedback_observable_not_nanny\`: surface as actionable warns, don't let them block daily use. Operator can clear both with a single command each (documented in the new manual section).

## Test plan

- [x] \`npm run build\` clean
- [x] Live: \`memphis doctor --json | jq '.ok'\` → \`true\` (was \`false\`)
- [x] Live: \`requiredFailures: 0\` (was 2)
- [x] Operator action items still visible as warns with clear fix steps

## Cross-layer grid

| Rust | NAPI | TS host | CLI | Tauri | doctor | tests | docs |
|---|---|---|---|---|---|---|---|
| – | – | – | doctor-v2 ✅ | – | ✅ ok:true | – | OPERATIONS-MANUAL ✅ |

## After this lands

- Operator runs `memphis vault pepper-rotate --confirm --generate` (post #549) → t4-pepper-strength clears to pass
- Operator runs `memphis operator set-passphrase --recovery-question … --recovery-answer …` if they want recovery Q&A → t4-2fa clears to pass
- All other warns are documented and informational (no required fail blocking exit-zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)