### PR TITLE
feat(embed): chunk + multi-vector for >4KB content (Codex Option B)

### DIFF
--- a/src/infra/memory/embed-reindex.ts
+++ b/src/infra/memory/embed-reindex.ts
@@ -34,6 +34,11 @@ const BULK_CHUNK_SIZE = 256;
  * When truncation happens, append a small marker so the LLM consumer
  * can tell content was clipped (rare but real — operator's daily
  * insight blocks hit 8-10 KB).
+ *
+ * Kept for callers that legitimately want a single embed (e.g. small
+ * indicator blocks where chunking would be overkill); the embed-reindex
+ * path itself now uses `chunkForEmbed` instead so long content gets
+ * multi-vector coverage rather than silent tail loss.
  */
 export function truncateUtf8(text: string, maxBytes: number): string {
   const encoded = Buffer.from(text, 'utf8');
@@ -46,6 +51,121 @@ export function truncateUtf8(text: string, maxBytes: number): string {
     cut -= 1;
   }
   return encoded.subarray(0, cut).toString('utf8') + '\n[truncated for embed]';
+}
+
+/**
+ * Codex review #585 finding #4 (Option B chunk + multi-vector):
+ * split `text` into overlapping windows so the entire content lands in
+ * the embed index, not just the first 4 KB. Without unique chunk IDs
+ * the Rust embed store (a `HashMap<id, doc>` per
+ * `EmbedPipeline::upsert_many`) would overwrite earlier chunks of the
+ * same block; Codex caught that explicitly.
+ *
+ * Contract:
+ *
+ *   - Returns `[{ chunkIdx: 0, text }]` verbatim when the input
+ *     already fits in `maxBytes`. Callers can branch on
+ *     `chunks.length === 1` to skip the `#cN` suffix and keep the
+ *     existing single-vector storage shape for short blocks.
+ *   - Returns N > 1 windows, each ≤ `maxBytes` UTF-8 bytes, with
+ *     `overlapBytes` of byte-level overlap so semantic context
+ *     spanning the cut isn't lost. Each window respects UTF-8
+ *     codepoint boundaries (no half emoji, no replacement chars).
+ *   - `chunkIdx` is monotonic 0..N-1.
+ *
+ * Recall plumbing: the dedup-by-base-id step in
+ * `src/mcp/tools/recall.ts:mapSemanticHits` collapses multi-chunk
+ * hits to one entry per source block (max-pool by score) so operators
+ * don't see the same long insight five times in a row.
+ */
+export interface EmbedChunk {
+  chunkIdx: number;
+  text: string;
+}
+
+export function chunkForEmbed(
+  text: string,
+  maxBytes: number,
+  overlapBytes = 200,
+): EmbedChunk[] {
+  if (maxBytes <= 0) return [{ chunkIdx: 0, text }];
+  const encoded = Buffer.from(text, 'utf8');
+  if (encoded.length <= maxBytes) return [{ chunkIdx: 0, text }];
+
+  const stepBytes = Math.max(1, maxBytes - overlapBytes);
+  const chunks: EmbedChunk[] = [];
+  let cursor = 0;
+  let idx = 0;
+
+  while (cursor < encoded.length) {
+    const tentativeEnd = Math.min(cursor + maxBytes, encoded.length);
+    let safeEnd = tentativeEnd;
+    // Don't slice mid-codepoint: walk back over UTF-8 continuation
+    // bytes (0b10xxxxxx → 0x80..=0xBF). If safeEnd is at the buffer
+    // end, no walk-back is needed.
+    while (
+      safeEnd > cursor &&
+      safeEnd < encoded.length &&
+      (encoded[safeEnd] ?? 0) >= 0x80 &&
+      (encoded[safeEnd] ?? 0) < 0xc0
+    ) {
+      safeEnd -= 1;
+    }
+
+    chunks.push({
+      chunkIdx: idx,
+      text: encoded.subarray(cursor, safeEnd).toString('utf8'),
+    });
+
+    if (safeEnd >= encoded.length) break;
+    // Step forward by `stepBytes`, but also do the codepoint-boundary
+    // walk-back on the next cursor so the overlap window starts cleanly.
+    let nextCursor = cursor + stepBytes;
+    while (
+      nextCursor > 0 &&
+      nextCursor < encoded.length &&
+      (encoded[nextCursor] ?? 0) >= 0x80 &&
+      (encoded[nextCursor] ?? 0) < 0xc0
+    ) {
+      nextCursor -= 1;
+    }
+    if (nextCursor <= cursor) {
+      // Degenerate: would loop forever. Force advance by 1 byte and
+      // re-walk; the next iteration's safeEnd boundary check still
+      // protects against mid-codepoint slicing.
+      nextCursor = cursor + 1;
+    }
+    cursor = nextCursor;
+    idx += 1;
+  }
+
+  return chunks;
+}
+
+/**
+ * Build the per-chunk embed-store ID. Single-chunk blocks keep the
+ * original `memoryId` (backward-compatible — existing recall consumers
+ * see the same IDs they always did). Multi-chunk blocks get a `#cN`
+ * suffix so the Rust embed store doesn't overwrite earlier chunks.
+ *
+ * Recall dedup (recall.ts:mapSemanticHits) strips the suffix to collapse
+ * multi-chunk hits back to one entry per source block.
+ */
+export function buildChunkEmbedId(memoryId: string, chunkIdx: number, totalChunks: number): string {
+  return totalChunks === 1 ? memoryId : `${memoryId}#c${chunkIdx}`;
+}
+
+/**
+ * Inverse of buildChunkEmbedId — strip the `#cN` suffix if present,
+ * return the base block memoryId. Idempotent for non-suffixed ids.
+ */
+export function baseMemoryIdFromChunkId(id: string): string {
+  const idx = id.lastIndexOf('#c');
+  if (idx === -1) return id;
+  // Make sure the part after `#c` is purely digits — guards against
+  // base IDs that happen to contain `#c` as legitimate content.
+  const tail = id.slice(idx + 2);
+  return /^\d+$/.test(tail) ? id.slice(0, idx) : id;
 }
 
 // Sprint 0.5 G2: searchable chain set pulled from canonical catalog so new
