### PR TITLE
fix(startup): tolerate known fork markers in chain integrity check

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -301,16 +301,50 @@ export async function bootstrap(): Promise<void> {
       details: { message: 'chain verification passed' },
     });
   } catch (error) {
-    writeSecurityAudit({
-      action: 'chain.verify.startup',
-      status: 'error',
-      details: { message: error instanceof Error ? error.message : 'chain verification failed' },
-    });
-    throw new MemphisExitError(
-      EXIT_CODES.ERR_CORRUPTION,
-      `chain integrity verification failed: ${error instanceof Error ? error.message : 'unknown error'}`,
-      error,
-    );
+    const message = error instanceof Error ? error.message : 'chain verification failed';
+    // Block 1853 fork-marker (operator decision PR #595 Opcja A,
+    // 2026-05-12): a single test escape produced a permanent prev_hash
+    // mismatch at the system chain 1852→1853 boundary. Operator chose
+    // to keep the corruption on disk as a forensic scar rather than
+    // truncate or renumber. Startup must tolerate this specific known
+    // fork — without the tolerance, every restart of an affected
+    // install crashes here and the operator can't bring the daemon
+    // back up. The audit-write guard (PR #595) prevents NEW corruption
+    // from this class; the runtime chain-append path is unaffected.
+    // Future known forks land here too — append, don't replace.
+    const KNOWN_FORK_MARKERS = [
+      'chain \'system\' integrity check failed at block 1853',
+    ];
+    const isKnownFork = KNOWN_FORK_MARKERS.some((marker) => message.includes(marker));
+    if (isKnownFork) {
+      writeSecurityAudit({
+        action: 'chain.verify.startup',
+        status: 'mitigated',
+        details: {
+          message,
+          mitigation: 'known-fork-marker accepted per operator decision',
+          fork_markers: KNOWN_FORK_MARKERS,
+        },
+      });
+      const fallbackLog = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
+      fallbackLog.warn(
+        { event: 'chain.verify.startup.known-fork', message },
+        `chain integrity check flagged a known fork marker; ` +
+          `continuing startup per operator decision (see PR #595, ` +
+          `notes/system-chain-corruption-2026-05-12.md)`,
+      );
+    } else {
+      writeSecurityAudit({
+        action: 'chain.verify.startup',
+        status: 'error',
+        details: { message },
+      });
+      throw new MemphisExitError(
+        EXIT_CODES.ERR_CORRUPTION,
+        `chain integrity verification failed: ${message}`,
+        error,
+      );
+    }
   }
 
   // Soul system: ensure manifest exists on disk before any MCP tool or system prompt reads it


### PR DESCRIPTION
Operator's daemon won't restart since block 1853 incident (2026-05-12) — startup chain verify hits the known prev_hash mismatch and exits 102. PR #595 (operator's Opcja A) accepted block 1853 as a permanent fork-marker but didn't touch the startup gate.

This adds a small `KNOWN_FORK_MARKERS` substring-match list. On match: emit `chain.verify.startup` with `status: mitigated` (audit trail intact) and continue startup. Unknown integrity errors still throw — not a generic bypass.

Unblocks operator restart + B-step verification of T1-T3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)