### PR TITLE
feat(kartograf): activate ONNX runtime — Memphis routes via real model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,14 @@ MEMPHIS_TELEGRAM_ALLOWED_USER_IDS=VAULT:telegram_allowed_user_ids
 MEMPHIS_RATE_LIMIT_GLOBAL_MAX=600                 # requests/min, range: 1–100000
 MEMPHIS_RATE_LIMIT_SENSITIVE_MAX=60                # requests/min, range: 1–10000
 
+# ── Kartograf inference (optional — zone classifier + 256-d embedding) ──
+# Set to 1 to enable the memphis_kartograf tool. Lazy-loads the ~700 MB
+# ONNX checkpoint on first call, then keeps it in memory (singleton).
+# Requires an installed checkpoint: `memphis kartograf install --file
+# <envelope>.json --source file`. Without an installed checkpoint the tool
+# returns stateKind=no-checkpoint rather than crashing.
+# MEMPHIS_KARTOGRAF_ENABLE=1
+
 # ── Tier-3 elevation (time-limited, operator-gated unrestricted mode) ──
 # Default tier is 2: Memphis may create new files anywhere, install packages,
 # download dependencies, run additive helpers — but cannot modify or delete

--- a/docs/operator/kartograf.md
+++ b/docs/operator/kartograf.md
@@ -2,20 +2,38 @@
 
 Sprint K (Q1 N32) — operator surface for Kartograf checkpoint distribution.
 
-## What ships today (Q1)
+## What ships today
 
 - `memphis kartograf verify --file <envelope.json>` — verify a signed checkpoint envelope (operator-trusted source) without installing
 - `memphis kartograf install --file <envelope.json> --source file` — verify + stage to `~/.memphis/kartograf/checkpoints/<signer-slug>/`
 - `memphis kartograf status` — list installed checkpoints + integrity status
-- `memphis kartograf query` — reserved for Y2 (returns structured "not yet" with the path forward)
-- Doctor `ta13-kartograf` check — visibility on installed checkpoint count + signers
+- `memphis kartograf query --query "<text>"` — run inference and report top zones + embedding preview. Requires `MEMPHIS_KARTOGRAF_ENABLE=1` and an installed checkpoint.
+- `memphis_kartograf` tool — Memphis daemon can call this during agent loops (singleton-cached ONNX session: ~5 s cold load, <200 ms per warm call).
+- `kartograf-zone-router` built-in skill — composes routing decisions over Kartograf + `memphis_recall` before writing.
+- Doctor `ta13-kartograf` check — visibility on installed checkpoint count + signers.
+- Training pipeline (`tools/training/train-kartograf.py`) — produces ONNX checkpoints locally on a single GPU.
 
-## What lands Q2
+## Activation
 
-- Kartograf training pipeline (`tools/training/train-kartograf.py`) — produces ONNX checkpoints
-- ONNX runtime loader — feeds embeddings + zone classification back into Memphis
-- `memphis kartograf query --query <text>` — pulls embedding + zone from the installed checkpoint
-- HF hub + GitHub release transports for `--source` (today only `file` and `federation` work locally)
+The ONNX runtime is opt-in (the ~700-MB checkpoint + 80-MB onnxruntime-node binary aren't loaded otherwise). To enable:
+
+```bash
+# 1. Install a checkpoint (one-time per operator install)
+memphis kartograf install --file <envelope>.json --source file
+
+# 2. Flip the flag in ~/memphis/.env
+echo 'MEMPHIS_KARTOGRAF_ENABLE=1' >> .env
+
+# 3. Restart the daemon to pick up the new flag
+systemctl --user restart memphis
+```
+
+After restart, `memphis kartograf status` shows the active checkpoint, the `memphis_kartograf` tool appears in `memphis_self_describe`, and the daemon advertises one more tool at startup. The first `memphis_kartograf` call pays the cold-load cost; subsequent calls within the same daemon process reuse the cached session.
+
+## Roadmap (not yet)
+
+- HF hub + GitHub release transports for `--source` (today only `file` and `federation` work locally).
+- Cascade integration — wiring Kartograf as the tier-0 retriever in `memphis_recall` ranking. Today the tool exists standalone; semantic recall still uses the existing local embeddings pipeline.
 
 ## Concepts
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,6 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
+        "@huggingface/transformers": "^3.7.6",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
@@ -24,6 +25,7 @@
         "dotenv": "^17.3.1",
         "fastify": "^5.8.2",
         "grammy": "^1.41.1",
+        "onnxruntime-node": "^1.21.0",
         "pino": "^10.3.1",
         "prompts": "^2.4.2",
         "yaml": "^2.8.2",
@@ -351,7 +353,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1229,6 +1230,27 @@
         "hono": "^4"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.7.6.tgz",
+      "integrity": "sha512-OYlIRY8vj8r/pNx2CdXcDHz4KqpEC+bUMKzdVW5Dx//gp4XRmK+/g8as0h3cssRQYT0vG1A6VCfZy8SV0F4RDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.1",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1279,6 +1301,483 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -3427,6 +3926,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -4237,7 +4743,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -4255,7 +4760,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -4319,6 +4823,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -4595,6 +5105,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -4656,7 +5172,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5753,6 +6268,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -6058,6 +6579,35 @@
       "dev": true,
       "license": "BSD"
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -6075,7 +6625,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -6145,6 +6694,12 @@
         "node": "^12.20.0 || >=14.13.1"
       }
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6172,7 +6727,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -7924,6 +8478,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -8437,6 +8997,18 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8591,6 +9163,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mixin-deep": {
@@ -8899,7 +9492,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9094,6 +9686,49 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -9439,6 +10074,12 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
@@ -9981,6 +10622,29 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/roarr/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
@@ -10218,6 +10882,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -10242,6 +10912,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serve-static": {
@@ -10369,6 +11054,62 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -11141,6 +11882,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -11167,6 +11924,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/text-table": {
@@ -11381,7 +12156,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -11428,6 +12202,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
+    "@huggingface/transformers": "^3.7.6",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
@@ -200,17 +201,18 @@
     "dotenv": "^17.3.1",
     "fastify": "^5.8.2",
     "grammy": "^1.41.1",
+    "onnxruntime-node": "^1.21.0",
     "pino": "^10.3.1",
     "prompts": "^2.4.2",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
-    "ollama": "^0.5.14",
-    "@memphis-chains/memphis-linux-x64-gnu": "*",
-    "@memphis-chains/memphis-linux-arm64-gnu": "*",
+    "@memphis-chains/memphis-darwin-arm64": "*",
     "@memphis-chains/memphis-darwin-x64": "*",
-    "@memphis-chains/memphis-darwin-arm64": "*"
+    "@memphis-chains/memphis-linux-arm64-gnu": "*",
+    "@memphis-chains/memphis-linux-x64-gnu": "*",
+    "ollama": "^0.5.14"
   },
   "overrides": {
     "fast-uri": ">=3.1.2",

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -37,6 +37,7 @@ import { runMemphisGrep } from '../mcp/tools/grep.js';
 import { runMemphisHealthCheck } from '../mcp/tools/health-check.js';
 import { runMemphisHealth } from '../mcp/tools/health.js';
 import { runMemphisJournal } from '../mcp/tools/journal.js';
+import { runMemphisKartograf } from '../mcp/tools/kartograf.js';
 import { runMemphisLoopStep } from '../mcp/tools/loop-step.js';
 import { runMemphisMediaIngest } from '../mcp/tools/media-ingest.js';
 import { runMemphisPackage } from '../mcp/tools/package.js';
@@ -212,6 +213,42 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
           sessionId: deps.sessionId,
           turnId: deps.turnId,
         });
+      },
+    }),
+    buildTool({
+      name: 'memphis_kartograf',
+      description:
+        'Run Kartograf inference on text — returns 256-d embedding + zone classification (12 chains). Requires installed checkpoint + MEMPHIS_KARTOGRAF_ENABLE=1. Returns structured error if either is missing.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Text to classify (1-8192 chars)' },
+          top_k_zones: {
+            type: 'number',
+            description: 'Return only top-K zones (1-12). Omit for full distribution.',
+          },
+        },
+        required: ['query'],
+      },
+      isConcurrencySafe: true,
+      isReadOnly: true,
+      validateInput(args) {
+        const q = (args as { query?: unknown }).query;
+        if (typeof q !== 'string' || q.length === 0) {
+          throw new Error('memphis_kartograf: query (string, 1-8192 chars) is required');
+        }
+        if (q.length > 8192) {
+          throw new Error('memphis_kartograf: query exceeds 8192-char limit');
+        }
+        const topKRaw = (args as { top_k_zones?: unknown }).top_k_zones;
+        const top_k_zones =
+          typeof topKRaw === 'number' && Number.isFinite(topKRaw) && topKRaw >= 1 && topKRaw <= 12
+            ? Math.floor(topKRaw)
+            : undefined;
+        return { query: q, ...(top_k_zones !== undefined ? { top_k_zones } : {}) };
+      },
+      execute(input) {
+        return runMemphisKartograf(input, deps.rawEnv);
       },
     }),
     buildTool({

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -97,6 +97,22 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
       },
     ],
   },
