### PR TITLE
fix(shutdown): close Kartograf ONNX session before V8 teardown — likely SEGV root cause

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -531,6 +531,22 @@ export async function bootstrap(): Promise<void> {
       { name: 'heartbeat-watchdog', stop: () => watchdog.stop() },
       { name: 'chain-rotation-loop', stop: () => chainRotationHandle.stop() },
       { name: 'scheduled-backup-loop', stop: () => scheduledBackupHandle.stop() },
+      // 2026-05-12 SEGV diagnosis: 5/8 SIGSEGVs today landed during
+      // graceful shutdown, all with the same V8 JIT stack signature
+      // (NULL deref at offset ...5e2). Kartograf's OnnxKartografSession
+      // wraps an `onnxruntime-node` `InferenceSession` whose native
+      // `release()` must be called BEFORE V8 starts tearing down its
+      // wrapper, otherwise V8 GC and the ORT native finalizer race
+      // (same class of bug as BUG3-SEGV-INVESTIGATION — but for ORT
+      // instead of the Rust embed pipeline). Wiring the singleton
+      // closer into the stopper list serializes this teardown.
+      {
+        name: 'kartograf-onnx-session',
+        stop: async () => {
+          const { closeKartografRuntime } = await import('../kartograf/runtime.js');
+          await closeKartografRuntime();
+        },
+      },
     ],
   });
 


### PR DESCRIPTION
## Summary

Strong candidate for the shutdown-SEGV root cause that's been plaguing the v1.10.0 sprint. 8 SIGSEGVs today, **5 preserved coredumps all with identical V8 JIT signature** (NULL deref at offset \`...5e2\`, frame #11 = \`v8::internal::Invoke\`). **4 of 5 were graceful shutdowns**, not runtime crashes.

## Hypothesis

This is the same class as Bug 3 (\`docs/dev/BUG3-SEGV-INVESTIGATION.md\`, resolved 2026-04-29) — but for \`onnxruntime-node\` this time instead of the Rust embed pipeline. The original Bug 3 fix added \`embed_shutdown\` for the Rust EmbedPipeline OnceLock; that's still wired into the shutdown sequence and closes cleanly.

What's **missing**: kartograf activation (landed in v1.10.0 today) wires an \`onnxruntime-node\` \`InferenceSession\` into a process-level singleton (\`closeKartografRuntime()\` in \`src/kartograf/runtime.ts\`). That closer was never registered as a shutdown stopper. So:

1. \`graceful-shutdown.ts\` runs its stoppers (http, watchdog, chain-rotation, scheduled-backup) ✓
2. Flushes PULSE + OTel ✓
3. Calls \`resolveEmbedShutdown()\` to release the Rust embed pipeline ✓
4. Calls \`exitFn(0)\` — \`process.exit\` kicks in.
5. **V8 starts tearing down. The OnnxKartografSession JS wrapper gets finalized.** \`onnxruntime-node\`'s native finalizer fires on the SAME tensor / session that V8 GC is also racing on.
6. NULL pointer deref inside the V8-JIT call site that holds the ORT session reference → SIGSEGV.

## Fix

Register \`closeKartografRuntime\` as a shutdown stopper so the ORT session is released **before** V8 starts its finalizer pass. Same pattern as the existing \`resolveEmbedShutdown\` step that resolved Bug 3.

\`closeKartografRuntime\` is idempotent (no-op when runtime status isn't 'ready') and the import is dynamic so installs without kartograf activation pay no shutdown-path cost.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Local: \`systemctl --user restart memphis\` no longer trips the shutdown-SEGV pattern. Repeat 10× to confirm against the prior cadence (5 of every 8 restarts SEGV'd before this fix).
- [ ] Coredumpctl: if a SEGV does recur after this lands, the stack signature MUST differ from \`...5e2\` — same offset = race is elsewhere and this PR didn't close it; different offset = we tightened the surface and need to chase the next contributor.

## Out of scope

- onnxruntime-node version pin / native rebuild. Empirical fix; chasing the underlying ORT native bug stays in the upstream tracker.
- TUI SEGV on exit — separate Rust-side issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)