### PR TITLE
fix(doctor): whitelist ~/.memphis/docs/ as known dir

### DIFF
--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -112,6 +112,8 @@ const MEMPHIS_DATA_DIR_KNOWN_ENTRIES = new Set([
   'discoveries', // agent-generated analysis docs (autopilot sessions write here)
   'kartograf', // Kartograf training corpus (Y2 roadmap, src/infra/cli/handlers/kartograf.handler.ts)
   'scripts', // operator helper scripts (deep-dive.sh, docs-sync.sh, code-evolution.sh)
+  'docs', // operator/agent-generated briefs (T1-T5 koder briefs, daily ops notes) — parallel to scripts/ but for human-readable docs rather than executable helpers
+
   // Closure sprint Z.2.2 (2026-05-09): runtime files that were
   // previously flagged as orphans on every doctor run, despite being
   // load-bearing (memphis.db = SQLite, memphis.pid = process lock from


### PR DESCRIPTION
## Summary
- One-line allowlist: `'docs'` added to `MEMPHIS_DATA_DIR_KNOWN_ENTRIES` (`src/infra/cli/utils/doctor-v2.ts`), mirroring the `'scripts'` precedent
- Prevents `memphis doctor` false-positive "1 orphan(s): docs" warn
- Protects operator-curated briefs (e.g. `~/.memphis/docs/koder-brief-2026-05-10.md`) from `doctor --fix` deletion

## Why
2026-05-11 doctor run flagged `~/.memphis/docs/` as orphan. The dir holds operator + agent-generated Markdown briefs (T1-T5 koder briefs, daily ops notes). Architecture map 2026-05-11 documents it explicitly as "operator-generated docs". Without this fix, running `memphis doctor --fix` would `rm -rf` the human-curated file — violating `feedback_keep_future_dev_surface` rule ("only delete what's NECESSARY; preserve real stubs / WIP scaffolds").

## Test plan
- [x] Manual: `ls ~/.memphis/docs/` shows brief intact
- [ ] After merge + rebuild: `memphis doctor` should drop "1 orphan(s)" warn line
- [ ] Existing `isKnownDataDirEntry` tests still pass (data-driven, no new test needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)