@@ -162,25 +282,28 @@ export function rebuildDerivedEmbeddings(
           ? block.data.memory_id.trim()
           : undefined;
       const memoryId = rawMemoryId ?? buildDefaultMemoryId(chain, block.index);
-      // Rust embed pipeline rejects text whose UTF-8 byte length exceeds
-      // `DEFAULT_MAX_TEXT_BYTES = 4096` (crates/memphis-embed/src/pipeline.rs:64).
-      // Live observation 2026-05-12: 38 insight blocks (8-10 KB JSON
-      // dumps from the daily reflection loop) silently rejected with
-      // `embed_store_failed: text too large`. Truncate at the byte
-      // boundary, NOT at JavaScript char count — Codex review #585
-      // caught that `.length` and `.slice()` count UTF-16 code units,
-      // so Polish-heavy text could still exceed 4096 UTF-8 bytes after
-      // a 4000-char slice.
-      const embedText = truncateUtf8(entry.content, 4000);
-      prepared.push({
-        chain,
-        index: block.index,
-        item: {
-          id: memoryId,
-          text: embedText,
-          tags: buildEmbedTags(chain, entry.tags),
-        },
-      });
+      // Rust embed pipeline rejects text > 4096 UTF-8 bytes
+      // (crates/memphis-embed/src/pipeline.rs:64). Long content
+      // (insight blocks 8-10 KB, future chain types) gets split into
+      // overlapping byte-aware windows so the whole content is
+      // searchable. Each chunk gets a unique #cN id — Codex review
+      // #585 caught that sharing IDs across chunks would let the
+      // Rust embed store HashMap overwrite earlier chunks. Recall-
+      // side dedup (recall.ts:mapSemanticHits) collapses chunks back
+      // to one hit per source block at search time.
+      const chunks = chunkForEmbed(entry.content, 4000);
+      const tags = buildEmbedTags(chain, entry.tags);
+      for (const chunk of chunks) {
+        prepared.push({
+          chain,
+          index: block.index,
+          item: {
+            id: buildChunkEmbedId(memoryId, chunk.chunkIdx, chunks.length),
+            text: chunk.text,
+            tags,
+          },
+        });
+      }
     }
   }
 

