### PR TITLE
fix(shutdown): dedup embed_shutdown calls between graceful + napi paths (REV2 Temat 2)

### DIFF
--- a/src/infra/runtime/embed-shutdown-state.ts
+++ b/src/infra/runtime/embed-shutdown-state.ts
@@ -1,0 +1,52 @@
+/**
+ * Process-wide flag indicating whether `embed_shutdown()` has been
+ * called on the Rust NAPI bridge. Two independent code paths can fire
+ * the call:
+ *
+ *   1. `graceful-shutdown.ts` step 5.5 — runs from the SIGTERM /
+ *      explicit-stop path before V8 begins releasing the NAPI env.
+ *   2. `napi-shutdown.ts` `beforeExit` / `exit` handler — last-resort
+ *      safety net for natural-exit or `process.exit()` paths the
+ *      graceful path didn't cover.
+ *
+ * If BOTH fire in sequence (graceful shutdown → process.exit() →
+ * beforeExit listener), the second call lands AFTER V8 has started
+ * unmapping the cdylib that owns the `EMBED_PIPELINE` static. Reading
+ * the OnceLock's internal atomic state then dereferences a freed
+ * page → SIGSEGV with the stack signature documented in
+ * `notes/segv-rca-2026-05-12.md` (NULL `Once::is_completed` →
+ * `AtomicU32::load` at offset 0x0).
+ *
+ * This module is the synchronization point: whichever caller fires
+ * first marks the flag; the other checks the flag and skips its own
+ * call. The Rust side is already idempotent + arms a shutdown barrier
+ * after the first invocation, so the only thing we need to prevent is
+ * the second invocation reaching a torn-down cdylib.
+ *
+ * The flag lives in module scope (process-wide). It is intentionally
+ * NOT exposed via env or persisted to disk — embed shutdown is a
+ * one-shot per-process operation; restarting the daemon resets the
+ * flag with the rest of the module.
+ */
+
+let embedShutdownCalled = false;
+let embedShutdownCaller: string | undefined;
+
+export function markEmbedShutdownCalled(caller: string): void {
+  embedShutdownCalled = true;
+  embedShutdownCaller = caller;
+}
+
+export function hasEmbedShutdownRun(): boolean {
+  return embedShutdownCalled;
+}
+
+export function getEmbedShutdownCaller(): string | undefined {
+  return embedShutdownCaller;
+}
+
+/** Test-only: reset the flag between cases. Production never calls this. */
+export function __resetEmbedShutdownStateForTests(): void {
+  embedShutdownCalled = false;
+  embedShutdownCaller = undefined;
+}

--- a/src/infra/runtime/graceful-shutdown.ts
+++ b/src/infra/runtime/graceful-shutdown.ts
@@ -23,6 +23,10 @@
  * (typical when an operator hits Ctrl-C twice impatiently).
  */
 
+import {
+  hasEmbedShutdownRun,
+  markEmbedShutdownCalled,
+} from './embed-shutdown-state.js';
 import { writePulseEvent } from './heartbeat-watchdog.js';
 import { resolveRustBridgePath } from './install-root.js';
 import { activeTurnCount, signalDrain } from './self-restart.js';
