### PR TITLE
ci: allowlist OTEL prometheus exporter advisory (unblocks #566/#567/#568)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,41 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Audit production dependencies (fail on high+ advisories)
-        run: npm audit --omit=dev --audit-level=high
+      - name: Audit production dependencies (fail on high+ advisories, OTEL prometheus exporter excluded)
+        # GHSA-q7rr-3cgh-j5r3 — @opentelemetry/exporter-prometheus <0.217.0 — High.
+        # OTEL is opt-in (default disabled, never imported in default runtime
+        # path per operator decision 2026-05-11). Fix is semver-major bump that
+        # the operator deliberately is not pursuing ("nie rozbudowujemy OTEL").
+        # Exclude this single advisory via jq filter; any OTHER high+ advisory
+        # still fails the gate. Critical-severity ALWAYS fails regardless.
+        run: |
+          set -o pipefail
+          audit_json=$(npm audit --omit=dev --json || true)
+          # Critical = fail unconditionally (no allowlist for crit)
+          critical_count=$(echo "$audit_json" | jq '.metadata.vulnerabilities.critical // 0')
+          if [ "$critical_count" -gt 0 ]; then
+            echo "::error::$critical_count critical vulnerabilities — fix required"
+            echo "$audit_json" | jq -r '.vulnerabilities | to_entries[] | select(.value.severity == "critical") | "\(.key): \(.value.via[0].url // .value.via[0])"'
+            exit 1
+          fi
+          # High = fail unless ALL highs are in the allowlist
+          allowlist="GHSA-q7rr-3cgh-j5r3"
+          unallowed=$(echo "$audit_json" | jq -r --arg al "$allowlist" '
+            .vulnerabilities
+            | to_entries[]
+            | select(.value.severity == "high")
+            | .value.via[]?
+            | select(type == "object")
+            | .url // empty
+            | sub("https://github.com/advisories/"; "")
+            | select(($al | split(" ")) | index(.) | not)
+          ')
+          if [ -n "$unallowed" ]; then
+            echo "::error::Unallowed high advisories detected:"
+            echo "$unallowed"
+            exit 1
+          fi
+          echo "Audit passed (allowlisted: $allowlist)"
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary

- The CI audit gate (`npm audit --omit=dev --audit-level=high`) has been red across all open PRs (#566 / #567 / #568) on a single transitive HIGH-severity advisory: **GHSA-q7rr-3cgh-j5r3** (Prometheus exporter process crash via malformed HTTP request) in `@opentelemetry/exporter-prometheus <0.217.0`.
- Operator decision 2026-05-11: OTEL is opt-in external telemetry, default disabled (`MEMPHIS_OTEL_ENABLED=0`). The prometheus exporter is never imported in the default runtime path. The semver-major bump to `@opentelemetry/sdk-node@0.217.0` that fixes the advisory is deliberately not being pursued ("nie rozbudowujemy OTEL").
- Replace the audit step with an explicit allowlist gate built on `npm audit --json` + `jq`. Critical-severity always fails. High-severity must ALL be in the allowlist — currently just `GHSA-q7rr-3cgh-j5r3`. Any new high will fail until either fixed upstream or explicitly added here.

When upstream OTEL ships the fix AND operator chooses to bump (or drops OTEL entirely), remove the allowlist entry — the gate turns green naturally.

## Test plan

- [x] Reproduced locally with the exact `npm audit --omit=dev --json` output — the gate's jq filter rejects no high advisories (just `GHSA-q7rr-3cgh-j5r3` exists, and it's in the allowlist).
- [x] Verified `critical_count > 0` still fails the gate (manual injection — if a critical appears, gate trips immediately).
- [ ] CI run on this PR turns green (will confirm on push).
- [ ] Other open PRs (#566/#567/#568) re-run CI after merge → they go from red to green without any code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)