### PR TITLE
docs(operator): canonical entry — ONBOARDING/INSTALL/RUNBOOK (closure Z.5.2)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,48 @@
+# Memphis — Onboarding
+
+Welcome. Memphis is a sovereign cognitive runtime that lives on your hardware. This page is the canonical 5-minute first-run pointer.
+
+## First time? Read this first
+
+The single fastest path from zero to running operator:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Memphis-Chains/memphis/main/scripts/install.sh | bash -s -- --with-init
+```
+
+This installs Node 22, Rust stable, Ollama, clones the repo, builds everything, links the `memphis` CLI globally, and chains directly into `memphis init` (vault passphrase, identity, provider enrollment). At the end you have a running operator on `localhost`.
+
+## Already cloned the repo?
+
+Skip the curl step:
+
+```bash
+cd memphis
+./scripts/bootstrap.sh
+memphis init
+memphis health
+```
+
+## Where to go next
+
+| You want to | Read |
+|---|---|
+| **Install fresh** (full walkthrough) | [`docs/operator/INSTALLATION.md`](docs/operator/INSTALLATION.md) |
+| Install fresh in **English** | [`docs/operator/install.en.md`](docs/operator/install.en.md) |
+| Install fresh in **Polish** | [`docs/operator/install.pl.md`](docs/operator/install.pl.md) |
+| **Daily-use 5-minute runbook** | [`docs/operator/OPERATOR-5MIN-RUNBOOK.md`](docs/operator/OPERATOR-5MIN-RUNBOOK.md) |
+| **Full operations manual** (backup, restore, troubleshooting) | [`docs/operator/OPERATIONS-MANUAL.md`](docs/operator/OPERATIONS-MANUAL.md) |
+| **All CLI commands** | [`docs/operator/CLI-REFERENCE.md`](docs/operator/CLI-REFERENCE.md) |
+| **Configuration profiles** | [`docs/operator/CONFIG-PROFILES.md`](docs/operator/CONFIG-PROFILES.md) |
+| **Vault rotation + recovery** | [`docs/operator/example-installation/04-vault-setup.md`](docs/operator/example-installation/04-vault-setup.md) |
+| **Telegram setup** | [`docs/operator/GUIDE-FIRST-BOOTSTRAP.md`](docs/operator/GUIDE-FIRST-BOOTSTRAP.md) |
+| Demo readiness (per Zawoja postmortem) | `memphis demo arm`, then `memphis demo rehearse`, then `memphis demo plan-b record` |
+
+## What runs locally vs what doesn't
+
+- **Local-only**: vault, journal/decisions/case chains, embeddings index, soul memory, scheduler, doctor, audit log, cron tasks, demo state. All live in `~/.memphis/` (Linux/macOS).
+- **Optional cloud (only if you opt in)**: provider LLM calls (OpenAI / Anthropic / GLM / DeepSeek / Codex / etc.). Memphis does not phone home for telemetry — `MEMPHIS_TELEMETRY=off` is the default.
+
+## When something looks wrong
+
+Always run `memphis doctor` first. It returns `ok: true` when daily-use is healthy; warns are documented and actionable. If `ok: false`, the report tells you which check failed and how to fix it. See [`docs/operator/OPERATIONS-MANUAL.md`](docs/operator/OPERATIONS-MANUAL.md) section "Doctor warns that need operator action".

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Every decision Memphis makes is recorded. Every secret is encrypted at rest. Eve
 
 ---
 
+## First time? Read [`ONBOARDING.md`](./ONBOARDING.md)
+
+The canonical 5-minute pointer: install paths, daily-use runbook, operator docs map. Skip to "Install in 8 minutes" below if you already know what you want.
+
 ## Install in 8 minutes
 
 Linux, macOS, or WSL2. Installs Node 22, Rust stable, Ollama, clones the repo, builds everything, and links the `memphis` CLI globally:

--- a/docs/operator/INSTALL.md
+++ b/docs/operator/INSTALL.md
@@ -1,0 +1,31 @@
+# Install
+
+This file is a thin pointer. Memphis has multiple install paths covered in dedicated docs — pick the one that matches your context.
+
+## Canonical install
+
+For most operators (Linux / macOS / WSL2):
+
+→ **[`INSTALLATION.md`](INSTALLATION.md)**
+
+## Language-specific walkthroughs
+
+- English fresh-user walkthrough → [`install-fresh-user.en.md`](install-fresh-user.en.md)
+- Polish fresh-user walkthrough → [`install-fresh-user.pl.md`](install-fresh-user.pl.md)
+- English full install → [`install.en.md`](install.en.md)
+- Polish full install → [`install.pl.md`](install.pl.md)
+- Install from a fresh shell (no shortcuts) → [`install-from-scratch.md`](install-from-scratch.md)
+
+## Clean install (factory-reset existing setup)
+
+→ [`CLEAN-INSTALL.md`](CLEAN-INSTALL.md)
+
+## Full guided install with all options explained
+
+→ [`FULL_INSTALL_GUIDE.md`](FULL_INSTALL_GUIDE.md)
+
+## After install
+
+- 5-minute daily-use runbook → [`OPERATOR-5MIN-RUNBOOK.md`](OPERATOR-5MIN-RUNBOOK.md)
+- Full operations manual → [`OPERATIONS-MANUAL.md`](OPERATIONS-MANUAL.md)
+- ONBOARDING (repo-root quick pointer) → [`/ONBOARDING.md`](../../ONBOARDING.md)

--- a/docs/operator/RUNBOOK.md
+++ b/docs/operator/RUNBOOK.md
@@ -1,0 +1,45 @@
+# Runbook
+
+This file is a thin pointer to the actual runbook docs. Memphis has runbooks split by use case — pick the one that matches what you're doing.
+
+## Daily use (5-minute runbook)
+
+For the operator running Memphis day-to-day on their workstation:
+
+→ **[`OPERATOR-5MIN-RUNBOOK.md`](OPERATOR-5MIN-RUNBOOK.md)**
+
+Covers: starting the daemon, sending a Telegram message, checking doctor, opening the TUI, looking at the journal, restarting the runtime.
+
+## Full operations manual
+
+For backup/restore, systemd, monitoring, troubleshooting, performance tuning, upgrade procedures, and the daily operational checklist:
+
+→ **[`OPERATIONS-MANUAL.md`](OPERATIONS-MANUAL.md)**
+
+## Tier-3 escalation (destructive ops gating)
+
+For operator-passphrase-protected destructive operations:
+
+→ [`tier3-runbook.md`](tier3-runbook.md)
+
+## Other dedicated runbooks
+
+| Topic | File |
+|---|---|
+| Ollama bridge | [`OLLAMA-BRIDGE-RUNBOOK.md`](OLLAMA-BRIDGE-RUNBOOK.md) |
+| Vault rotation + recovery | [`example-installation/04-vault-setup.md`](example-installation/04-vault-setup.md) |
+| Demo readiness (Zawoja postmortem) | `memphis demo arm` / `memphis demo rehearse` / `memphis demo plan-b record` (CLI-driven, no separate runbook) |
+| Deployment checklist | [`DEPLOYMENT-CHECKLIST.md`](DEPLOYMENT-CHECKLIST.md) |
+| DB backup baseline | [`DB-BACKUP-BASELINE.md`](DB-BACKUP-BASELINE.md) |
+| Force-flag bypass contracts | [`FORCE-FLAGS.md`](FORCE-FLAGS.md) |
+
+## Diagnostic commands
+
+```bash
+memphis doctor                    # tier-1..6 + tier-A health summary
+memphis health                    # short runtime probe
+memphis service status            # systemd user service state
+memphis tier status               # active operator-passphrase sessions
+memphis demo status               # demo-arm state (per Zawoja runbook)
+memphis audit search --limit 20   # recent security audit events
+```


### PR DESCRIPTION
## Summary

Closure sprint Z.5.2. Three thin pointer docs that resolve the canonical-entry confusion (6 install variants + 3 runbook variants without a single front door):

1. \`/ONBOARDING.md\` — repo-root 5-minute pointer
2. \`docs/operator/INSTALL.md\` — install-doc map
3. \`docs/operator/RUNBOOK.md\` — runbook-doc map

Plus README.md "Install in 8 minutes" now opens with a one-line pointer to ONBOARDING.md.

## Test plan

- [x] All 28 internal markdown link refs verified to resolve
- [x] No content duplication — these are thin pointers, not rewrites
- [x] README change is additive (no removed sections)

## Cross-layer grid

| Rust | NAPI | TS host | CLI | Tauri | doctor | tests | docs |
|---|---|---|---|---|---|---|---|
| – | – | – | – | – | – | – | ✅ 3 NEW + README pointer |

🤖 Generated with [Claude Code](https://claude.com/claude-code)