### PR TITLE
fix(release): build Rust NAPI bridge before release-smoke tests

### DIFF
--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -3,6 +3,19 @@ set -euo pipefail
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$project_root"
 
+# Build the Rust NAPI bridge in release mode so the downstream tests
+# (cli.completion / cli.init-status / first-run-plan / etc.) can load
+# `crates/memphis-paths` via the bridge. Without this, the release
+# workflow only has what `npm ci` produced — no Rust build at all,
+# because `prepack` runs before `npm pack`, not before release-smoke.
+# v1.9.1 / v1.9.2 / v1.10.0 release workflows all failed with
+# `paths bridge unavailable` before this line landed.
+# Skip via SKIP_RUST_BUILD=1 when iterating locally with a fresh
+# bridge already on disk.
+if [[ "${SKIP_RUST_BUILD:-}" != "1" ]]; then
+  npm run -s build:rust:release
+fi
+
 npm run -s lint
 npm run -s typecheck
 npm run -s test:rust


### PR DESCRIPTION
## Summary

Three consecutive release workflow runs failed with the same error:

| Tag | Result |
|---|---|
| v1.9.1 (2026-05-08) | release.yml fail |
| v1.9.2 (2026-05-08) | release.yml fail |
| v1.10.0 (2026-05-12) | release.yml fail |

Each one failed at \`scripts/release-smoke.sh\` with:

\`\`\`
Error: paths bridge unavailable — \`crates/memphis-paths\` NAPI module
did not load. Rebuild via \`npm run build:rust:release\` or install the
platform sub-package.
\`\`\`

The smoke script runs four test files that load the paths bridge: \`cli.completion\`, \`cli.init-status\`, \`first-run-plan\`, \`rust-tui-launcher\`. But the workflow path \`npm ci\` → \`bash run-release-gates.sh\` → \`release-smoke.sh\` never builds Rust:

- \`postinstall\` only *checks* for the native module, doesn't build it.
- \`prepack\` builds Rust release — but \`prepack\` only runs before \`npm pack\` (which happens later in the workflow, in a separate job), not before the smoke gate.

## Fix

Prepend \`npm run -s build:rust:release\` to \`release-smoke.sh\`. Skippable via \`SKIP_RUST_BUILD=1\` for local fast-iteration when the bridge is already on disk.

Adds ~1-2 min to the release-gate wallclock, unblocks every release tag from now on.

## Test plan

- [x] Local: \`SKIP_RUST_BUILD=1 bash scripts/release-smoke.sh\` still completes (dev-loop unchanged).
- [ ] Next release tag's \`release.yml\` run should now pass through the smoke gate.
- [ ] After merge, retroactively confirm by triggering a workflow_dispatch on \`v1.10.0\` (or wait for v1.10.1).

## Out of scope

- This doesn't republish v1.10.0 to GitHub Releases / npm — that needs either a workflow re-run on the existing tag or a v1.10.1 patch tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)