### PR TITLE
chore(gitignore): operator-machine-local + secret-leak hard-blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,31 @@ watra.zip
 # it once. Same pattern as scheduled_tasks.lock — operator-machine-local,
 # never source. Memory: feedback_local_artifacts_never_stage.
 crons/simple-reminder.sh
+# 2026-05-12 audit: telegram-insights-push.sh appeared as untracked across
+# multiple sessions (operator's 6-hourly Telegram health-report cron on
+# this machine). Same per-machine-local pattern as simple-reminder.sh.
+crons/telegram-insights-push.sh
+
+# ── Coredumps & vault-state backups (NEVER publish) ──────────────────────────
+# Operator generates these regularly via systemd-coredump + pre-incident
+# tar snapshots (e.g. 2026-05-11 vault recovery, 2026-05-12 SEGV). A
+# coredump or vault-state tarball at repo root would leak the entire
+# operator vault key material + decrypted secrets. Hard-block at every
+# path.
+memphis-coredump-*
+memphis-pre-*.tar.*
+memphis-pre-*.zst
+live-memphis-*/
+vault-broken-*/
+vault-pre-reinit-*/
+
+# ── Local direnv / shell config (per-machine, may carry secrets) ─────────────
+.envrc
+.envrc.*
+
+# ── Merge conflict / rebase artifacts ────────────────────────────────────────
+*.orig
+*.rej
 
 # ── Temporary scratch ────────────────────────────────────────────────────────
 *.tmp
@@ -111,8 +136,12 @@ inventory/
 memphis-test-report.md
 
 # Python compiled bytecode (corpus + training tools)
-tools/**/__pycache__/
+# 2026-05-12 audit: broadened from tools/**/ to global — Python bytecode
+# can land anywhere a venv runs (status_writer tests, future scripts).
+__pycache__/
 *.pyc
+*.pyo
+*.pyd
 
 # Closure sprint Z.7 (2026-05-09): health-watch.sh writes JSON run
 # records and incident reports to ~/.memphis/. They're operator-local


### PR DESCRIPTION
## Summary

Five `.gitignore` additions surfaced by the **2026-05-12 secret-scan + worktree audit** session:

1. **`crons/telegram-insights-push.sh`** — operator's per-machine 6-hourly Telegram health-report cron. Appeared as untracked across multiple sessions. Symmetric to existing `crons/simple-reminder.sh` ignore (memory: `feedback_local_artifacts_never_stage`).

2. **Coredumps + vault-state backup tarballs** — `memphis-coredump-*`, `memphis-pre-*.tar.*`, `memphis-pre-*.zst`, `live-memphis-*/`, `vault-broken-*/`, `vault-pre-reinit-*/`. Operator generates these regularly (systemd-coredump for daemon SEGVs; pre-incident snapshots for vault recovery). **A coredump or vault-state tarball at repo root would leak the entire operator vault key material + decrypted secrets.** Hard-block at every path.

3. **`.envrc` + `.envrc.*`** — direnv local shell config. May carry per-host secrets (provider API keys via direnv shim). Symmetric to existing `.env` / `.env.*` block.

4. **`*.orig` + `*.rej`** — merge conflict / rebase artifacts. Never source.

5. **Python bytecode broadened** from `tools/**/__pycache__/` to global `__pycache__/` + added `*.pyo` and `*.pyd`. Bytecode can land anywhere a venv runs.

## Scan result

**Zero real secret leaks** in current worktree OR in git history.

- `scripts/secret-scan.sh` on worktree → `[secret-scan] OK`
- `git log --all -p` grep for AWS / GCP / GitHub / Anthropic / OpenAI / Stripe / Slack / PEM patterns → only false-positives (npm dotenv README in node_modules history + secret-scan.test.ts fixtures)

This commit is **preventive** — closes potential future leak paths surfaced by the audit, not reacting to an actual leak.

## Cross-refs

- `scripts/secret-scan.sh` — existing pattern coverage
- Memory: `feedback_local_artifacts_never_stage.md`
- Companion docs PR: #599 (post-Y1 roadmap snapshot)

## Test plan

- [x] `git check-ignore -v crons/telegram-insights-push.sh` matches new rule
- [x] No previously-tracked file falls into the new patterns (verified `git ls-files` × new globs)
- [x] No code changes — zero behavioral impact