### PR TITLE
release: v1.10.0 — Kartograf ONNX runtime + Telegram media + MiniMax lineup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,228 @@
 ## Unreleased
 
+## v1.10.0 - 2026-05-12
+
+Closes the 10-day window since `v1.9.2` (2026-05-08 → 2026-05-12) — 91
+commits across 15 feats, 42 fixes, 10 docs, plus a full Kartograf v4
+training arc. The `package.json` version field jumps from `1.8.0` to
+`1.10.0` to re-sync with the `v1.9.x` tag line; the intermediate
+`v1.9.0/.1/.2` shipped without `package.json` bumps or CHANGELOG
+entries (post-Zawoja autopilot pace — operator deliberately held
+`v1.10` for stability per `project_closure_2026-05-09.md`).
+
+This is the **bigger-than-usual** release: Kartograf inference goes
+from "stub returning zeros" to a real ONNX runtime backed by an
+operator-trained checkpoint, three new ingestion surfaces land on
+Telegram (voice, photo, document/PDF), and the MiniMax provider
+finally knows about its actual model lineup.
+
+### Highlights
+
+- **Kartograf ONNX runtime** — the Q2-spec `Runtime (onnxruntime-node)`
+  closure. `memphis_kartograf` tool gates on `MEMPHIS_KARTOGRAF_ENABLE=1`
+  + an installed checkpoint, lazy-loads the ~700-MB ONNX graph as a
+  process singleton, returns a 256-d embedding + 12-class zone
+  distribution per call. Replaces `StubKartografSession` which was
+  silently emitting zero vectors. (#573)
+- **Kartograf v4 training stack** — DeBERTa-v3-base + LoRA fine-tune
+  pipeline (`tools/training/train-kartograf.py`) producing signed
+  Ed25519 checkpoint envelopes. Operator-grade GPU (GTX 960 / Maxwell
+  sm52) end-to-end run completed 2026-05-12 (10h12min, 1846 steps,
+  recall@10 = 0.27, macro_f1 = 0.63). (#564)
+- **`kartograf-zone-router` built-in skill** — composes routing
+  decisions over `memphis_kartograf` + `memphis_recall` +
+  `memphis_journal` before writing to a chain. Cites the model's
+  `checkpointId` in the audit trail so writes can be traced to the
+  model version that picked them. (#573)
+- **First-class skill composition** — five `memphis_skill_{list,show,
+  create,validate,install}` tools so Memphis can scaffold + validate
+  + install skills without round-tripping via `memphis_fs_write` +
+  `memphis_exec memphis skills create`. The validator catches schema
+  mistakes BEFORE install with a `suggestedFix` hint ("did you mean
+  memphis_self_describe?"). Anti-confab rule E rejects fake tool
+  names in code fences via Levenshtein nearest-match. (#572)
+- **Telegram document / PDF ingestion** — `bot.on('message:document')`
+  handler. PDFs go through `pdftotext -layout` (poppler), text files
+  read raw UTF-8, images-as-documents reuse the vision+OCR pipeline,
+  every other type gets honest "unsupported, ask the user" framing.
+  Caps: 10 MB per attachment, 12 KB PDF body / 256 KB text body in
+  the prompt. (#574)
+- **Full MiniMax model lineup** — provider config refreshed against
+  `platform.minimax.io/docs/guides/models-intro` (2026-05-12 snapshot).
+  All 12 current chat models exposed in `listModels()`: M2.7 +
+  highspeed, M2.5 + highspeed, M2 (200k/128k), M2.1 + highspeed,
+  m2-her (roleplay), plus legacy M1 / Text-01 / abab-*. Per-model
+  context windows in `minimaxCapabilities()` (M2 family = 200k; was
+  hardcoded 32k for every model). Endpoint routing fixed to handle
+  `m2-her` (which doesn't have the `MiniMax-` prefix). (#575)
+- **Telegram TTS shaping** — voice replies cap at 6 sentences with
+  "Reszta w tekście" overflow notice; markdown/URLs/emoji/ZWJ stripped
+  before synthesis; default voice flipped from `gosia` to `darkman`
+  (operator preference). Piper HTTP server defaults to the new voice.
+  (#571)
+- **Voice pipeline reboot survival** — `whisper-server.service` and
+  `piper-server.service` user units installed by
+  `scripts/voice-install.sh`. STT/TTS comes back automatically after
+  daemon reboots; no manual `python -m whisper_cpp_server` dance.
+- **Provider stamp flipped to opt-in** — the in-body
+  `— via {provider}/{model}` footer is OFF by default. Operator
+  confirmed 2026-05-12 it was noise on Telegram and frequently
+  misleading when provider cascade switched mid-call. Power users
+  can re-enable via `MEMPHIS_PROVIDER_STAMP=1`. Legacy `=0` still
+  honored. (#573)
+
+### Security & Vault
+
+- **Degraded boot on missing vault secrets** — operator's
+  `MEMPHIS_API_TOKEN=VAULT:...` reference with a missing vault entry
+  no longer crashes the daemon. The boot path distinguishes
+  "secret unconfigured intentionally" from "secret missing", emits a
+  recovery hint, and brings the daemon up in degraded mode so the
+  operator can diagnose interactively. (#568, addresses P1 #5 from
+  `docs/roadmap/2026-05-11-post-autonomy-todo-and-gap.md`)
+- **Vault-recovery runbook** — `docs/operator/VAULT-RECOVERY-RUNBOOK.md`
+  documents the path operators take when `pepper-rotate` leaves
+  vault inconsistent (the 2026-05-11 incident). Three recovery
+  options (plain-text bypass, master-key restore, full re-init) with
+  decision criteria. (#567, addresses P1 #6)
+- **Tier-3 session persistence across daemon restart** — tier-3
+  sessions now persist via `data/tier3-sessions.json` (encrypted
+  under the vault master key) so a daemon restart doesn't drop the
+  operator's elevation. Auto-expires sessions whose TTL has passed
+  during the offline window. (#566)
+- **OTEL audit allowlist** — `GHSA-q7rr-3cgh-j5r3` (prometheus
+  exporter transitive advisory) added to CI's `npm audit` filter so
+  the unrelated advisory doesn't block PRs. The advisory itself is
+  tracked as out-of-scope (we don't use the prometheus exporter
+  path). (#569)
+
+### Provider / orchestration
+
+- **Provider auto-failover on stream timeout** — orchestration service
+  detects per-provider stream timeouts and rotates to the next
+  configured provider in the cascade instead of returning a partial
+  reply. Cooldown-blocked providers are skipped; auth + validation
+  errors are NOT retried (operator must fix the credentials).
+  Audit-event-stamped each rotation. (#570)
+- **Fallback provider real LLM** — `fallbackProvider` switched from
+  `local-fallback` stub to real `ollama`. Cross-provider cascade now
+  ends in a working model when MiniMax / Anthropic both refuse,
+  instead of a placeholder stub message.
+- **Anthropic whitespace text-block filter** — strips whitespace-only
+  text content blocks before sending; pre-fix, the Anthropic API
+  rejected such blocks with 400 errors that surfaced as cryptic TUI
+  errors.
+- **Anthropic Opus 4.6 default + fallback chain** — default Anthropic
+  model promoted to `claude-opus-4-6` with `claude-opus-4-7` as
+  fallback. Window-cache 128k enabled so long-context conversations
+  don't pay full-prompt token cost per turn.
+- **Per-provider timeout knobs** — every per-provider timeout reads
+  from `src/config/env-registry.ts` instead of hardcoded constants.
+  Operator can tune `MEMPHIS_ANTHROPIC_TIMEOUT_MS`,
+  `MEMPHIS_MINIMAX_TIMEOUT_MS`, etc. without touching code. (#520)
+
+### Memory + cognition
+
+- **Anti-confab Phase 2 (warn-append) → Phase 3 (strip-sentence)** —
+  Phase 2 default-shipped in `v1.9.x`; Phase 3 implemented as opt-in
+  via `MEMPHIS_ANTICONFAB_PHASE=3` (regex-strips offending sentences
+  from the reply instead of just appending a warning). New rule E
+  catches fake-tool-name claims in code fences with Levenshtein
+  nearest-match → "did you mean memphis_self_describe?". Default
+  stays Phase 2; operator can flip to 3 after 1-2 weeks of data.
+- **Schema-error sample in `memphis_soul_write` rejection** — the
+  validator now emits a "Correct shape: ..." example beside the
+  error so the model can self-correct in one retry instead of
+  flipping array vs string on consecutive attempts.
+- **Embed bulk upsert + NDJSON v2 + explicit flush** — embed-reindex
+  pipeline rewrites the disk index with bulk SQL upserts + an
+  explicit periodic flush. Eliminates the I/O amplification storm
+  the repair-runtime path was triggering on full rebuilds.
+  `MEMPHIS_EMBED_DISK_V2=1` opt-in default-flip pending P5 #17.
+
+### Operator surface
+
+- **`memphis_kartograf` first-class tool** — daemon agent loops can
+  call Kartograf inference directly during chain-routing decisions.
+  Tier-1 read-only; structured `stateKind` (`disabled` /
+  `no-checkpoint` / `load-failed` / `ready`) instead of silent
+  zero-vector degradation. (#573)
+- **Doctor `~/.memphis/docs/` whitelisted** — operator's brief
+  output no longer flags the docs subdirectory as "unknown dir".
+  (#562, P3 #14)
+- **Install prerequisites auto-installs `python3-venv` +
+  `tesseract-ocr`** — fresh installs no longer hit "python3 -m venv:
+  command not found" mid-onboarding.
+- **TUI CPU halved** — poll interval doubled (50 → 100 ms active,
+  250 → 500 ms idle). Operator's TUI session goes from 110% CPU to
+  ~55%.
+- **MiniMax (None / None) overflow render gone** — the operator-side
+  ContextOverflow render no longer emits ugly `(None / None tokens)`
+  placeholders when upstream metadata is unavailable.
+- **`memphis vault pepper-rotate` cwd anchoring** — pepper-rotate
+  writes to `~/memphis/.env` regardless of cwd. Previously could
+  write to `$HOME/.env` if the operator ran it from outside the
+  repo root (cause of 2026-05-11 vault desync incident).
+
+### Docs
+
+- **`docs/operator/DAILY-ASSISTANT-SETUP.md`** — one-stop
+  "dżin w komputerze" guide covering install → init → Telegram →
+  voice → first conversation.
+- **`docs/dev/agent-operational-patterns-2026-05-10.md`** — 10
+  heuristics for log analysis + daemon-watch agent ops.
+- **`docs/dev/full-memphis-recon-2026-05-11.md`** — three architecture
+  maps (process tree, chain topology, vault encryption boundary).
+- **`docs/operator/kartograf.md`** — Y2-deferred → "ships today"
+  section, activation steps, and `kartograf-zone-router` skill
+  description.
+- **`docs/dev/vault-pepper-atomic-rotate-plan-2026-05-12.md`** — full
+  plan for the deferred atomic re-encrypt work (12-16 h focused
+  engineering across 4 phases). Plan + risks; implementation
+  intentionally not shipped this release (size + crypto-correctness
+  risk).
+- **`docs/roadmap/2026-05-11-post-autonomy-todo-and-gap.md`** — P0-P5
+  punch list from the post-autonomy session, with status callouts
+  resolved in this release.
+- **`docs/roadmap/post-v1.9-broad-roadmap.md`** — six-item operator-
+  dictated direction (OAuth Anthropic, STT/TTS local, video
+  pipeline, offline, Matrix Agora, `/marketplace`).
+- **`docs/dev/v1.10.0-deferred-work.md`** — explicit map of
+  TODO-not-shipped items per category with rationale.
+
+### Deferred from this release (carry-over)
+
+Per `docs/dev/v1.10.0-deferred-work.md`:
+
+- **Vault pepper atomic re-encrypt** (P1 #4) — plan written
+  (`docs/dev/vault-pepper-atomic-rotate-plan-2026-05-12.md`); 12-16 h
+  of focused crypto work across 4 phases. Holding for a dedicated
+  sprint with operator review between Phase 2 and Phase 3.
+- **Fresh-install validation surface** (P2 #7-9) — automated
+  `fresh-install-smoke.test.ts` + operator-runnable script + manual
+  verification doc. Will close the loop on "does a clean install
+  actually work end-to-end".
+- **Cache-stability test for Anthropic prompt caching** (P5 #18) —
+  byte-equality assertion on rebuilt system prompts across calls.
+- **Daemon native-fault diagnosis** — operator installed
+  `systemd-coredump` on 2026-05-12 so the next runtime SIGSEGV will
+  be preserved. Pattern observed: ~17-41 min uptime → silent native
+  crash → systemd auto-restart. `Node --report-on-fatalerror`
+  doesn't catch it (fault is below the V8 signal handler). After
+  the next preserved coredump → `gdb` stack identifies the native
+  library responsible.
+
+### CI / infrastructure
+
+- **OTEL transitive-advisory allowlist** — `GHSA-q7rr-3cgh-j5r3`
+  filtered via `jq` in the `npm audit` step so `quality-gate`
+  doesn't red-flag every PR over a transitive advisory in an
+  unused export path. (#569)
+- **Scheduler git-pull `--ff-only`** — the auto-update path refuses
+  to do non-fast-forward rebases. Eliminates the race where two
+  concurrent daemon-side `git pull`s could leave the work tree in a
+  merge-conflict state.
+
 ## v1.8.0 - 2026-05-02
 
 Closes an 84-commit window since `v1.7.2` (2026-04-25 → 2026-05-02).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Memphis is a local-first cognitive runtime born from [Oswobodzeni](https://oswob
 
 Every decision Memphis makes is recorded. Every secret is encrypted at rest. Every tool it touches requires your authorization. This is not a chatbot — it is a sovereign cognitive system designed for operators who refuse to rent their intelligence from Big Tech.
 
-**Current version: `v1.8.0`** (matches `package.json`) | **Status: production-ready for operator-supervised runtime** — vault hardening (0600 perms + heal-on-load), Rust+TS path resolver alignment, declarative provider cascade, cross-arch CI (linux + ubuntu-arm + macos), Telegram bot + Rust TUI surfaces, expanded secret-scan patterns (OpenAI / Stripe / GitHub / AWS / GCP / Slack / Anthropic). See `docs/CHANGELOG.md` for full history.
+**Current version: `v1.10.0`** (matches `package.json`) | **Status: production-ready for operator-supervised runtime** — Kartograf ONNX runtime + `memphis_kartograf` tool + `kartograf-zone-router` built-in skill, Telegram document/PDF ingestion (pdftotext + raw text + image-as-doc), full MiniMax model lineup (12 chat models, accurate context windows), first-class skill composition (`memphis_skill_*`), provider auto-failover on stream timeout, tier-3 session persistence across daemon restart, degraded boot + vault-recovery runbook. See [`CHANGELOG.md`](./CHANGELOG.md) for full history.
 
 ---
 

--- a/docs/dev/v1.10.0-deferred-work.md
+++ b/docs/dev/v1.10.0-deferred-work.md
@@ -1,0 +1,103 @@
+# v1.10.0 — deferred work carry-over
+
+**Snapshot:** 2026-05-12. Companion to `CHANGELOG.md`'s `v1.10.0`
+section. Captures what `docs/roadmap/2026-05-11-post-autonomy-todo-
+and-gap.md` flagged as P1-P5 versus what actually shipped in the
+v1.10.0 release window — so the next sprint planner doesn't have to
+re-derive it.
+
+## Status against P0-P5 from 2026-05-11 punch list
+
+### P0 — Bot offline (resolved before v1.10.0)
+
+| # | Item | Status |
+|---|---|---|
+| 1 | Vault recover OR plain-text bypass | ✅ Operator handled 2026-05-11 — vault live |
+| 2 | Provision `MEMPHIS_API_TOKEN` | ✅ Operator handled — daemon up |
+| 3 | Daemon restart clean | ✅ Done |
+
+### P1 — Production safety net
+
+| # | Item | Status |
+|---|---|---|
+| 4 | `fix(vault): pepper-rotate must re-encrypt entries` | 📋 **Plan written** at `docs/dev/vault-pepper-atomic-rotate-plan-2026-05-12.md`. 12-16 h focused engineering across 4 phases. Not shipped in v1.10.0 — crypto-correctness risk too high without operator review between Phase 2 (atomic flip) and Phase 3 (CLI surface). |
+| 5 | `fix(config): missing vault entry should not crash daemon` | ✅ **Shipped** (#568, this release) |
+| 6 | `docs(operator): vault-recovery RUNBOOK` | ✅ **Shipped** (#567, this release) |
+
+### P2 — Fresh install validation path
+
+| # | Item | Status |
+|---|---|---|
+| 7 | `tests/integration/fresh-install-smoke.test.ts` | ❌ Not shipped. Targets: spawn temp `MEMPHIS_HOME`, run `init` + onboarding, assert daemon starts + doctor green + Telegram/TUI wire + vault create+store+rotate cycle. ~3-5 h. |
+| 8 | `scripts/fresh-install-test.sh` | ❌ Not shipped. Operator-runnable bridge between the integration test and a full e2e on `/tmp/memphis-test-$ts/`. Pairs with #7. |
+| 9 | `docs/operator/FRESH-INSTALL-VERIFICATION.md` | ❌ Not shipped. Manual smoke-test runbook the operator runs after every major release. Pairs with `docs/operator/CLEAN-INSTALL.md` (install instructions) — this one is *verification*. |
+
+### P3 — Operator-pending (manual, by design)
+
+P3 items belong to the operator and are tracked but not engineered.
+`docs/roadmap/2026-05-11-post-autonomy-todo-and-gap.md:95-102` for
+the full list. Status snapshot 2026-05-12:
+
+- P3 #10 (Whisper :9000 live) — ✅ done (operator ran voice-install.sh)
+- P3 #11 (vault recovery Q&A) — ✅ done
+- P3 #12 (demo arm) — operator's call per session
+- P3 #13 (TUI restart) — ✅ CPU 110% → 55% confirmed live
+- P3 #14 (PR #562 merge) — ✅ shipped (`fix(doctor): whitelist docs`)
+- P3 #15 (`morning-report.sh` decision) — operator-pending
+
+### P4 — Plan completion
+
+| # | Item | Status |
+|---|---|---|
+| 16 | Phase 6 — Autonomous self-modify smoke test | ❌ Not shipped. Operator-supervised runtime walk-through, no PR per the agile-nibbling plan. Holding for a deliberate operator session — the smoke needs the operator at the console to grade success. |
+
+### P5 — Roadmap items surfaced
+
+| # | Item | Status |
+|---|---|---|
+| 17 | `MEMPHIS_EMBED_DISK_V2=1` default flip | ⏳ **Operator has it on** (`.env`) but the codebase default is still OFF. Flip the default after 1 more rebuild session without regressions (mid-v1.11 window). |
+| 18 | Cache-stability test for Anthropic prompt caching | ❌ Not shipped. Standing unit test that builds the system prompt twice and asserts byte-equality. ~1 h, low-risk. |
+| 19 | Anti-confab Phase 3 default flip | ⏳ **Operator has it on** (`MEMPHIS_ANTICONFAB_PHASE=3` in `.env`). Codebase default stays at 2 — re-evaluate after 1-2 weeks of Phase 2 / 3 data. |
+
+## Daemon SIGSEGV — separate diagnosis track
+
+**Not on the original punch list.** Surfaced during the v1.10.0
+release window when the operator's daemon SEGV'd a handful of times
+(2026-05-12: 14:53:27, 15:11:08, plus 3-4 before instrumentation).
+
+- **Pattern:** ~17-41 min uptime → silent native crash → systemd
+  auto-restart. No JS-side exception, no `--report-on-fatalerror`
+  output. Fault is below V8's signal handler.
+- **Likely culprits:** `better-sqlite3`, the `memphis-napi` Rust
+  bridge (vault crypto path), or `onnxruntime-node` (newly loaded
+  by `memphis_kartograf`). One of these mishandles a teardown / state
+  invariant; without a coredump there's no way to point at the
+  right one.
+- **Instrumentation as of 2026-05-12:**
+  - `systemd-coredump` installed (apt) — replaces apport's
+    crash-handler, preserves coredumps in `/var/lib/systemd/coredump/`.
+  - `NODE_OPTIONS=--report-on-fatalerror --report-uncaught-exception
+    --report-directory=/tmp/memphis-reports` set via systemd drop-in.
+    Catches V8 fatals but not native faults.
+- **Next step:** wait for the next preserved coredump → `coredumpctl
+  info <PID>` + `gdb` stack → identify the native library →
+  targeted fix.
+
+## What v1.11.0 should likely cover
+
+Priority-ordered for the next sprint, integrating the deferrals
+above:
+
+1. **Vault pepper atomic re-encrypt** (P1 #4) — finally close the
+   root-cause for the 2026-05-11 incident. Owner needs the
+   Phase 1 / Phase 2 plan from the design doc.
+2. **Fresh-install validation** (P2 #7-9) — bundle automated test +
+   script + runbook. Operator releases will gain a single
+   "is the install actually working?" lever.
+3. **Daemon SIGSEGV diagnosis** — after the next preserved coredump
+   lands. Fix is whatever the gdb stack names.
+4. **Cache-stability test** (P5 #18) — quick win, lock in
+   prompt-determinism so cache hit-rate stays measurable.
+5. **NDJSON v2 / Anti-confab Phase 3 default flips** (P5 #17 + #19) —
+   after another quiet week, flip both defaults and clear the
+   `.env` overrides.

--- a/docs/dev/vault-pepper-atomic-rotate-plan-2026-05-12.md
+++ b/docs/dev/vault-pepper-atomic-rotate-plan-2026-05-12.md
@@ -1,0 +1,91 @@
+# Vault pepper rotation — atomic re-encrypt plan
+
+**Status.** Design (2026-05-12). Replaces the never-pushed Coder B PR per memory `feedback_pepper_desync_twice_same_day`. Awaiting operator sign-off before implementation.
+
+## Why we need this
+
+Memory `feedback_pepper_desync_twice_same_day` (P0 follow-up): the vault pepper-rotate path rewraps the master key under the new pepper but leaves OTHER pepper-derived artifacts orphaned. Operator hit this twice on 2026-05-11 — vault refused decrypt after rotation because tier-3 session blobs / provider secret bundles / sync-trade signing keys were still tied to the old pepper.
+
+Current rotate implementation: `src/infra/cli/handlers/vault.handler.ts:471` → `rotateVaultStatePepper(oldPepper, newPepper, env)`. That function rewraps `data/vault-state.json` only. Everything else is left to drift.
+
+## Pepper consumers (audit 2026-05-12)
+
+| Consumer | Location | Mode | Rotation handling |
+|---|---|---|---|
+| Vault master key wrapping | `crates/memphis-vault/src/vault.rs:151,162` | `derive_master_key_v2(pepper)` → wraps master | ✅ Current rotate handles |
+| Provider v2 secrets | `crates/memphis-operator/src/provider.rs:write_v2_vault_secret` | aead-encrypted under pepper-derived key | ❌ NOT walked |
+| Operator runtime crypto | `crates/memphis-operator/src/runtime.rs:1183-1191` | pepper passed to crypto primitive (need re-read) | ❌ NOT walked |
+| Sync trade signing | `src/sync/trade.ts:24` | pepper used directly as signing key material | ⚠ Non-durable: trades are ephemeral, but in-flight trades may fail to verify after rotate. Likely acceptable. |
+| Tier-3 session blobs | `data/tier3-sessions.json` (encrypted) | likely pepper-derived (per memory `feedback_pepper_desync_twice_same_day`) | ❌ NOT walked |
+| Chain block payloads | `~/.memphis/chains/<chain>/*.json` | NOT pepper-encrypted (Ed25519 signed, payloads plaintext per spec) | n/a |
+
+The two REAL blockers: provider v2 secrets + tier-3 session blobs. These break the operator's daily use immediately on rotate.
+
+## Atomic re-encrypt plan
+
+### Phase 1 — Audit + write paths (NO rotate yet)
+
+1. Read each consumer's KDF input + output format. Produce a `PepperKeyedArtifact` enumeration:
+   ```ts
+   type PepperKeyedArtifact =
+     | { kind: 'vault-state'; path: string }           // already handled
+     | { kind: 'provider-secret'; path: string }       // crates/memphis-operator/provider.rs
+     | { kind: 'tier3-session'; path: string }
+     | { kind: 'operator-runtime'; path: string };     // if applicable
+   ```
+2. For each kind, expose a Rust function `re_encrypt(old_pepper, new_pepper, path) -> Result<()>`:
+   - Decrypt with old pepper-derived key.
+   - Re-encrypt with new pepper-derived key.
+   - Write to `{path}.rotating` (staging, not atomic yet).
+3. No rotate yet — just write the primitives + unit tests.
+
+### Phase 2 — Atomic flip
+
+1. Add `vault.handler.ts:handleVaultPepperRotate` walker that enumerates all artifact paths.
+2. Two-phase commit:
+   - **Phase A (write):** For each artifact, decrypt-with-old + write `{path}.rotating` with new-encrypted bytes. If ANY artifact fails decrypt-or-encrypt, abort + delete all `.rotating` files. Vault state untouched.
+   - **Phase B (flip):** `rename({path}.rotating, {path})` for each artifact in deterministic order: provider secrets → tier-3 sessions → vault-state.json last (since vault is the lookup key for everything else). `.env` flip happens AFTER all renames succeed.
+3. Failure during Phase B is the dangerous window. Mitigation:
+   - Write a `data/pepper-rotation-in-progress.json` marker file before Phase B begins, listing all `(path, sha256-of-rotating-file)` pairs.
+   - On daemon startup, if marker exists, refuse to boot until `memphis vault recover-rotation` is run.
+   - `recover-rotation` reads marker, retries failed renames, OR (operator confirms) reverts every successful rename to its `.pre-rotate` backup.
+4. Each artifact gets `{path}.pre-rotate` snapshot before being touched (under old pepper still readable), kept for 7 days then garbage-collected by `memphis vault gc`.
+
+### Phase 3 — CLI surface
+
+- `memphis vault pepper-rotate --confirm` → existing flow, now walks all artifacts.
+- `memphis vault recover-rotation` → resumes / aborts a partially-applied rotation.
+- `memphis vault list-pepper-artifacts` → diagnostic, prints every file that would be touched by a rotate.
+
+### Phase 4 — Test surface (mandatory before merging)
+
+- Unit: each `re_encrypt(kind, ...)` round-trips correctly.
+- Integration: full rotation against a tmp Memphis home with all 4 artifact kinds present. Assert post-rotate, every artifact decrypts under new pepper AND fails under old pepper.
+- Failure injection: simulate fs error mid-Phase-B; assert `pepper-rotation-in-progress.json` written + `recover-rotation` restores cleanly.
+- Performance: rotate with 1000 vault entries + 500 tier-3 sessions completes in < 30 s on the GTX-960-grade install.
+
+## Out of scope (this iteration)
+
+- KDF parameter migration (e.g. argon2 cost increase). Separate concern.
+- Hardware-backed pepper storage (Yubikey, TPM). Tracked in `docs/roadmap/`.
+- Federation sync of pepper across multiple operator hosts.
+
+## Risks
+
+- **Crypto correctness.** Mis-routing an artifact's re-encrypt = unrecoverable data loss for that artifact. Tests in Phase 4 must enumerate every kind; any newly-introduced pepper-keyed artifact MUST register itself with the walker or rotate refuses to proceed (audit-trail-by-design).
+- **Time-of-check vs time-of-use.** If the daemon writes a new artifact during Phase B, it could land under the OLD pepper after the flip. Mitigation: rotate refuses to proceed unless daemon is stopped (operator already required to be tier-3 for rotate; ask the daemon to drain first).
+- **Memory cost.** Walking 500+ tier-3 sessions in memory at once is fine; for chains the count could be 100k+ (if ever pepper-keyed in future) — currently they aren't, so not a blocker for v1.
+
+## Time estimate
+
+- Phase 1: 4-6 h focused (Rust re-encrypt primitives + tests per artifact kind).
+- Phase 2: 3-4 h (walker + atomic flip + marker file).
+- Phase 3: 1-2 h (CLI verbs + doctor visibility).
+- Phase 4: 3-4 h (test matrix, including failure injection).
+
+Total: ~12-16 h. Should be done across two sessions with operator review between Phase 2 and Phase 3.
+
+## Decision pending
+
+- ✅ Plan structure agreeable?
+- ⏳ Awaiting operator: greenlight to start Phase 1, or first audit `crates/memphis-operator/src/runtime.rs:1183-1191` more carefully to confirm whether it's pepper-keyed durable state or just runtime-only key material?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memphis-chains/memphis",
-  "version": "1.8.0",
+  "version": "1.10.0",
   "description": "Memphis sovereign AI runtime with chain-backed memory, encrypted vault, and a native operator console",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Bumps \`package.json\` from \`1.8.0\` → \`1.10.0\` (re-syncs the version field with the v1.9.x tag line — v1.9.0/.1/.2 shipped during the post-Zawoja autopilot without package.json bumps or CHANGELOG entries; operator deliberately held v1.10 per \`project_closure_2026-05-09.md\`).

**91 commits since v1.9.2**: 15 feats, 42 fixes, 10 docs, plus a full Kartograf v4 training arc.

## Headline changes

- **Kartograf ONNX runtime** (#573) — Q2 deliverable closure. \`memphis_kartograf\` tool + \`kartograf-zone-router\` skill. Replaces \`StubKartografSession\` which was silently emitting zero vectors.
- **Kartograf v4 training stack** (#564) — DeBERTa-v3-base + LoRA fine-tune pipeline. Operator-grade end-to-end run landed 2026-05-12 (10h12min on GTX 960, 1846 steps, recall@10 = 0.27).
- **First-class skill composition** (#572) — five \`memphis_skill_*\` tools with schema-error \"did you mean?\" fuzzy-match.
- **Telegram document / PDF ingestion** (#574) — \`bot.on('message:document')\` via \`pdftotext\` + raw UTF-8 + image-as-document.
- **Full MiniMax model lineup** (#575) — 12 chat models + per-model context windows + endpoint routing fix for \`m2-her\`.
- **Telegram TTS shaping** (#571) — 6-sentence cap, darkman voice.
- **Provider stamp flipped to opt-in** — defaults to OFF; set \`MEMPHIS_PROVIDER_STAMP=1\` for legacy footer.
- **Provider auto-failover on stream timeout** (#570).
- **Tier-3 session persistence across restart** (#566).
- **Degraded boot on missing vault secrets** (#568) + **vault-recovery runbook** (#567).

Full release notes in \`CHANGELOG.md\`.

## Deferred to v1.11.0

Captured in \`docs/dev/v1.10.0-deferred-work.md\` so the next sprint planner doesn't have to re-derive:

- **Vault pepper atomic re-encrypt** (plan written, 12-16h focused crypto work)
- **Fresh-install validation surface** (P2 #7-9 — automated test + script + runbook)
- **Daemon SIGSEGV root cause** (\`systemd-coredump\` installed today; next preserved core → \`gdb\` stack)
- **Cache-stability test for Anthropic prompt caching** (P5 #18)

## Test plan

- [x] \`npm run build\` clean (package.json version visible in build output as \`@memphis-chains/memphis@1.10.0\`)
- [x] No code changes — version bump + docs only, so existing test suite is the validator
- [ ] Operator approval — merge → tag \`v1.10.0\` → \`release.yml\` workflow fires (SHA256SUMS, GitHub release, npm publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)