+  memphis_kartograf: {
+    name: 'memphis_kartograf',
+    tier: 1,
+    capabilities: ['read'],
+    description:
+      'Run Kartograf inference on a text — returns a 256-d embedding plus zone classification across the 12 canonical chain slots. Requires an installed checkpoint (`memphis kartograf install`) and MEMPHIS_KARTOGRAF_ENABLE=1. When the runtime is disabled or no checkpoint is staged, returns a structured error rather than silently degrading to zero vectors.',
+    inputSchema: z
+      .object({
+        query: z.string().min(1).max(8192),
+        top_k_zones: z.number().int().min(1).max(12).optional(),
+        approval_request_id: z.string().optional(),
+      })
+      .strict(),
+    helpText:
+      'Use this BEFORE writing to a chain when you need a confident routing decision — the zone with highest score names the chain Kartograf thinks the text belongs to. `top_k_zones=3` is a good default for human-facing reports; omit it to get the full softmax. Output includes `checkpointId` (sha256 of the active ONNX model) so audit logs can pin which model version produced the routing. ⚠ Kartograf v1 has recall@10 = 0.27 — treat the top zone as a hint, not a hard route; corroborate via memphis_recall when stakes are high.',
+  },
   memphis_recall: {
     name: 'memphis_recall',
     tier: 0,

--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -107,14 +107,19 @@ export function stripThinkBlocks(output: string, rawEnv: NodeJS.ProcessEnv): str
 }
 
 /**
- * Tag every reply with a small "— via {provider}/{model}" footer so
- * the operator always knows which model actually generated the text.
- * The TUI's status bar already shows the same data; Telegram and other
- * surfaces have no equivalent, so we put it in the message body
- * itself.
+ * Optional "— via {provider}/{model}" footer. OFF by default — operator
+ * 2026-05-12 confirmed the stamp was noise on Telegram (and frequently
+ * misleading, since the active provider can change mid-cascade while
+ * the stamp shows the call-time provider). The TUI status bar already
+ * surfaces the active provider/model on its own, and audit logs carry
+ * the same data with more precision; the in-body footer added nothing
+ * the operator wanted to see in chat.
  *
- * Idempotent: if the model already rendered a footer (rare, defensive),
- * we don't double-stamp. Suppressed when MEMPHIS_PROVIDER_STAMP=0.
+ * Keeping the function (rather than ripping out the call site) so
+ * power users can flip it back on via `MEMPHIS_PROVIDER_STAMP=1` —
+ * useful when bisecting a provider-cascade misroute. The opt-in
+ * inverts the prior default; legacy `MEMPHIS_PROVIDER_STAMP=0` is
+ * still honored (no-op redundancy) so old .env files keep working.
  */
 export function appendProviderStamp(
   output: string,
@@ -122,7 +127,8 @@ export function appendProviderStamp(
   model: string,
   rawEnv: NodeJS.ProcessEnv,
 ): string {
-  if (rawEnv.MEMPHIS_PROVIDER_STAMP === '0' || rawEnv.MEMPHIS_PROVIDER_STAMP === 'false') {
+  const flag = rawEnv.MEMPHIS_PROVIDER_STAMP;
+  if (flag !== '1' && flag !== 'true') {
     return output;
   }
   const trimmed = output.trimEnd();

--- a/src/infra/cli/handlers/kartograf.handler.ts
+++ b/src/infra/cli/handlers/kartograf.handler.ts
@@ -424,6 +424,31 @@ async function handleQuery(context: CliContext): Promise<boolean> {
     ...(Number.isFinite(topK) ? { topKZones: topK as number } : {}),
   });
 
+  // Codex review (#573, 2026-05-12): createKartografSession falls back
+  // to StubKartografSession when the ONNX/tokenizer load throws (ABI
+  // mismatch, missing artifact, opset gap). Without this check the CLI
+  // would happily print ok:true with a zero-vector embedding and a
+  // single "none" zone — looking successful while silently returning
+  // garbage. Detect the stub by its sentinel checkpointId prefix and
+  // surface the load failure with the same hint shape as the disabled
+  // / no-checkpoint paths.
+  if (session.checkpointId.startsWith('stub:')) {
+    await session.close();
+    print(
+      {
+        ok: false,
+        mode: 'kartograf.query',
+        error: 'ONNX session load failed; runtime fell back to stub',
+        hint:
+          'Check daemon stderr / kartograf-handler stderr for the underlying ONNX load error. ' +
+          'Most common: onnxruntime-node ABI mismatch with @huggingface/transformers nested ' +
+          'copy, or model.onnx sha mismatch vs envelope.',
+      },
+      context.args.json,
+    );
+    return false;
+  }
+
   try {
     const t0 = Date.now();
     const result = await session.embed(query);

--- a/src/infra/cli/handlers/kartograf.handler.ts
+++ b/src/infra/cli/handlers/kartograf.handler.ts
@@ -352,26 +352,103 @@ async function handleStatus(context: CliContext): Promise<boolean> {
 }
 
 async function handleQuery(context: CliContext): Promise<boolean> {
-  // Kartograf inference (the model that consumes installed checkpoints)
-  // is Y2 scope per docs/dev/KARTOGRAF-SPEC.md. The CLI surface ships
-  // now so operators have a stable verb when the inference pipeline
-  // lands; today it returns a structured "not yet" with the path
-  // forward so callers don't get a generic "unknown subcommand".
+  const query = (context.args.query ?? '').toString().trim();
+  if (!query) {
+    print(
+      {
+        ok: false,
+        mode: 'kartograf.query',
+        error: 'kartograf query requires --query <text>',
+      },
+      context.args.json,
+    );
+    return false;
+  }
+
   const { checkpoints } = listInstalledCheckpoints();
-  print(
-    {
-      ok: false,
-      mode: 'kartograf.query',
-      reason:
-        'Kartograf inference is Y2 scope (training + ONNX session loader land Q2). ' +
-        'CLI surface reserved; install + verify + status work today.',
-      installedCheckpoints: checkpoints.length,
-      hint:
-        checkpoints.length === 0
-          ? 'Run `memphis kartograf install --file <envelope.json> --source file` to stage a checkpoint first.'
-          : 'When inference ships, this verb will accept --query <text> and return zone + embedding from the installed checkpoint.',
-    },
-    context.args.json,
-  );
-  return true;
+  const usable = checkpoints.find((c) => c.ok);
+  if (!usable) {
+    print(
+      {
+        ok: false,
+        mode: 'kartograf.query',
+        error: 'no verified checkpoint installed',
+        hint: 'Run `memphis kartograf install --file <envelope>.json --source file` first.',
+      },
+      context.args.json,
+    );
+    return false;
+  }
+
+  if (process.env.MEMPHIS_KARTOGRAF_ENABLE !== '1') {
+    print(
+      {
+        ok: false,
+        mode: 'kartograf.query',
+        error: 'MEMPHIS_KARTOGRAF_ENABLE=1 not set',
+        hint:
+          'Set MEMPHIS_KARTOGRAF_ENABLE=1 in your .env (or shell) to activate the ' +
+          'ONNX runtime. The flag is opt-in so the 80-MB onnxruntime-node binary ' +
+          'is only loaded on installs that intend to use Kartograf.',
+      },
+      context.args.json,
+    );
+    return false;
+  }
+
+  // Top-K parse — accept --top-k <N>, default to all zones.
+  const topKRaw = context.args.topK;
+  const topK =
+    typeof topKRaw === 'number'
+      ? topKRaw
+      : typeof topKRaw === 'string'
+        ? Number.parseInt(topKRaw, 10)
+        : undefined;
+
+  const { createKartografSession } = await import('../../../kartograf/session.js');
+  const read = readEnvelopeFrom(usable.envelopePath);
+  if (!read.ok) {
+    print(
+      {
+        ok: false,
+        mode: 'kartograf.query',
+        error: `installed envelope unreadable: ${read.error}`,
+      },
+      context.args.json,
+    );
+    return false;
+  }
+  const session = await createKartografSession({
+    checkpointPath: usable.envelopePath,
+    headsConfig: read.envelope.heads_config,
+    ...(Number.isFinite(topK) ? { topKZones: topK as number } : {}),
+  });
+
+  try {
+    const t0 = Date.now();
+    const result = await session.embed(query);
+    const elapsedMs = Date.now() - t0;
+    print(
+      {
+        ok: true,
+        mode: 'kartograf.query',
+        checkpointId: result.checkpointId,
+        signerDid: usable.signerDid,
+        query,
+        // Don't dump the full 256-d vector by default — surface the
+        // norm + first 8 dims so operators can sanity-check without
+        // flooding the terminal. Full vector available via --json
+        // consumers can re-derive from .embeddingPreview if they need
+        // the demonstration, or call the tool surface in a script.
+        embeddingDim: result.embedding.length,
+        embeddingPreview: Array.from(result.embedding.slice(0, 8)),
+        zones: result.zones,
+        elapsedMs,
+      },
+      context.args.json,
+    );
+    return true;
+  } finally {
+    await session.close();
+  }
 }

--- a/src/kartograf/onnx-session.ts
+++ b/src/kartograf/onnx-session.ts
@@ -1,0 +1,271 @@
+/**
+ * Real ONNX-backed Kartograf session — closes the Q2 deliverable
+ * (spec docs/dev/KARTOGRAF-SPEC.md `Runtime (onnxruntime-node)` section).
+ *
+ * Loads a verified checkpoint into onnxruntime-node, attaches a tokenizer
+ * via @huggingface/transformers, and serves `embed(text)` returning both
+ * the 256-d embedding and the 12-class zone distribution. Factory in
+ * `session.ts` gates this behind `MEMPHIS_KARTOGRAF_ENABLE=1` + an
+ * installed checkpoint; otherwise consumers fall back to the stub.
+ *
+ * Durability notes (per operator "działa na lata" mandate 2026-05-12):
+ *   - Envelope verify runs at load — broken/tampered checkpoints refuse
+ *     to load rather than producing silent garbage.
+ *   - ONNX bytes are re-hashed against `envelope.onnx_sha256` at load —
+ *     same defense as the install handler, in case a checkpoint dir was
+ *     hand-edited after install.
+ *   - Zone-label count is checked against `envelope.heads_config
+ *     .zone_classes` and the spec-locked `KARTOGRAF_V1_ZONE_LABELS`
+ *     length. Mismatch refuses to load so we never report scores
+ *     against a misaligned label set.
+ *   - Session caches `model.onnx` in memory (~700 MB for full-v4
+ *     DeBERTa-base). `close()` releases the native handle. Reload
+ *     requires a fresh `OnnxKartografSession.load()`.
+ *   - Tokenizer is loaded eagerly. transformers.js requires
+ *     `tokenizer.json` + at minimum a stub `tokenizer_config.json` in
+ *     the checkpoint dir. The loader auto-stamps a minimal config if
+ *     none is present (matches DeBERTa-v3 defaults).
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { AutoTokenizer, env as TxEnv } from '@huggingface/transformers';
+import { InferenceSession, Tensor } from 'onnxruntime-node';
+
+import { sha256Hex, verifyCheckpoint, type CheckpointEnvelope } from './checkpoint.js';
+import type { KartografOutput, KartografSession, ZoneClassification } from './session.js';
+import { KARTOGRAF_V1_ZONE_LABELS } from './zone-labels.js';
+
+// Force transformers.js into local-only mode — Memphis runs offline-by-
+// default and remote model downloads at runtime would violate that.
+// (TxEnv mutates a shared singleton; safe because this is the only
+// consumer wired into the daemon.)
+TxEnv.allowLocalModels = true;
+TxEnv.allowRemoteModels = false;
+TxEnv.cacheDir = ''; // discourage cache lookups outside checkpoint dir
+
+/**
+ * Minimum tokenizer_config.json shape transformers.js needs to load a
+ * raw tokenizer.json without trying to fetch sibling configs from HF.
+ * DeBERTa-v3 specials match microsoft/deberta-v3-base; max length matches
+ * the corpus build (chunks ≤ 512 tokens per spec line 137).
+ */
+const FALLBACK_TOKENIZER_CONFIG = {
+  tokenizer_class: 'DebertaV2Tokenizer',
+  model_max_length: 512,
+  do_lower_case: false,
+  bos_token: '[CLS]',
+  eos_token: '[SEP]',
+  unk_token: '[UNK]',
+  sep_token: '[SEP]',
+  pad_token: '[PAD]',
+  cls_token: '[CLS]',
+  mask_token: '[MASK]',
+};
+
+const FALLBACK_TOKENIZER_CONFIG_NAME = 'tokenizer_config.json';
+
+export interface OnnxKartografLoadOptions {
+  /** Top-K zones to return per inference (default: all zones above 0). */
+  topKZones?: number;
+}
+
+export class OnnxKartografSession implements KartografSession {
+  readonly checkpointId: string;
+  readonly headsConfig: CheckpointEnvelope['heads_config'];
+  readonly signerDid: string;
+  readonly basemodel: string;
+
+  private readonly session: InferenceSession;
+  private readonly tokenizer: Awaited<ReturnType<typeof AutoTokenizer.from_pretrained>>;
+  private readonly zoneLabels: readonly string[];
+  private readonly topKZones: number | null;
+  private closed = false;
+
+  private constructor(args: {
+    envelope: CheckpointEnvelope;
+    session: InferenceSession;
+    tokenizer: Awaited<ReturnType<typeof AutoTokenizer.from_pretrained>>;
+    zoneLabels: readonly string[];
+    topKZones: number | null;
+  }) {
+    this.headsConfig = args.envelope.heads_config;
+    this.signerDid = args.envelope.signer_did;
+    this.basemodel = args.envelope.base_model;
+    this.checkpointId = args.envelope.onnx_sha256;
+    this.session = args.session;
+    this.tokenizer = args.tokenizer;
+    this.zoneLabels = args.zoneLabels;
+    this.topKZones = args.topKZones;
+  }
+
+  /**
+   * Load a verified checkpoint from disk.
+   *
+   * `envelopePath` is the path to `checkpoint.json` under the install
+   * staging dir (e.g. `~/.memphis/kartograf/checkpoints/<slug>/checkpoint.json`).
+   *
+   * Throws on: missing files, envelope verify failure, sha mismatch on
+   * `model.onnx`, zone class count mismatch, ONNX session creation
+   * failure. The thrown error carries enough detail for the operator to
+   * fix without dumping internals (e.g. raw signature bytes).
+   */
+  static async load(
+    envelopePath: string,
+    options: OnnxKartografLoadOptions = {},
+  ): Promise<OnnxKartografSession> {
+    if (!existsSync(envelopePath)) {
+      throw new Error(`kartograf: envelope not found at ${envelopePath}`);
+    }
+    const dir = dirname(envelopePath);
+    const envelope = JSON.parse(readFileSync(envelopePath, 'utf8')) as CheckpointEnvelope;
+
+    const verify = verifyCheckpoint(envelope);
+    if (!verify.valid) {
+      throw new Error(`kartograf: envelope verify failed: ${verify.reason}`);
+    }
+
+    const onnxPath = join(dir, 'model.onnx');
+    if (!existsSync(onnxPath)) {
+      throw new Error(`kartograf: model.onnx missing beside ${envelopePath}`);
+    }
+    const onnxBytes = readFileSync(onnxPath);
+    const actualOnnxSha = sha256Hex(onnxBytes);
+    if (actualOnnxSha !== envelope.onnx_sha256) {
+      throw new Error(
+        `kartograf: model.onnx sha mismatch (envelope=${envelope.onnx_sha256.slice(0, 12)}..., ` +
+          `disk=${actualOnnxSha.slice(0, 12)}...). Re-install the checkpoint.`,
+      );
+    }
+
+    const tokenizerPath = join(dir, 'tokenizer.json');
+    if (!existsSync(tokenizerPath)) {
+      throw new Error(`kartograf: tokenizer.json missing beside ${envelopePath}`);
+    }
+
+    if (envelope.heads_config.zone_classes !== KARTOGRAF_V1_ZONE_LABELS.length) {
+      throw new Error(
+        `kartograf: zone class count mismatch (envelope=${envelope.heads_config.zone_classes}, ` +
+          `runtime labels=${KARTOGRAF_V1_ZONE_LABELS.length}). Runtime needs ` +
+          `kartograf-v1 — newer checkpoints require an updated zone-labels module.`,
+      );
+    }
+
+    // transformers.js wants a sibling tokenizer_config.json to set
+    // special-token boundaries. Auto-stamp a minimal one (matches the
+    // DeBERTa-v3 base config) so operators don't need to copy it
+    // manually. The actual tokenizer.json carries the SP unigram vocab.
+    const tokConfigPath = join(dir, FALLBACK_TOKENIZER_CONFIG_NAME);
+    if (!existsSync(tokConfigPath)) {
+      writeFileSync(tokConfigPath, JSON.stringify(FALLBACK_TOKENIZER_CONFIG, null, 2));
+    }
+
+    const session = await InferenceSession.create(onnxBytes, {
+      executionProviders: ['cpu'],
+      graphOptimizationLevel: 'all',
+      logSeverityLevel: 3, // error-only; trims tracer noise from DeBERTa export
+    });
+
+    const tokenizer = await AutoTokenizer.from_pretrained(dir);
+
+    return new OnnxKartografSession({
+      envelope,
+      session,
+      tokenizer,
+      zoneLabels: KARTOGRAF_V1_ZONE_LABELS,
+      topKZones: options.topKZones ?? null,
+    });
+  }
+
+  async embed(text: string): Promise<KartografOutput> {
+    if (this.closed) throw new Error('OnnxKartografSession is closed');
+    // transformers.js default-returns Tensor objects with `.data`
+    // (BigInt64Array for int64 inputs) and `.dims` ([batch, seq]). The
+    // tokenizer truncates to max_length so the encoder never sees more
+    // than its 512-token context window.
+    const tokens = await this.tokenizer(text, {
+      padding: false,
+      truncation: true,
+      max_length: 512,
+    } as Parameters<typeof this.tokenizer>[1]);
+
+    const feeds = this.encodingsToFeeds(tokens);
+    const out = await this.session.run(feeds);
+    return this.parseSessionOutput(out);
+  }
+
+  async embedBatch(texts: string[]): Promise<KartografOutput[]> {
+    if (this.closed) throw new Error('OnnxKartografSession is closed');
+    // Naive per-call batching keeps the first cut simple; we can switch
+    // to packed-batch tokenize + single session.run() as a follow-up when
+    // chain-side callers start hitting per-query latency walls. The
+    // spec's "p95 < 25ms cold, < 8ms warm" applies to single-text;
+    // batched tier-0 cascade is Q2 N21 scope (separate PR).
+    return Promise.all(texts.map((t) => this.embed(t)));
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      await this.session.release();
+    } catch {
+      // release() can throw if ORT already torn down via process exit;
+      // mark closed regardless so embed() refuses subsequent calls.
+    }
+  }
+
+  private encodingsToFeeds(tokens: {
+    input_ids: { data: BigInt64Array; dims: number[] };
+    attention_mask: { data: BigInt64Array; dims: number[] };
+  }): Record<string, Tensor> {
+    // transformers.js produces Tensor objects with `.data` (BigInt64Array
+    // for int64) + `.dims` ([batch, seq]). The exported ONNX graph
+    // declares int64 inputs (matches training-side `dummy_ids.long()`),
+    // so we forward both buffers directly into onnxruntime-node tensors.
+    const ids = tokens.input_ids;
+    const mask = tokens.attention_mask;
+    return {
+      input_ids: new Tensor('int64', ids.data, ids.dims),
+      attention_mask: new Tensor('int64', mask.data, mask.dims),
+    };
+  }
+
+  private parseSessionOutput(out: InferenceSession.OnnxValueMapType): KartografOutput {
+    const embTensor = out.embedding;
+    const zoneTensor = out.zone_logits;
+    if (!embTensor || !zoneTensor) {
+      throw new Error(
+        `kartograf: ONNX output missing expected names (got: ${Object.keys(out).join(',')}). ` +
+          `Producer must export with output_names=['embedding', 'zone_logits'].`,
+      );
+    }
+    const embedFlat = embTensor.data as Float32Array;
+    const logitsFlat = zoneTensor.data as Float32Array;
+
+    // Output shape is [1, dim] (batch=1). Slice to a copy so the caller
+    // can hold onto the buffer past the next embed() call (which reuses
+    // ORT's internal pools).
+    const embedding = new Float32Array(this.headsConfig.embedding_dim);
+    embedding.set(embedFlat.subarray(0, this.headsConfig.embedding_dim));
+
+    const zones = this.softmaxToZones(logitsFlat.subarray(0, this.zoneLabels.length));
+
+    return { embedding, zones, checkpointId: this.checkpointId };
+  }
+
+  private softmaxToZones(logits: Float32Array | number[]): ZoneClassification[] {
+    const arr = Array.from(logits);
+    const maxLogit = Math.max(...arr);
+    const exps = arr.map((v) => Math.exp(v - maxLogit));
+    const sum = exps.reduce((a, b) => a + b, 0) || 1;
+    const probs = exps.map((v) => v / sum);
+    const ranked = probs
+      .map((score, idx) => ({ zone: this.zoneLabels[idx]!, score }))
+      .sort((a, b) => b.score - a.score);
+    if (this.topKZones !== null && this.topKZones > 0) {
+      return ranked.slice(0, this.topKZones);
+    }
+    return ranked;
+  }
+}

--- a/src/kartograf/runtime.ts
+++ b/src/kartograf/runtime.ts
@@ -1,0 +1,168 @@
+/**
+ * Process-level singleton for the active Kartograf session.
+ *
+ * Loading a real ONNX session means reading ~700 MB of model weights from
+ * disk + initializing onnxruntime-node graph optimization. Doing that
+ * per-tool-call would be untenable for the daemon path (one call = ~3-8 s
+ * cold-load on CPU; spec line 200 budget says < 25 ms p95 warm). The
+ * singleton here keeps a single loaded session in memory and serves all
+ * callers; first call pays the load cost, subsequent calls are warm.
+ *
+ * The CLI path (`memphis kartograf query`) bypasses this singleton — each
+ * CLI invocation is a fresh process so caching wouldn't help, and the CLI
+ * also explicitly closes() at exit. For daemon-side tool calls, code
+ * should reach for `getKartografRuntime()`.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { verifyCheckpoint, type CheckpointEnvelope } from './checkpoint.js';
+import { createKartografSession, type KartografSession } from './session.js';
+import { getDataDir } from '../config/paths.js';
+
+export type KartografRuntimeStatus =
+  | { kind: 'disabled'; reason: string }
+  | { kind: 'no-checkpoint'; reason: string }
+  | { kind: 'load-failed'; reason: string; checkpointPath: string }
+  | { kind: 'ready'; session: KartografSession; envelopePath: string };
+
+let cached: KartografRuntimeStatus | null = null;
+let loading: Promise<KartografRuntimeStatus> | null = null;
+
+/**
+ * Resolve the first verifiable installed checkpoint envelope. Returns
+ * null if no install dir, no slug subdirs, or every envelope fails
+ * verify — caller decides how to surface that to the operator.
+ */
+function findFirstVerifiedEnvelope(rawEnv: NodeJS.ProcessEnv): {
+  envelopePath: string;
+  envelope: CheckpointEnvelope;
+} | null {
+  const stageRoot = join(getDataDir(rawEnv), 'kartograf', 'checkpoints');
+  if (!existsSync(stageRoot)) return null;
+  let slugs: string[];
+  try {
+    slugs = readdirSync(stageRoot).filter((entry) => {
+      try {
+        return statSync(join(stageRoot, entry)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return null;
+  }
+  for (const slug of slugs) {
+    const envelopePath = join(stageRoot, slug, 'checkpoint.json');
+    if (!existsSync(envelopePath)) continue;
+    try {
+      const envelope = JSON.parse(readFileSync(envelopePath, 'utf8')) as CheckpointEnvelope;
+      const verify = verifyCheckpoint(envelope);
+      if (!verify.valid) continue;
+      return { envelopePath, envelope };
+    } catch {
+      // Try next slug
+    }
+  }
+  return null;
+}
+
+/**
+ * Get (or lazily create) the singleton Kartograf runtime. Returns a
+ * status discriminator the caller can pattern-match against — production
+ * tools should refuse to operate when status !== 'ready' rather than
+ * silently using zero embeddings.
+ */
+export async function getKartografRuntime(
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): Promise<KartografRuntimeStatus> {
+  if (cached) return cached;
+  if (loading) return loading;
+
+  loading = (async (): Promise<KartografRuntimeStatus> => {
+    if (rawEnv.MEMPHIS_KARTOGRAF_ENABLE !== '1') {
+      const status: KartografRuntimeStatus = {
+        kind: 'disabled',
+        reason: 'MEMPHIS_KARTOGRAF_ENABLE=1 not set in environment',
+      };
+      cached = status;
+      return status;
+    }
+    const found = findFirstVerifiedEnvelope(rawEnv);
+    if (!found) {
+      const status: KartografRuntimeStatus = {
+        kind: 'no-checkpoint',
+        reason: 'no verifiable checkpoint under ~/.memphis/kartograf/checkpoints',
+      };
+      cached = status;
+      return status;
+    }
+    try {
+      const session = await createKartografSession(
+        {
+          checkpointPath: found.envelopePath,
+          headsConfig: found.envelope.heads_config,
+        },
+        rawEnv,
+      );
+      // createKartografSession may itself fall back to a stub on internal
+      // load failure (e.g. ABI mismatch). Detect that and surface as
+      // load-failed so callers don't think they have a real session.
+      if (session.checkpointId.startsWith('stub:')) {
+        const status: KartografRuntimeStatus = {
+          kind: 'load-failed',
+          reason:
+            'createKartografSession fell back to stub (see daemon stderr for ONNX load reason)',
+          checkpointPath: found.envelopePath,
+        };
+        cached = status;
+        return status;
+      }
+      const status: KartografRuntimeStatus = {
+        kind: 'ready',
+        session,
+        envelopePath: found.envelopePath,
+      };
+      cached = status;
+      return status;
+    } catch (err) {
+      const status: KartografRuntimeStatus = {
+        kind: 'load-failed',
+        reason: err instanceof Error ? err.message : String(err),
+        checkpointPath: found.envelopePath,
+      };
+      cached = status;
+      return status;
+    }
+  })();
+
+  try {
+    return await loading;
+  } finally {
+    loading = null;
+  }
+}
+
+/**
+ * Release the singleton session — called from the graceful shutdown
+ * path so we don't leak ORT handles. Idempotent.
+ */
+export async function closeKartografRuntime(): Promise<void> {
+  if (!cached || cached.kind !== 'ready') {
+    cached = null;
+    return;
+  }
+  const session = cached.session;
+  cached = null;
+  await session.close();
+}
+
+/**
+ * Test-only: forget the cached runtime so a new load attempt runs.
+ * Production code must NOT call this — concurrent callers will see
+ * inconsistent state.
+ */
+export function _resetKartografRuntimeForTests(): void {
+  cached = null;
+  loading = null;
+}

--- a/src/kartograf/runtime.ts
+++ b/src/kartograf/runtime.ts
@@ -59,6 +59,18 @@ function findFirstVerifiedEnvelope(rawEnv: NodeJS.ProcessEnv): {
       const envelope = JSON.parse(readFileSync(envelopePath, 'utf8')) as CheckpointEnvelope;
       const verify = verifyCheckpoint(envelope);
       if (!verify.valid) continue;
+      // Codex review (#573, 2026-05-12): `memphis kartograf install`
+      // can leave a staging dir with a signed envelope but no
+      // model.onnx / tokenizer.json (sha mismatch warning during
+      // install — envelope copied, artifacts skipped). Without this
+      // check the runtime would happily return the envelope, cache it,
+      // and crash on the first embed() call when OnnxKartografSession
+      // tries to read the missing artifact. Skip incomplete checkpoints
+      // here so we fall through to the next slug or report
+      // no-checkpoint cleanly.
+      const slugDir = join(stageRoot, slug);
+      if (!existsSync(join(slugDir, 'model.onnx'))) continue;
+      if (!existsSync(join(slugDir, 'tokenizer.json'))) continue;
       return { envelopePath, envelope };
     } catch {
       // Try next slug

--- a/src/kartograf/session.ts
+++ b/src/kartograf/session.ts
@@ -135,16 +135,42 @@ class StubKartografSession implements KartografSession {
 }
 
 /**
- * Factory — currently always returns the stub. Q2 N32 will gate on a
- * config check (presence of onnxruntime-node + verified checkpoint
- * envelope) and return either the real ONNX session or fall back to
- * the stub when running outside an operator deploy (CI, doc tests).
+ * Factory. Returns either:
+ *
+ *   - `OnnxKartografSession` — real onnxruntime-node loader, when
+ *     `MEMPHIS_KARTOGRAF_ENABLE=1` AND the config points at a verifiable
+ *     checkpoint envelope. Lazy-imported so the 80-MB ORT binary isn't
+ *     pulled into CI / doc-test paths that don't need it.
+ *   - `StubKartografSession` — zero-vector fallback. Used at boot
+ *     before checkpoints land, on CI, on installs where the operator
+ *     hasn't opted in, and as the recovery path when ONNX load fails
+ *     (so a broken checkpoint doesn't crash the daemon).
  *
  * Keeping this as the sole entry point so consumers don't take
  * implementation dependencies they'll need to unwind.
+ *
+ * The `rawEnv` arg is plumbed for test isolation — production callers
+ * pass `process.env`.
  */
 export async function createKartografSession(
   config: KartografSessionConfig,
+  rawEnv: NodeJS.ProcessEnv = process.env,
 ): Promise<KartografSession> {
-  return new StubKartografSession(config);
+  const enabled = rawEnv.MEMPHIS_KARTOGRAF_ENABLE === '1';
+  if (!enabled) {
+    return new StubKartografSession(config);
+  }
+  try {
+    const { OnnxKartografSession } = await import('./onnx-session.js');
+    return await OnnxKartografSession.load(config.checkpointPath, {
+      topKZones: config.topKZones,
+    });
+  } catch (err) {
+    // Boot-time fallback: surface the reason via stderr so the operator
+    // can debug, but keep the daemon up. A broken checkpoint must not
+    // wedge cognitive frames that don't even use kartograf yet.
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(`[kartograf] OnnxKartografSession.load failed — falling back to stub: ${reason}`);
+    return new StubKartografSession(config);
+  }
 }

--- a/src/kartograf/zone-labels.ts
+++ b/src/kartograf/zone-labels.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical zone labels for the Kartograf v1 zone classifier head.
+ *
+ * The classifier emits 12 logits. Indices map 1:1 to the labels below in
+ * the order produced by the training corpus (`zone-labels.json` written
+ * by `tools/training/kartograf-pair-miner.py` during corpus build).
+ *
+ * Indices 0-9 align with the canonical Memphis chain catalog at the
+ * training-corpus snapshot (Sprint 0.5 G2 = 10 chains pre-`messages`).
+ * Indices 10-11 are reserved slots that the spec leaves for two new
+ * chains without a full encoder retrain (Y2 zone-head fine-tune).
+ *
+ * If a future Kartograf model is trained against a different zone set
+ * (e.g. v2 with `messages` promoted out of `reserved_*`), the producer
+ * MUST emit a new constant here AND the runtime loader MUST verify
+ * `envelope.heads_config.zone_classes === labels.length` before
+ * reporting zone scores — see OnnxKartografSession.load() for the
+ * runtime check.
+ *
+ * Source of truth: `~/.memphis/kartograf/corpus/v4/zone-labels.json`.
+ * If you change anything here, mirror the change in the corpus zone
+ * file (or re-train against an updated corpus) so producer + consumer
+ * agree on label ordering.
+ */
+export const KARTOGRAF_V1_ZONE_LABELS: readonly string[] = [
+  'journal',
+  'decisions',
+  'reflections',
+  'cases',
+  'patterns',
+  'system',
+  'collective',
+  'proactive',
+  'insights',
+  'soul',
+  'reserved_1',
+  'reserved_2',
+] as const;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -32,6 +32,7 @@ import { runMemphisGrep } from './tools/grep.js';
 import { runMemphisHealthCheck } from './tools/health-check.js';
 import { runMemphisHealth } from './tools/health.js';
 import { runMemphisJournal } from './tools/journal.js';
+import { runMemphisKartograf } from './tools/kartograf.js';
 import { runMemphisLoopStep } from './tools/loop-step.js';
 import { runMemphisMediaIngest } from './tools/media-ingest.js';
 import { runMemphisPackage } from './tools/package.js';
@@ -276,6 +277,36 @@ export function createMemphisMcpServer(
           structuredContent: result as Record<string, unknown>,
         };
       }),
+    );
+  }
+
+  const kartografPolicy = getToolPolicy(permissions, 'memphis_kartograf', resolvedManifest);
+  if (shouldRegisterTool('memphis_kartograf', kartografPolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_kartograf',
+      {
+        description: getToolDescription('memphis_kartograf'),
+        inputSchema: {
+          query: z.string().min(1).max(8192),
+          top_k_zones: z.number().int().min(1).max(12).optional(),
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate(
+        'memphis_kartograf',
+        kartografPolicy,
+        approvals,
+        async ({ query, top_k_zones }) => {
+          const result = await runMemphisKartograf({
+            query,
+            ...(top_k_zones !== undefined ? { top_k_zones } : {}),
+          });
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        },
+      ),
     );
   }
 

--- a/src/mcp/tools/kartograf.ts
+++ b/src/mcp/tools/kartograf.ts
@@ -1,0 +1,90 @@
+/**
+ * memphis_kartograf — first-class tool wrapping the runtime singleton.
+ *
+ * Daemon callers (cognitive frames, cron triggers) reach for this when
+ * they want a zone-routing hint plus a 256-d embedding. The runtime is
+ * lazy-loaded the first time anyone asks; subsequent calls share the
+ * singleton (no 700-MB reload).
+ *
+ * Returns a structured error rather than zero vectors when the runtime
+ * is disabled or the checkpoint is broken — silent degradation here
+ * would propagate as misrouted writes, exactly what the spec calls out
+ * as "P0 routing failure" in docs/dev/KARTOGRAF-SPEC.md.
+ */
+import { getKartografRuntime } from '../../kartograf/runtime.js';
+import type { ZoneClassification } from '../../kartograf/session.js';
+
+export interface MemphisKartografInput {
+  query: string;
+  top_k_zones?: number;
+}
+
+export type MemphisKartografOutput =
+  | {
+      ok: true;
+      query: string;
+      checkpointId: string;
+      embeddingDim: number;
+      embeddingPreview: number[];
+      zones: ZoneClassification[];
+      elapsedMs: number;
+    }
+  | {
+      ok: false;
+      error: string;
+      hint?: string;
+      stateKind: 'disabled' | 'no-checkpoint' | 'load-failed';
+    };
+
+export async function runMemphisKartograf(
+  input: MemphisKartografInput,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): Promise<MemphisKartografOutput> {
+  const query = input.query?.toString().trim();
+  if (!query) {
+    return {
+      ok: false,
+      error: 'memphis_kartograf requires non-empty query',
+      stateKind: 'disabled',
+    };
+  }
+
+  const runtime = await getKartografRuntime(rawEnv);
+  if (runtime.kind !== 'ready') {
+    return {
+      ok: false,
+      error: runtime.reason,
+      stateKind: runtime.kind,
+      hint:
+        runtime.kind === 'disabled'
+          ? 'Set MEMPHIS_KARTOGRAF_ENABLE=1 in .env and restart the daemon'
+          : runtime.kind === 'no-checkpoint'
+            ? 'Run `memphis kartograf install --file <envelope>.json --source file` first'
+            : 'Check daemon stderr for the ONNX load error; the most common cause is an ABI mismatch between onnxruntime-node versions',
+    };
+  }
+
+  const session = runtime.session;
+  const topK = input.top_k_zones;
+
+  const t0 = Date.now();
+  const result = await session.embed(query);
+  const elapsedMs = Date.now() - t0;
+
+  const zones = typeof topK === 'number' && topK > 0 ? result.zones.slice(0, topK) : result.zones;
+
+  return {
+    ok: true,
+    query,
+    checkpointId: result.checkpointId,
+    embeddingDim: result.embedding.length,
+    // Surface only the first 8 dims to keep tool output token-cheap.
+    // Consumers needing the full vector should call the underlying
+    // KartografSession directly (intentionally not exposed as a tool —
+    // 256 floats × 4 bytes × N tools-per-frame would balloon prompt
+    // size with no actionable value for the LLM).
+    embeddingPreview: Array.from(result.embedding.slice(0, 8)),
+    zones,
+    elapsedMs,
+  };
+}

--- a/src/modules/skills/catalog.ts
+++ b/src/modules/skills/catalog.ts
@@ -230,6 +230,39 @@ const BUILTIN_MANIFESTS: SkillManifestRef[] = [
       ],
     }),
   ),
+  builtinSkill(
+    normalizeSkillManifest({
+      schemaVersion: 1,
+      id: 'kartograf-zone-router',
+      name: 'Kartograf Zone Router',
+      description:
+        'Use Kartograf inference to pick the right Memphis chain before writing. Surface the top zones and corroborate with recall when stakes are high.',
+      tags: ['kartograf', 'routing', 'memory', 'chains'],
+      tools: ['memphis_kartograf', 'memphis_recall', 'memphis_journal'],
+      workflow: [
+        'Call memphis_kartograf with the text you intend to remember.',
+        'Inspect the top zones — if score(top) > 0.7 take it as the destination chain, else short-list top 3 and corroborate via memphis_recall on each candidate chain.',
+        'Write to the chosen chain via memphis_journal (or chain-specific tool). Cite the kartograf checkpointId + top zone score in the audit trail so future readers can trace the routing decision.',
+      ],
+      promptHints: [
+        'Kartograf v1 has recall@10 = 0.27 — treat the top zone as a HINT, not a hard route.',
+        'When the top two zones are within 0.2 of each other, prefer corroboration over the model alone.',
+        'If memphis_kartograf returns stateKind=disabled, fall back to memphis_recall + the chain catalog before writing — do NOT proceed silently with the default chain.',
+      ],
+      examples: [
+        {
+          prompt:
+            'I have a decision about migrating from Anthropic to MiniMax — which chain should this go in?',
+          outcome:
+            'Skill calls memphis_kartograf, gets zones (likely top=decisions), confirms via memphis_recall against the decisions chain, then writes to decisions with the model-provided routing hint cited.',
+        },
+      ],
+      notes: [
+        'Requires MEMPHIS_KARTOGRAF_ENABLE=1 and an installed checkpoint. If neither is true the tool returns stateKind=disabled / no-checkpoint and the skill bails to manual routing.',
+        'The kartograf model is small (DeBERTa-v3-base, 12-class classifier). It will mis-classify edge cases — corroboration is non-optional for important writes.',
+      ],
+    }),
+  ),
 ] as const;
 
 function catalogDir(rawEnv: NodeJS.ProcessEnv = process.env): string {

--- a/tests/unit/cli.skills.test.ts
+++ b/tests/unit/cli.skills.test.ts
@@ -21,6 +21,7 @@ describe('CLI skills', () => {
 
     expect(data.manifests.map((item) => item.id)).toEqual([
       'deploy-troubleshooter',
+      'kartograf-zone-router',
       'memory-curator',
       'self-mod-operator',
     ]);

--- a/tests/unit/in-process-tool-executor.test.ts
+++ b/tests/unit/in-process-tool-executor.test.ts
@@ -27,6 +27,12 @@ describe('in-process tool executor', () => {
       isConcurrencySafe: true,
       isReadOnly: true,
     });
+    // Kartograf inference is read-only (no chain writes, no FS mutation)
+    // and concurrency-safe (singleton session is internally serialized).
+    expect(toolMap.get('memphis_kartograf')).toMatchObject({
+      isConcurrencySafe: true,
+      isReadOnly: true,
+    });
     expect(toolMap.get('memphis_search')).toMatchObject({
       isConcurrencySafe: true,
       isReadOnly: true,

--- a/tests/unit/kartograf-cli.test.ts
+++ b/tests/unit/kartograf-cli.test.ts
@@ -375,7 +375,11 @@ describe('memphis kartograf CLI (N40.2)', () => {
     expect(out.checkpoints[0].signerDid).toMatch(/^did:key:ed25519:/);
   });
 
-  it('query returns ok=false with Y2 reason + installed-checkpoint count (Sprint K)', async () => {
+  it('query without --query returns ok=false with usage error (kartograf-runtime PR 2026-05-12)', async () => {
+    // The Y2-scope stub message went away when the ONNX runtime
+    // shipped. The CLI now validates --query upfront and emits a
+    // usage error if it's missing — operator no longer needs to know
+    // about "Y2 scope" to understand what to type.
     const dir = tempDir();
     process.env.MEMPHIS_DATA_DIR = dir;
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -388,9 +392,7 @@ describe('memphis kartograf CLI (N40.2)', () => {
 
     expect(out.ok).toBe(false);
     expect(out.mode).toBe('kartograf.query');
-    expect(out.reason).toMatch(/Y2 scope/);
-    expect(out.installedCheckpoints).toBe(0);
-    expect(out.hint).toMatch(/install/);
+    expect(out.error).toMatch(/--query/);
   });
 });
 

--- a/tests/unit/kartograf-runtime.test.ts
+++ b/tests/unit/kartograf-runtime.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the Kartograf runtime singleton.
+ *
+ * These cover the disabled / no-checkpoint paths (which run on every
+ * machine — no ONNX runtime needed) plus the cache-once contract.
+ * The "real ONNX session loads and serves embeddings" path is exercised
+ * by the live smoke run + `memphis kartograf query`; reproducing it
+ * here would require shipping the 737 MB checkpoint in CI, which the
+ * spec explicitly rules out.
+ */
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { _resetKartografRuntimeForTests, getKartografRuntime } from '../../src/kartograf/runtime.js';
+
+describe('kartograf runtime', () => {
+  beforeEach(() => {
+    _resetKartografRuntimeForTests();
+  });
+
+  it('returns disabled when MEMPHIS_KARTOGRAF_ENABLE is unset', async () => {
+    const status = await getKartografRuntime({
+      MEMPHIS_HOME: '/tmp/kartograf-rt-test-1',
+    } as NodeJS.ProcessEnv);
+    expect(status.kind).toBe('disabled');
+    if (status.kind === 'disabled') {
+      expect(status.reason).toMatch(/MEMPHIS_KARTOGRAF_ENABLE/);
+    }
+  });
+
+  it('returns no-checkpoint when flag set but stage dir is empty', async () => {
+    const status = await getKartografRuntime({
+      MEMPHIS_KARTOGRAF_ENABLE: '1',
+      MEMPHIS_HOME: '/tmp/kartograf-rt-test-2-no-such-dir-xyz123',
+      MEMPHIS_DATA_DIR: '/tmp/kartograf-rt-test-2-no-such-dir-xyz123/data',
+    } as NodeJS.ProcessEnv);
+    expect(status.kind).toBe('no-checkpoint');
+  });
+
+  it('caches the disabled status across subsequent calls', async () => {
+    const env = { MEMPHIS_HOME: '/tmp/kartograf-rt-test-3' } as NodeJS.ProcessEnv;
+    const a = await getKartografRuntime(env);
+    const b = await getKartografRuntime(env);
+    expect(a).toBe(b); // same object reference — pulled from cache
+  });
+
+  it('reset clears the cache', async () => {
+    const env = { MEMPHIS_HOME: '/tmp/kartograf-rt-test-4' } as NodeJS.ProcessEnv;
+    const a = await getKartografRuntime(env);
+    _resetKartografRuntimeForTests();
+    const b = await getKartografRuntime(env);
+    expect(a).not.toBe(b); // different objects after reset
+    expect(a.kind).toBe(b.kind); // but same status
+  });
+});

--- a/tests/unit/provider-stamp.test.ts
+++ b/tests/unit/provider-stamp.test.ts
@@ -1,16 +1,22 @@
 /**
- * Anti-confab provider stamp — sprint 2026-05-04.
+ * Anti-confab provider stamp — sprint 2026-05-04, flipped to opt-in
+ * 2026-05-12.
  *
- * Bot was claiming "ja, cogito:3b" / "Pisałem to sam" while the actual
- * provider was MiniMax. Source-of-truth fix: the runtime appends a
- * "— via {provider}/{model}" footer to every reply across every
- * surface so the operator (and any later auditor reading persisted
- * sessions) sees who actually generated the text.
+ * Original problem: bot was claiming "ja, cogito:3b" / "Pisałem to sam"
+ * while the actual provider was MiniMax. The fix added a "— via
+ * {provider}/{model}" footer so operators (and any later auditor
+ * reading persisted sessions) could trace who generated the text.
+ *
+ * 2026-05-12 flip: operator confirmed the in-body footer was noise on
+ * operator-facing surfaces and frequently misleading when provider
+ * cascade switched mid-call. Default is now OFF — set
+ * MEMPHIS_PROVIDER_STAMP=1 to bring the footer back for bisecting
+ * misroutes. Legacy "=0" still honored (no-op redundancy).
  *
  * This file pins the helper's contract:
- *   - default ON, regardless of provider/model
+ *   - default OFF
+ *   - emits the footer when MEMPHIS_PROVIDER_STAMP=1 / true
  *   - idempotent (won't double-stamp when model imitates the format)
- *   - suppressed via MEMPHIS_PROVIDER_STAMP=0 / false
  *   - safe against missing/empty provider or model strings
  */
 import { describe, expect, it } from 'vitest';
@@ -18,49 +24,56 @@ import { describe, expect, it } from 'vitest';
 import { appendProviderStamp } from '../../src/gateway/turn-runtime.js';
 
 describe('appendProviderStamp', () => {
-  it('appends "— via provider/model" by default', () => {
+  const ON = { MEMPHIS_PROVIDER_STAMP: '1' };
+
+  it('passes the body through verbatim by default (flag unset)', () => {
     const out = appendProviderStamp('Cześć!', 'minimax', 'MiniMax-M2.7', {});
-    expect(out).toBe('Cześć!\n\n— via minimax/MiniMax-M2.7');
+    expect(out).toBe('Cześć!');
   });
 
-  it('preserves the original body verbatim', () => {
-    const body = '## Status\n\nBloki: 2883\nVault: 4 wpisy';
-    const out = appendProviderStamp(body, 'ollama', 'cogito:3b', {});
-    expect(out.startsWith(body)).toBe(true);
-    expect(out.endsWith('— via ollama/cogito:3b')).toBe(true);
-  });
-
-  it('trims trailing whitespace before the footer (no orphan blank lines)', () => {
-    const out = appendProviderStamp('text\n\n\n\n', 'ollama', 'cogito:3b', {});
-    // exactly one blank line between body and footer
-    expect(out).toBe('text\n\n— via ollama/cogito:3b');
-  });
-
-  it('suppresses footer when MEMPHIS_PROVIDER_STAMP=0', () => {
+  it('passes the body through verbatim when MEMPHIS_PROVIDER_STAMP=0 (legacy off)', () => {
     const out = appendProviderStamp('hi', 'minimax', 'MiniMax-M2.7', {
       MEMPHIS_PROVIDER_STAMP: '0',
     });
     expect(out).toBe('hi');
   });
 
-  it('suppresses footer when MEMPHIS_PROVIDER_STAMP=false', () => {
+  it('passes the body through verbatim when MEMPHIS_PROVIDER_STAMP=false (legacy off)', () => {
     const out = appendProviderStamp('hi', 'minimax', 'MiniMax-M2.7', {
       MEMPHIS_PROVIDER_STAMP: 'false',
     });
     expect(out).toBe('hi');
   });
 
+  it('appends "— via provider/model" when MEMPHIS_PROVIDER_STAMP=1', () => {
+    const out = appendProviderStamp('Cześć!', 'minimax', 'MiniMax-M2.7', ON);
+    expect(out).toBe('Cześć!\n\n— via minimax/MiniMax-M2.7');
+  });
+
+  it('preserves the original body verbatim under MEMPHIS_PROVIDER_STAMP=1', () => {
+    const body = '## Status\n\nBloki: 2883\nVault: 4 wpisy';
+    const out = appendProviderStamp(body, 'ollama', 'cogito:3b', ON);
+    expect(out.startsWith(body)).toBe(true);
+    expect(out.endsWith('— via ollama/cogito:3b')).toBe(true);
+  });
+
+  it('trims trailing whitespace before the footer (no orphan blank lines)', () => {
+    const out = appendProviderStamp('text\n\n\n\n', 'ollama', 'cogito:3b', ON);
+    // exactly one blank line between body and footer
+    expect(out).toBe('text\n\n— via ollama/cogito:3b');
+  });
+
   it('does not double-stamp when reply already ends with a "— via X/Y" line', () => {
     // A pathological model that imitates the footer in its own reply
     // shouldn't get a second one bolted on.
     const already = 'sample reply\n\n— via somebody/something';
-    const out = appendProviderStamp(already, 'minimax', 'MiniMax-M2.7', {});
+    const out = appendProviderStamp(already, 'minimax', 'MiniMax-M2.7', ON);
     expect(out).toBe(already);
   });
 
-  it('falls back to "unknown" when provider or model is empty', () => {
-    expect(appendProviderStamp('hi', '', 'M', {})).toMatch(/— via unknown\/M$/);
-    expect(appendProviderStamp('hi', 'P', '', {})).toMatch(/— via P\/unknown$/);
-    expect(appendProviderStamp('hi', '', '', {})).toMatch(/— via unknown\/unknown$/);
+  it('falls back to "unknown" when provider or model is empty (stamp on)', () => {
+    expect(appendProviderStamp('hi', '', 'M', ON)).toMatch(/— via unknown\/M$/);
+    expect(appendProviderStamp('hi', 'P', '', ON)).toMatch(/— via P\/unknown$/);
+    expect(appendProviderStamp('hi', '', '', ON)).toMatch(/— via unknown\/unknown$/);
   });
 });

--- a/tests/unit/skills.catalog.test.ts
+++ b/tests/unit/skills.catalog.test.ts
@@ -24,6 +24,7 @@ describe('skills catalog', () => {
 
     expect(catalog.manifests.map((item) => item.manifest.id)).toEqual([
       'deploy-troubleshooter',
+      'kartograf-zone-router',
       'memory-curator',
       'self-mod-operator',
     ]);

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -20,7 +20,9 @@ describe('tool registry', () => {
     // PR #497 (2026-05-05): added memphis_media_ingest (tier 2, read+write+network).
     // PR #572 (2026-05-12): added memphis_skill_{list,show,create,validate,install}
     //   — 5 first-class skill tools (3 tier-1 read, 2 tier-2 write).
-    expect(getToolNames()).toHaveLength(43);
+    // PR (2026-05-12, kartograf-runtime): added memphis_kartograf (tier-1 read)
+    //   — wraps the new OnnxKartografSession singleton.
+    expect(getToolNames()).toHaveLength(44);
   });
 
   it('hides experimental preview tools by default', () => {
@@ -85,10 +87,13 @@ describe('tool registry', () => {
     const tier1 = getToolsByTier(1);
     // PR #572 (2026-05-12): added 3 tier-1 read tools — memphis_skill_list,
     // memphis_skill_show, memphis_skill_validate (info-only operations).
-    expect(tier1.length).toBe(4);
+    // PR (kartograf-runtime, 2026-05-12): added memphis_kartograf (inference,
+    // read-only — returns embedding + zones, no chain writes).
+    expect(tier1.length).toBe(5);
     expect(tier1.map((t) => t.name).sort()).toEqual(
       [
         'memphis_health_check',
+        'memphis_kartograf',
         'memphis_skill_list',
         'memphis_skill_show',
         'memphis_skill_validate',

--- a/tests/unit/turn-runtime.test.ts
+++ b/tests/unit/turn-runtime.test.ts
@@ -123,19 +123,19 @@ describe('turn runtime', () => {
       persistSession,
     });
 
-    // Sprint anti-confab 2026-05-04: every reply gets a "— via X/Y"
-    // footer appended (suppressible via MEMPHIS_PROVIDER_STAMP=0).
-    // Both sendReply and persistSession see the stamped output, so
-    // surfaces and audit history stay aligned.
+    // 2026-05-12: provider stamp is now OFF by default (operator
+    // confirmed the in-body "— via X/Y" footer was noise on operator-
+    // facing surfaces, and often misleading when provider cascade
+    // switched mid-call). Reply body matches the raw assistant text
+    // verbatim, no stamp. Power users can re-enable via
+    // MEMPHIS_PROVIDER_STAMP=1.
     await vi.waitFor(() => {
-      expect(sendReply).toHaveBeenCalledWith(
-        expect.stringMatching(/^assistant raw reply\n\n— via .+\/.+$/),
-      );
+      expect(sendReply).toHaveBeenCalledWith('assistant raw reply');
     });
     expect(persistSession).toHaveBeenCalledWith(
       expect.objectContaining({
         userText: expect.stringContaining('<user_input>'),
-        assistantReply: expect.stringMatching(/^assistant raw reply\n\n— via .+\/.+$/),
+        assistantReply: 'assistant raw reply',
       }),
     );
 
@@ -197,7 +197,7 @@ describe('turn runtime', () => {
     );
   });
 
-  it('stamps real provider/model labels when using the llm: branch (no fallback to "provider/unknown")', async () => {
+  it('stamps real provider/model labels when MEMPHIS_PROVIDER_STAMP=1 (no fallback to "provider/unknown")', async () => {
     // Bug repro from operator session 2026-05-04: chat-loop wraps the
     // active provider as a bare LlmClient, then calls runTurnRuntime
     // with `llm: config.llm`. Pre-fix, resolveLlm() defaulted provider
@@ -205,7 +205,10 @@ describe('turn runtime', () => {
     // appendProviderStamp dutifully emitted "— via provider/unknown"
     // on every Telegram reply. Pin the path: when the caller forwards
     // providerLabel + model alongside an opaque llm, the stamp uses
-    // those real labels.
+    // those real labels. 2026-05-12: stamp is now opt-in, so set the
+    // flag explicitly to cover the regression path.
+    const prevStamp = process.env.MEMPHIS_PROVIDER_STAMP;
+    process.env.MEMPHIS_PROVIDER_STAMP = '1';
     const { runTurnRuntime } = await import('../../src/gateway/turn-runtime.js');
 
     const sendReply = vi.fn(async () => undefined);
@@ -222,17 +225,22 @@ describe('turn runtime', () => {
       isAvailable: vi.fn(() => true),
     };
 
-    await runTurnRuntime({
-      input: 'hello',
-      messages: [],
-      llm,
-      providerLabel: 'minimax',
-      model: 'MiniMax-M2.7',
-      memory,
-      memoryUserId: 'tg:1316033647',
-      surface: 'telegram',
-      sendReply,
-    });
+    try {
+      await runTurnRuntime({
+        input: 'hello',
+        messages: [],
+        llm,
+        providerLabel: 'minimax',
+        model: 'MiniMax-M2.7',
+        memory,
+        memoryUserId: 'tg:1316033647',
+        surface: 'telegram',
+        sendReply,
+      });
+    } finally {
+      if (prevStamp === undefined) delete process.env.MEMPHIS_PROVIDER_STAMP;
+      else process.env.MEMPHIS_PROVIDER_STAMP = prevStamp;
+    }
 
     await vi.waitFor(() => {
       expect(sendReply).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- **Closes Q2 deliverable** from `docs/dev/KARTOGRAF-SPEC.md` (`Runtime (onnxruntime-node)` section). The session factory previously always returned `StubKartografSession`; now it loads installed checkpoints via `onnxruntime-node@1.21.0` + `@huggingface/transformers@3.7.6`.
- **New `memphis_kartograf` tool** (tier-1 read) — Memphis daemon can call it during agent loops to get a 256-d embedding + 12-class zone classification from the active checkpoint. Singleton-cached at runtime so first call pays the ~5 s ONNX load and subsequent calls run in <200 ms.
- **New `kartograf-zone-router` skill** (built-in) — composes routing decisions over `memphis_kartograf` + `memphis_recall` + `memphis_journal` so the agent corroborates the model hint before writing.
- **Opt-in via `MEMPHIS_KARTOGRAF_ENABLE=1`** — the 80-MB ORT binary isn't loaded on installs that don't use Kartograf. Without the flag the tool returns a structured `stateKind: 'disabled'` rather than silently degrading to zero vectors.
- **Provider stamp flipped to opt-in** (`MEMPHIS_PROVIDER_STAMP=1` to re-enable) — the in-body "— via X/Y" footer was noise on operator-facing surfaces and often misleading when provider cascade switched mid-call. TUI status bar + audit logs already carry the same data with more precision.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/kartograf/ src/mcp/tools/kartograf.ts tests/unit/kartograf-runtime.test.ts` — clean
- [x] Unit: `tests/unit/kartograf-runtime.test.ts` (4 tests, disabled/no-checkpoint/cache paths)
- [x] Updated counts: `tests/unit/tool-registry.test.ts` (43→44, tier1 4→5), `tests/unit/in-process-tool-executor.test.ts` (memphis_kartograf concurrency/read assertions)
- [x] Updated: `tests/unit/turn-runtime.test.ts` for stamp-flip default
- [x] Live smoke (CLI): `MEMPHIS_KARTOGRAF_ENABLE=1 memphis kartograf query --query "..."` returns real 256-d embedding + softmax zones
- [x] Live smoke (Telegram): operator confirmed via Telegram — Memphis called `memphis_kartograf` on a status-update prompt, classifier returned `journal: 0.99` with `checkpointId: 7c82bc97…`

## Activation steps (operator-side)

```bash
# 1. Install a checkpoint (already done from training run 2026-05-12)
memphis kartograf install --file <envelope>.json --source file

# 2. Flip the flag in .env
echo 'MEMPHIS_KARTOGRAF_ENABLE=1' >> .env

# 3. Restart daemon
systemctl --user restart memphis
```

Daemon startup will then advertise `tools: N+1` (one more than before activation).

## Out of scope (deferred)

- Cascade integration — wiring Kartograf as tier-0 retriever in `memphis_recall` ranking. Tool is standalone today; semantic recall still uses existing local embeddings pipeline.
- HF hub + GitHub release `--source` transports.
- Better-trained checkpoint with balanced classes (v4 model has recall@10 = 0.27 and over-fits to journal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)