--- a/src/mcp/tools/recall.ts
+++ b/src/mcp/tools/recall.ts
@@ -1,3 +1,4 @@
+import { baseMemoryIdFromChunkId } from '../../infra/memory/embed-reindex.js';
 import { searchChainsDirectly, searchExactMemory } from '../../infra/memory/exact-search.js';
 import { embedSearch, type EmbedSearchHit } from '../../infra/storage/rust-embed-adapter.js';
 import type { ExactSearchHit } from '../../infra/storage/sqlite/repositories/memory-search-repository.js';
@@ -56,13 +57,43 @@ function semanticSearchTags(tags: string[] | undefined, chain?: string): string[
 }
 
 function mapSemanticHits(hits: EmbedSearchHit[]): MemphisRecallOutput['results'] {
-  return hits.map((hit) => ({
-    content: hit.text_preview,
-    score: hit.score,
-    tags: hit.tags ?? [],
-    chain: getChainTag(hit.tags),
-    sourceKey: hit.id,
-  }));
+  // Dedup chunks back to their source block (Codex review #585 — when
+  // a long insight is split into N overlapping chunks via
+  // `chunkForEmbed`, each chunk lands in the index with id `<base>#cN`
+  // so they don't overwrite each other. At search time, multiple
+  // chunks of the same block can all rank top-K and the operator
+  // would see what looks like a 5-duplicate result. Collapse by
+  // stripping the `#cN` suffix, keep the highest-scoring chunk per
+  // base block, and pin its surface output to that hit's preview /
+  // tags so the operator sees coherent ranking).
+  const bestByBase = new Map<string, EmbedSearchHit>();
+  for (const hit of hits) {
+    const base = baseMemoryIdFromChunkId(hit.id);
+    const incumbent = bestByBase.get(base);
+    if (!incumbent || hit.score > incumbent.score) {
+      bestByBase.set(base, hit);
+    }
+  }
+  // Preserve original input ordering for tied-or-non-grouped hits —
+  // walk `hits` once and emit the best-per-base entry on first
+  // encounter (so the top hit's position in the result list is
+  // determined by its original rank, not by Map iteration order).
+  const emitted = new Set<string>();
+  const results: MemphisRecallOutput['results'] = [];
+  for (const hit of hits) {
+    const base = baseMemoryIdFromChunkId(hit.id);
+    if (emitted.has(base)) continue;
+    const best = bestByBase.get(base) ?? hit;
+    emitted.add(base);
+    results.push({
+      content: best.text_preview,
+      score: best.score,
+      tags: best.tags ?? [],
+      chain: getChainTag(best.tags),
+      sourceKey: base,
+    });
+  }
+  return results;
 }
 
 function mapExactHits(hits: ExactSearchHit[]): MemphisRecallOutput['results'] {

--- a/tests/unit/embed-chunk-option-b.test.ts
+++ b/tests/unit/embed-chunk-option-b.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Pins the chunk-and-multi-vector contract for long content. Codex
+ * review #585 finding #4: when a block exceeds the Rust embed
+ * pipeline's 4096-byte limit, we now split into overlapping windows
+ * and store each as a separate vector — keyed by a per-chunk `#cN`
+ * suffix so the Rust embed HashMap doesn't overwrite them.
+ *
+ * Recall-side dedup (`mapSemanticHits` in recall.ts) collapses the
+ * multi-chunk hits back to one entry per source block (max-pool by
+ * score), so operators never see the same long insight five times
+ * in a row at top-K.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  baseMemoryIdFromChunkId,
+  buildChunkEmbedId,
+  chunkForEmbed,
+} from '../../src/infra/memory/embed-reindex.js';
+
+describe('chunkForEmbed', () => {
+  it('returns the input verbatim as one chunk when it already fits', () => {
+    const out = chunkForEmbed('hello world', 4000);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.chunkIdx).toBe(0);
+    expect(out[0]?.text).toBe('hello world');
+  });
+
+  it('splits ASCII text into N chunks all within the byte budget', () => {
+    const text = 'a'.repeat(12_000);
+    const out = chunkForEmbed(text, 4000);
+    expect(out.length).toBeGreaterThan(2); // 12k bytes / 4k window = at least 3 chunks
+    for (const c of out) {
+      expect(Buffer.byteLength(c.text, 'utf8')).toBeLessThanOrEqual(4000);
+    }
+    // Chunk indices monotonic from 0.
+    expect(out.map((c) => c.chunkIdx)).toEqual(Array.from({ length: out.length }, (_, i) => i));
+  });
+
+  it('overlaps consecutive chunks for semantic continuity (default 200 bytes)', () => {
+    const text = 'a'.repeat(10_000);
+    const out = chunkForEmbed(text, 4000, 200);
+    // Each adjacent pair should share at least some overlap bytes;
+    // exact alignment depends on the byte-boundary walk-back, but
+    // consecutive chunk pairs should not be wholly disjoint.
+    for (let i = 0; i < out.length - 1; i += 1) {
+      const a = out[i]!.text;
+      const b = out[i + 1]!.text;
+      const overlap = a.slice(-200);
+      // Some prefix of b matches the tail of a.
+      expect(b.startsWith(overlap.slice(0, 50))).toBe(true);
+    }
+  });
+
+  it('never splits a multi-byte codepoint at a chunk boundary', () => {
+    // Polish "ą" = 2 UTF-8 bytes; pack a long string of them so cuts
+    // land mid-codepoint repeatedly. None of the chunks should end with
+    // a half codepoint (`Buffer.toString('utf8')` would surface a
+    // U+FFFD if it did).
+    const text = 'ą'.repeat(4000);
+    const out = chunkForEmbed(text, 4000);
+    expect(out.length).toBeGreaterThan(1);
+    for (const c of out) {
+      expect(c.text).not.toContain('�'); // replacement char on split
+      expect(Buffer.byteLength(c.text, 'utf8')).toBeLessThanOrEqual(4000);
+    }
+  });
+
+  it('handles 4-byte emoji on the boundary', () => {
+    // 😀 = 4 UTF-8 bytes. Pack to land cut inside one.
+    const text = 'a'.repeat(3998) + '😀'.repeat(2000);
+    const out = chunkForEmbed(text, 4000);
+    for (const c of out) {
+      expect(c.text).not.toContain('�');
+      expect(Buffer.byteLength(c.text, 'utf8')).toBeLessThanOrEqual(4000);
+    }
+  });
+
+  it('respects degenerate maxBytes <= 0 by returning a single passthrough chunk', () => {
+    // Belt-and-braces: would otherwise loop forever. Caller should
+    // never pass 0; if they do, give a coherent fallback.
+    const out = chunkForEmbed('hello', 0);
+    expect(out).toEqual([{ chunkIdx: 0, text: 'hello' }]);
+  });
+});
+
+describe('buildChunkEmbedId + baseMemoryIdFromChunkId', () => {
+  it('keeps the original id when there is only one chunk (backward compat)', () => {
+    expect(buildChunkEmbedId('journal-42', 0, 1)).toBe('journal-42');
+  });
+
+  it('appends #cN suffix when there are multiple chunks', () => {
+    expect(buildChunkEmbedId('journal-42', 0, 3)).toBe('journal-42#c0');
+    expect(buildChunkEmbedId('journal-42', 2, 3)).toBe('journal-42#c2');
+  });
+
+  it('round-trips: chunk id back to base id', () => {
+    expect(baseMemoryIdFromChunkId('journal-42#c0')).toBe('journal-42');
+    expect(baseMemoryIdFromChunkId('journal-42#c5')).toBe('journal-42');
+  });
+
+  it('returns the input unchanged for non-chunked ids', () => {
+    expect(baseMemoryIdFromChunkId('journal-42')).toBe('journal-42');
+    expect(baseMemoryIdFromChunkId('insights-7')).toBe('insights-7');
+  });
+
+  it('does not strip non-numeric `#c` patterns', () => {
+    // Legitimate content like `mem-id#config` must survive.
+    expect(baseMemoryIdFromChunkId('mem-id#config')).toBe('mem-id#config');
+    expect(baseMemoryIdFromChunkId('mem-id#c-not-a-number')).toBe('mem-id#c-not-a-number');
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the simple truncate (PR #586 / Option A) with **chunking + multi-vector storage** for content that exceeds the Rust embed pipeline's 4096-byte limit. Codex review #585 finding #4 explicitly called out that Option B was the better choice if we could dedup chunk-IDs cleanly — this PR does that.

## Why

After PR #586, long content (insight blocks 8-10 KB, future chain types) shipped as the first 4 KB truncated. The remaining 50-60% of each block was unsearchable. Operator asks \"co Memphis odkrył w insights\" → top-K recall hits only the prefix.

## Design

Three new exported helpers in \`src/infra/memory/embed-reindex.ts\`:

| Helper | Contract |
|---|---|
| \`chunkForEmbed(text, maxBytes, overlapBytes=200)\` | UTF-8 byte-aware windowed split. Never cuts mid-codepoint; consecutive chunks share \`overlapBytes\` of context for cross-boundary semantic continuity. Single-chunk passthrough when input already fits. |
| \`buildChunkEmbedId(memoryId, chunkIdx, totalChunks)\` | Returns \`memoryId\` for single-chunk (back-compat). Else \`<memoryId>#c<idx>\`. |
| \`baseMemoryIdFromChunkId(id)\` | Strips \`#cN\` suffix. Idempotent on non-suffixed ids; conservative about content that contains \`#c\` literally (only strips when followed by purely digits). |

**Recall dedup:** \`mapSemanticHits\` in \`src/mcp/tools/recall.ts\` now collapses multi-chunk hits by base memoryId. Takes the highest-scoring chunk's \`text_preview\` + tags, preserves original ranking position. Operators see one hit per source block, never N duplicates.

**Why unique IDs per chunk** (the Codex-flagged catch): \`EmbedPipeline::upsert_many\` keys docs by id in a \`HashMap\`. Sharing one \`memoryId\` across chunks of a long block would let later chunks overwrite earlier ones — exact regression Codex pointed at.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] 11 new tests in \`tests/unit/embed-chunk-option-b.test.ts\` pin: ASCII chunking, multibyte Polish, 4-byte emoji on boundary, overlap contract, degenerate \`maxBytes <= 0\`, id round-trip, non-numeric \`#c\` carve-out
- [x] Existing \`embed-reindex-utf8-truncate.test.ts\` + \`recall.test.ts\` (14 tests) still pass — \`truncateUtf8\` is kept exported for callers that legitimately want single-vector storage
- [ ] After merge: operator runs \`memphis embed reindex\` once so the 38 insight blocks (currently unsearchable per the daemon log noise) pick up the chunked form

## Out of scope

- Replacing \`truncateUtf8\` entirely. Kept exported because there are real cases where single-vector storage is desirable (short blocks, indicator messages); keeping the helper available lets future callers choose explicitly.
- Migrating existing index entries on the fly. \`memphis embed reset && memphis embed reindex\` rebuilds cleanly; daemon-side hot-migration isn't worth the complexity for a one-time index format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)