### PR TITLE
fix(cli): wire 'demo' + 'stop' into system registry — demo arm now works (closure Z.5.1)

### DIFF
--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -84,6 +84,14 @@ export const CLI_COMMAND_REGISTRY = [
       'repair',
       'kill-zombies',
       'readiness',
+      // Closure sprint Z.5.1 (2026-05-09): `demo` was registered in
+      // SYSTEM_COMMANDS (system.handler.ts) and routed to handleDemoCommand
+      // there, but the dispatcher-level command-name registry below this
+      // comment was missing it — every `memphis demo arm/status/...`
+      // invocation hit the "Unknown command: demo" path. Adding it here
+      // wires the existing implementation into the dispatcher.
+      'demo',
+      'stop',
     ],
     createLazyHandlerLoader(() => import('./handlers/system.handler.js'), 'systemCommandHandler'),
   ),

--- a/src/infra/cli/registry.ts
+++ b/src/infra/cli/registry.ts
@@ -340,6 +340,12 @@ export const CLI_COMPLETION_COMMANDS = [
   'self-update',
   'restart',
   'readiness',
+  // Closure sprint Z.5.1 (2026-05-09): newly wired into the system
+  // registration's commands array (above) — surface them in shell
+  // completion too so operators can tab-complete `memphis demo` and
+  // `memphis stop`. Mirrors registry-consistency test expectation.
+  'demo',
+  'stop',
 ] as const;
 
 /**

--- a/tests/integration/demo-command.test.ts
+++ b/tests/integration/demo-command.test.ts
@@ -76,6 +76,19 @@ describe('memphis demo command surface', () => {
     expect(handled).toBe(true);
   });
 
+  // Closure sprint Z.5.1 (2026-05-09): the dispatcher-level command
+  // registry was missing 'demo' even though SYSTEM_COMMANDS in
+  // system.handler.ts listed it. Result: every `memphis demo …`
+  // invocation hit "Unknown command: demo" before the handler ran.
+  // This pin asserts 'demo' stays wired into the system registration's
+  // commands array so the regression cannot recur silently.
+  it("'demo' is registered in the system command registry (regression guard for Z.5.1)", async () => {
+    const { CLI_COMMAND_REGISTRY } = await import('../../src/infra/cli/registry.js');
+    const systemReg = CLI_COMMAND_REGISTRY.find((r) => r.name === 'system');
+    expect(systemReg, 'system registration must exist').toBeDefined();
+    expect(systemReg!.commands).toContain('demo');
+  });
+
   it('demo arm writes state file at the canonical path on success path (smoke contract)', async () => {
     // We don't mock the entire doctor / backup / telegram surface — that
     // would couple the test to internals. Instead we assert the contract:


### PR DESCRIPTION
## Summary

Closure sprint Z.5.1. The full \`memphis demo arm/status/disarm/rehearse/plan-b\` flow ships in this PR — \`demo.ts\` was already 648 lines complete, \`system.handler.ts\` routed it correctly, but \`registry.ts\` was missing 'demo' (and 'stop') from the dispatcher-level command registry. **One-liner fix.**

## Live verification on operator's machine

\`\`\`
✅ memphis demo arm        → DEMO ARMED, state file written
✅ memphis demo status     → DEMO ARMED, checks summary
✅ memphis demo rehearse   → REHEARSAL OK, 3/3 probes pass (4503ms)
✅ memphis demo plan-b record → PLAN-B RECORDED, 20 blocks captured
\`\`\`

## Test plan

- [x] \`npx vitest run tests/integration/demo-command.test.ts\` → 6/6 pass (1 NEW regression guard)
- [x] Live: all 4 demo subcommands exit 0
- [x] \`memphis doctor\` will show \`t5-demo-readiness: ARMED\` after operator runs \`demo arm\` (Z.7 verification)

## Cross-layer grid

| Rust | NAPI | TS host | CLI | Tauri | doctor | tests |
|---|---|---|---|---|---|---|
| – | – | – | registry ✅ | – | demo-readiness flips to ARMED | 🧪 1 NEW |

## After this lands

Closure verification gate item "demo arm/rehearse/plan-b record exit 0" is achievable. Operator can now follow the post-Zawoja runbook (\`feedback_demo_readiness_rules\`: 1-day-prior, test before stage, Plan B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)