### PR TITLE
feat(exec-wisdom): Memphis operator-mode wisdom — 5-layer (REV2 Temat 3.5)

### DIFF
--- a/src/gateway/exec-failure-budget.ts
+++ b/src/gateway/exec-failure-budget.ts
@@ -1,0 +1,96 @@
+/**
+ * Exec failure budget — REV2 Temat 3.5 Warstwa 5.
+ *
+ * In-memory per-(surface, actorId) counter of consecutive non-zero exec
+ * exit codes. The wisdom doctrine in the soul seed tells the agent to
+ * stop blind-retrying after 3 failures; this module enforces it at the
+ * runtime layer so a non-compliant LLM still gets stopped.
+ *
+ * Semantics:
+ *   - Each non-zero exit increments the counter for that (surface, actor).
+ *   - Each successful exec decrements (clamped at 0).
+ *   - At counter >= MAX_CONSECUTIVE_FAILURES (3), the next exec attempt
+ *     is refused with a structured error.
+ *   - Counter resets when the actor's NEXT non-exec tool call fires
+ *     (signal: "agent moved on from the failing exec loop"). Callers
+ *     in the tool-executor invoke `resetOnNonExecToolCall(key)` at
+ *     dispatch time for any non-`memphis_exec` tool.
+ *
+ * State is in-memory only — process restart resets every counter. The
+ * intent is to break THIS conversation's retry loop, not a permanent
+ * lockout.
+ */
+
+export const MAX_CONSECUTIVE_FAILURES = 3;
+
+interface BudgetEntry {
+  failures: number;
+  lastUpdate: number;
+}
+
+const buckets = new Map<string, BudgetEntry>();
+
+function keyFor(surface: string | undefined, actorId: string | undefined): string {
+  return `${surface ?? 'unknown'}::${actorId ?? 'unknown'}`;
+}
+
+export interface ExecFailureBudgetKey {
+  surface?: string;
+  actorId?: string;
+}
+
+export function recordExecOutcome(
+  identity: ExecFailureBudgetKey,
+  exitCode: number,
+): void {
+  const key = keyFor(identity.surface, identity.actorId);
+  const current = buckets.get(key) ?? { failures: 0, lastUpdate: Date.now() };
+  if (exitCode === 0) {
+    current.failures = Math.max(0, current.failures - 1);
+  } else {
+    current.failures += 1;
+  }
+  current.lastUpdate = Date.now();
+  buckets.set(key, current);
+}
+
+export function isExecBlockedForBudget(identity: ExecFailureBudgetKey): boolean {
+  const entry = buckets.get(keyFor(identity.surface, identity.actorId));
+  if (!entry) return false;
+  return entry.failures >= MAX_CONSECUTIVE_FAILURES;
+}
+
+export function getConsecutiveFailures(identity: ExecFailureBudgetKey): number {
+  return buckets.get(keyFor(identity.surface, identity.actorId))?.failures ?? 0;
+}
+
+/**
+ * Reset signal: the actor invoked some non-exec tool, which means
+ * they're moving on from the failing retry loop. Clears the counter
+ * so the next exec attempt isn't pre-emptively blocked.
+ *
+ * Called from tool-executor when dispatching ANY tool whose name
+ * isn't `memphis_exec`.
+ */
+export function resetOnNonExecToolCall(identity: ExecFailureBudgetKey): void {
+  buckets.delete(keyFor(identity.surface, identity.actorId));
+}
+
+/**
+ * Operator-facing reset (e.g. /tier revoke clears state; also used by
+ * tests). Wipes all buckets — use sparingly outside test paths.
+ */
+export function resetAllExecBudgetsForTests(): void {
+  buckets.clear();
+}
+
+export function describeBudgetRefusal(identity: ExecFailureBudgetKey): string {
+  const n = getConsecutiveFailures(identity);
+  return (
+    `${n} consecutive exec failures hit the safety budget ` +
+    `(max ${MAX_CONSECUTIVE_FAILURES}). Stop blind-retrying. ` +
+    `Re-analyze the approach, run memphis_exec_analyze on the next ` +
+    `attempt, or ask the operator for guidance. The counter resets ` +
+    `when you invoke any non-exec tool (signals you moved on).`
+  );
+}

--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -28,6 +28,7 @@ import { runMemphisCron } from '../mcp/tools/cron.js';
 import { runMemphisDb } from '../mcp/tools/db.js';
 import { runMemphisDecide } from '../mcp/tools/decide.js';
 import { runMemphisDeploy } from '../mcp/tools/deploy.js';
+import { runMemphisExecAnalyze } from '../mcp/tools/exec-analyze.js';
 import { runMemphisExec } from '../mcp/tools/exec.js';
 import { runMemphisFsOps } from '../mcp/tools/fs-ops.js';
 import { runMemphisFsWrite } from '../mcp/tools/fs-write.js';
