### PR TITLE
fix(slo+confab): S1 + S2 operator decisions — memphis_repair exclusion + STRIP env alias

### DIFF
--- a/src/gateway/turn-runtime.ts
+++ b/src/gateway/turn-runtime.ts
@@ -163,6 +163,14 @@ export type ConfabMitigationPhase = 0 | 1 | 2 | 3;
 export const DEFAULT_CONFAB_PHASE: ConfabMitigationPhase = 2;
 
 export function resolveConfabPhase(rawEnv: NodeJS.ProcessEnv): ConfabMitigationPhase {
+  // S1 operator decision 2026-05-12: phase 3 (strip-sentence) stays
+  // opt-in. Operators get a single-purpose toggle
+  // (`MEMPHIS_ANTICONFAB_STRIP=1`) so they don't have to remember the
+  // numeric phase scale. The explicit phase env still works for A/B
+  // experiments + back-compat with existing configs.
+  const stripRaw = (rawEnv.MEMPHIS_ANTICONFAB_STRIP ?? '').trim().toLowerCase();
+  if (stripRaw === '1' || stripRaw === 'true' || stripRaw === 'on') return 3;
+
   const raw = (rawEnv.MEMPHIS_ANTICONFAB_PHASE ?? '').trim();
   if (raw === '') return DEFAULT_CONFAB_PHASE;
   switch (raw) {
@@ -1406,8 +1414,14 @@ async function runTurnRuntimeImpl(options: TurnRuntimeInput): Promise<TurnRuntim
     });
 
     // Codex Round 5 P1 fix: record end-to-end turn latency for the SLO probe.
+    // S2 operator decision 2026-05-12: turns that invoked memphis_repair
+    // are written to the full-fidelity histogram but excluded from the
+    // SLO-scoped one — a single repair call is 100k+ tokens in/out and
+    // legitimately runs 2 minutes, which would otherwise dominate p99.
     const totalDurationMs = Date.now() - startedAt;
