### PR TITLE
hotfix(tests): napi-shutdown reset embed-shutdown-state (orphan from #597)

### DIFF
--- a/tests/unit/napi-shutdown.test.ts
+++ b/tests/unit/napi-shutdown.test.ts
@@ -7,6 +7,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { __resetEmbedShutdownStateForTests } from '../../src/infra/runtime/embed-shutdown-state.js';
 import {
   __isNapiShutdownGuardInstalled,
   __resetNapiShutdownGuardForTests,
@@ -16,10 +17,18 @@ import {
 describe('installNapiShutdownGuard', () => {
   beforeEach(() => {
     __resetNapiShutdownGuardForTests();
+    // Temat 2 dedup: the process-wide `embed-shutdown-state` flag
+    // persists across vitest test instances within the same worker.
+    // Without this reset, a previous test's mark-the-flag side effect
+    // causes the next test's beforeExit handler to skip embedShutdown,
+    // breaking call-count assertions. The reset restores the "fresh
+    // process" precondition each test expects.
+    __resetEmbedShutdownStateForTests();
   });
 
   afterEach(() => {
     __resetNapiShutdownGuardForTests();
+    __resetEmbedShutdownStateForTests();
   });
 
   it('is a no-op when the bridge module is null (binary not loadable)', () => {


### PR DESCRIPTION
Cherry-pick of orphan commit `0a74813d` that should have landed with #597 but got stranded after the auto-merge squash deleted the source branch.

Without this, main fails `tests/unit/napi-shutdown.test.ts` (4-6 cases) on every CI run — the dedup flag introduced by #597 persists across test instances. Reset in beforeEach/afterEach restores 'fresh process' precondition.

Unblocks #599, #602, #603 CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)