### PR TITLE
fix(config): degraded boot instead of crash on missing vault secrets (P1 #5)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -33,7 +33,7 @@ import { providerToLlmClient } from '../gateway/provider-adapter.js';
 import { createInProcessToolExecutor } from '../gateway/tool-executor.js';
 import { checkOllama, checkRustToolchain } from '../infra/cli/utils/dependencies.js';
 import { resolveDotEnvPath } from '../infra/config/dotenv-file.js';
-import { loadConfig } from '../infra/config/env.js';
+import { loadConfigDetailed } from '../infra/config/env.js';
 import type { AppConfig } from '../infra/config/schema.js';
 import { createHttpServer } from '../infra/http/server.js';
 import { startAlertSuppressionFlushLoop } from '../infra/logging/alert-runtime.js';
@@ -183,7 +183,37 @@ export async function bootstrap(): Promise<void> {
     throw new AppError('CONFIG_ERROR', rust.detail, 500, rust.meta, rust.fix);
   }
 
-  const config = loadConfig();
+  const { config, degradedReasons: configDegradedReasons } = loadConfigDetailed();
+  // Surface production-safety degraded-boot reasons via the existing
+  // bootstrap-warning channel + audit log. operator sees them in
+  // doctor output + /health.degradedConfig.reasons. The reasons array
+  // is also threaded into the HTTP server context so /health can
+  // re-emit it on every probe (boot-time-only audit is once; live
+  // /health needs to mirror it for ops dashboards).
+  if (configDegradedReasons.length > 0) {
+    for (const reason of configDegradedReasons) {
+      addBootstrapWarning({
+        component: 'config',
+        message: 'production-safety degraded boot',
+        detail: reason,
+      });
+    }
+    try {
+      const { writeSecurityAudit } = await import('../infra/logging/security-audit.js');
+      writeSecurityAudit(
+        {
+          action: 'config-degraded-boot',
+          status: 'allowed',
+          details: { reasons: configDegradedReasons },
+        },
+        process.env,
+      );
+    } catch {
+      // audit-log write must never block daemon boot. The reasons are
+      // already in bootstrap warnings + /health, so a silent audit
+      // failure here is acceptable.
+    }
+  }
   startAlertSuppressionFlushLoop(process.env);
 
   // Phase 3.2 production sprint: auto-migrate chain schema if operator
@@ -423,6 +453,7 @@ export async function bootstrap(): Promise<void> {
     operatorChatSessionRepository: container.operatorChatSessionRepository,
     conversationContextService: container.conversationContextService,
     workPollingService: container.workPollingService,
+    degradedReasons: configDegradedReasons,
   });
 
   try {

--- a/src/infra/config/env.ts
+++ b/src/infra/config/env.ts
@@ -335,7 +335,18 @@ export function loadConfig(rawEnv: NodeJS.ProcessEnv = process.env): AppConfig {
   const normalized = resolveDefaultProvider(parsed.data);
   const profiled = applyConfigProfile(normalized);
   try {
-    validateProductionSafety(profiled);
+    // validateProductionSafety no longer throws in default (non-strict)
+    // mode — it returns collected degradedReasons so the caller can
+    // surface them via /health + bootstrap warnings. Strict mode
+    // (MEMPHIS_STRICT_PRODUCTION_SAFETY=1) restores the throw; that's
+    // the only path that hits this catch block.
+    const { degradedReasons } = validateProductionSafety(profiled);
+    // Stash the reasons on the returned config so loadConfigDetailed
+    // can surface them without re-running validation. The double-
+    // underscore prefix marks this as a runtime-only field; Zod parse
+    // ignored unknown keys, so this doesn't collide with schema-defined
+    // properties.
+    (profiled as AppConfig & { __degradedReasons?: string[] }).__degradedReasons = degradedReasons;
   } catch (error) {
     throw errorTemplates.missingEnv({
       message: error instanceof Error ? error.message : String(error),
@@ -343,4 +354,22 @@ export function loadConfig(rawEnv: NodeJS.ProcessEnv = process.env): AppConfig {
     });
   }
   return profiled;
+}
+
+/**
+ * Like `loadConfig()` but also returns the production-safety degraded
+ * reasons collected during boot, so the bootstrap path can plumb them
+ * into the bootstrap-warning channel + the HTTP /health endpoint.
+ *
+ * Use this from the bootstrap entry point. Plain `loadConfig()` is the
+ * back-compat shim for the ~40 in-tree consumers that don't need the
+ * extra signal (CLI commands, tests, MCP tool harness).
+ */
+export function loadConfigDetailed(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): { config: AppConfig; degradedReasons: string[] } {
+  const config = loadConfig(rawEnv);
+  const degradedReasons = (config as AppConfig & { __degradedReasons?: string[] })
+    .__degradedReasons ?? [];
+  return { config, degradedReasons };
 }

--- a/src/infra/config/profiles.ts
+++ b/src/infra/config/profiles.ts
@@ -65,11 +65,38 @@ function describeRequirement(requirement: KeyRequirement): string {
   return typeof requirement === 'string' ? requirement : requirement.join(' or ');
 }
 
-export function validateProductionSafety(config: AppConfig): void {
-  if (config.NODE_ENV !== 'production') return;
+/**
+ * Result of the production-safety probe.
+ *
+ * BEFORE 2026-05-11: this function returned void and threw on any
+ * missing-secret condition, killing the daemon process before HTTP
+ * came up. Operator hit it as a 63-restart crash loop after a
+ * pepper-rotate left the vault unreadable — the daemon couldn't
+ * boot in degraded mode, couldn't surface the cause on /health,
+ * and operator had no recovery path that didn't involve manual
+ * .env surgery.
+ *
+ * AFTER 2026-05-11 (this PR): we collect the missing-secret reasons,
+ * warn on each, and return them so the bootstrap path can surface
+ * them via /health.degradedConfig and the bootstrap-warning channel.
+ * Operator-facing copy + recovery is documented in
+ * docs/operator/VAULT-RECOVERY-RUNBOOK.md.
+ *
+ * Escape hatch: set `MEMPHIS_STRICT_PRODUCTION_SAFETY=1` to restore
+ * the original hard-throw behavior at the end of this function. The
+ * pepper-not-set boundary (security gate) is enforced upstream in
+ * env.ts:resolveVaultSecrets() regardless of this flag.
+ */
+export interface ProductionSafetyResult {
+  degradedReasons: string[];
+}
+
+export function validateProductionSafety(config: AppConfig): ProductionSafetyResult {
+  const degradedReasons: string[] = [];
+  if (config.NODE_ENV !== 'production') return { degradedReasons };
 
   if (!process.env.MEMPHIS_API_TOKEN) {
-    throw new Error('Production safety check failed: MEMPHIS_API_TOKEN is required in production');
+    degradedReasons.push('MEMPHIS_API_TOKEN missing — HTTP auth gates disabled');
   }
 
   const providerRequirements: ReadonlyArray<{
@@ -87,6 +114,16 @@ export function validateProductionSafety(config: AppConfig): void {
     { provider: 'minimax', keys: [['MINIMAX_API_KEY', 'MINIMAX_VAULT_KEY']] },
     { provider: 'deepseek', keys: [['DEEPSEEK_API_KEY', 'DEEPSEEK_VAULT_KEY']] },
     { provider: 'glm', keys: [['GLM_API_KEY', 'GLM_VAULT_KEY']] },
+    // Memphis production deployment 2026-05-11+ runs on Anthropic
+    // (OAuth-flow or API key). Without this entry the daemon currently
+    // crashes on FIRST TURN when the adapter tries to use auth instead
+    // of fail-fast/degrade at boot. The OAuth client id is an alternative
+    // path that bypasses raw API key — operator authorizes via browser
+    // flow handled by src/providers/anthropic/oauth-flow.ts.
+    {
+      provider: 'anthropic',
+      keys: [['ANTHROPIC_API_KEY', 'ANTHROPIC_VAULT_KEY', 'ANTHROPIC_OAUTH_CLIENT_ID']],
+    },
   ] as const;
 
   for (const requirement of providerRequirements) {
@@ -96,13 +133,29 @@ export function validateProductionSafety(config: AppConfig): void {
 
     const missing = requirement.keys.filter((key) => !isRequirementSatisfied(config, key));
     if (missing.length === 0) {
-      return;
+      break;
     }
 
-    throw new Error(
-      `Production safety check failed: ${requirement.provider} requires ${missing
+    degradedReasons.push(
+      `${requirement.provider} provider missing credentials: ${missing
         .map(describeRequirement)
         .join(' and ')}`,
     );
+    break;
   }
+
+  for (const reason of degradedReasons) {
+    console.warn(`[memphis-config] degraded: ${reason}`);
+  }
+
+  if (process.env.MEMPHIS_STRICT_PRODUCTION_SAFETY === '1' && degradedReasons.length > 0) {
+    // Opt-in escape hatch for CI / paranoid prod deployments that
+    // preferred the pre-2026-05-11 hard-throw behavior. Operator-
+    // confirmed: default is degraded-by-default, strict mode is opt-in.
+    throw new Error(
+      `Production safety check failed (strict mode): ${degradedReasons.join('; ')}`,
+    );
+  }
+
+  return { degradedReasons };
 }

--- a/src/infra/http/health.ts
+++ b/src/infra/http/health.ts
@@ -166,6 +166,19 @@ export type HealthPayload = {
     activeSessions: number;
     expiringWithinMinutes: number;
   };
+  /**
+   * Production-safety degraded-boot reasons. Empty/absent when the
+   * daemon booted with all production secrets resolved; populated when
+   * MEMPHIS_API_TOKEN / provider credentials were missing and the
+   * daemon chose graceful degradation over crash-loop (default behavior
+   * post-PR `fix/config-degraded-boot-on-missing-vault`, opt-out via
+   * `MEMPHIS_STRICT_PRODUCTION_SAFETY=1`). Each reason is operator-
+   * facing copy — same text as bootstrap warnings + audit log.
+   * Operator recovery guide: `docs/operator/VAULT-RECOVERY-RUNBOOK.md`.
+   */
+  degradedConfig?: {
+    reasons: string[];
+  };
 };
 
 function runtimeIsOperational(runtime: RuntimeHealthSnapshot): boolean {
@@ -313,7 +326,16 @@ async function checkEmbeddingProvider(rawEnv: NodeJS.ProcessEnv): Promise<CheckR
 export async function buildHealthPayload(
   config: AppConfig,
   rawEnv: NodeJS.ProcessEnv = process.env,
-  options?: { workPolling?: WorkPollingSnapshot | null },
+  options?: {
+    workPolling?: WorkPollingSnapshot | null;
+    /**
+     * Production-safety degraded-boot reasons captured at boot time
+     * by `loadConfigDetailed()`. Mirror to /health so operators +
+     * monitoring dashboards see "this daemon is up but degraded"
+     * without re-reading logs.
+     */
+    degradedReasons?: string[];
+  },
 ): Promise<HealthPayload> {
   const runtime = await buildRuntimeHealthSnapshot(config, rawEnv);
   const checks = {
@@ -386,6 +408,10 @@ export async function buildHealthPayload(
     },
     tier3: readTier3Snapshot(rawEnv),
     demo: readDemoReadinessSnapshot(rawEnv),
+    degradedConfig:
+      options?.degradedReasons && options.degradedReasons.length > 0
+        ? { reasons: options.degradedReasons }
+        : undefined,
   };
 }
 

--- a/src/infra/http/server.ts
+++ b/src/infra/http/server.ts
@@ -154,8 +154,16 @@ export function createHttpServer(
     seenProposalRepository?: SeenProposalRepository;
     webhookEventRepository?: SqliteWebhookEventRepository;
     agentPeerRepository?: SqliteAgentPeerRepository;
+    /**
+     * Production-safety degraded-boot reasons captured at boot time
+     * by `loadConfigDetailed()`. Surfaced via /health.degradedConfig
+     * so operators + monitoring see "this daemon is up but degraded"
+     * without re-reading logs. Empty/absent on clean boot.
+     */
+    degradedReasons?: string[];
   },
 ) {
+  const degradedReasons = repos?.degradedReasons ?? [];
   const logger = createLogger(config.LOG_LEVEL, config.LOG_FORMAT);
 
   const app = Fastify({
@@ -386,6 +394,7 @@ export function createHttpServer(
   app.get('/health', async (_request, reply) => {
     const payload = await buildHealthPayload(config, process.env, {
       workPolling: repos?.workPollingService?.snapshot() ?? null,
+      degradedReasons,
     });
     const code = payload.status === 'healthy' ? 200 : 503;
     return reply.status(code).send(payload);

--- a/tests/unit/config-production-safety.test.ts
+++ b/tests/unit/config-production-safety.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Production safety — degraded-boot path tests.
+ *
+ * The legacy hard-throw behavior is regression-covered in
+ * tests/unit/config-profiles.test.ts under the strict-mode flag.
+ * This file exercises the new default (degraded-by-default) added
+ * in `fix/config-degraded-boot-on-missing-vault` so the daemon
+ * boots with collected `degradedReasons` instead of crashing the
+ * systemd restart loop when a production secret is missing.
+ *
+ * Plumbing:
+ *   validateProductionSafety(config) returns { degradedReasons }
+ *   loadConfigDetailed() exposes that on the AppConfig consumer side
+ *   /health.degradedConfig.reasons mirrors it for monitoring
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  validateProductionSafety,
+  applyConfigProfile,
+} from '../../src/infra/config/profiles.js';
+import type { AppConfig } from '../../src/infra/config/schema.js';
+
+function base(): AppConfig {
+  // Mirror the shape used by tests/unit/config-profiles.test.ts.
+  return {
+    NODE_ENV: 'production',
+    LOG_LEVEL: 'info',
+    LOG_FORMAT: 'json',
+    HOST: '127.0.0.1',
+    PORT: 3000,
+    DATABASE_URL: 'file:./test.db',
+    DEFAULT_PROVIDER: 'local-fallback',
+    GEN_TIMEOUT_MS: 20_000,
+    GEN_MAX_TOKENS: 1024,
+  } as unknown as AppConfig;
+}
+
+describe('validateProductionSafety — degraded-boot path (default)', () => {
+  const cleanedEnv: string[] = [];
+
+  beforeEach(() => {
+    cleanedEnv.length = 0;
+  });
+
+  afterEach(() => {
+    for (const key of cleanedEnv) delete process.env[key];
+  });
+
+  const setEnv = (key: string, value: string) => {
+    process.env[key] = value;
+    cleanedEnv.push(key);
+  };
+
+  it('collects MEMPHIS_API_TOKEN missing into degradedReasons (no throw)', () => {
+    const cfg = base();
+    delete process.env.MEMPHIS_API_TOKEN;
+    const result = validateProductionSafety(cfg);
+    expect(result.degradedReasons).toHaveLength(1);
+    expect(result.degradedReasons[0]).toMatch(/MEMPHIS_API_TOKEN/);
+  });
+
+  it('multi-reason aggregation — token + provider gap', () => {
+    // Both: MEMPHIS_API_TOKEN missing AND DEFAULT_PROVIDER=minimax with no credentials.
+    const cfg = { ...base(), DEFAULT_PROVIDER: 'minimax' as const };
+    delete process.env.MEMPHIS_API_TOKEN;
+    const result = validateProductionSafety(cfg);
+    expect(result.degradedReasons.length).toBe(2);
+    expect(result.degradedReasons.some((r) => /MEMPHIS_API_TOKEN/.test(r))).toBe(true);
+    expect(result.degradedReasons.some((r) => /minimax/i.test(r))).toBe(true);
+  });
+
+  it('Anthropic provider gap — captures the production-incident shape (R3)', () => {
+    // The actual case Memphis runs into: DEFAULT_PROVIDER=anthropic with
+    // none of (ANTHROPIC_API_KEY | ANTHROPIC_VAULT_KEY | ANTHROPIC_OAUTH_CLIENT_ID).
+    // Before this PR + R3: daemon currently crashes on FIRST TURN when
+    // adapter tries to use missing auth (no boot-time signal).
+    // After: degradedReasons surfaced at boot via /health.
+    setEnv('MEMPHIS_API_TOKEN', 'token-123');
+    const cfg = { ...base(), DEFAULT_PROVIDER: 'anthropic' as const };
+    const result = validateProductionSafety(cfg);
+    expect(result.degradedReasons.length).toBe(1);
+    expect(result.degradedReasons[0]).toMatch(/anthropic/i);
+    expect(result.degradedReasons[0]).toMatch(/ANTHROPIC_API_KEY/);
+  });
+
+  it('Anthropic provider satisfied by OAuth client id (vault-equivalent)', () => {
+    // ANTHROPIC_OAUTH_CLIENT_ID is the operator-authorized browser-flow
+    // path — counts as a valid credential. No degradation reason.
+    setEnv('MEMPHIS_API_TOKEN', 'token-123');
+    const cfg = {
+      ...base(),
+      DEFAULT_PROVIDER: 'anthropic' as const,
+      ANTHROPIC_OAUTH_CLIENT_ID: 'client-abc',
+    } as unknown as AppConfig;
+    const result = validateProductionSafety(cfg);
+    expect(result.degradedReasons).toHaveLength(0);
+  });
+
+  it('clean production boot — no degradedReasons', () => {
+    setEnv('MEMPHIS_API_TOKEN', 'token-123');
+    const cfg = base();
+    const result = validateProductionSafety(cfg);
+    expect(result.degradedReasons).toHaveLength(0);
+  });
+
+  it('non-production NODE_ENV skips production safety entirely', () => {
+    const cfg = { ...base(), NODE_ENV: 'development' as const };
+    delete process.env.MEMPHIS_API_TOKEN;
+    const result = validateProductionSafety(cfg);
+    expect(result.degradedReasons).toHaveLength(0);
+  });
+
+  it('MEMPHIS_STRICT_PRODUCTION_SAFETY=1 restores hard-throw on collected reasons', () => {
+    // Opt-in escape hatch for CI / paranoid prod deployments.
+    setEnv('MEMPHIS_STRICT_PRODUCTION_SAFETY', '1');
+    const cfg = base();
+    delete process.env.MEMPHIS_API_TOKEN;
+    expect(() => validateProductionSafety(cfg)).toThrow(/strict mode/);
+  });
+
+  it('MEMPHIS_STRICT_PRODUCTION_SAFETY=1 with no reasons — does NOT throw', () => {
+    // Strict mode is opt-in for the hard-fail, not a default-toxic mode.
+    // Clean production boot with strict ON still returns gracefully.
+    setEnv('MEMPHIS_STRICT_PRODUCTION_SAFETY', '1');
+    setEnv('MEMPHIS_API_TOKEN', 'token-123');
+    const cfg = base();
+    const result = validateProductionSafety(cfg);
+    expect(result.degradedReasons).toHaveLength(0);
+  });
+
+  it('applyConfigProfile is unaffected by safety probe — production caps still applied', () => {
+    // applyConfigProfile + validateProductionSafety are independent.
+    // Confirming the refactor didn't ripple into profile handling.
+    const cfg = {
+      ...base(),
+      LOG_LEVEL: 'debug' as const,
+      GEN_TIMEOUT_MS: 600_000,
+      GEN_MAX_TOKENS: 128_000,
+    };
+    const out = applyConfigProfile(cfg);
+    expect(out.LOG_LEVEL).toBe('info');
+    expect(out.GEN_TIMEOUT_MS).toBe(20_000);
+    expect(out.GEN_MAX_TOKENS).toBe(1024);
+  });
+});

--- a/tests/unit/config-profiles.test.ts
+++ b/tests/unit/config-profiles.test.ts
@@ -54,10 +54,20 @@ describe('config profiles', () => {
     expect(out.LOG_LEVEL).toBe('info');
   });
 
-  it('requires api token in production', () => {
+  it('requires api token in production (strict mode regression)', () => {
+    // After 2026-05-11 default flip, validateProductionSafety returns
+    // degradedReasons instead of throwing on missing MEMPHIS_API_TOKEN.
+    // To preserve the original hard-fail behavior + regression coverage,
+    // we exercise the same code path with the opt-in strict-mode flag.
+    // The plain-default path is covered by tests/unit/config-production-safety.test.ts.
     const cfg = { ...base(), NODE_ENV: 'production' as const };
     delete process.env.MEMPHIS_API_TOKEN;
-    expect(() => validateProductionSafety(cfg)).toThrow(/MEMPHIS_API_TOKEN/);
+    process.env.MEMPHIS_STRICT_PRODUCTION_SAFETY = '1';
+    try {
+      expect(() => validateProductionSafety(cfg)).toThrow(/MEMPHIS_API_TOKEN/);
+    } finally {
+      delete process.env.MEMPHIS_STRICT_PRODUCTION_SAFETY;
+    }
   });
 
   it('passes production safety with API token and local-fallback', () => {
@@ -100,15 +110,24 @@ describe('config profiles', () => {
     delete process.env.MEMPHIS_API_TOKEN;
   });
 
-  it('still throws when neither plaintext nor vault key is present', () => {
+  it('still throws when neither plaintext nor vault key is present (strict mode regression)', () => {
+    // Strict-mode opt-in (MEMPHIS_STRICT_PRODUCTION_SAFETY=1) preserves
+    // the original hard-fail when a provider is named but its credentials
+    // are missing. Default-mode behavior (graceful degradation w/ reasons)
+    // is covered in tests/unit/config-production-safety.test.ts.
     process.env.MEMPHIS_API_TOKEN = 'token-123';
+    process.env.MEMPHIS_STRICT_PRODUCTION_SAFETY = '1';
     const cfg = {
       ...base(),
       NODE_ENV: 'production' as const,
       DEFAULT_PROVIDER: 'minimax' as const,
       // No MINIMAX_API_KEY, no MINIMAX_VAULT_KEY
     };
-    expect(() => validateProductionSafety(cfg)).toThrow(/MINIMAX_API_KEY or MINIMAX_VAULT_KEY/);
-    delete process.env.MEMPHIS_API_TOKEN;
+    try {
+      expect(() => validateProductionSafety(cfg)).toThrow(/MINIMAX_API_KEY or MINIMAX_VAULT_KEY/);
+    } finally {
+      delete process.env.MEMPHIS_API_TOKEN;
+      delete process.env.MEMPHIS_STRICT_PRODUCTION_SAFETY;
+    }
   });
 });


### PR DESCRIPTION
## Summary
Closes P1 #5 from `docs/roadmap/2026-05-11-post-autonomy-todo-and-gap.md`. Daemon no longer crash-loops when `MEMPHIS_API_TOKEN` / provider credentials are missing — it boots in degraded mode, surfaces the gap via `/health.degradedConfig.reasons` + bootstrap warnings + audit log, and lets the operator recover gracefully.

## Why
2026-05-11 ~01:20 CEST: pepper-rotate left vault entries undecryptable → `MEMPHIS_API_TOKEN` unresolved → `validateProductionSafety()` threw `AppError` → daemon exit status 4 → systemd auto-restart → **63-restart crash loop**. No degraded boot, no `/health` signal, no recovery hint.

## What changed
- `validateProductionSafety()` signature `(config): void` → `(config): { degradedReasons }` (R5: existing throw-asserting tests wrapped with `MEMPHIS_STRICT_PRODUCTION_SAFETY=1` to preserve regression coverage)
- **R3:** Added Anthropic to `providerRequirements` — Memphis runs on Anthropic, missing entry before this caused crash on FIRST TURN (adapter use) instead of fail-fast at boot. OAuth client id is an alternative path (browser-flow auth)
- **R4:** opt-in strict mode via `MEMPHIS_STRICT_PRODUCTION_SAFETY=1` restores hard-throw — back-compat escape hatch for CI / paranoid prod
- New `loadConfigDetailed()` wrapper returns `{ config, degradedReasons }`; existing `loadConfig()` unchanged (~40 consumers untouched)
- Bootstrap plumbs reasons to `addBootstrapWarning` + `writeSecurityAudit({ action: 'config-degraded-boot' })`
- HTTP `/health` surfaces `degradedConfig.reasons` — daemon status stays `healthy` when only soft-degrade (operator chose degraded boot)
- Vault-pepper-failed boundary preserved as hard-throw in `env.ts:resolveVaultSecrets()` — only token + provider creds soft-degrade

## Test results
- **9/9** new `tests/unit/config-production-safety.test.ts` pass
- **10/10** existing `tests/unit/config-profiles.test.ts` pass (R5 wrap applied)
- **7/7** `http.health` + `health-summary` pass (HealthPayload optional field, no breakage)
- **2/2** `health-tier3-snapshot` integration pass
- typecheck clean, eslint clean

## Operator recovery
After this PR + the RUNBOOK PR (#567) land:
```bash
curl localhost:3000/health | jq '.degradedConfig.reasons'
# Follow docs/operator/VAULT-RECOVERY-RUNBOOK.md
```

## Coordination with Coder B (P1 #4 atomic pepper-rotate)
- **No file overlap.** Coder B owns `vault-*.ts`, `crates/memphis-vault/`, `rust-vault-adapter.ts`, `tests/unit/vault-pepper-rotate.test.ts`, `doctor-v2.ts` (`ta3-pepper-rotate-atomic` check only).
- **Sequencing:** Coder B's PR lands FIRST. This rebases on main after theirs.
- **Shared codepath** `resolveVaultSecrets()` (`env.ts:294-322`) preserved — they change internals, signature/contract holds.

## Plan reference
- `.claude/plans/agile-nibbling-feigenbaum.md` § PR-A2 + R3/R4/R5 refinements
- `docs/dev/holistic-audit-and-refactor-plan-2026-05-11.md` § P1.5
- `docs/roadmap/2026-05-11-post-autonomy-todo-and-gap.md` § P1 #5

## Test plan
- [x] New tests cover: token missing, multi-reason aggregation, Anthropic gap (R3), OAuth alt, clean boot, non-prod skip, strict mode throw/no-throw
- [x] R5 regression: existing throw assertions preserved under `MEMPHIS_STRICT_PRODUCTION_SAFETY=1`
- [ ] Manual smoke (post-merge, post Coder B merge): `NODE_ENV=production MEMPHIS_API_TOKEN= memphis serve` → daemon stays up, `/health.degradedConfig.reasons` shows MEMPHIS_API_TOKEN entry
- [ ] Manual smoke: `MEMPHIS_STRICT_PRODUCTION_SAFETY=1 MEMPHIS_API_TOKEN= memphis serve` → hard-fails as before (escape hatch works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)