@@ -290,21 +294,38 @@ export async function performGracefulShutdown(
   // Rust OnceLock<Mutex<EmbedPipeline>> static destructor. Calling
   // embed_shutdown() here serializes the teardown — the Mutex is
   // released and persistence flushed before exitFn() triggers V8 exit.
-  try {
-    const shutdownFn = await resolveEmbedShutdown(options);
-    if (shutdownFn) {
-      shutdownFn();
-    }
-  } catch (err) {
+  //
+  // Marks the process-wide `embed-shutdown-state` flag after a
+  // successful call. `napi-shutdown.ts`'s beforeExit/exit handler
+  // checks the same flag and skips its own embed_shutdown if we
+  // already ran — without this dedup the second call could land on
+  // a torn-down cdylib (RCA: notes/segv-rca-2026-05-12.md, NULL
+  // deref in OnceLock::is_completed at offset 0x0).
+  if (hasEmbedShutdownRun()) {
     logLine(
       options.logger,
-      'warn',
-      {
-        event: 'shutdown.embed-shutdown.failed',
-        error: err instanceof Error ? err.message : String(err),
-      },
-      'embed_shutdown() failed — proceeding to exit anyway',
+      'info',
+      { event: 'shutdown.embed-shutdown.skipped', reason: 'already-run' },
+      'embed_shutdown() already ran — skipping (idempotency guard)',
     );
+  } else {
+    try {
+      const shutdownFn = await resolveEmbedShutdown(options);
+      if (shutdownFn) {
+        shutdownFn();
+        markEmbedShutdownCalled('graceful-shutdown:step-5.5');
+      }
+    } catch (err) {
+      logLine(
+        options.logger,
+        'warn',
+        {
+          event: 'shutdown.embed-shutdown.failed',
+          error: err instanceof Error ? err.message : String(err),
+        },
+        'embed_shutdown() failed — proceeding to exit anyway',
+      );
+    }
   }
 
   // 5.6. Sprint 2.3 (#270): flush all pino destinations before exit.

--- a/src/infra/runtime/napi-shutdown.ts
+++ b/src/infra/runtime/napi-shutdown.ts
@@ -36,6 +36,10 @@
  * re-exercise the registration path.
  */
 
+import {
+  hasEmbedShutdownRun,
+  markEmbedShutdownCalled,
+} from './embed-shutdown-state.js';
 import { flushAllPinoStreamsSync } from '../logging/pino.js';
 
 let installed = false;
@@ -153,14 +157,29 @@ function buildHandler(
     // 1. Tell the Rust EmbedPipeline to release its global Mutex
     //    BEFORE the V8 isolate tears down the napi env. Skipping this
     //    is the original issue #270 SEGV signature.
+    //
+    // Temat 2 dedup (2026-05-12): if `graceful-shutdown.ts` step 5.5
+    // already called embed_shutdown, skip the second invocation.
+    // Without this guard the duplicate call lands AFTER V8 has begun
+    // unmapping the cdylib (graceful-shutdown finished → process.exit
+    // → beforeExit listener fires → cdylib partially gone) and
+    // OnceLock::is_completed dereferences a freed page → SIGSEGV.
+    // See notes/segv-rca-2026-05-12.md for the full stack trace.
+    // The Rust side is already idempotent for back-to-back calls, but
+    // the bug is the underlying memory being freed BETWEEN them.
     try {
-      const embedShutdown =
-        options.embedShutdownFn ??
-        (typeof bridge.embed_shutdown === 'function'
-          ? (bridge.embed_shutdown as () => void)
-          : undefined);
-      if (embedShutdown) {
-        embedShutdown();
+      if (hasEmbedShutdownRun()) {
+        // graceful-shutdown.ts already drained the pipeline; skip.
+      } else {
+        const embedShutdown =
+          options.embedShutdownFn ??
+          (typeof bridge.embed_shutdown === 'function'
+            ? (bridge.embed_shutdown as () => void)
+            : undefined);
+        if (embedShutdown) {
+          embedShutdown();
+          markEmbedShutdownCalled('napi-shutdown:beforeExit');
+        }
       }
     } catch {
       // Swallowed — the guard runs at exit; surfacing here would

--- a/tests/unit/embed-shutdown-dedup.test.ts
+++ b/tests/unit/embed-shutdown-dedup.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Temat 2 (2026-05-12) — embed_shutdown dedup between graceful-shutdown
+ * and napi-shutdown handlers.
+ *
+ * RCA: notes/segv-rca-2026-05-12.md — duplicate embed_shutdown() call
+ * from beforeExit listener landed on torn-down cdylib (graceful path
+ * ran first, then process.exit fired the napi-shutdown handler, then
+ * V8 began unmapping native module → second call hit NULL deref in
+ * OnceLock::is_completed).
+ *
+ * Fix: a process-wide flag (`embed-shutdown-state`) lets either caller
+ * mark the work done; the other skips its own invocation. Rust side
+ * is already idempotent for back-to-back calls, but the bug is the
+ * memory being freed BETWEEN them.
+ *
+ * Tests:
+ *   - flag starts false, mark sets it, second caller sees it set
+ *   - napi-shutdown handler skips embedShutdown when flag is set
+ *   - napi-shutdown handler runs embedShutdown when flag is unset
+ *   - call site is recorded for forensics
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetEmbedShutdownStateForTests,
+  getEmbedShutdownCaller,
+  hasEmbedShutdownRun,
+  markEmbedShutdownCalled,
+} from '../../src/infra/runtime/embed-shutdown-state.js';
+import {
+  __resetNapiShutdownGuardForTests,
+  installNapiShutdownGuard,
+} from '../../src/infra/runtime/napi-shutdown.js';
+
+describe('embed-shutdown-state', () => {
+  beforeEach(() => {
+    __resetEmbedShutdownStateForTests();
+  });
+
+  it('flag starts false; mark flips it; caller string is recorded', () => {
+    expect(hasEmbedShutdownRun()).toBe(false);
+    expect(getEmbedShutdownCaller()).toBeUndefined();
+    markEmbedShutdownCalled('test:caller-A');
+    expect(hasEmbedShutdownRun()).toBe(true);
+    expect(getEmbedShutdownCaller()).toBe('test:caller-A');
+  });
+
+  it('repeated mark calls update the recorded caller (last writer wins)', () => {
+    markEmbedShutdownCalled('test:caller-A');
+    markEmbedShutdownCalled('test:caller-B');
+    expect(getEmbedShutdownCaller()).toBe('test:caller-B');
+  });
+
+  it('reset (test-only) clears the flag', () => {
+    markEmbedShutdownCalled('test:caller-A');
+    expect(hasEmbedShutdownRun()).toBe(true);
+    __resetEmbedShutdownStateForTests();
+    expect(hasEmbedShutdownRun()).toBe(false);
+  });
+});
+
+describe('napi-shutdown handler skips embed_shutdown when flag is set', () => {
+  beforeEach(() => {
+    __resetEmbedShutdownStateForTests();
+    __resetNapiShutdownGuardForTests();
+  });
+
+  afterEach(() => {
+    __resetEmbedShutdownStateForTests();
+    __resetNapiShutdownGuardForTests();
+  });
+
+  it('handler runs embedShutdown when flag is unset (no prior graceful call)', () => {
+    const embedShutdown = vi.fn();
+    const pinoFlush = vi.fn();
+    installNapiShutdownGuard(
+      { embed_shutdown: embedShutdown },
+      { embedShutdownFn: embedShutdown, pinoFlushFn: pinoFlush, hardExit: false },
+    );
+    // Fire beforeExit (Node lifecycle simulation)
+    process.emit('beforeExit', 0);
+    expect(embedShutdown).toHaveBeenCalledTimes(1);
+    expect(pinoFlush).toHaveBeenCalledTimes(1);
+    // Flag now set with napi-shutdown's caller string.
+    expect(hasEmbedShutdownRun()).toBe(true);
+    expect(getEmbedShutdownCaller()).toBe('napi-shutdown:beforeExit');
+  });
+
+  it('handler SKIPS embedShutdown when graceful-shutdown already marked the flag', () => {
+    // Simulate the prior graceful-shutdown step 5.5 call.
+    markEmbedShutdownCalled('graceful-shutdown:step-5.5');
+    const embedShutdown = vi.fn();
+    const pinoFlush = vi.fn();
+    installNapiShutdownGuard(
+      { embed_shutdown: embedShutdown },
+      { embedShutdownFn: embedShutdown, pinoFlushFn: pinoFlush, hardExit: false },
+    );
+    process.emit('beforeExit', 0);
+    expect(embedShutdown).not.toHaveBeenCalled();
+    // pinoFlush still runs — separate concern, separate dedup story.
+    expect(pinoFlush).toHaveBeenCalledTimes(1);
+    // Original caller string preserved (we only mark when WE call it).
+    expect(getEmbedShutdownCaller()).toBe('graceful-shutdown:step-5.5');
+  });
+
+  it('handler is single-shot across beforeExit + exit (existing behavior preserved)', () => {
+    const embedShutdown = vi.fn();
+    const pinoFlush = vi.fn();
+    installNapiShutdownGuard(
+      { embed_shutdown: embedShutdown },
+      { embedShutdownFn: embedShutdown, pinoFlushFn: pinoFlush, hardExit: false },
+    );
+    process.emit('beforeExit', 0);
+    process.emit('exit', 0);
+    // Cleanup ran once total across both events.
+    expect(embedShutdown).toHaveBeenCalledTimes(1);
+    expect(pinoFlush).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary — REV2 Temat 2 (P1 daemon stability)

Closes residual SIGSEGV class from `notes/segv-rca-2026-05-12.md`. Two independent paths fire `embed_shutdown()`; when both run in sequence, the second hits a torn-down cdylib (NULL deref in OnceLock::is_completed at offset 0x0).

### Root cause

- `graceful-shutdown.ts` step 5.5 fires `embed_shutdown` on SIGTERM.
- `napi-shutdown.ts` beforeExit/exit handler ALSO fires it as a safety net.
- After step 5.5 completes, process.exit() triggers beforeExit → handler reruns embed_shutdown → cdylib partially unmapped by V8 → SIGSEGV.

### Fix

Process-wide flag in new module `src/infra/runtime/embed-shutdown-state.ts`. Either caller marks the flag; the other reads it and skips. Existing Rust-side idempotency holds for back-to-back calls; the bug is the memory being freed BETWEEN them.

### Why not the Rust stopFn approach from the RCA

Coder B's RCA suggested mirroring PR #588 (Kartograf) by adding a Memphis stopFn entry. But embed is ALREADY wired through `graceful-shutdown.ts` step 5.5 — a third call site would just widen the race. TS-side dedup matches Memphis's existing idempotency-via-state idiom.

## Tests

- `tests/unit/embed-shutdown-dedup.test.ts` — 6 cases:
  - flag semantics (start, mark, reset, last-writer caller string)
  - handler runs embed_shutdown when flag unset
  - handler SKIPS when graceful-shutdown already marked the flag
  - single-shot beforeExit+exit preserved (existing cleanupRan behavior)
- `npx tsc --noEmit` clean, `npx eslint` clean on touched files.

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – (no Rust change — idempotency already holds) |
| NAPI bridge | – (no signature change, no rebuild) |
| TS host | ✅ `src/infra/runtime/embed-shutdown-state.ts` (new), `graceful-shutdown.ts`, `napi-shutdown.ts` |
| CLI/Tauri | – |
| doctor/status | – (could surface caller string in shutdown forensics; deferred) |
| tests | ✅ 6 new unit cases |

## Operator B-step (post-merge + restart)

`systemctl --user stop memphis` during heavy embed activity (e.g., `memphis health` loop emitting writes). Pre-fix: occasional SEGV core dumps with the stack from `notes/segv-rca-2026-05-12.md`. Post-fix: clean exits over many cycles.

## Refs

- RCA: `notes/segv-rca-2026-05-12.md`
- Sibling: PR #588 (Kartograf ONNX session, same class different singleton)
- Handoff: `.claude/handoff-coder-a-review-queue-2026-05-12.md` REV2 Temat 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)