### PR TITLE
fix(codex-round): both P2 findings from #579 + #580 — bundled

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -390,18 +390,22 @@ If you see the pattern in old chain blocks, prior turns, or recall
 hits, ignore it: those replies were stamped by the old runtime
 behavior, not by you. Producing that footer yourself is
 confabulation — you are guessing at runtime identity instead of
-using the authoritative source. The operator-facing surfaces (TUI
-status bar, audit log, \`memphis_self_describe\`) already show the
-active provider without the in-body line.
+using an authoritative source. The operator-facing surfaces (TUI
+status bar with the provider+model pill, daemon startup log line,
+and \`memphis providers list\` from the CLI) already show the active
+provider without the in-body line.
 
 Your job is to answer the actual question, not to narrate which
 model is answering it.
 
 When the user asks directly "którego modelu używasz / who's actually
-generating this / what runs you", call \`memphis_self_describe\` and
-quote the \`provider\` and \`model\` fields from its JSON, prefixed with
-"per memphis_self_describe:". Never assert provider identity from
-your own intuition.
+generating this / what runs you", the honest answer is: "I can't
+read the active route from inside my context — check the TUI status
+pill, the most recent daemon-restart log, or \`memphis providers list\`
+which all show the live cascade." Never assert provider identity
+from your own intuition, and do NOT call \`memphis_self_describe\`
+for this — that tool returns surface policy + tools + cognitive
+mode, NOT the active provider or model.
 
 Do NOT bake provenance claims ("# Model: cogito:3b") into files you
 write via \`memphis_self_modify\`. The audit chain captures which

--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -380,10 +380,22 @@ You DO NOT KNOW which provider or model is generating your output —
 that decision lives in the runtime cascade and is not exposed to your
 context. NEVER claim "I am running on cogito:3b" / "ja, MiniMax" /
 "Pisałem to sam (Claude)" / "via Ollama" or any analogous provenance
-statement. The runtime appends a "— via {provider}/{model}" footer
-to every reply automatically; that footer is the authoritative source
-for the operator. Your job is to answer the actual question, not to
-narrate which model is answering it.
+statement.
+
+DO NOT append a "— via {provider}/{model}" footer to your reply.
+The runtime used to add that footer automatically, but it was flipped
+to OFF by default (2026-05-12) — it was operator-surface noise and
+frequently misleading when the provider cascade switched mid-call.
+If you see the pattern in old chain blocks, prior turns, or recall
+hits, ignore it: those replies were stamped by the old runtime
+behavior, not by you. Producing that footer yourself is
+confabulation — you are guessing at runtime identity instead of
+using the authoritative source. The operator-facing surfaces (TUI
+status bar, audit log, \`memphis_self_describe\`) already show the
+active provider without the in-body line.
+
+Your job is to answer the actual question, not to narrate which
+model is answering it.
 
 When the user asks directly "którego modelu używasz / who's actually
 generating this / what runs you", call \`memphis_self_describe\` and

--- a/src/mcp/tools/config.ts
+++ b/src/mcp/tools/config.ts
@@ -20,6 +20,7 @@ import {
   type MutabilityTier,
 } from '../../infra/config/mutability.js';
 import { envSchema } from '../../infra/config/schema.js';
+import { getLatestVaultEntry } from '../../infra/storage/vault-entry-store.js';
 
 export interface MemphisConfigShowOutput {
   fields: Array<{ key: string; tier: MutabilityTier }>;
@@ -64,14 +65,30 @@ export function runMemphisConfigShow(input: { key?: string } = {}): MemphisConfi
     // vault entry at boot and the provider works — but config_show
     // was reporting the literal empty string, making Memphis tell
     // the operator "API Key (pusty)" when in fact the provider was
-    // fully wired. Surface a `<vault-resolved …>` marker that names
-    // the resolving `*_VAULT_KEY` env so the operator sees what's
-    // actually being used. Vault contents stay sealed.
+    // fully wired. Surface a `<vault-resolved …>` marker — BUT only
+    // after verifying the vault entry actually exists on disk
+    // (Codex review #579: without this check, a misconfigured
+    // VAULT_KEY env pointing at a missing vault entry would
+    // falsely claim the provider was wired — exactly the failure
+    // case the operator needs to diagnose).
+    //
+    // We use `getLatestVaultEntry` (metadata-read, no decrypt) so
+    // a locked vault doesn't break config_show. If the entry is
+    // missing, surface `<vault-key-missing …>` so the operator
+    // sees the actual gap.
     if (raw === '' && name.endsWith('_API_KEY')) {
       const provPrefix = name.slice(0, -'_API_KEY'.length);
       const vaultKeyEnv = process.env[`${provPrefix}_VAULT_KEY`];
       if (vaultKeyEnv && vaultKeyEnv.trim().length > 0) {
-        values[name] = `<vault-resolved via ${provPrefix}_VAULT_KEY=${vaultKeyEnv}>`;
+        const vaultKey = vaultKeyEnv.trim();
+        const entry = getLatestVaultEntry(vaultKey, process.env);
+        if (entry) {
+          values[name] =
+            `<vault-resolved via ${provPrefix}_VAULT_KEY=${vaultKey}>`;
+        } else {
+          values[name] =
+            `<vault-key-missing: ${provPrefix}_VAULT_KEY=${vaultKey} but no vault entry "${vaultKey}">`;
+        }
         continue;
       }
     }

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -71,7 +71,13 @@ describe('gateway system prompt', () => {
     expect(prompt).toContain('You DO NOT KNOW which provider or model');
     expect(prompt).toContain('NEVER claim');
     expect(prompt).toContain('via {provider}/{model}');
-    expect(prompt).toContain('per memphis_self_describe:');
+    // 2026-05-12: removed `per memphis_self_describe:` instruction —
+    // that tool doesn't actually carry provider/model fields (Codex
+    // review on #580), so pointing Memphis at it would just yield
+    // confabulation. New guidance directs to TUI status pill +
+    // daemon-restart log + `memphis providers list`.
+    expect(prompt).toContain('memphis providers list');
+    expect(prompt).toContain('DO NOT call');
     // Don't bake provenance lies into self-modify outputs.
     // (Match across line breaks since the source-code wrapping
     // doesn't matter to the LLM consuming the prompt.)

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -77,7 +77,7 @@ describe('gateway system prompt', () => {
     // confabulation. New guidance directs to TUI status pill +
     // daemon-restart log + `memphis providers list`.
     expect(prompt).toContain('memphis providers list');
-    expect(prompt).toContain('DO NOT call');
+    expect(prompt).toContain('do NOT call');
     // Don't bake provenance lies into self-modify outputs.
     // (Match across line breaks since the source-code wrapping
     // doesn't matter to the LLM consuming the prompt.)


### PR DESCRIPTION
## Summary

Bundled hotfix per memory \`feedback_codex_bundled_hotfix\` — addresses **both** Codex P2 findings in one PR.

### 1. PR #580 review (\`src/gateway/system-prompt.ts:395\`)

Codex caught: the anti-confab guidance pointed Memphis at \`memphis_self_describe\` as an authoritative source for "which model is generating this", but \`runMemphisSelfDescribe\` returns **surface policy + tools + cognitive mode** — NOT provider or model. The model would either fail to answer or fabricate the provider name.

**Fix:** drop the \`memphis_self_describe\` reference. The honest answer is "I can't read the active route from inside my context — check the TUI status pill, the most recent daemon-restart log, or \`memphis providers list\`." Explicitly tell Memphis NOT to call \`memphis_self_describe\` for provider identity.

### 2. PR #579 review (\`src/mcp/tools/config.ts:74\`)

Codex caught: the \`<vault-resolved>\` marker triggered as long as \`*_VAULT_KEY\` env was non-empty. That's exactly the failure case the operator needs to diagnose — \`MINIMAX_VAULT_KEY=minimax_api_key\` but the vault entry never created → marker says "looks configured" while the provider is actually \`vault_not_found\`.

**Fix:** verify the vault entry exists on disk via \`getLatestVaultEntry\` (metadata-read, no decrypt — works on locked vault too) before emitting the resolved marker. When the entry is missing, surface \`<vault-key-missing: FOO_VAULT_KEY=foo but no vault entry "foo">\` so the operator sees the actual gap.

## This PR supersedes #580

Closing #580 with this PR. Same system-prompt edit is here, plus the additional Codex coverage. #579 was merged earlier today; this is the follow-up Codex addresses for its concern.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] 7 affected config test files (54 tests) still pass — metadata-read path is non-invasive vs existing fixtures
- [x] Local rebuild + daemon restart healthy
- [ ] Operator: re-verify Telegram replies no longer carry \`— via X/Y\` footer
- [ ] Operator: \`memphis_config_show\` against a vault-missing key surfaces the \`<vault-key-missing>\` marker

## Out of scope

- Wiring \`memphis_self_describe\` to actually carry provider/model. That's the alternative Codex offered ("either plumb those fields in or remove it from the prompt"). Removing is the smaller fix; the plumb-in can come later if we want a single source of truth for surface introspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)