### PR TITLE
test(handlers): bundle smoke for operator + schedule (closure Z.4.1)

### DIFF
--- a/tests/unit/operator.handler.test.ts
+++ b/tests/unit/operator.handler.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Closure sprint Z.4.1 (2026-05-09): smoke coverage for the operator
+ * command handler. Pre-Z.4.1 the handler had no dedicated test —
+ * it was exercised only via `cli-router.integration.test.ts`'s
+ * dispatcher smoke and indirectly through `operator-gate` unit tests.
+ * These two cases pin the dispatch contract: status reports JSON when
+ * --json + configured, and unknown subcommands surface a usage hint.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/infra/auth/operator-gate.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/infra/auth/operator-gate.js')>(
+    '../../src/infra/auth/operator-gate.js',
+  );
+  return {
+    ...actual,
+    loadOperatorConfig: vi.fn(() => ({
+      schemaVersion: 1,
+      passphraseHash: 'mock-hash',
+      salt: 'mock-salt',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-05-09T00:00:00.000Z',
+      recoveryQuestionHint: 'mock?',
+      recoveryHash: 'mock-recovery',
+    })),
+    isOperatorConfigured: vi.fn(() => true),
+  };
+});
+
+const { operatorCommandHandler } = await import(
+  '../../src/infra/cli/handlers/operator.handler.js'
+);
+
+import type { CliContext } from '../../src/infra/cli/context.js';
+
+function buildContext(opts: { subcommand?: string; json?: boolean } = {}): CliContext {
+  return {
+    argv: [],
+    args: {
+      command: 'operator',
+      subcommand: opts.subcommand,
+      json: opts.json ?? false,
+    } as CliContext['args'],
+    getConfig: () => ({}) as ReturnType<CliContext['getConfig']>,
+    getContainer: () => ({}) as ReturnType<CliContext['getContainer']>,
+  };
+}
+
+describe('operator command handler', () => {
+  it('status subcommand reports configured operator with JSON payload (happy path)', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    try {
+      const result = await operatorCommandHandler.handle(
+        buildContext({ subcommand: 'status', json: true }),
+      );
+      expect(result).toBe(true);
+      expect(log).toHaveBeenCalledOnce();
+      const printed = log.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(printed) as {
+        configured: boolean;
+        hasRecovery: boolean;
+        createdAt: string;
+        updatedAt: string;
+      };
+      expect(parsed.configured).toBe(true);
+      expect(parsed.hasRecovery).toBe(true);
+      expect(parsed.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it('unknown subcommand surfaces usage hint to stderr (error path)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const result = await operatorCommandHandler.handle(
+        buildContext({ subcommand: 'gibberish' }),
+      );
+      // Handler returns true to signal "command was claimed" so the
+      // dispatcher doesn't fall through to the unknown-command path —
+      // the error is surfaced to stderr instead.
+      expect(result).toBe(true);
+      const calls = errorSpy.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((line) => line.includes('Unknown operator subcommand: gibberish'))).toBe(
+        true,
+      );
+      expect(
+        calls.some((line) => line.includes('Usage: memphis operator <status|set-passphrase|recover>')),
+      ).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/schedule.handler.test.ts
+++ b/tests/unit/schedule.handler.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Closure sprint Z.4.1 (2026-05-09): smoke coverage for the schedule
+ * command handler. Pre-Z.4.1 the handler had no dedicated test —
+ * it was exercised only via dispatcher smoke. These two cases pin
+ * the dispatch contract: list returns JSON of registered tasks, and
+ * unknown subcommands surface a usage hint without throwing.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const listTasksMock = vi.fn(() => [] as ReadonlyArray<unknown>);
+
+vi.mock('../../src/infra/runtime/scheduler.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/infra/runtime/scheduler.js')>(
+    '../../src/infra/runtime/scheduler.js',
+  );
+  return {
+    ...actual,
+    getScheduler: vi.fn(() => ({
+      listTasks: listTasksMock,
+      addTask: vi.fn(),
+      removeTask: vi.fn(),
+      enableTask: vi.fn(),
+      disableTask: vi.fn(),
+    })),
+  };
+});
+
+const { scheduleCommandHandler } = await import(
+  '../../src/infra/cli/handlers/schedule.handler.js'
+);
+
+import type { CliContext } from '../../src/infra/cli/context.js';
+
+function buildContext(opts: { subcommand?: string; json?: boolean } = {}): CliContext {
+  return {
+    argv: [],
+    args: {
+      command: 'schedule',
+      subcommand: opts.subcommand,
+      json: opts.json ?? false,
+    } as CliContext['args'],
+    getConfig: () => ({}) as ReturnType<CliContext['getConfig']>,
+    getContainer: () => ({}) as ReturnType<CliContext['getContainer']>,
+  };
+}
+
+describe('schedule command handler', () => {
+  it('list (or no subcommand) returns empty task array as JSON (happy path, no auth required)', async () => {
+    listTasksMock.mockReturnValue([]);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    try {
+      const result = await scheduleCommandHandler.handle(
+        buildContext({ subcommand: 'list', json: true }),
+      );
+      expect(result).toBe(true);
+      const printed = log.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(printed) as { tasks: unknown[] };
+      expect(Array.isArray(parsed.tasks)).toBe(true);
+      expect(parsed.tasks).toHaveLength(0);
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it('unknown subcommand surfaces usage hint to stderr (error path, no auth check on read)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const result = await scheduleCommandHandler.handle(
+        buildContext({ subcommand: 'gibberish' }),
+      );
+      expect(result).toBe(true);
+      const calls = errorSpy.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((line) => line.includes('Unknown subcommand: gibberish'))).toBe(true);
+      expect(calls.some((line) => line.includes('memphis schedule help'))).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closure sprint Z.4.1. Z.0 audit flagged 4 handlers without tests; re-audit found consent + system already covered. **Real gaps:** schedule + operator. Bundled in 1 PR per \`feedback_codex_bundled_hotfix\`.

- \`tests/unit/operator.handler.test.ts\` — 2 cases (status JSON happy, unknown subcommand error)
- \`tests/unit/schedule.handler.test.ts\` — 2 cases (list empty JSON happy, unknown subcommand error)

## Test plan

- [x] \`npx vitest run tests/unit/operator.handler.test.ts tests/unit/schedule.handler.test.ts\` → 4/4 pass

## Cross-layer grid

| Rust | NAPI | TS host | CLI | Tauri | doctor | tests |
|---|---|---|---|---|---|---|
| – | – | – | – | – | – | 🧪 4 NEW |

🤖 Generated with [Claude Code](https://claude.com/claude-code)