-    metrics.recordTurnDuration(totalDurationMs);
+    const toolsCalledForSlo = extractToolsCalled(result.messages);
+    const excludeFromSlo = toolsCalledForSlo.has('memphis_repair');
+    metrics.recordTurnDuration(totalDurationMs, { excludeFromSlo });
 
     return {
       provider: llm.provider,

--- a/src/infra/logging/metrics.ts
+++ b/src/infra/logging/metrics.ts
@@ -120,9 +120,21 @@ export class InMemoryMetrics {
   // Codex Round 5 P1 fix: end-to-end turn duration histogram (separate
   // from the HTTP /v1/chat/dispatch latency, which only measures the
   // enqueue path). Used by the SLO probe.
+  //
+  // Two parallel histograms maintained:
+  //   - turnDuration* — full sample, every turn. Visible in Prometheus,
+  //     used for general observability.
+  //   - turnDurationSlo* — same data MINUS turns flagged as
+  //     `excludeFromSlo` (today: turns that invoked memphis_repair,
+  //     which is a one-call 100k+-token write that legitimately runs
+  //     2 minutes). The SLO probe reads from the filtered histogram so
+  //     a single repair invocation doesn't blow the p99 budget.
   private turnDurationCount = 0;
   private turnDurationSumSeconds = 0;
   private turnDurationBuckets: number[] = TURN_HISTOGRAM_BUCKETS_SECONDS.map(() => 0);
+  private turnDurationSloCount = 0;
+  private turnDurationSloSumSeconds = 0;
+  private turnDurationSloBuckets: number[] = TURN_HISTOGRAM_BUCKETS_SECONDS.map(() => 0);
 
   public metricsEnabled(rawEnv: NodeJS.ProcessEnv = process.env): boolean {
     return parseBool(rawEnv.METRICS_ENABLED, true);
@@ -132,14 +144,32 @@ export class InMemoryMetrics {
    * Record an end-to-end turn duration. Called from runTurnRuntime
    * after the full turn has produced its final output (including all
    * cascade fallbacks, tool calls, and audit writes).
+   *
+   * `excludeFromSlo`: when true, the sample is added to the
+   * full-fidelity histogram (for ops visibility) but NOT to the
+   * SLO histogram (so the p95/p99 probe stays representative of
+   * normal turn latency). Use for turns the operator has classified
+   * as out-of-SLO scope — currently memphis_repair calls.
    */
-  public recordTurnDuration(durationMs: number): void {
+  public recordTurnDuration(
+    durationMs: number,
+    options?: { excludeFromSlo?: boolean },
+  ): void {
     const dSec = Math.max(0, durationMs / 1000);
     this.turnDurationCount += 1;
     this.turnDurationSumSeconds += dSec;
     for (let i = 0; i < TURN_HISTOGRAM_BUCKETS_SECONDS.length; i += 1) {
       if (dSec <= TURN_HISTOGRAM_BUCKETS_SECONDS[i]!) {
         this.turnDurationBuckets[i]! += 1;
+      }
+    }
+    if (!options?.excludeFromSlo) {
+      this.turnDurationSloCount += 1;
+      this.turnDurationSloSumSeconds += dSec;
+      for (let i = 0; i < TURN_HISTOGRAM_BUCKETS_SECONDS.length; i += 1) {
+        if (dSec <= TURN_HISTOGRAM_BUCKETS_SECONDS[i]!) {
+          this.turnDurationSloBuckets[i]! += 1;
+        }
       }
     }
   }
@@ -435,6 +465,26 @@ export class InMemoryMetrics {
     lines.push(`turn_duration_seconds_bucket${labels({ le: '+Inf' })} ${this.turnDurationCount}`);
     lines.push(`turn_duration_seconds_sum ${this.turnDurationSumSeconds.toFixed(6)}`);
     lines.push(`turn_duration_seconds_count ${this.turnDurationCount}`);
+
+    // SLO-scoped duplicate of the same histogram (excludes
+    // long-running tool turns flagged via recordTurnDuration's
+    // excludeFromSlo). The SLO probe reads this one; operators reading
+    // /metrics can still see both via the suffix `_slo`.
+    lines.push(
+      '# HELP turn_duration_slo_seconds Turn duration in seconds, filtered for SLO compliance (excludes operator-flagged long-running tool turns).',
+    );
+    lines.push('# TYPE turn_duration_slo_seconds histogram');
+    for (let i = 0; i < TURN_HISTOGRAM_BUCKETS_SECONDS.length; i += 1) {
+      const le = TURN_HISTOGRAM_BUCKETS_SECONDS[i]!;
+      lines.push(
+        `turn_duration_slo_seconds_bucket${labels({ le })} ${this.turnDurationSloBuckets[i] ?? 0}`,
+      );
+    }
+    lines.push(
+      `turn_duration_slo_seconds_bucket${labels({ le: '+Inf' })} ${this.turnDurationSloCount}`,
+    );
+    lines.push(`turn_duration_slo_seconds_sum ${this.turnDurationSloSumSeconds.toFixed(6)}`);
+    lines.push(`turn_duration_slo_seconds_count ${this.turnDurationSloCount}`);
 
     lines.push(
       '# HELP chain_blocks_total Total number of chain blocks discovered in scanned chain JSON files.',

--- a/src/infra/observability/slo-check.ts
+++ b/src/infra/observability/slo-check.ts
@@ -173,21 +173,26 @@ function aggregateByRoute(
  * histogram (separate from the per-route HTTP histogram). The turn
  * histogram has wider buckets for the long-running cascade tail.
  */
-function parseTurnHistogramFromPrometheus(prom: string): {
+function parseTurnHistogramFromPrometheus(
+  prom: string,
+  metricName: 'turn_duration_seconds' | 'turn_duration_slo_seconds' = 'turn_duration_seconds',
+): {
   buckets: number[];
   count: number;
 } {
   const buckets = TURN_HISTOGRAM_BUCKETS_SECONDS.map(() => 0);
   let count = 0;
+  const bucketPrefix = `${metricName}_bucket{`;
+  const countPrefix = `${metricName}_count`;
   for (const line of prom.split('\n')) {
-    if (line.startsWith('turn_duration_seconds_bucket{')) {
+    if (line.startsWith(bucketPrefix)) {
       const m = line.match(/le="([^"]+)"\}\s+(\d+(?:\.\d+)?)/);
       if (!m) continue;
       const le = m[1]!;
       if (le === '+Inf') continue;
       const idx = TURN_HISTOGRAM_BUCKETS_SECONDS.indexOf(Number(le));
       if (idx >= 0) buckets[idx] = Number(m[2]);
-    } else if (line.startsWith('turn_duration_seconds_count')) {
+    } else if (line.startsWith(countPrefix)) {
       const m = line.match(/\s+(\d+(?:\.\d+)?)/);
       if (m) count = Number(m[1]);
     }
@@ -231,11 +236,16 @@ export function checkAllSlos(metrics: InMemoryMetrics, options: SloCheckOptions 
 
   const results: SloResult[] = [];
 
-  // Codex Round 5 P1 fix: SLO 1+2 measure END-TO-END turn duration via
-  // the dedicated `turn_duration_seconds` histogram, NOT the HTTP
-  // /v1/chat/dispatch latency (which only times the enqueue path; the
-  // actual model run happens asynchronously).
-  const turnHist = parseTurnHistogramFromPrometheus(prom);
+  // S2 operator decision 2026-05-12: SLO probes read the SLO-scoped
+  // histogram, which excludes operator-flagged long-running tool turns
+  // (today: memphis_repair). The full-fidelity `turn_duration_seconds`
+  // histogram is still emitted to Prometheus for ops visibility; this
+  // probe just uses the cleaner signal.
+  //
+  // p99 threshold tightened 30→20s per Q2C (post-exclusion baseline is
+  // healthy; 20s covers MiniMax 15-33s real LLM turns without
+  // memphis_repair noise).
+  const turnHist = parseTurnHistogramFromPrometheus(prom, 'turn_duration_slo_seconds');
   const turnP95 = estimatePercentileSeconds(
     turnHist.buckets,
     turnHist.count,
@@ -261,9 +271,9 @@ export function checkAllSlos(metrics: InMemoryMetrics, options: SloCheckOptions 
   );
   results.push({
     sloId: 'turn.p99',
-    target: 'p99 ≤ 30s',
+    target: 'p99 ≤ 20s',
     observed: `${turnP99.toFixed(3)}s`,
-    ok: turnHist.count < minSamples || turnP99 <= 30,
+    ok: turnHist.count < minSamples || turnP99 <= 20,
     detail:
       turnHist.count < minSamples
         ? `insufficient samples (${turnHist.count} < ${minSamples}); skipping`

--- a/tests/unit/anti-confab-strip-env.test.ts
+++ b/tests/unit/anti-confab-strip-env.test.ts
@@ -1,0 +1,45 @@
+/**
+ * S1 operator decision 2026-05-12: phase 3 (strip-sentence) opt-in
+ * via the cleaner `MEMPHIS_ANTICONFAB_STRIP=1` env alias.
+ * `MEMPHIS_ANTICONFAB_PHASE` still works for back-compat + A/B.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { resolveConfabPhase } from '../../src/gateway/turn-runtime.js';
+
+describe('resolveConfabPhase — MEMPHIS_ANTICONFAB_STRIP alias', () => {
+  it('default (no envs set) is phase 2 (warn-append)', () => {
+    expect(resolveConfabPhase({})).toBe(2);
+  });
+
+  it.each(['1', 'true', 'on', 'TRUE', 'On'])(
+    'MEMPHIS_ANTICONFAB_STRIP=%s flips to phase 3',
+    (value) => {
+      expect(resolveConfabPhase({ MEMPHIS_ANTICONFAB_STRIP: value })).toBe(3);
+    },
+  );
+
+  it.each(['0', 'false', 'off', ''])(
+    'MEMPHIS_ANTICONFAB_STRIP=%s does NOT flip — falls back to phase env or default',
+    (value) => {
+      expect(resolveConfabPhase({ MEMPHIS_ANTICONFAB_STRIP: value })).toBe(2);
+    },
+  );
+
+  it('MEMPHIS_ANTICONFAB_PHASE=3 still works (back-compat)', () => {
+    expect(resolveConfabPhase({ MEMPHIS_ANTICONFAB_PHASE: '3' })).toBe(3);
+  });
+
+  it('STRIP=1 takes precedence over PHASE=0 (operator forced strip beats explicit off)', () => {
+    expect(
+      resolveConfabPhase({
+        MEMPHIS_ANTICONFAB_STRIP: '1',
+        MEMPHIS_ANTICONFAB_PHASE: '0',
+      }),
+    ).toBe(3);
+  });
+
+  it('PHASE=1 still selectable when STRIP is unset', () => {
+    expect(resolveConfabPhase({ MEMPHIS_ANTICONFAB_PHASE: '1' })).toBe(1);
+  });
+});

--- a/tests/unit/slo-memphis-repair-exclusion.test.ts
+++ b/tests/unit/slo-memphis-repair-exclusion.test.ts
@@ -1,0 +1,82 @@
+/**
+ * S2 operator decision 2026-05-12: memphis_repair turns excluded from
+ * SLO histogram; p99 threshold tightened 30→20s.
+ *
+ * Test invariants:
+ *   - excludeFromSlo: true is recorded in full histogram but NOT SLO one.
+ *   - Default (no option) is recorded in BOTH.
+ *   - Prometheus output exposes both histograms with distinct names.
+ *   - SLO probe reads the SLO histogram (p99 target now '≤ 20s').
+ *   - A 120s memphis_repair turn does NOT trip the SLO when normal
+ *     turns are healthy.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { InMemoryMetrics } from '../../src/infra/logging/metrics.js';
+import { checkAllSlos } from '../../src/infra/observability/slo-check.js';
+
+describe('SLO turn-duration histogram — memphis_repair exclusion', () => {
+  it('excludeFromSlo records into full histogram but not SLO histogram', () => {
+    const metrics = new InMemoryMetrics();
+    metrics.recordTurnDuration(120_000, { excludeFromSlo: true });
+
+    const prom = metrics.toPrometheus();
+    // Full histogram count = 1
+    expect(prom).toMatch(/^turn_duration_seconds_count\s+1$/m);
+    // SLO histogram count = 0 (the +Inf bucket is "0" too)
+    expect(prom).toMatch(/^turn_duration_slo_seconds_count\s+0$/m);
+  });
+
+  it('default (no options) records into both histograms', () => {
+    const metrics = new InMemoryMetrics();
+    metrics.recordTurnDuration(5_000);
+    metrics.recordTurnDuration(8_000);
+
+    const prom = metrics.toPrometheus();
+    expect(prom).toMatch(/^turn_duration_seconds_count\s+2$/m);
+    expect(prom).toMatch(/^turn_duration_slo_seconds_count\s+2$/m);
+  });
+
+  it('p99 SLO target is "p99 ≤ 20s"', () => {
+    const metrics = new InMemoryMetrics();
+    // Need ≥ 10 samples (minSamples default).
+    for (let i = 0; i < 20; i += 1) {
+      metrics.recordTurnDuration(2_000);
+    }
+    const results = checkAllSlos(metrics);
+    const p99 = results.find((r) => r.sloId === 'turn.p99');
+    expect(p99?.target).toBe('p99 ≤ 20s');
+    expect(p99?.ok).toBe(true);
+  });
+
+  it('a single memphis_repair-flagged 120s turn does NOT breach SLO when normal turns are healthy', () => {
+    const metrics = new InMemoryMetrics();
+    // 20 healthy normal turns ~ 3s each.
+    for (let i = 0; i < 20; i += 1) {
+      metrics.recordTurnDuration(3_000);
+    }
+    // One huge memphis_repair turn — flagged for exclusion.
+    metrics.recordTurnDuration(120_000, { excludeFromSlo: true });
+
+    const results = checkAllSlos(metrics);
+    const p99 = results.find((r) => r.sloId === 'turn.p99');
+    expect(p99?.ok).toBe(true);
+    const p95 = results.find((r) => r.sloId === 'turn.p95');
+    expect(p95?.ok).toBe(true);
+  });
+
+  it('SLO probe correctly fails when the SLO-scoped histogram exceeds 20s', () => {
+    const metrics = new InMemoryMetrics();
+    // 100 healthy turns + 5 25-second slow turns NOT excluded — 5/105
+    // is ~4.7% so p99 lands in the 25s bucket.
+    for (let i = 0; i < 100; i += 1) {
+      metrics.recordTurnDuration(2_000);
+    }
+    for (let i = 0; i < 5; i += 1) {
+      metrics.recordTurnDuration(25_000);
+    }
+    const results = checkAllSlos(metrics);
+    const p99 = results.find((r) => r.sloId === 'turn.p99');
+    expect(p99?.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Lands operator decisions from the 2026-05-12 review of PR #590 (S1 confab analysis) and PR #591 (S2 p99 latency analysis).

### S1 — anti-confab Phase 3 env opt-in
- New env: `MEMPHIS_ANTICONFAB_STRIP=1` (or `true`/`on`) → Phase 3.
- Default behavior unchanged: Phase 2 (warn-append).
- `MEMPHIS_ANTICONFAB_PHASE` still works for back-compat + A/B.

### S2 — SLO histogram excludes memphis_repair + p99 tightened 30→20s
- New parallel histogram `turn_duration_slo_seconds` — same data as the existing `turn_duration_seconds`, minus turns flagged `excludeFromSlo`.
- Turn runtime flags any turn that called `memphis_repair`.
- SLO probe reads the SLO histogram. Full histogram stays on `/metrics`.
- p99 tightened 30→20s; covers MiniMax 15-33s real LLM turns without the 127s repair outlier dominating.

## Why

**S1 background**: PR #590's analysis showed all 8 confab events today were `persistence` category, single phrases (gotowe/zapisane/zapisałem). Operator wanted to keep Phase 2 (warn-append) as default and only flip to strip via an explicit toggle — without forcing operators to remember the numeric phase scale.

**S2 background**: PR #591's analysis traced p99=263s to a single `memphis_repair` call at 127,726ms (one tool, two write batches at 100k+ tokens each, real provider work). Excluding it drops baseline to healthy range; tightening to 20s gives a meaningful gate.

## Tests

- `tests/unit/slo-memphis-repair-exclusion.test.ts` — 5 cases:
  - excludeFromSlo records into full histogram but not SLO histogram
  - default (no options) records into both
  - p99 target is "p99 ≤ 20s"
  - a single 120s memphis_repair-flagged turn does NOT breach SLO
  - SLO probe correctly fails when the SLO-scoped histogram exceeds 20s
- `tests/unit/anti-confab-strip-env.test.ts` — 13 cases (alias forms, back-compat, precedence)
- Regression: existing `slo-check` (6) + anti-confab (51) suites green

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – (TS-only) |
| NAPI bridge | – |
| TS host | ✅ `src/infra/logging/metrics.ts`, `src/infra/observability/slo-check.ts`, `src/gateway/turn-runtime.ts` |
| CLI | – |
| Tauri | – |
| doctor/status | – (`memphis_slo_status` surfaces the new probe verdict; threshold visible there) |
| tests | ✅ 18 new + 57 regression green |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on touched files
- [x] 18 new unit cases pass
- [x] 57 existing slo+confab regression cases pass
- [ ] Post-merge restart: operator sets `MEMPHIS_ANTICONFAB_STRIP=1` to test Phase 3 in their runtime, verifies the p99 SLO is reading the new `turn_duration_slo_seconds` histogram

## Closes

- The S1 B-step from PR #590 (Phase 3 default flip decision — chose env opt-in)
- The S2 B-step from PR #591 (Q1B + Q2C — exclude memphis_repair + raise p99 to 20s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)