@@ -830,20 +831,60 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
       },
     }),
     buildTool({
+      name: 'memphis_exec_analyze',
+      description:
+        'Pre-exec analysis: parse + classify side-effects, reversibility, dry-run hint, recommendation. No side effects.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          command: { type: 'string', description: 'Shell command to analyze (not executed)' },
+          surface_intent: {
+            type: 'string',
+            description: "Operator's high-level intent — surfaced unchanged for audit context.",
+          },
+        },
+        required: ['command'],
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      validateInput(args) {
+        return {
+          command: requiredString(args, 'command'),
+          surface_intent: optionalString(args, 'surface_intent'),
+        };
+      },
+      execute(input) {
+        return runMemphisExecAnalyze(input);
+      },
+    }),
+    buildTool({
       name: 'memphis_exec',
       description: 'Execute a shell command',
       inputSchema: {
         type: 'object',
-        properties: { command: { type: 'string', description: 'Command to execute' } },
+        properties: {
+          command: { type: 'string', description: 'Command to execute' },
+          surface_intent: {
+            type: 'string',
+            description:
+              "Optional operator-stated intent (the prompt that prompted this exec). Audit-logged alongside the predicted-vs-actual outcome.",
+          },
+        },
         required: ['command'],
       },
       isDestructive: true,
       validateInput(args) {
-        return { command: requiredString(args, 'command') };
+        return {
+          command: requiredString(args, 'command'),
+          surface_intent: optionalString(args, 'surface_intent'),
+        };
       },
       execute(input) {
         try {
-          return runMemphisExec(input, deps.rawEnv);
+          return runMemphisExec(input, deps.rawEnv, {
+            surface: deps.surface,
+            actorId: deps.sessionId,
+          });
         } catch (err) {
           return { error: err instanceof Error ? err.message : String(err) };
         }
@@ -1753,6 +1794,16 @@ async function executeTool(
   deps: InProcessToolExecutorDeps,
   runtimeTools: Map<string, RuntimeToolDefinition>,
 ): Promise<string> {
+  // REV2 Temat 3.5: failure-budget reset on any non-exec tool call.
+  // The wisdom doctrine in the soul seed tells the agent "if 3 exec
+  // failures in a row, stop and re-analyze". We enforce that at the
+  // runtime layer; this reset signals "agent moved on from the exec
+  // retry loop" and clears the per-(surface, actor) counter so the
+  // NEXT exec attempt isn't pre-emptively blocked.
+  if (call.name !== 'memphis_exec' && call.name !== 'memphis_exec_analyze') {
+    const { resetOnNonExecToolCall } = await import('./exec-failure-budget.js');
+    resetOnNonExecToolCall({ surface: deps.surface, actorId: deps.sessionId });
+  }
   // Enforce tiered authorization before execution
   // Thread rawEnv from request deps so per-request env overrides
   // (e.g. MEMPHIS_AUTONOMY_MODE=full carried in the HTTP request env

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -896,6 +896,22 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
       },
     ],
   },
+  memphis_exec_analyze: {
+    name: 'memphis_exec_analyze',
+    tier: 1,
+    capabilities: ['read'],
+    description:
+      'Pre-exec analysis: parse a command and predict its side-effects without running it',
+    inputSchema: z
+      .object({
+        command: z.string().min(1),
+        surface_intent: z.string().optional(),
+        approval_request_id: z.string().optional(),
+      })
+      .strict(),
+    helpText:
+      "Call BEFORE `memphis_exec` for any command that isn't obviously read-only. Returns `{parsed, semantic, side_effects, files_touched, reversibility, tier_required, dry_run_command?, warnings, recommendation}`. Recommendation values: `safe-to-run` (just execute), `analyze-then-run` (surface the analysis to the operator first), `ask-operator` (irreversible — must get explicit go-ahead), `refuse` (touches vault/protected paths — never run regardless of tier). Pure parser + heuristics; safe to call at any tier without side effects.",
+  },
   memphis_exec: {
     name: 'memphis_exec',
     tier: 2,
@@ -904,11 +920,12 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
     inputSchema: z
       .object({
         command: z.string().min(1),
+        surface_intent: z.string().optional(),
         approval_request_id: z.string().optional(),
       })
       .strict(),
     helpText:
-      'Run a shell command in the Memphis runtime context (cwd: install root, env: filtered). Tier-2 with approval-required default — operator must whitelist or one-shot approve before each call. Stdout + stderr are returned together (capped at 64KB). Use for one-off diagnostics + dev commands; tier-2 commands that mutate the filesystem prefer memphis_fs_write or memphis_git so the change is auditable. NEVER pipe secrets into commands here — the audit log captures the full argv.',
+      "Run a shell command in the Memphis runtime context (cwd: install root, env: filtered). Tier-2 with approval-required default — operator must whitelist or one-shot approve before each call. Stdout + stderr are returned together (capped at 64KB). At tier-3, the allowlist + metachar block are dropped; the wisdom doctrine (soul-seed `exec wisdom` section) tells the agent to call `memphis_exec_analyze` FIRST and surface predicted impact before running anything destructive. `surface_intent` (optional) — the operator's high-level prompt that prompted this exec; appears in audit logs alongside the predicted-vs-actual outcome. Failure budget: after 3 consecutive non-zero exits in a row, further calls are refused with a 'stop blind-retrying' error — call any non-exec tool to reset.",
     cliFlags: [
       {
         name: '--command',

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,6 +23,7 @@ import { runMemphisCron } from './tools/cron.js';
 import { runMemphisDb } from './tools/db.js';
 import { runMemphisDecide } from './tools/decide.js';
 import { runMemphisDeploy } from './tools/deploy.js';
+import { runMemphisExecAnalyze } from './tools/exec-analyze.js';
 import { runMemphisExec } from './tools/exec.js';
 import { runMemphisFsOps } from './tools/fs-ops.js';
 import { runMemphisFsWrite } from './tools/fs-write.js';
@@ -972,6 +973,34 @@ export function createMemphisMcpServer(
     );
   }
 
+  const execAnalyzePolicy = getToolPolicy(permissions, 'memphis_exec_analyze', resolvedManifest);
+  if (shouldRegisterTool('memphis_exec_analyze', execAnalyzePolicy, rawEnv)) {
+    server.registerTool(
+      'memphis_exec_analyze',
+      {
+        description:
+          'Pre-exec analysis: parse + classify side-effects, reversibility, dry-run hint, recommendation. No side effects.',
+        inputSchema: {
+          command: z.string().min(1).max(2048),
+          surface_intent: z.string().optional(),
+          approval_request_id: z.string().optional(),
+        },
+      },
+      withApprovalGate(
+        'memphis_exec_analyze',
+        execAnalyzePolicy,
+        approvals,
+        async ({ command, surface_intent }) => {
+          const result = runMemphisExecAnalyze({ command, surface_intent });
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        },
+      ),
+    );
+  }
+
   const execPolicy = getToolPolicy(permissions, 'memphis_exec', resolvedManifest);
   if (shouldRegisterTool('memphis_exec', execPolicy, rawEnv)) {
     server.registerTool(
@@ -980,24 +1009,30 @@ export function createMemphisMcpServer(
         description: 'Execute a shell command',
         inputSchema: {
           command: z.string().min(1).max(256),
+          surface_intent: z.string().optional(),
           approval_request_id: z.string().optional(),
         },
       },
-      withApprovalGate('memphis_exec', execPolicy, approvals, async ({ command }) => {
-        try {
-          const result = runMemphisExec({ command }, rawEnv);
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-            structuredContent: result as Record<string, unknown>,
-          };
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify({ error: msg }) }],
-            isError: true,
-          };
-        }
-      }),
+      withApprovalGate(
+        'memphis_exec',
+        execPolicy,
+        approvals,
+        async ({ command, surface_intent }) => {
+          try {
+            const result = runMemphisExec({ command, surface_intent }, rawEnv);
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+              structuredContent: result as Record<string, unknown>,
+            };
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify({ error: msg }) }],
+              isError: true,
+            };
+          }
+        },
+      ),
     );
   }
 

