### PR TITLE
fix: address Codex #585 — embed UTF-8 truncate + napi env race

### DIFF
--- a/crates/memphis-napi/src/lib.rs
+++ b/crates/memphis-napi/src/lib.rs
@@ -1018,8 +1018,40 @@ mod tests {
     use memphis_core::hash::compute_hash;
     use memphis_embed::EmbedMode;
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex, MutexGuard, OnceLock,
+    };
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// Codex review #585 — `cargo test` ran fine on dev boxes but
+    /// `testRust` exited 101 on every release-gate run since v1.9.1
+    /// (2026-05-08 → 2026-05-12). Tests that mutate process-wide env
+    /// (`std::env::set_var("RUST_EMBED_MODE", …)` /
+    /// `RUST_CHAIN_REQUIRE_SIGNATURES` / `RUST_CHAIN_SIGNER_KEY_HEX`)
+    /// raced against any other test reading those vars when cargo
+    /// scheduled them in parallel. On the operator's box test
+    /// ordering happened to interleave benignly; CI runners hit the
+    /// failing interleave.
+    ///
+    /// Fix: every env-mutating test takes this lock at the top so they
+    /// serialize against each other. Other tests are free to read env
+    /// vars without locking — the only writers are gated here, and
+    /// each writer cleans up after itself before releasing the lock.
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| {
+                // Poisoned means a prior test panicked while holding
+                // the lock; the env-cleanup at the bottom of that test
+                // didn't run. We can still proceed — the next test
+                // will overwrite the leaked env value with its own
+                // before reading anything.
+                poisoned.into_inner()
+            })
+    }
 
     struct TestCaseIndexPath {
         dir: PathBuf,
@@ -1122,6 +1154,7 @@ mod tests {
 
     #[test]
     fn embed_mode_supports_additional_provider_aliases() {
+        let _guard = env_lock();
         std::env::set_var("RUST_EMBED_MODE", "voyage");
         assert_eq!(
             embed_mode_from_env(),
@@ -1163,6 +1196,7 @@ mod tests {
 
     #[test]
     fn chain_append_auto_signs_when_signer_key_is_configured() {
+        let _guard = env_lock();
         std::env::set_var("RUST_CHAIN_REQUIRE_SIGNATURES", "true");
         std::env::set_var("RUST_CHAIN_SIGNER_KEY_HEX", "11".repeat(32));
 

--- a/src/infra/memory/embed-reindex.ts
+++ b/src/infra/memory/embed-reindex.ts
@@ -20,6 +20,34 @@ import {
 // for ~1KB-text-per-doc corpora.
 const BULK_CHUNK_SIZE = 256;
 
+/**
+ * Truncate `text` so its UTF-8 byte length is at most `maxBytes`. Used
+ * before forwarding text to the Rust embed pipeline, which rejects
+ * inputs above `DEFAULT_MAX_TEXT_BYTES = 4096` outright. Returns the
+ * original string when it already fits.
+ *
+ * Important: counts UTF-8 *bytes*, not JS-side UTF-16 code units. The
+ * naive `text.slice(0, 4000)` would still let multi-byte characters
+ * (Polish ą/ę/ó etc., or emoji) overflow the byte budget — Codex review
+ * #585 specifically called this out for operator-language inputs.
+ *
+ * When truncation happens, append a small marker so the LLM consumer
+ * can tell content was clipped (rare but real — operator's daily
+ * insight blocks hit 8-10 KB).
+ */
+export function truncateUtf8(text: string, maxBytes: number): string {
+  const encoded = Buffer.from(text, 'utf8');
+  if (encoded.length <= maxBytes) return text;
+  // Walk back from `maxBytes` to the nearest UTF-8 boundary so we don't
+  // split a multi-byte codepoint. Continuation bytes are 0b10xxxxxx
+  // (range 0x80..=0xBF) — keep stepping while we see one.
+  let cut = maxBytes;
+  while (cut > 0 && (encoded[cut] ?? 0) >= 0x80 && (encoded[cut] ?? 0) < 0xc0) {
+    cut -= 1;
+  }
+  return encoded.subarray(0, cut).toString('utf8') + '\n[truncated for embed]';
+}
+
 // Sprint 0.5 G2: searchable chain set pulled from canonical catalog so new
 // chains (insights, soul, cases etc.) get indexed without touching this
 // file. Previously hard-coded 5 chains here; missed insights and cases and
@@ -134,12 +162,22 @@ export function rebuildDerivedEmbeddings(
           ? block.data.memory_id.trim()
           : undefined;
       const memoryId = rawMemoryId ?? buildDefaultMemoryId(chain, block.index);
+      // Rust embed pipeline rejects text whose UTF-8 byte length exceeds
+      // `DEFAULT_MAX_TEXT_BYTES = 4096` (crates/memphis-embed/src/pipeline.rs:64).
+      // Live observation 2026-05-12: 38 insight blocks (8-10 KB JSON
+      // dumps from the daily reflection loop) silently rejected with
+      // `embed_store_failed: text too large`. Truncate at the byte
+      // boundary, NOT at JavaScript char count — Codex review #585
+      // caught that `.length` and `.slice()` count UTF-16 code units,
+      // so Polish-heavy text could still exceed 4096 UTF-8 bytes after
+      // a 4000-char slice.
+      const embedText = truncateUtf8(entry.content, 4000);
       prepared.push({
         chain,
         index: block.index,
         item: {
           id: memoryId,
-          text: entry.content,
+          text: embedText,
           tags: buildEmbedTags(chain, entry.tags),
         },
       });

--- a/tests/unit/embed-reindex-utf8-truncate.test.ts
+++ b/tests/unit/embed-reindex-utf8-truncate.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Pins the UTF-8-aware truncation contract for the embed pipeline.
+ *
+ * Live observation 2026-05-12: 38 insight blocks (8-10 KB JSON dumps)
+ * silently rejected by the Rust embed pipeline (`text too large:
+ * 8970 bytes exceeds max 4096`). Codex review #585 caught that a naive
+ * `text.slice(0, 4000)` truncate would still let Polish or emoji text
+ * exceed the 4096-UTF-8-byte budget because JS string slice counts
+ * UTF-16 code units. These tests pin the correct behaviour so a
+ * future refactor can't drop back to the byte-unsafe path.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { truncateUtf8 } from '../../src/infra/memory/embed-reindex.js';
+
+describe('truncateUtf8', () => {
+  it('returns the original string when already within budget', () => {
+    expect(truncateUtf8('hello', 100)).toBe('hello');
+    expect(truncateUtf8('', 100)).toBe('');
+  });
+
+  it('cuts ASCII text at the byte budget and appends marker', () => {
+    const text = 'a'.repeat(5000);
+    const out = truncateUtf8(text, 4000);
+    expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(4000 + 22); // + '\n[truncated for embed]'
+    expect(out.endsWith('[truncated for embed]')).toBe(true);
+    expect(out.startsWith('aaaa')).toBe(true);
+  });
+
+  it('counts UTF-8 bytes (not UTF-16 chars) for multibyte input', () => {
+    // Polish "ą" is 2 UTF-8 bytes. 3000 "ą" = 6000 bytes > 4096 budget.
+    // A naive `.slice(0, 4000)` would keep 4000 chars = 8000 bytes —
+    // still over budget and the Rust pipeline would reject. The
+    // UTF-8-aware truncate must clip past the actual byte limit.
+    const text = 'ą'.repeat(3000);
+    expect(Buffer.byteLength(text, 'utf8')).toBe(6000);
+    const out = truncateUtf8(text, 4000);
+    // 'ą' marker line is 22 bytes; cut body must fit in 4000 bytes.
+    const bodyBytes = Buffer.byteLength(out.replace(/\n\[truncated for embed\]$/, ''), 'utf8');
+    expect(bodyBytes).toBeLessThanOrEqual(4000);
+    expect(out.endsWith('[truncated for embed]')).toBe(true);
+  });
+
+  it('does not split a multibyte codepoint at the cut boundary', () => {
+    // Construct text where the byte-budget edge falls in the middle
+    // of a 4-byte emoji. The truncator must walk back to the start of
+    // that codepoint, not leave a half-emoji.
+    // 😀 = 4 UTF-8 bytes (F0 9F 98 80). Pad with 3998 ASCII bytes so
+    // the cut would land at byte 4000 = position 2 inside the emoji.
+    const text = 'a'.repeat(3998) + '😀😀😀';
+    const out = truncateUtf8(text, 4000);
+    // Every codepoint in the truncated body must survive decode —
+    // String#length counting and re-encoding both succeed without
+    // replacement chars (U+FFFD).
+    const body = out.replace(/\n\[truncated for embed\]$/, '');
+    expect(body).not.toContain('�');
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(4000);
+  });
+
+  it('handles an empty budget gracefully (degenerate edge)', () => {
+    // maxBytes=0 with non-empty input should still emit the marker
+    // rather than throw; the rest of the pipeline can refuse it.
+    const out = truncateUtf8('hello', 0);
+    expect(out).toBe('\n[truncated for embed]');
+  });
+});


### PR DESCRIPTION
## Summary

Implements **two of four** findings from Codex's review on PR #585. The other two (Node profiling command + Option B chunk dedup) stay in the open triage PR for a later sprint.

### 1. Insights embed truncation — UTF-8 bytes, not char count

The Rust embed pipeline rejects text over **4096 UTF-8 bytes**. Daily reflection insight blocks (8-10 KB JSON) were silently dropped — 38 blocks unsearchable per the 2026-05-12 daemon log.

Codex caught that the obvious \`text.slice(0, 4000)\` fix would still exceed the budget for Polish text because JavaScript string slice counts UTF-16 code units, not UTF-8 bytes. Polish "ą" is 2 UTF-8 bytes — 3000 "ą" = 6000 bytes but only 3000 chars.

\`truncateUtf8(text, maxBytes)\`:
- Encodes via \`Buffer.byteLength\` + \`Buffer.subarray\` (byte-accurate).
- Walks back from the cut to the nearest UTF-8 codepoint boundary so multibyte chars never split (no \`U+FFFD\` replacement chars).
- Appends a \`[truncated for embed]\` marker so consumers can tell content was clipped.

**5 unit tests** pin: ASCII, multibyte Polish (ą × 3000), 4-byte emoji on boundary, already-fits passthrough, empty-budget edge case.

### 2. memphis-napi Rust test race — process-wide env mutation

\`cargo test -p memphis-napi --lib\` passed 20/20 locally on the operator's box but exited 101 on every release-gate run since v1.9.1. Codex pointed at the actual cause: two tests mutate process-wide env vars (\`RUST_EMBED_MODE\`, \`RUST_CHAIN_REQUIRE_SIGNATURES\`, \`RUST_CHAIN_SIGNER_KEY_HEX\`). When cargo's parallel scheduler interleaved them with a reader, the reader saw stale state and panicked.

Fix: \`env_lock()\` helper backed by \`OnceLock<Mutex<()>>\`; both env-mutating tests acquire it at function entry. Poison recovery included.

## Test plan

- [x] \`cargo test -p memphis-napi --lib\` → 20/20 pass locally
- [x] \`npx vitest run tests/unit/embed-reindex-utf8-truncate.test.ts\` → 5/5 pass
- [x] \`npx tsc --noEmit\` clean
- [ ] Next release-gate CI run on this PR (or a follow-up) should now keep \`testRust\` green

## Out of scope

- Codex finding #3 (Node profiling): \`node --enable-extra-features\` doesn't exist; the right command is \`node --prof\` / \`--prof-process\`. Stays in #585 triage doc — we'd update it as part of the SEGV diagnosis follow-up rather than as a one-line README edit.
- Codex finding #4 (Option B chunk + unique vector IDs): if we move from truncate to chunk-and-multi-vector later, the rebase will need unique \`memoryId\` per chunk (Rust embed store is a \`HashMap\` keyed by id, so chunks sharing an id overwrite). Documented in the triage doc as the upgrade path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)