### PR TITLE
fix(install): add poppler-utils to install-prerequisites

### DIFF
--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -59,9 +59,16 @@ install_base_apt() {
   # tesseract-ocr + tesseract-ocr-pol — Memphis media pipeline OCR
   # adapter (`src/gateway/media/`) bez tego cicho degraduje do
   # "no OCR backend" na zdjęciach z tekstem.
+  #
+  # poppler-utils — provides `pdftotext`, used by the Telegram
+  # document-ingestion handler (PR #574) for PDF attachments.
+  # Without it: operator forwards a PDF → handler fails with
+  # `pdftotext: command not found` → bot replies "Błąd obsługi
+  # dokumentu". Cheap install, ~3 MB.
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ffmpeg libasound2-dev \
-    tesseract-ocr tesseract-ocr-pol
+    tesseract-ocr tesseract-ocr-pol \
+    poppler-utils
 }
 
 install_base_dnf() {
@@ -74,9 +81,11 @@ install_base_dnf() {
   # python3-virtualenv = Fedora equivalent of Debian's python3-venv;
   # same rationale (voice-install.sh needs working `python3 -m venv`).
   # tesseract — OCR for media pipeline.
+  # poppler-utils — `pdftotext` for Telegram PDF ingestion (PR #574).
   sudo dnf install -y \
     ffmpeg-free alsa-lib-devel \
-    tesseract tesseract-langpack-pol
+    tesseract tesseract-langpack-pol \
+    poppler-utils
 }
 
 install_node() {


### PR DESCRIPTION
## Summary

Spotted during the v1.10.0 fresh-install audit. \`scripts/install-prerequisites.sh\` covers tesseract + ffmpeg + Python venv but missed **poppler-utils**, which provides \`pdftotext\`.

The Telegram document-ingestion handler (PR #574) shells out to \`pdftotext -layout\` for PDF attachments. Without the binary, the handler emits \`Błąd obsługi dokumentu: pdftotext: command not found\` and the operator sees a noisy failure instead of the extracted PDF body.

Fix: add \`poppler-utils\` to both apt (Debian/Ubuntu/WSL) and dnf (Fedora/RHEL) install paths. ~3 MB extra; cheap insurance for any operator who will ever forward a PDF on Telegram.

## Test plan

- [x] Verified runtime dependency by grepping \`spawn('pdftotext'\` in \`src/gateway/channels/telegram.ts\` (PR #574).
- [x] \`poppler-utils\` is the canonical Debian/Ubuntu package name for the \`pdftotext\` binary.
- [ ] Operator: re-run \`bash scripts/install-prerequisites.sh\` on a fresh-install image and confirm \`which pdftotext\` returns a path.

## Out of scope (separate items)

- macOS / brew install path — not handled by this script today; brew users would need \`brew install poppler\`.
- \`whisper-cpp\` / \`piper\` are installed by \`scripts/voice-install.sh\`, not this script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)