--- a/src/mcp/tools/exec-analyze.ts
+++ b/src/mcp/tools/exec-analyze.ts
@@ -1,0 +1,675 @@
+/**
+ * memphis_exec_analyze — REV2 Temat 3.5.
+ *
+ * Pre-exec inspection tool. The LLM calls this BEFORE memphis_exec when
+ * the command isn't obviously read-only — surfaces predicted impact so
+ * the agent can decide whether to (a) just run, (b) dry-run first,
+ * (c) ask the operator, or (d) refuse.
+ *
+ * Pure parser + heuristics. Returns analysis without ever invoking the
+ * underlying command. Safe to call at any tier (read-only).
+ *
+ * Anti-confab note: the analysis is a hint, not a contract. A
+ * command marked `idempotent` can still fail or surprise; the agent
+ * is expected to verify post-exec, not assume.
+ */
+
+export type SideEffectKind =
+  | 'read-only'
+  | 'local-write'
+  | 'system-state'
+  | 'network'
+  | 'irreversible';
+
+export type Reversibility = 'idempotent' | 'reversible' | 'irreversible' | 'unknown';
+
+export type ExecAnalyzeRecommendation =
+  | 'safe-to-run'
+  | 'analyze-then-run'
+  | 'ask-operator'
+  | 'refuse';
+
+export interface MemphisExecAnalyzeInput {
+  command: string;
+  /** Optional operator-stated intent — surfaced unchanged for audit. */
+  surface_intent?: string;
+}
+
+export interface MemphisExecAnalyzeOutput {
+  parsed: { base: string; args: string[] };
+  semantic: string;
+  side_effects: SideEffectKind;
+  files_touched: string[];
+  reversibility: Reversibility;
+  tier_required: 2 | 3;
+  dry_run_command?: string;
+  warnings: string[];
+  recommendation: ExecAnalyzeRecommendation;
+  surface_intent?: string;
+}
+
+interface CommandProfile {
+  /** Base command name(s) this profile matches (lowercase, leading binary). */
+  base: readonly string[];
+  semantic: string;
+  side_effects: SideEffectKind;
+  reversibility: Reversibility;
+  tier_required: 2 | 3;
+  /** When set, the analyzer suggests a dry-run flavour to try first. */
+  dryRunMutator?: (args: string[]) => string | undefined;
+  /** Extra warnings keyed on argument shape (e.g. `--force` present). */
+  warnings?: (args: string[]) => string[];
+}
+
+const READ_ONLY_BASES = new Set([
+  'ls',
+  'pwd',
+  'echo',
+  'cat',
+  'head',
+  'tail',
+  'wc',
+  'file',
+  'stat',
+  'du',
+  'df',
+  'free',
+  'uptime',
+  'date',
+  'whoami',
+  'id',
+  'env',
+  'printenv',
+  'which',
+  'whereis',
+  'type',
+  'history',
+  'tree',
+  'tldr',
+  'man',
+  'help',
+  'less',
+  'more',
+  'grep',
+  'rg',
+  'awk',
+  'sed', // sed without `-i` is read-only; -i is caught by warning
+  'find', // safe unless -exec / -delete
+  'fd',
+  'fdfind',
+  'jq',
+  'yq',
+  'true',
+  'false',
+  'test',
+  'ps',
+  'top',
+  'htop',
+  'pgrep',
+  'pidof',
+  'lsof',
+  'netstat',
+  'ss',
+  'ip',
+  'ifconfig',
+  'ping',
+  'nslookup',
+  'dig',
+  'host',
+]);
+
+const GIT_SAFE_SUBS = new Set([
+  'status',
+  'log',
+  'show',
+  'diff',
+  'blame',
+  'branch', // listing branches; `-D` caught below
+  'remote',
+  'config', // reading; `--add`/`--set` caught below
+  'describe',
+  'rev-parse',
+  'rev-list',
+  'shortlog',
+  'stash',
+  'tag', // listing; create caught below
+  'reflog',
+  'ls-files',
+  'ls-tree',
+  'cat-file',
+  'merge-base',
+]);
+
+const GIT_DESTRUCTIVE_SUBS = new Set([
+  'reset',
+  'clean',
+  'rebase',
+  'cherry-pick',
+  'push',
+  'rm',
+  'filter-branch',
+]);
+
+const NPM_READ_SUBS = new Set([
+  'list',
+  'ls',
+  'view',
+  'info',
+  'audit',
+  'doctor',
+  'config get',
+  'help',
+  'version',
+  'whoami',
+  'outdated',
+]);
+
+const PROTECTED_PATHS = [
+  /\.memphis\/vault\b/i,
+  /\.memphis\/keys\b/i,
+  /(^|\/|=)\.env(\b|\.)/,
+  /(^|\/)signing-seed\.bin\b/,
+  // Block-device patterns — match anywhere in the arg so `of=/dev/sda`
+  // (dd argument form) registers. We're hunting these regardless of
+  // how the path is embedded.
+  /\/dev\/sd[a-z]\b/,
+  /\/dev\/nvme/,
+  /\/dev\/mapper\//,
+  /\/dev\/disk\//,
+];
+
+const PROFILES: readonly CommandProfile[] = [
+  {
+    base: ['rm'],
+    semantic: 'remove files/directories',
+    side_effects: 'irreversible',
+    reversibility: 'irreversible',
+    tier_required: 3,
+    warnings: (args) => {
+      const w: string[] = [];
+      if (args.includes('-rf') || (args.includes('-r') && args.includes('-f'))) {
+        w.push('recursive force delete — no undo');
+      }
+      if (args.includes('--no-preserve-root')) {
+        w.push('--no-preserve-root: actively dangerous');
+      }
+      return w;
+    },
+  },
+  {
+    base: ['dd'],
+    semantic: 'low-level block copy / disk wipe',
+    side_effects: 'irreversible',
+    reversibility: 'irreversible',
+    tier_required: 3,
+    warnings: () => ['dd to a device path is permanent data loss'],
+  },
+  {
+    base: ['mkfs', 'mkfs.ext4', 'mkfs.xfs', 'mkfs.btrfs', 'mkfs.fat'],
+    semantic: 'format filesystem',
+    side_effects: 'irreversible',
+    reversibility: 'irreversible',
+    tier_required: 3,
+    warnings: () => ['formatting destroys all data on the target'],
+  },
+  {
+    base: ['shred'],
+    semantic: 'overwrite file content to make recovery impossible',
+    side_effects: 'irreversible',
+    reversibility: 'irreversible',
+    tier_required: 3,
+  },
+  {
+    base: ['apt', 'apt-get', 'dpkg'],
+    semantic: 'system package management',
+    side_effects: 'system-state',
+    reversibility: 'reversible', // apt remove / dpkg --remove
+    tier_required: 3,
+    warnings: (args) => {
+      if (args.includes('purge') || args.includes('--purge')) {
+        return ['--purge removes config files; only partially reversible'];
+      }
+      return [];
+    },
+  },
+  {
+    base: ['systemctl', 'service'],
+    semantic: 'systemd service control',
+    side_effects: 'system-state',
+    reversibility: 'reversible',
+    tier_required: 3,
+  },
+  {
+    base: ['mv'],
+    semantic: 'move/rename file or directory',
+    side_effects: 'local-write',
+    reversibility: 'reversible',
+    tier_required: 2,
+  },
+  {
+    base: ['cp'],
+    semantic: 'copy file or directory',
+    side_effects: 'local-write',
+    reversibility: 'reversible',
+    tier_required: 2,
+  },
+  {
+    base: ['mkdir'],
+    semantic: 'create directory',
+    side_effects: 'local-write',
+    reversibility: 'reversible',
+    tier_required: 2,
+  },
+  {
+    base: ['touch'],
+    semantic: 'create empty file or update timestamp',
+    side_effects: 'local-write',
+    reversibility: 'reversible',
+    tier_required: 2,
+  },
+  {
+    base: ['chmod', 'chown', 'chgrp'],
+    semantic: 'change file ownership/permissions',
+    side_effects: 'local-write',
+    reversibility: 'reversible',
+    tier_required: 2,
+  },
+  {
+    base: ['curl', 'wget'],
+    semantic: 'HTTP/HTTPS request',
+    side_effects: 'network',
+    reversibility: 'idempotent', // for GETs; POSTs are server-side
+    tier_required: 2,
+    warnings: (args) => {
+      const w: string[] = [];
+      if (args.includes('-X') || args.includes('--request')) {
+        w.push('non-GET method — may have server-side side effects');
+      }
+      if (args.includes('-d') || args.includes('--data')) {
+        w.push('payload body — likely POST/PUT/PATCH');
+      }
+      return w;
+    },
+  },
+  {
+    base: ['ssh', 'scp', 'rsync'],
+    semantic: 'remote shell / file transfer',
+    side_effects: 'network',
+    reversibility: 'unknown',
+    tier_required: 3,
+    dryRunMutator: (args) => {
+      // rsync supports --dry-run
+      const cmd = args[0] ?? '';
+      if (cmd.startsWith('rsync')) {
+        return `rsync --dry-run ${args.slice(1).join(' ')}`;
+      }
+      return undefined;
+    },
+  },
+  {
+    base: ['cargo'],
+    semantic: 'Rust build / test',
+    side_effects: 'local-write',
+    reversibility: 'idempotent',
+    tier_required: 2,
+  },
+  {
+    base: ['make'],
+    semantic: 'invoke Makefile target',
+    side_effects: 'local-write',
+    reversibility: 'unknown',
+    tier_required: 2,
+  },
+  {
+    base: ['docker', 'podman'],
+    semantic: 'container runtime',
+    side_effects: 'system-state',
+    reversibility: 'reversible',
+    tier_required: 3,
+  },
+  {
+    base: ['sudo', 'doas'],
+    semantic: 'elevated execution',
+    side_effects: 'system-state',
+    reversibility: 'unknown',
+    tier_required: 3,
+    warnings: () => ['sudo: full root authority on the spawned command'],
+  },
+];
+
+interface ParsedCommand {
+  base: string;
+  args: string[];
+}
+
+export function parseCommand(command: string): ParsedCommand {
+  const trimmed = command.trim();
+  // Split on whitespace, ignoring quoted substrings (simple-pass; the
+  // full shell grammar isn't needed here — we just want the base and
+  // a flat arg list good enough for heuristics).
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < trimmed.length) {
+    const ch = trimmed[i];
+    if (ch === ' ' || ch === '\t') {
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      i += 1;
+      const start = i;
+      while (i < trimmed.length && trimmed[i] !== quote) i += 1;
+      tokens.push(trimmed.slice(start, i));
+      if (i < trimmed.length) i += 1;
+      continue;
+    }
+    const start = i;
+    while (i < trimmed.length && trimmed[i] !== ' ' && trimmed[i] !== '\t') i += 1;
+    tokens.push(trimmed.slice(start, i));
+  }
+  const [base, ...args] = tokens;
+  return { base: (base ?? '').toLowerCase(), args };
+}
+
+function findProfile(base: string): CommandProfile | undefined {
+  return PROFILES.find((p) => p.base.includes(base));
+}
+
+function classifyGit(args: string[]): {
+  semantic: string;
+  side_effects: SideEffectKind;
+  reversibility: Reversibility;
+  tier_required: 2 | 3;
+  warnings: string[];
+} {
+  const sub = args[0] ?? '';
+  if (GIT_SAFE_SUBS.has(sub)) {
+    // Special cases on the sub itself
+    if (
+      sub === 'branch' &&
+      (args.includes('-d') || args.includes('-D') || args.includes('--delete'))
+    ) {
+      return {
+        semantic: 'git: delete branch',
+        side_effects: 'local-write',
+        reversibility: 'reversible', // git reflog
+        tier_required: 2,
+        warnings: ['branch deletion (recoverable via reflog within 90 days default)'],
+      };
+    }
+    if (sub === 'config' && (args.includes('--add') || args.includes('--set'))) {
+      return {
+        semantic: 'git: write config',
+        side_effects: 'local-write',
+        reversibility: 'reversible',
+        tier_required: 2,
+        warnings: [],
+      };
+    }
+    return {
+      semantic: `git: ${sub} (read)`,
+      side_effects: 'read-only',
+      reversibility: 'idempotent',
+      tier_required: 2,
+      warnings: [],
+    };
+  }
+  if (GIT_DESTRUCTIVE_SUBS.has(sub)) {
+    const warnings: string[] = [];
+    if (sub === 'reset' && (args.includes('--hard') || args.includes('--keep'))) {
+      warnings.push('git reset --hard: discards uncommitted changes (no reflog for them)');
+    }
+    if (sub === 'clean' && args.includes('-f')) {
+      warnings.push('git clean -f: discards untracked files unrecoverably');
+    }
+    if (sub === 'push' && args.includes('--force')) {
+      warnings.push('git push --force: rewrites remote history');
+    }
+    if (sub === 'rm') {
+      warnings.push('removes file from working tree + index');
+    }
+    return {
+      semantic: `git: ${sub} (write)`,
+      side_effects: 'local-write',
+      reversibility: warnings.length > 0 ? 'unknown' : 'reversible',
+      tier_required: 2,
+      warnings,
+    };
+  }
+  // Unknown git subcommand
+  return {
+    semantic: `git: ${sub || '<no-sub>'} (unclassified)`,
+    side_effects: 'local-write',
+    reversibility: 'unknown',
+    tier_required: 2,
+    warnings: ['unrecognised git subcommand — review manually'],
+  };
+}
+
+function classifyNpm(args: string[]): {
+  semantic: string;
+  side_effects: SideEffectKind;
+  reversibility: Reversibility;
+  tier_required: 2 | 3;
+  warnings: string[];
+} {
+  const sub = args[0] ?? '';
+  if (NPM_READ_SUBS.has(sub)) {
+    return {
+      semantic: `npm: ${sub} (read)`,
+      side_effects: 'read-only',
+      reversibility: 'idempotent',
+      tier_required: 2,
+      warnings: [],
+    };
+  }
+  if (sub === 'install' || sub === 'i' || sub === 'add') {
+    return {
+      semantic: `npm: ${sub} (install)`,
+      side_effects: 'local-write',
+      reversibility: 'reversible',
+      tier_required: 2,
+      warnings: ['mutates node_modules + package-lock.json'],
+    };
+  }
+  if (sub === 'run' || sub === 'test') {
+    return {
+      semantic: `npm: ${sub} <script>`,
+      side_effects: 'local-write', // depends on the script
+      reversibility: 'unknown',
+      tier_required: 2,
+      warnings: ['effect depends on the npm script body'],
+    };
+  }
+  if (sub === 'publish') {
+    return {
+      semantic: 'npm: publish',
+      side_effects: 'irreversible',
+      reversibility: 'irreversible',
+      tier_required: 3,
+      warnings: ['publishing a package version is permanent (unpublish has narrow window)'],
+    };
+  }
+  return {
+    semantic: `npm: ${sub || '<no-sub>'} (unclassified)`,
+    side_effects: 'local-write',
+    reversibility: 'unknown',
+    tier_required: 2,
+    warnings: ['unrecognised npm subcommand'],
+  };
+}
+
+function findTouchedPaths(args: string[]): string[] {
+  // Heuristic: args that look like paths (contain / or .). Filters out
+  // flags (start with -). Keeps shell glob patterns verbatim.
+  return args.filter((a) => {
+    if (a.startsWith('-')) return false;
+    if (a.includes('/') || /\.[a-z0-9]+$/i.test(a)) return true;
+    return false;
+  });
+}
+
+function detectProtectedHits(touched: string[]): string[] {
+  const hits: string[] = [];
+  for (const path of touched) {
+    for (const re of PROTECTED_PATHS) {
+      if (re.test(path)) {
+        hits.push(path);
+        break;
+      }
+    }
+  }
+  return hits;
+}
+
+function deriveDryRun(base: string, args: string[]): string | undefined {
+  if (base === 'rm') {
+    // GNU coreutils rm has no real --dry-run, but `ls -la` against the
+    // same targets is a useful preview.
+    if (args.length === 0) return undefined;
+    return `ls -la ${args.filter((a) => !a.startsWith('-')).join(' ')}`;
+  }
+  if (base === 'rsync') return `rsync --dry-run ${args.join(' ')}`;
+  if (base === 'mv') return undefined; // No standard dry-run; ls preview not useful
+  if (base === 'apt' || base === 'apt-get') {
+    return `${base} -s ${args.join(' ')}`; // -s = simulate
+  }
+  if (base === 'cp') {
+    return undefined;
+  }
+  return undefined;
+}
+
+function recommend(
+  base: string,
+  sideEffects: SideEffectKind,
+  reversibility: Reversibility,
+  warnings: string[],
+  protectedHits: string[],
+): ExecAnalyzeRecommendation {
+  if (protectedHits.length > 0) return 'refuse';
+  if (sideEffects === 'read-only') return 'safe-to-run';
+  if (reversibility === 'irreversible') return 'ask-operator';
+  if (warnings.length >= 2) return 'analyze-then-run';
+  if (sideEffects === 'system-state' || sideEffects === 'network') return 'analyze-then-run';
+  // base unknown + non-readonly → cautious
+  if (!READ_ONLY_BASES.has(base) && !findProfile(base) && base !== 'git' && base !== 'npm') {
+    return 'analyze-then-run';
+  }
+  return 'safe-to-run';
+}
+
+export function runMemphisExecAnalyze(
+  input: MemphisExecAnalyzeInput,
+): MemphisExecAnalyzeOutput {
+  const parsed = parseCommand(input.command);
+  const { base, args } = parsed;
+
+  if (!base) {
+    return {
+      parsed,
+      semantic: 'empty command',
+      side_effects: 'read-only',
+      files_touched: [],
+      reversibility: 'idempotent',
+      tier_required: 2,
+      warnings: ['empty command after parsing'],
+      recommendation: 'refuse',
+      ...(input.surface_intent ? { surface_intent: input.surface_intent } : {}),
+    };
+  }
+
+  // git / npm get richer subcommand-level routing.
+  let semantic: string;
+  let side_effects: SideEffectKind;
+  let reversibility: Reversibility;
+  let tier_required: 2 | 3;
+  let warnings: string[] = [];
+
+  if (base === 'git') {
+    const g = classifyGit(args);
+    semantic = g.semantic;
+    side_effects = g.side_effects;
+    reversibility = g.reversibility;
+    tier_required = g.tier_required;
+    warnings = g.warnings;
+  } else if (base === 'npm' || base === 'pnpm' || base === 'yarn') {
+    const n = classifyNpm(args);
+    semantic = n.semantic;
+    side_effects = n.side_effects;
+    reversibility = n.reversibility;
+    tier_required = n.tier_required;
+    warnings = n.warnings;
+  } else if (READ_ONLY_BASES.has(base)) {
+    semantic = `${base}: read-only inspection`;
+    side_effects = 'read-only';
+    reversibility = 'idempotent';
+    tier_required = 2;
+    // Special read-only-with-caveats
+    if (base === 'sed' && (args.includes('-i') || args.some((a) => a.startsWith('-i')))) {
+      side_effects = 'local-write';
+      reversibility = 'reversible';
+      warnings.push('sed -i: in-place edit, not strictly read-only');
+    }
+    if (
+      base === 'find' &&
+      (args.includes('-delete') || args.includes('-exec') || args.includes('-execdir'))
+    ) {
+      side_effects = 'local-write';
+      reversibility = 'unknown';
+      warnings.push('find with -delete/-exec: actually mutates the filesystem');
+    }
+  } else {
+    const profile = findProfile(base);
+    if (profile) {
+      semantic = profile.semantic;
+      side_effects = profile.side_effects;
+      reversibility = profile.reversibility;
+      tier_required = profile.tier_required;
+      warnings = profile.warnings ? profile.warnings(args) : [];
+    } else {
+      // Unknown base
+      semantic = `${base}: unclassified command`;
+      side_effects = 'local-write';
+      reversibility = 'unknown';
+      tier_required = 2;
+      warnings = ['unrecognised command — treating as unknown-impact'];
+    }
+  }
+
+  // Universal --force / -f hardening warning for write commands.
+  if (
+    side_effects !== 'read-only' &&
+    (args.includes('--force') || args.includes('-f')) &&
+    base !== 'cargo' &&
+    base !== 'cp' &&
+    base !== 'mv'
+  ) {
+    warnings.push('--force flag detected: bypasses normal safeguards');
+  }
+
+  const files_touched = findTouchedPaths(args);
+  const protectedHits = detectProtectedHits(files_touched);
+  if (protectedHits.length > 0) {
+    warnings.push(
+      `touches protected path(s): ${protectedHits.slice(0, 3).join(', ')} — refusing`,
+    );
+  }
+
+  const dry_run_command = deriveDryRun(base, args);
+  const recommendation = recommend(base, side_effects, reversibility, warnings, protectedHits);
+
+  return {
+    parsed,
+    semantic,
+    side_effects,
+    files_touched,
+    reversibility,
+    tier_required,
+    ...(dry_run_command ? { dry_run_command } : {}),
+    warnings,
+    recommendation,
+    ...(input.surface_intent ? { surface_intent: input.surface_intent } : {}),
+  };
+}

