### PR TITLE
fix(config): show <vault-resolved> marker for empty *_API_KEY with *_VAULT_KEY

### DIFF
--- a/src/mcp/tools/config.ts
+++ b/src/mcp/tools/config.ts
@@ -59,6 +59,22 @@ export function runMemphisConfigShow(input: { key?: string } = {}): MemphisConfi
   for (const name of targetKeys) {
     const raw = process.env[name];
     if (raw === undefined) continue;
+    // Honesty surface (2026-05-12): when `.env` has `FOO_API_KEY=""`
+    // but `FOO_VAULT_KEY=foo_api_key`, the runtime resolves the
+    // vault entry at boot and the provider works — but config_show
+    // was reporting the literal empty string, making Memphis tell
+    // the operator "API Key (pusty)" when in fact the provider was
+    // fully wired. Surface a `<vault-resolved …>` marker that names
+    // the resolving `*_VAULT_KEY` env so the operator sees what's
+    // actually being used. Vault contents stay sealed.
+    if (raw === '' && name.endsWith('_API_KEY')) {
+      const provPrefix = name.slice(0, -'_API_KEY'.length);
+      const vaultKeyEnv = process.env[`${provPrefix}_VAULT_KEY`];
+      if (vaultKeyEnv && vaultKeyEnv.trim().length > 0) {
+        values[name] = `<vault-resolved via ${provPrefix}_VAULT_KEY=${vaultKeyEnv}>`;
+        continue;
+      }
+    }
     values[name] = redactFieldValue(name, raw);
   }
   return { fields, values, requestedKey: input.key ?? null };


### PR DESCRIPTION
## Summary

Operator 2026-05-12 forwarded a Telegram conversation where Memphis reported "API Key | (pusty) ❌" for MiniMax, even though the vault entry \`minimax_api_key\` was fully wired and MiniMax requests were going through.

Root cause: \`runMemphisConfigShow\` reads raw \`process.env\` then redacts. When the operator pattern is:

\`\`\`dotenv
MINIMAX_API_KEY=
MINIMAX_VAULT_KEY=minimax_api_key
\`\`\`

…the literal env value is empty (vault resolution happens later in the provider boot path, not in env). So config_show shows the misleading "(pusty)" when the runtime actually has a working key.

## Fix

In the loop that builds redacted values: if \`<FOO>_API_KEY\` is empty AND \`<FOO>_VAULT_KEY\` is set, emit:

\`\`\`
<vault-resolved via FOO_VAULT_KEY=<vault-entry-name>>
\`\`\`

instead of the empty string. The vault contents themselves stay sealed — we surface only which env var is doing the resolution, not the resolved key material.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] 7 affected config test files (54 tests) still pass; fallback path only triggers when raw env is exactly \`""\` AND the sibling \`_VAULT_KEY\` env is non-empty
- [ ] Operator runs \`/config_show\` on Telegram and sees \`<vault-resolved via MINIMAX_VAULT_KEY=minimax_api_key>\` instead of "(pusty)"

## Out of scope

- The "Memphis on Telegram appends \`— via anthropic/claude-opus-4-6\` footer" issue. The runtime stops adding the footer (PR #573 flipped it to opt-in) — what operator is seeing is the LLM imitating the pattern itself from old chain blocks / system prompt residue. Fix needs a system-prompt edit ("do NOT generate that footer"), but that file is a template literal full of escaped backticks and my first attempt at editing it broke compilation — keeping that work in a separate, more careful PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)