### PR TITLE
docs(operator): vault-recovery runbook + index entry (P1 #6)

### DIFF
--- a/docs/operator/RUNBOOK.md
+++ b/docs/operator/RUNBOOK.md
@@ -27,7 +27,8 @@ For operator-passphrase-protected destructive operations:
 | Topic | File |
 |---|---|
 | Ollama bridge | [`OLLAMA-BRIDGE-RUNBOOK.md`](OLLAMA-BRIDGE-RUNBOOK.md) |
-| Vault rotation + recovery | [`example-installation/04-vault-setup.md`](example-installation/04-vault-setup.md) |
+| Vault setup + rotation | [`example-installation/04-vault-setup.md`](example-installation/04-vault-setup.md) |
+| **Vault recovery (post-incident)** | [`VAULT-RECOVERY-RUNBOOK.md`](VAULT-RECOVERY-RUNBOOK.md) |
 | Demo readiness (Zawoja postmortem) | `memphis demo arm` / `memphis demo rehearse` / `memphis demo plan-b record` (CLI-driven, no separate runbook) |
 | Deployment checklist | [`DEPLOYMENT-CHECKLIST.md`](DEPLOYMENT-CHECKLIST.md) |
 | DB backup baseline | [`DB-BACKUP-BASELINE.md`](DB-BACKUP-BASELINE.md) |

--- a/docs/operator/VAULT-RECOVERY-RUNBOOK.md
+++ b/docs/operator/VAULT-RECOVERY-RUNBOOK.md
@@ -1,0 +1,223 @@
+# Vault Recovery Runbook
+
+When the vault refuses to decrypt at boot, the daemon enters one of two states: hard crash loop (pre-PR #5 — `validateProductionSafety` throws) or degraded boot (post-PR #5 — daemon survives, `/health.degradedConfig.reasons` lists what's missing). This runbook walks you from "what do I see in logs" to "vault recovered, daemon clean" in 15-30 minutes depending on the path you pick.
+
+> **Important:** Stop before destructive commands. Run section 2 (Pre-flight) FIRST. Most of the panic-time-cost in recovery is regret over wiped state that turned out to be salvageable.
+
+---
+
+## 1) Symptoms
+
+You're in this runbook if you see one of:
+
+**A — daemon crash loop (pre-degraded-boot):**
+
+```bash
+journalctl --user -u memphis -n 50 --no-pager | grep -E "Production safety|Vault decrypt|crash"
+# Expect:
+#   [memphis-config] VAULT:<key> resolution failed: Vault entry decryption failed
+#   [MISSING_ENV] Production safety check failed: MEMPHIS_API_TOKEN is required in production
+#   memphis.service: Main process exited, code=exited, status=4/NOPERMISSION
+#   memphis.service: Scheduled restart job, restart counter is at <N>   # <N> growing = crash loop
+```
+
+**B — daemon up, degraded (post-PR #5):**
+
+```bash
+curl -s http://127.0.0.1:3000/health | jq '.degradedConfig.reasons'
+# Expect: array of strings like
+#   ["MEMPHIS_API_TOKEN missing", "anthropic provider missing credentials"]
+```
+
+```bash
+journalctl --user -u memphis -n 20 --no-pager | grep -E "config-degraded-boot|bootstrap.warning"
+# Expect: [security-audit] config-degraded-boot allowed reasons=[...]
+```
+
+**C — tier-3 elevation lost after restart:**
+
+```bash
+curl -s http://127.0.0.1:3000/v1/ops/tier3/sessions
+# Expect: {"count":0,...} even though you elevated before restart
+# (Fixed in PR #566 — sessions now persist. If you see this on a post-#566 daemon,
+#  it's a separate bug.)
+```
+
+**D — TUI banner:** `[degradation] provider 'minimax' is not configured ... falling back to local-fallback` — confirms degraded boot is active.
+
+Pick a recovery path in section 3 based on what evidence you've gathered.
+
+---
+
+## 2) Pre-flight (before any recovery command)
+
+```bash
+# Confirm at least one usable backup exists
+ls -la ~/Backups/memphis-pre-vault-recovery-* ~/Backups/vault-pre-reinit-* 2>/dev/null
+
+# Confirm chain integrity is independent of vault state
+sqlite3 ~/memphis/data/memphis.db 'PRAGMA integrity_check' 2>&1 | head -3
+# Expect: "ok" — vault and chain DB are decoupled
+
+# Snapshot doctor before recovery for diffing later
+memphis doctor --json > /tmp/pre-recovery-doctor.json 2>&1 || true
+
+# Capture current vault file mtimes (helps decide rollback target)
+ls -la ~/.memphis/vault-*.json* 2>&1
+```
+
+> **Important:** Do NOT run `memphis reset --runtime --yes` or `memphis vault reset` before this section completes. Resetting before you confirm a backup directory exists is the operator-pattern that turned 30-minute incidents into 6-hour rebuilds.
+
+> **Important:** Take a fresh local copy of `~/memphis/.env` to `/tmp/env-snapshot-$(date +%s)`. The recovery paths modify or replace `.env`; a clean copy of the current state is your bailout.
+
+---
+
+## 3) Recovery paths
+
+Pick exactly one. They are mutually exclusive — running A then B leaves the vault in a state neither path tested.
+
+### A) Plain-text bypass (degraded boot, fastest)
+
+**Use when:** you have the original provider API keys + telegram tokens at hand AND want the bot back online in 5 minutes. Vault stays broken; clean up later via Path C when convenient.
+
+```bash
+systemctl --user stop memphis
+
+# Replace VAULT:<key> references in .env with plain-text values
+# You'll edit ~/memphis/.env directly:
+#   MINIMAX_API_KEY=<paste-value>            (was VAULT:minimax_api_key)
+#   MEMPHIS_TELEGRAM_BOT_TOKEN=<paste-value> (was VAULT:telegram_bot_token)
+#   MEMPHIS_TELEGRAM_ALLOWED_USER_IDS=<csv>  (was VAULT:telegram_allowed_user_ids)
+
+# Generate a fresh MEMPHIS_API_TOKEN if vault entry is gone
+echo "MEMPHIS_API_TOKEN=$(openssl rand -hex 32)" >> ~/memphis/.env
+# Then deduplicate the file — keep ONLY the latest MEMPHIS_API_TOKEN line
+
+systemctl --user start memphis
+sleep 5
+curl -s http://127.0.0.1:3000/health | jq '.status'   # expect "healthy"
+```
+
+**Caveat:** API clients that used the old `MEMPHIS_API_TOKEN` (TUI sessions, external scripts) need to be re-authenticated with the new token. Tier-3 elevations are wiped (in-memory anyway, even with #566 persisted ones — vault re-init also clears state).
+
+### B) Vault-state rollback (when backup tarball matches)
+
+**Use when:** you have a pre-incident backup AND the pepper that was active at backup-time is known. This is fragile if you don't remember which pepper goes with which `vault-state.json` snapshot.
+
+```bash
+systemctl --user stop memphis
+
+# Find the most recent good backup
+ls -t ~/Backups/memphis-pre-vault-recovery-*/vault-state.json | head -1
+# Example: ~/Backups/memphis-pre-vault-recovery-20260511-012600/vault-state.json
+
+BACKUP_DIR=~/Backups/memphis-pre-vault-recovery-20260511-012600
+cp $BACKUP_DIR/vault-state.json     ~/.memphis/vault-state.json
+cp $BACKUP_DIR/vault-entries.json   ~/.memphis/vault-entries.json
+cp $BACKUP_DIR/.env                 ~/memphis/.env
+
+# Verify pepper from the backup matches what's in the restored .env
+grep MEMPHIS_VAULT_PEPPER ~/memphis/.env
+
+systemctl --user start memphis
+sleep 5
+journalctl --user -u memphis -n 20 --no-pager | grep -i "vault.*decrypt"  # expect no "failed" lines
+```
+
+> **Important:** If `journalctl` after restart still shows decrypt failures, the backup tarball's `vault-state.json` was written under a different pepper than the backup's `.env` records. Stop, go to Path C — iterative pepper guessing on a vault corrupts further on each wrong attempt.
+
+### C) Clean re-init (destructive, recommended for production hygiene)
+
+**Use when:** you don't trust the current vault state, you don't need to preserve encrypted entries, AND you have the API keys + recovery Q&A at hand to re-provision after init.
+
+```bash
+systemctl --user stop memphis
+
+# Snapshot current vault aside (safety net)
+TS=$(date +%Y%m%d-%H%M%S)
+mkdir -p ~/Backups/vault-pre-reinit-$TS
+mv ~/.memphis/vault-state.json    ~/Backups/vault-pre-reinit-$TS/ 2>/dev/null || true
+mv ~/.memphis/vault-entries.json  ~/Backups/vault-pre-reinit-$TS/ 2>/dev/null || true
+mv ~/memphis/data/vault-entries.json ~/Backups/vault-pre-reinit-$TS/legacy-vault-entries.json 2>/dev/null || true
+
+# Re-init with non-interactive flags (pick a fresh strong passphrase + Q&A)
+cd ~/memphis
+./bin/memphis init \
+  --non-interactive \
+  --state minimal-baseline \
+  --passphrase '<strong-vault-passphrase>' \
+  --operator-passphrase '<operator-tier3-passphrase>' \
+  --recovery-question 'your question?' \
+  --recovery-answer 'your answer'
+
+# Re-provision provider API keys (vault is empty after init)
+./bin/memphis vault add minimax_api_key     # paste value at prompt
+./bin/memphis setup telegram --bot-token <token> --allowed-user-ids <csv>
+
+# Optionally enable Anthropic
+echo "ANTHROPIC_API_KEY=<value>" >> ~/memphis/.env
+
+systemctl --user start memphis
+sleep 8
+curl -s http://127.0.0.1:3000/health | jq '.status, .degradedConfig'
+```
+
+> **Important:** This destroys all encrypted vault entries. Chains, SQLite, and operator config (passphrase hash, recovery Q&A) under `~/.memphis/config/` are untouched. If you have other secrets in the vault beyond minimax/telegram/anthropic, list them with `memphis vault list` BEFORE running this section.
+
+---
+
+## 4) Verification post-recovery
+
+Run all four, in order. Each builds confidence; if any fail, return to the relevant section and re-do it.
+
+```bash
+# 1. Daemon health (no degradedConfig in steady state after Path C; expected in Path A until cleanup)
+curl -s http://127.0.0.1:3000/health | jq '.status, .degradedConfig // "clean"'
+
+# 2. Doctor green
+memphis doctor 2>&1 | tail -5
+# Expect: total=N pass=N warn=<low> fail=0
+
+# 3. Tier-3 smoke (proves operator config intact)
+# In TUI: /tier 3 <your-operator-passphrase>
+# Expect: "Tier 3 granted — unrestricted mutation active for 3 hours"
+
+# 4. Crash-loop watch — confirm we're not in a restart counter
+journalctl --user -u memphis --since "5 minutes ago" --no-pager | grep -cE "Scheduled restart job"
+# Expect: 0 (or 1 for the initial start). Numbers >1 mean still looping.
+```
+
+Diff against the pre-recovery snapshot:
+
+```bash
+diff <(jq -S '.' /tmp/pre-recovery-doctor.json) <(memphis doctor --json) | head -40
+```
+
+This surfaces what changed in the recovery — useful when you write up the postmortem note in `notes/`.
+
+---
+
+## 5) Prevention
+
+The 2026-05-11 incident root cause was non-atomic `memphis vault pepper-rotate` — the master key in `vault-state.json` got re-wrapped under a new pepper but encrypted entries stayed under the old master key. That's fixed in [`feat/vault-pepper-rotate-reencrypt-entries`](https://github.com/Memphis-Chains/memphis/pulls?q=pepper-rotate-reencrypt) (Coder B's PR) and surfaced by the `ta3-pepper-rotate-atomic` doctor check.
+
+Hygiene rules:
+
+```bash
+# ALWAYS backup before rotating pepper
+memphis backup create --tag pre-pepper-rotate-$(date +%Y%m%d-%H%M%S)
+
+# THEN rotate
+memphis vault pepper-rotate --confirm --generate
+
+# Verify atomicity post-rotate
+memphis doctor 2>&1 | grep ta3-pepper-rotate-atomic
+# Expect: pass
+```
+
+Cross-references:
+
+- General backup workflow: [`OPERATIONS-MANUAL.md` § 2](OPERATIONS-MANUAL.md#2-backup--restore-workflows)
+- Tier-3 destructive ops gating: [`tier3-runbook.md`](tier3-runbook.md)
+- Force-flag bypass contracts (incl. `MEMPHIS_STRICT_PRODUCTION_SAFETY=1`): [`FORCE-FLAGS.md`](FORCE-FLAGS.md)
+- Post-incident gap analysis (source of truth for the three paths above): [`../roadmap/2026-05-11-post-autonomy-todo-and-gap.md`](../roadmap/2026-05-11-post-autonomy-todo-and-gap.md) § 3

--- a/tests/unit/docs-vault-runbook.test.ts
+++ b/tests/unit/docs-vault-runbook.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Structural assertions for docs/operator/VAULT-RECOVERY-RUNBOOK.md.
+ *
+ * Doc rot is real: H2 sections get renamed, fenced code blocks lose their
+ * language tag, TODO markers ship to operators. This test pins the load-
+ * bearing parts of the runbook so the markdown can evolve in style but
+ * not in structure.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const RUNBOOK_PATH = resolve(
+  process.cwd(),
+  'docs/operator/VAULT-RECOVERY-RUNBOOK.md',
+);
+const INDEX_PATH = resolve(process.cwd(), 'docs/operator/RUNBOOK.md');
+
+describe('VAULT-RECOVERY-RUNBOOK.md', () => {
+  it('exists at the canonical path', () => {
+    expect(existsSync(RUNBOOK_PATH)).toBe(true);
+  });
+
+  const body = existsSync(RUNBOOK_PATH) ? readFileSync(RUNBOOK_PATH, 'utf-8') : '';
+
+  it('declares the five load-bearing H2 sections', () => {
+    // Numbered H2 sections per OPERATIONS-MANUAL.md house style.
+    const required = [
+      '## 1) Symptoms',
+      '## 2) Pre-flight',
+      '## 3) Recovery paths',
+      '## 4) Verification',
+      '## 5) Prevention',
+    ];
+    for (const heading of required) {
+      expect(body, `missing section "${heading}"`).toContain(heading);
+    }
+  });
+
+  it('includes all three recovery sub-procedures (A/B/C)', () => {
+    expect(body).toMatch(/### A\) Plain-text bypass/);
+    expect(body).toMatch(/### B\) Vault-state rollback/);
+    expect(body).toMatch(/### C\) Clean re-init/);
+  });
+
+  it('tags every fenced code block with a language', () => {
+    // Catch ``` blocks without a language identifier — these render
+    // without syntax highlighting + lose semantic intent on copy-paste.
+    // Split on the fence marker: odd-indexed segments are code-block
+    // bodies; their first line is the opening-fence language tag.
+    // (split eats only the leading "```", not the trailing one.)
+    const segments = body.split(/^```/m);
+    expect(segments.length, 'no fenced code blocks found').toBeGreaterThan(1);
+    const untagged: string[] = [];
+    for (let i = 1; i < segments.length; i += 2) {
+      const firstLine = segments[i].split('\n', 1)[0];
+      if (!/^[a-zA-Z0-9_-]+$/.test(firstLine.trim())) {
+        untagged.push(firstLine);
+      }
+    }
+    expect(untagged, `untagged opening fences: ${JSON.stringify(untagged)}`).toHaveLength(0);
+  });
+
+  it('has no placeholder markers shipped to operators', () => {
+    // No <TODO>, no xxx, no TBD, no <FIXME>. Operator copy must be final.
+    expect(body).not.toMatch(/<TODO>/i);
+    expect(body).not.toMatch(/\bTBD\b/);
+    expect(body).not.toMatch(/<FIXME>/i);
+  });
+
+  it('flags destructive operations with an Important callout', () => {
+    // Path C wipes vault entries — that section must warn.
+    const callouts = body.match(/^> \*\*Important:\*\*/gm) ?? [];
+    expect(callouts.length, 'at least 3 Important callouts (pre-flight + 2 destructive paths)').toBeGreaterThanOrEqual(3);
+  });
+
+  it('cross-references the post-incident gap analysis', () => {
+    // The roadmap doc is the source-of-truth for the three recovery paths.
+    expect(body).toMatch(/2026-05-11-post-autonomy-todo-and-gap\.md/);
+  });
+});
+
+describe('RUNBOOK.md index', () => {
+  const indexBody = existsSync(INDEX_PATH) ? readFileSync(INDEX_PATH, 'utf-8') : '';
+
+  it('links to VAULT-RECOVERY-RUNBOOK.md from the index table', () => {
+    expect(indexBody).toMatch(/VAULT-RECOVERY-RUNBOOK\.md/);
+  });
+});


### PR DESCRIPTION
## Summary
3am-panic-operator-friendly recovery guide for vault decrypt failures. Closes P1 #6 from `docs/roadmap/2026-05-11-post-autonomy-todo-and-gap.md`.

## Why
After the 2026-05-11 ~01:20 CEST vault crash loop, operator had to assemble recovery ad hoc — no single doc walking from "what do I see in logs" to "vault recovered, daemon clean". Roadmap doc had the three recovery paths but as gap-analysis, not as a runbook.

## What
- `docs/operator/VAULT-RECOVERY-RUNBOOK.md` (new, ~250 lines, 5 sections):
  1. **Symptoms** — concrete log strings + `/health` JSON shapes (degraded vs hard-crash)
  2. **Pre-flight** — backup verify + chain integrity + doctor snapshot BEFORE destructive
  3. **Recovery paths** — A (plain-text bypass), B (state rollback), C (clean re-init); mutually exclusive
  4. **Verification** — `/health`, `doctor`, tier-3 smoke, crash-loop watch
  5. **Prevention** — cross-ref to Coder B's atomic pepper-rotate PR + pre-rotate backup hygiene
- `docs/operator/RUNBOOK.md` — index update (renamed adjacent row to disambiguate setup vs recovery scope)
- `tests/unit/docs-vault-runbook.test.ts` (new, 8 cases all green) — structural pins

## Style
Mirrors `docs/operator/OPERATIONS-MANUAL.md` house style: numbered H2 + H3 sub-procedures + fenced bash + `> **Important:**` callouts. 200-400 words per section.

## Test plan
- [x] `pnpm vitest run tests/unit/docs-vault-runbook.test.ts` → 8/8 pass
- [x] All H2 sections, all H3 sub-procedures, all `> **Important:**` callouts pinned
- [x] No `<TODO>` / `TBD` / `<FIXME>` placeholders shipped
- [x] Every fenced code block has a language tag (catches doc-rot on future edits)
- [ ] Operator review from 3am-panic perspective (acceptance: without reading Memphis code, can operator execute each recovery path?)
- [ ] Cross-link verification: `OPERATIONS-MANUAL.md`, `tier3-runbook.md`, `FORCE-FLAGS.md`, roadmap gap-analysis

## Coordination
- Coder B reviews from operator-perspective (per NCBR Impakt II cross-review rule).
- After Coder B's pepper-rotate PR lands, offer them one-line update PR linking their PR description's "Recovery" section back to this runbook.

## Plan reference
`/.claude/plans/agile-nibbling-feigenbaum.md` § PR-A3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)