### PR TITLE
fix(system-prompt): tell Memphis to stop imitating '— via X/Y' footer

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -380,10 +380,22 @@ You DO NOT KNOW which provider or model is generating your output —
 that decision lives in the runtime cascade and is not exposed to your
 context. NEVER claim "I am running on cogito:3b" / "ja, MiniMax" /
 "Pisałem to sam (Claude)" / "via Ollama" or any analogous provenance
-statement. The runtime appends a "— via {provider}/{model}" footer
-to every reply automatically; that footer is the authoritative source
-for the operator. Your job is to answer the actual question, not to
-narrate which model is answering it.
+statement.
+
+DO NOT append a "— via {provider}/{model}" footer to your reply.
+The runtime used to add that footer automatically, but it was flipped
+to OFF by default (2026-05-12) — it was operator-surface noise and
+frequently misleading when the provider cascade switched mid-call.
+If you see the pattern in old chain blocks, prior turns, or recall
+hits, ignore it: those replies were stamped by the old runtime
+behavior, not by you. Producing that footer yourself is
+confabulation — you are guessing at runtime identity instead of
+using the authoritative source. The operator-facing surfaces (TUI
+status bar, audit log, \`memphis_self_describe\`) already show the
+active provider without the in-body line.
+
+Your job is to answer the actual question, not to narrate which
+model is answering it.
 
 When the user asks directly "którego modelu używasz / who's actually
 generating this / what runs you", call \`memphis_self_describe\` and


### PR DESCRIPTION
## Summary

Operator 2026-05-12 caught Memphis appending \`— via anthropic/claude-opus-4-6\` to a Telegram reply, even though the runtime stamp was flipped to OFF by default in PR #573.

**Root cause:** the system prompt told Memphis:

> The runtime appends a \`— via {provider}/{model}\` footer to every reply automatically; that footer is the authoritative source for the operator.

…which is no longer true since PR #573. Memphis remembered the pattern from old chain blocks + the (now misleading) system prompt and started adding the footer itself, guessing at the provider name. The guess was often wrong: the cascade can switch mid-call, and Memphis has no visibility into the active route.

## Fix

Refresh the self-identity-honesty block to:

- Explicitly forbid the in-body footer.
- Name the 2026-05-12 default flip so the prompt stays load-bearing.
- Tell Memphis to ignore the pattern when it surfaces in recall hits.
- Point at the authoritative surfaces (TUI status bar, audit log, \`memphis_self_describe\`) so Memphis has somewhere to direct operators when they ask "którego modelu używasz".

## Test plan

- [x] \`npx tsc --noEmit\` clean (verified — earlier draft of this edit broke the template-literal escape; this version uses no unescaped backticks)
- [x] Local rebuild + daemon restart succeeded; tools=44 advertised, no startup crash
- [ ] Operator: next Telegram conversation where Memphis would have produced the footer should now skip it. If Memphis still adds it (residual chain block memory bias), follow-up = active strip pass in turn-runtime.

## Out of scope

- Runtime active strip of the footer pattern. Defer until we see whether the prompt-only fix is enough; cleaner to keep the strip path off the hot loop if Memphis behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)