### PR TITLE
feat(providers): expose full MiniMax model lineup (2026-05-12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,22 @@ OLLAMA_MODEL=cogito:3b
 MINIMAX_VAULT_KEY=minimax_api_key
 # MINIMAX_MODEL=MiniMax-M2.7
 # MINIMAX_BASE_URL=https://api.minimax.io/v1
+# Available chat models (https://platform.minimax.io/docs/guides/models-intro):
+#   MiniMax-M2.7              ← default, current flagship
+#   MiniMax-M2.7-highspeed    ← M2.7 with faster inference, polyglot code work
+#   MiniMax-M2.5              ← code generation + refactor focused
+#   MiniMax-M2.5-highspeed    ← M2.5 fast variant
+#   MiniMax-M2                ← agentic + function calling, 200k/128k context
+#   MiniMax-M2.1              ← M2 line legacy (code + reasoning)
+#   MiniMax-M2.1-highspeed    ← M2.1 fast variant
+#   m2-her                    ← roleplay / character / emotional expression
+#   MiniMax-M1                ← pre-M2 legacy
+#   MiniMax-Text-01           ← pre-M2 legacy
+#   abab6.5s-chat             ← pre-M2 legacy (16k context)
+#   abab6.5-chat              ← pre-M2 legacy
+#   abab5.5-chat              ← pre-M2 legacy
+# Per-request override via tool calls (`opts.model`) — agent can pick a
+# different model for a single call without changing the default.
 
 DEEPSEEK_VAULT_KEY=deepseek_api_key
 # DEEPSEEK_MODEL=deepseek-chat

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -358,8 +358,27 @@ export class MinimaxProvider implements Provider {
   }
 
   async listModels(): Promise<string[]> {
+    // Current as of 2026-05-12. Source: https://platform.minimax.io/docs/guides/models-intro
+    // Listed newest-first so default-pick heuristics (first match) stay
+    // aligned with what the operator most likely wants. `MiniMax-*`
+    // capitalization mirrors the existing operator .env convention;
+    // the API also accepts the docs' lowercase form (`minimax-m2.7`).
     return [
+      // M2.7 — current flagship, "recursive self-improvement" focused.
       'MiniMax-M2.7',
+      'MiniMax-M2.7-highspeed',
+      // M2.5 — code generation + refactor optimized.
+      'MiniMax-M2.5',
+      'MiniMax-M2.5-highspeed',
+      // M2 — agentic + function calling, 200k input / 128k output context.
+      'MiniMax-M2',
+      // M2.1 — code + reasoning (legacy of M2 line).
+      'MiniMax-M2.1',
+      'MiniMax-M2.1-highspeed',
+      // m2-her — character / roleplay / emotional expression. Lowercase
+      // per docs since this id doesn't use the MiniMax- prefix.
+      'm2-her',
+      // Pre-M2 legacy text models (kept for explicit operator opt-in).
       'MiniMax-M1',
       'MiniMax-Text-01',
       'abab6.5s-chat',
@@ -442,10 +461,15 @@ export class MinimaxProvider implements Provider {
       body.tools = mmTools;
     }
 
-    // M2.7+ models use OpenAI-compatible endpoint; legacy abab models use v2
-    const endpoint = model.startsWith('MiniMax-')
-      ? `${this.baseUrl}/chat/completions`
-      : `${this.baseUrl}/text/chatcompletion_v2`;
+    // M2/M2.5/M2.7 family + m2-her use the OpenAI-compatible endpoint
+    // (`/chat/completions`). Legacy abab-* and pre-M2 chat surfaces use
+    // the v2 endpoint. The model-id space is heterogeneous (some IDs
+    // are `MiniMax-X`, others lowercase `m2-her`), so route off a
+    // simple is-legacy heuristic instead of a fragile single prefix.
+    const isLegacy = /^abab/i.test(model);
+    const endpoint = isLegacy
+      ? `${this.baseUrl}/text/chatcompletion_v2`
+      : `${this.baseUrl}/chat/completions`;
 
     // P4 hotfix (Phase 1.4): resolve the request timeout via the env-registry
     // accessor. Before this fix, the MiniMax client had no AbortSignal at all

--- a/src/providers/model-capabilities.ts
+++ b/src/providers/model-capabilities.ts
@@ -52,9 +52,38 @@ function ollamaCapabilities(model: string): ModelCapabilitySnapshot {
 }
 
 function minimaxCapabilities(model: string): ModelCapabilitySnapshot {
+  // Updated 2026-05-12 to match the current MiniMax model lineup
+  // (https://platform.minimax.io/docs/guides/models-intro). All M2
+  // family models advertise the 200k-input / 128k-output window from
+  // M2's published spec; we pin to 200k here because that's the
+  // larger of the two and request-side truncation is what the runtime
+  // needs to guard against. The 32k fallback covers M1 + Text-01 +
+  // anything else not explicitly listed.
   const normalized = model.toLowerCase();
+  // abab-6.5s is the shortest-context variant in the legacy abab
+  // family (per old docs); keep the explicit override.
+  if (normalized.includes('abab6.5s')) {
+    return {
+      contextWindowTokens: 16384,
+      supportsStreaming: true,
+      supportsVision: false,
+      source: 'heuristic',
+    };
+  }
+  // M2 family (M2, M2.1, M2.5, M2.7 + their -highspeed variants) and
+  // m2-her: 200k input window. Regex matches both the `MiniMax-M2`
+  // capitalization Memphis sends and the docs' lowercase form.
+  if (/^(minimax-)?m2(\.\d+)?(-highspeed)?$|^m2-her$/i.test(model)) {
+    return {
+      contextWindowTokens: 200000,
+      supportsStreaming: true,
+      supportsVision: false,
+      source: 'heuristic',
+    };
+  }
+  // M1 + Text-01 + the remaining legacy chat surfaces: 32k.
   return {
-    contextWindowTokens: normalized.includes('abab6.5s') ? 16384 : 32000,
+    contextWindowTokens: 32000,
     supportsStreaming: true,
     supportsVision: false,
     source: 'heuristic',


### PR DESCRIPTION
## Summary

Refresh of Memphis's MiniMax provider config + capability table to match the current model lineup at https://platform.minimax.io/docs/guides/models-intro (snapshot 2026-05-12). Operator has a MiniMax token-plan and wanted Memphis to know about (and be able to pick from) the full set.

- **\`listModels()\`** returns all 12 current chat models in newest-first order: M2.7 + highspeed, M2.5 + highspeed, M2, M2.1 + highspeed, m2-her (roleplay), plus legacy M1 / Text-01 / abab-* for explicit opt-in.
- **\`minimaxCapabilities()\`** buckets context windows accurately: M2 family + m2-her → 200k (per M2's published 200k-input / 128k-output spec); abab6.5s → 16k; remaining legacy → 32k. Compaction-pressure detection in the gateway now reports correctly for M2.7 daemon installs (was reporting 32k = "high pressure" at much smaller inputs than reality).
- **Endpoint routing** flipped from \`startsWith('MiniMax-')\` to \`startsWith('abab')\` as the legacy marker. The old heuristic would misroute \`m2-her\` (lowercase id) to the v2 endpoint; now all modern models land on \`/chat/completions\`.
- **\`.env.example\`** documents every model id with a one-line purpose so operators can pick without round-tripping to the docs page.

Per-request model selection via \`opts.model\` on tool calls already worked — the agent can pick \`MiniMax-M2.7-highspeed\` for a single low-latency turn without changing \`MINIMAX_MODEL\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint src/providers/index.ts src/providers/model-capabilities.ts\` clean
- [x] \`tests/unit/provider-models.test.ts\` (6 tests) still green — \`arrayContaining\` assertion accepts the expanded list as a superset
- [ ] Live: operator sets \`MINIMAX_MODEL=MiniMax-M2.7-highspeed\` and restarts; verify request body in daemon log shows the new id and the response is faster than M2.7 baseline
- [ ] Live: agent picks \`m2-her\` for a roleplay-style prompt via tool-call \`opts.model\` override; verify it routes to \`/chat/completions\` and not the v2 endpoint

## Out of scope (separate sprint)

- **Audio models** (\`speech-2.8-hd\`, \`speech-2.8-turbo\`, etc.) — would replace / supplement local Piper TTS. Needs a new \`memphis_voice_synthesize\` tool surface + cloud-quota guard.
- **Video models** (\`minimax-hailuo-2.3\` etc.) — text-to-video / image-to-video. New tool surface \`memphis_video_generate\`.
- **Music models** (\`music-2.6\`, \`music-cover\`, \`music-2.0\`) — \`memphis_music_generate\`.
- **Smart fallback across MiniMax models** (e.g. M2.7 → M2.5 on rate limit). The existing provider-cascade handles cross-provider fallback; intra-MiniMax fallback would need a separate retry policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)