--- a/src/mcp/tools/exec.ts
+++ b/src/mcp/tools/exec.ts
@@ -1,8 +1,16 @@
 import { spawnSync } from 'node:child_process';
 
+import { runMemphisExecAnalyze } from './exec-analyze.js';
 import { MEMPHIS_EXEC_TIMEOUT_MS } from '../../config/env-registry.js';
 import { AppError } from '../../core/errors.js';
+import {
+  describeBudgetRefusal,
+  isExecBlockedForBudget,
+  recordExecOutcome,
+  type ExecFailureBudgetKey,
+} from '../../gateway/exec-failure-budget.js';
 import { enforceGatewayExecPolicy, loadGatewayExecPolicy } from '../../gateway/exec-policy.js';
+import { writeSecurityAudit } from '../../infra/logging/security-audit.js';
 
 // Phase 1.5.3: env-driven via MEMPHIS_EXEC_TIMEOUT_MS (default 1 h, was
 // 120 s hardcode — long-running corpus builds + training need the headroom).
@@ -11,6 +19,13 @@ const MAX_OUTPUT_CHARS = 32_000;
 
 export type MemphisExecInput = {
   command: string;
+  /**
+   * REV2 Temat 3.5 — operator-stated intent for audit context. The
+   * LLM forwards the high-level user prompt that prompted this exec
+   * so audit reviewers can trace WHY a command ran. Optional; absent
+   * intent gets logged as "(none provided)".
+   */
+  surface_intent?: string;
 };
 
 export type MemphisExecOutput = {
@@ -21,6 +36,16 @@ export type MemphisExecOutput = {
   truncated: boolean;
 };
 
+export interface RunMemphisExecDeps {
+  /**
+   * Surface + actor identity for the failure budget. When absent the
+   * budget falls back to a global "unknown::unknown" bucket — fine for
+   * unit tests; production callers thread the values through.
+   */
+  surface?: string;
+  actorId?: string;
+}
+
 /**
  * Execute a safe command via the gateway exec policy.
  * Only allowlisted commands with validated arguments pass through.
@@ -29,12 +54,78 @@ export type MemphisExecOutput = {
  * session is active the caller will have merged `MEMPHIS_AUTONOMY_MODE=full`
  * into rawEnv, which `loadGatewayExecPolicy` reads to drop restricted mode.
  * Passing process.env here bypasses that overlay.
+ *
+ * REV2 Temat 3.5 enhancements:
+ *   - Pre-exec analysis via `runMemphisExecAnalyze` is attached to the
+ *     `exec.attempt` audit so reviewers see predicted impact alongside
+ *     the actual command.
+ *   - Failure budget: after `MAX_CONSECUTIVE_FAILURES` (3) non-zero
+ *     exits per (surface, actor), further calls refuse with a clear
+ *     "stop blind-retrying" message. Counter resets on any non-exec
+ *     tool call (tool-executor does that bookkeeping).
+ *   - `exec.attempt` + `exec.result` audit events emit on every call,
+ *     not just policy denials.
  */
 export function runMemphisExec(
   input: MemphisExecInput,
   rawEnv: NodeJS.ProcessEnv = process.env,
+  deps: RunMemphisExecDeps = {},
 ): MemphisExecOutput {
   const policy = loadGatewayExecPolicy(rawEnv);
+  const budgetKey: ExecFailureBudgetKey = {
+    surface: deps.surface,
+    actorId: deps.actorId,
+  };
+
+  // Failure-budget pre-check (Warstwa 5). Audit the refusal so an
+  // operator reading the log sees WHY this exec was blocked even
+  // before policy ran.
+  if (isExecBlockedForBudget(budgetKey)) {
+    const reason = describeBudgetRefusal(budgetKey);
+    writeSecurityAudit(
+      {
+        action: 'exec.refused.budget',
+        status: 'blocked',
+        details: {
+          command: input.command,
+          surface: deps.surface,
+          actorId: deps.actorId,
+          reason,
+        },
+      },
+      rawEnv,
+    );
+    throw new AppError('VALIDATION_ERROR', reason, 429);
+  }
+
+  // Pre-exec analysis (Warstwa 4). Run unconditionally — cheap pure
+  // function. Surface as audit context so reviewers can compare
+  // predicted vs actual outcome.
+  const analysis = runMemphisExecAnalyze({
+    command: input.command,
+    surface_intent: input.surface_intent,
+  });
+
+  writeSecurityAudit(
+    {
+      action: 'exec.attempt',
+      status: 'allowed',
+      details: {
+        command: input.command,
+        semantic: analysis.semantic,
+        side_effects: analysis.side_effects,
+        reversibility: analysis.reversibility,
+        warnings: analysis.warnings,
+        tier_required: analysis.tier_required,
+        recommendation: analysis.recommendation,
+        surface_intent: input.surface_intent ?? '(none provided)',
+        surface: deps.surface,
+        actorId: deps.actorId,
+        autonomy_mode: (rawEnv.MEMPHIS_AUTONOMY_MODE ?? '').toLowerCase() || '(unset)',
+      },
+    },
+    rawEnv,
+  );
 
   // Enforce allowlist + metachar + argument validation
   enforceGatewayExecPolicy(input.command, policy);
@@ -47,16 +138,53 @@ export function runMemphisExec(
   });
 
   if (result.error) {
+    // Spawn-level failure (not a non-zero exit — process couldn't be
+    // started at all). Treat as a failure for budget purposes so a
+    // typo-loop doesn't ride the policy stage indefinitely.
+    recordExecOutcome(budgetKey, 1);
+    writeSecurityAudit(
+      {
+        action: 'exec.result',
+        status: 'error',
+        details: {
+          command: input.command,
+          exit_code: null,
+          spawn_error: result.error.message,
+          surface: deps.surface,
+          actorId: deps.actorId,
+        },
+      },
+      rawEnv,
+    );
     throw new AppError('INTERNAL_ERROR', `exec failed: ${result.error.message}`, 500);
   }
 
   const stdout = result.stdout ?? '';
   const stderr = result.stderr ?? '';
   const truncated = stdout.length > MAX_OUTPUT_CHARS || stderr.length > MAX_OUTPUT_CHARS;
+  const exitCode = result.status ?? 1;
+  recordExecOutcome(budgetKey, exitCode);
+
+  writeSecurityAudit(
+    {
+      action: 'exec.result',
+      status: exitCode === 0 ? 'allowed' : 'error',
+      details: {
+        command: input.command,
+        exit_code: exitCode,
+        stdout_first_500: stdout.slice(0, 500),
+        stderr_first_500: stderr.slice(0, 500),
+        truncated,
+        surface: deps.surface,
+        actorId: deps.actorId,
+      },
+    },
+    rawEnv,
+  );
 
   return {
     command: input.command,
-    exitCode: result.status ?? 1,
+    exitCode,
     stdout: stdout.slice(0, MAX_OUTPUT_CHARS),
     stderr: stderr.slice(0, MAX_OUTPUT_CHARS),
     truncated,

--- a/tests/unit/exec-analyze.test.ts
+++ b/tests/unit/exec-analyze.test.ts
@@ -1,0 +1,155 @@
+/**
+ * REV2 Temat 3.5 — memphis_exec_analyze tool.
+ *
+ * Pure-parser tests; no real exec.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseCommand,
+  runMemphisExecAnalyze,
+} from '../../src/mcp/tools/exec-analyze.js';
+
+describe('parseCommand', () => {
+  it('parses simple base + args', () => {
+    const r = parseCommand('ls -la /tmp');
+    expect(r.base).toBe('ls');
+    expect(r.args).toEqual(['-la', '/tmp']);
+  });
+
+  it('handles double-quoted args', () => {
+    const r = parseCommand('grep "needle in haystack" file.txt');
+    expect(r.base).toBe('grep');
+    expect(r.args).toEqual(['needle in haystack', 'file.txt']);
+  });
+
+  it('handles single-quoted args', () => {
+    const r = parseCommand("echo 'hello world'");
+    expect(r.base).toBe('echo');
+    expect(r.args).toEqual(['hello world']);
+  });
+
+  it('returns empty parse on empty input', () => {
+    expect(parseCommand('').base).toBe('');
+    expect(parseCommand('   ').base).toBe('');
+  });
+});
+
+describe('runMemphisExecAnalyze — read-only commands', () => {
+  it('classifies `ls` as safe-to-run', () => {
+    const r = runMemphisExecAnalyze({ command: 'ls -la' });
+    expect(r.side_effects).toBe('read-only');
+    expect(r.reversibility).toBe('idempotent');
+    expect(r.recommendation).toBe('safe-to-run');
+    expect(r.tier_required).toBe(2);
+  });
+
+  it('classifies `git status` as safe-to-run', () => {
+    const r = runMemphisExecAnalyze({ command: 'git status' });
+    expect(r.semantic).toContain('git: status');
+    expect(r.side_effects).toBe('read-only');
+    expect(r.recommendation).toBe('safe-to-run');
+  });
+
+  it('classifies `find -delete` as local-write with warning', () => {
+    const r = runMemphisExecAnalyze({ command: 'find . -name "*.tmp" -delete' });
+    expect(r.side_effects).toBe('local-write');
+    expect(r.warnings.some((w) => /delete|mutates/.test(w))).toBe(true);
+  });
+});
+
+describe('runMemphisExecAnalyze — destructive commands', () => {
+  it('classifies `rm -rf` as irreversible + ask-operator', () => {
+    const r = runMemphisExecAnalyze({ command: 'rm -rf /tmp/junk' });
+    expect(r.side_effects).toBe('irreversible');
+    expect(r.reversibility).toBe('irreversible');
+    expect(r.tier_required).toBe(3);
+    expect(r.recommendation).toBe('ask-operator');
+    expect(r.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('classifies `dd` as irreversible + ask-operator', () => {
+    const r = runMemphisExecAnalyze({ command: 'dd if=/dev/zero of=/tmp/x bs=1M' });
+    expect(r.side_effects).toBe('irreversible');
+    expect(r.recommendation).toBe('ask-operator');
+  });
+
+  it('classifies `git reset --hard` with strong warning', () => {
+    const r = runMemphisExecAnalyze({ command: 'git reset --hard HEAD~1' });
+    expect(r.semantic).toContain('git: reset');
+    expect(r.warnings.some((w) => /reset --hard|discards/.test(w))).toBe(true);
+  });
+
+  it('classifies `git push --force` with rewrite-history warning', () => {
+    const r = runMemphisExecAnalyze({ command: 'git push --force origin main' });
+    expect(r.warnings.some((w) => /rewrites remote history/.test(w))).toBe(true);
+  });
+});
+
+describe('runMemphisExecAnalyze — protected paths', () => {
+  it('refuses commands touching ~/.memphis/vault/', () => {
+    const r = runMemphisExecAnalyze({
+      command: 'cat /home/memphis/.memphis/vault/vault-state.json',
+    });
+    expect(r.recommendation).toBe('refuse');
+    expect(r.warnings.some((w) => /protected path/.test(w))).toBe(true);
+  });
+
+  it('refuses commands touching .env files', () => {
+    const r = runMemphisExecAnalyze({ command: 'cat .env' });
+    expect(r.recommendation).toBe('refuse');
+  });
+
+  it('refuses commands targeting block devices', () => {
+    const r = runMemphisExecAnalyze({ command: 'dd if=/dev/zero of=/dev/sda' });
+    expect(r.recommendation).toBe('refuse');
+  });
+});
+
+describe('runMemphisExecAnalyze — system-state commands', () => {
+  it('classifies `apt install` as system-state + analyze-then-run', () => {
+    const r = runMemphisExecAnalyze({ command: 'apt install vim' });
+    expect(r.side_effects).toBe('system-state');
+    expect(r.reversibility).toBe('reversible');
+    expect(r.tier_required).toBe(3);
+    expect(r.recommendation).toBe('analyze-then-run');
+    expect(r.dry_run_command).toContain('-s');
+  });
+
+  it('classifies `sudo X` with elevated-execution warning', () => {
+    const r = runMemphisExecAnalyze({ command: 'sudo apt update' });
+    expect(r.warnings.some((w) => /sudo|root authority/.test(w))).toBe(true);
+  });
+});
+
+describe('runMemphisExecAnalyze — network commands', () => {
+  it('classifies plain `curl` as network + safe', () => {
+    const r = runMemphisExecAnalyze({ command: 'curl https://example.com/data.json' });
+    expect(r.side_effects).toBe('network');
+    expect(r.recommendation).toBe('analyze-then-run');
+  });
+
+  it('warns when curl uses -X POST or -d', () => {
+    const r = runMemphisExecAnalyze({ command: 'curl -X POST -d "{}" https://api.example.com' });
+    expect(r.warnings.some((w) => /POST|payload body/.test(w))).toBe(true);
+  });
+});
+
+describe('runMemphisExecAnalyze — unknown commands', () => {
+  it('classifies unknown bases as unknown-impact with warning', () => {
+    const r = runMemphisExecAnalyze({ command: 'frobnicate --frob 5' });
+    expect(r.semantic).toContain('unclassified');
+    expect(r.recommendation).toBe('analyze-then-run');
+    expect(r.warnings.some((w) => /unrecognised command/.test(w))).toBe(true);
+  });
+});
+
+describe('runMemphisExecAnalyze — surface_intent', () => {
+  it('passes surface_intent through to output for audit', () => {
+    const r = runMemphisExecAnalyze({
+      command: 'ls /tmp',
+      surface_intent: 'verify the tg-photo file is on disk',
+    });
+    expect(r.surface_intent).toBe('verify the tg-photo file is on disk');
+  });
+});

--- a/tests/unit/exec-failure-budget.test.ts
+++ b/tests/unit/exec-failure-budget.test.ts
@@ -1,0 +1,88 @@
+/**
+ * REV2 Temat 3.5 Warstwa 5 — exec failure budget.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  describeBudgetRefusal,
+  getConsecutiveFailures,
+  isExecBlockedForBudget,
+  MAX_CONSECUTIVE_FAILURES,
+  recordExecOutcome,
+  resetAllExecBudgetsForTests,
+  resetOnNonExecToolCall,
+} from '../../src/gateway/exec-failure-budget.js';
+
+const KEY = { surface: 'telegram', actorId: 'chat-42' };
+
+describe('exec failure budget', () => {
+  beforeEach(() => {
+    resetAllExecBudgetsForTests();
+  });
+
+  afterEach(() => {
+    resetAllExecBudgetsForTests();
+  });
+
+  it('starts at 0 failures, not blocked', () => {
+    expect(getConsecutiveFailures(KEY)).toBe(0);
+    expect(isExecBlockedForBudget(KEY)).toBe(false);
+  });
+
+  it('non-zero exit increments the counter', () => {
+    recordExecOutcome(KEY, 1);
+    expect(getConsecutiveFailures(KEY)).toBe(1);
+    recordExecOutcome(KEY, 127);
+    expect(getConsecutiveFailures(KEY)).toBe(2);
+    expect(isExecBlockedForBudget(KEY)).toBe(false);
+  });
+
+  it(`blocks after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`, () => {
+    for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i += 1) {
+      recordExecOutcome(KEY, 1);
+    }
+    expect(getConsecutiveFailures(KEY)).toBe(MAX_CONSECUTIVE_FAILURES);
+    expect(isExecBlockedForBudget(KEY)).toBe(true);
+  });
+
+  it('successful exec decrements (clamped at 0)', () => {
+    recordExecOutcome(KEY, 1);
+    recordExecOutcome(KEY, 1);
+    expect(getConsecutiveFailures(KEY)).toBe(2);
+    recordExecOutcome(KEY, 0);
+    expect(getConsecutiveFailures(KEY)).toBe(1);
+    recordExecOutcome(KEY, 0);
+    recordExecOutcome(KEY, 0);
+    expect(getConsecutiveFailures(KEY)).toBe(0);
+  });
+
+  it('resetOnNonExecToolCall clears the bucket entirely', () => {
+    recordExecOutcome(KEY, 1);
+    recordExecOutcome(KEY, 1);
+    recordExecOutcome(KEY, 1);
+    expect(isExecBlockedForBudget(KEY)).toBe(true);
+    resetOnNonExecToolCall(KEY);
+    expect(getConsecutiveFailures(KEY)).toBe(0);
+    expect(isExecBlockedForBudget(KEY)).toBe(false);
+  });
+
+  it('tracks (surface, actor) independently', () => {
+    const a = { surface: 'telegram', actorId: 'chat-1' };
+    const b = { surface: 'telegram', actorId: 'chat-2' };
+    recordExecOutcome(a, 1);
+    recordExecOutcome(a, 1);
+    recordExecOutcome(a, 1);
+    expect(isExecBlockedForBudget(a)).toBe(true);
+    expect(isExecBlockedForBudget(b)).toBe(false);
+  });
+
+  it('refusal message names the counter + remediation', () => {
+    recordExecOutcome(KEY, 1);
+    recordExecOutcome(KEY, 1);
+    recordExecOutcome(KEY, 1);
+    const msg = describeBudgetRefusal(KEY);
+    expect(msg).toContain('3');
+    expect(msg).toContain('blind-retry');
+    expect(msg).toContain('memphis_exec_analyze');
+  });
+});

--- a/tests/unit/tool-registry.test.ts
+++ b/tests/unit/tool-registry.test.ts
@@ -27,7 +27,9 @@ describe('tool registry', () => {
     //   memphis_self_review (tier-0 read),
     //   memphis_self_pr_open (tier-2 execute+network),
     //   memphis_self_deploy_verify (tier-0 read+execute).
-    expect(getToolNames()).toHaveLength(51);
+    // REV2 Temat 3.5: +1 tier-1 read — memphis_exec_analyze (pre-exec
+    // impact analyzer; companion to memphis_exec for wisdom doctrine).
+    expect(getToolNames()).toHaveLength(52);
   });
 
   it('hides experimental preview tools by default', () => {
@@ -96,9 +98,11 @@ describe('tool registry', () => {
     // memphis_skill_show, memphis_skill_validate (info-only operations).
     // PR (kartograf-runtime, 2026-05-12): added memphis_kartograf (inference,
     // read-only — returns embedding + zones, no chain writes).
-    expect(tier1.length).toBe(5);
+    // REV2 Temat 3.5: +1 tier-1 read — memphis_exec_analyze.
+    expect(tier1.length).toBe(6);
     expect(tier1.map((t) => t.name).sort()).toEqual(
       [
+        'memphis_exec_analyze',
         'memphis_health_check',
         'memphis_kartograf',
         'memphis_skill_list',


### PR DESCRIPTION
REV2 Temat 3.5 (P1) — operator's vision implementation: tier-3 unrestricted exec gains a wisdom layer via 5 layers — (1) tier-3 plumbing (#596 prerequisite), (2) NEW `memphis_exec_analyze` (tier-1 read parser + heuristics returning side-effects/reversibility/recommendation), (3) soul-seed wisdom doctrine (6 rules: analyze first, ask on irreversible, dry-run when possible, audit intent, respect budget, protect vault), (4) enhanced exec audit (exec.attempt + exec.result events with predicted-vs-actual), (5) failure budget (3 consecutive non-zero exits → refuse + remediation message, reset on non-exec tool call).

46 unit cases green. tsc + eslint clean. See handoff REV2 T3.5 for full spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)