### PR TITLE
hotfix(codex-round-1): bundled fixes from #596/#597/#601/#602 reviews

### DIFF
--- a/crons/prune-telegram-attachments.sh
+++ b/crons/prune-telegram-attachments.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Memphis telegram-attachments retention — REV2 Temat 1 follow-up (PR #596 W1).
+#
+# PR #596 persisted Telegram photo/document attachments under
+# `<MEMPHIS_DATA_DIR>/state/telegram-attachments/` so the agent can
+# re-discover them in subsequent turns. Coder B's #596 review flagged
+# that the comment claimed "a retention cron prunes >7d-old files
+# separately" but the cron wasn't wired. This script is that cron.
+#
+# Default policy: unlink files with mtime > 7 days. Operator can
+# override via env:
+#   MEMPHIS_TG_ATTACHMENTS_RETAIN_DAYS=14  ← keep 2 weeks instead
+#   MEMPHIS_TG_ATTACHMENTS_DRY_RUN=1       ← log + skip unlink
+#
+# Cron suggestion (operator's user crontab):
+#   17 4 * * * /home/memphis/memphis/crons/prune-telegram-attachments.sh \
+#     >> ~/.memphis/logs/prune-telegram-attachments.log 2>&1
+#
+# Skipped silently when the attachments dir doesn't exist (fresh
+# install, or operator hasn't received a Telegram attachment yet).
+
+set -euo pipefail
+
+DATA_DIR="${MEMPHIS_DATA_DIR:-$HOME/.memphis}"
+ATTACH_DIR="${DATA_DIR%/}/state/telegram-attachments"
+RETAIN_DAYS="${MEMPHIS_TG_ATTACHMENTS_RETAIN_DAYS:-7}"
+DRY_RUN="${MEMPHIS_TG_ATTACHMENTS_DRY_RUN:-0}"
+
+now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+if [ ! -d "$ATTACH_DIR" ]; then
+  echo "{\"ts\":\"$now\",\"event\":\"telegram-attachments.prune.skipped\",\"reason\":\"dir-missing\",\"dir\":\"$ATTACH_DIR\"}"
+  exit 0
+fi
+
+# Validate retention value (integer 1..365).
+if ! [[ "$RETAIN_DAYS" =~ ^[0-9]+$ ]] || [ "$RETAIN_DAYS" -lt 1 ] || [ "$RETAIN_DAYS" -gt 365 ]; then
+  echo "{\"ts\":\"$now\",\"event\":\"telegram-attachments.prune.invalid-config\",\"retain_days\":\"$RETAIN_DAYS\"}" >&2
+  exit 2
+fi
+
+# Collect candidates first so we can audit-log the set before mutation.
+mapfile -t candidates < <(find "$ATTACH_DIR" -maxdepth 1 -type f -mtime +"$RETAIN_DAYS" -print 2>/dev/null || true)
+total_files=$(find "$ATTACH_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l)
+candidate_count=${#candidates[@]}
+
+if [ "$candidate_count" -eq 0 ]; then
+  echo "{\"ts\":\"$now\",\"event\":\"telegram-attachments.prune.clean\",\"total_files\":$total_files,\"retain_days\":$RETAIN_DAYS}"
+  exit 0
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+  for f in "${candidates[@]}"; do
+    echo "{\"ts\":\"$now\",\"event\":\"telegram-attachments.prune.dry-run\",\"file\":\"$f\"}"
+  done
+  echo "{\"ts\":\"$now\",\"event\":\"telegram-attachments.prune.summary\",\"would_prune\":$candidate_count,\"total_files\":$total_files,\"retain_days\":$RETAIN_DAYS,\"dry_run\":true}"
+  exit 0
+fi
+
+pruned=0
+errors=0
+for f in "${candidates[@]}"; do
+  if rm -f -- "$f" 2>/dev/null; then
+    pruned=$((pruned + 1))
+    echo "{\"ts\":\"$now\",\"event\":\"telegram-attachments.prune.unlinked\",\"file\":\"$f\"}"
+  else
+    errors=$((errors + 1))
+    echo "{\"ts\":\"$now\",\"event\":\"telegram-attachments.prune.unlink-failed\",\"file\":\"$f\"}" >&2
+  fi
+done
+
+echo "{\"ts\":\"$now\",\"event\":\"telegram-attachments.prune.summary\",\"pruned\":$pruned,\"errors\":$errors,\"total_files\":$total_files,\"retain_days\":$RETAIN_DAYS}"
+
+if [ "$errors" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/src/mcp/tools/exec.ts
+++ b/src/mcp/tools/exec.ts
@@ -71,6 +71,22 @@ export function runMemphisExec(
   rawEnv: NodeJS.ProcessEnv = process.env,
   deps: RunMemphisExecDeps = {},
 ): MemphisExecOutput {
+  // Codex round-1 N1 (PR #601 review): WARN when production callers
+  // forget to thread (surface, actorId). Without identity, the
+  // failure budget falls back to a global "unknown::unknown" bucket
+  // — one actor's blind-retry loop ends up masked under another
+  // actor's budget. The check skips in vitest (deps absent is
+  // intentional for unit tests).
+  if (
+    rawEnv.VITEST !== 'true' &&
+    (deps.surface === undefined || deps.actorId === undefined)
+  ) {
+    process.stderr.write(
+      `[memphis-exec] WARN: budget-key threading missing — ` +
+        `surface=${deps.surface ?? '<undefined>'} actorId=${deps.actorId ?? '<undefined>'}. ` +
+        `Failures will bucket under "unknown::unknown" and may mask retry loops.\n`,
+    );
+  }
   const policy = loadGatewayExecPolicy(rawEnv);
   const budgetKey: ExecFailureBudgetKey = {
     surface: deps.surface,

--- a/src/mcp/tools/glob.ts
+++ b/src/mcp/tools/glob.ts
@@ -5,10 +5,12 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 import { AppError } from '../../core/errors.js';
+import { resolveInstallRoot } from '../../infra/runtime/install-root.js';
 
 export type MemphisGlobInput = {
   /** Glob pattern (e.g. "src/components/*.ts", "*.json") */
@@ -26,7 +28,13 @@ export type MemphisGlobOutput = {
   error?: string;
 };
 
-const PROJECT_ROOT = path.join(os.homedir(), 'memphis');
+// Codex round-1 W2 (PR #596 review): resolve PROJECT_ROOT via
+// `resolveInstallRoot()` instead of hardcoded `~/memphis/`. The
+// hardcoded path broke systemd-user / npm-installed-CLI deployments
+// where Memphis isn't under HOME/memphis. `resolveInstallRoot()`
+// reads MEMPHIS_INSTALL_ROOT env, otherwise falls back to the
+// install-root anchor from package.json or repo discovery.
+const PROJECT_ROOT = resolveInstallRoot();
 const MAX_RESULTS = 500;
 
 // REV2 Temat 1 (2026-05-12): additional read-only roots the LLM may
@@ -48,28 +56,42 @@ function buildAdditionalReadRoots(rawEnv: NodeJS.ProcessEnv): string[] {
   return roots;
 }
 
-function isInsideAnyAllowedRoot(resolvedPath: string, extraRoots: string[]): boolean {
-  const normalized = path.normalize(resolvedPath);
-  if (normalized.startsWith(PROJECT_ROOT + path.sep) || normalized === PROJECT_ROOT) {
-    return true;
+// Codex round-1 N1 (PR #596 review): hardening against symlink path
+// traversal. Without this, a same-uid local process could pre-plant
+// `~/.memphis/state/telegram-attachments/<sub>` as a symlink targeting
+// `/etc/` (or any other readable path) — `path.normalize` doesn't
+// follow symlinks, so the string-prefix check would pass. Resolve
+// through `realpath` to anchor on the actual filesystem target.
+// realpath throws for non-existent paths; tolerate that case (the
+// caller will get a fd/find error downstream) by falling back to the
+// non-resolved normalized form.
+function safeRealpath(target: string): string {
+  try {
+    return realpathSync(target);
+  } catch {
+    return path.normalize(target);
   }
-  for (const root of extraRoots) {
-    if (normalized.startsWith(root + path.sep) || normalized === root) return true;
-  }
-  return false;
 }
 
 function assertInProject(
   resolvedPath: string,
   rawEnv: NodeJS.ProcessEnv = process.env,
 ): void {
-  if (!isInsideAnyAllowedRoot(resolvedPath, buildAdditionalReadRoots(rawEnv))) {
-    throw new AppError(
-      'VALIDATION_ERROR',
-      `Path '${resolvedPath}' is outside ~/memphis/ and the allowed extra roots (telegram-attachments)`,
-      403,
-    );
+  const realResolved = safeRealpath(resolvedPath);
+  const extraRoots = buildAdditionalReadRoots(rawEnv).map(safeRealpath);
+  const realProjectRoot = safeRealpath(PROJECT_ROOT);
+  const normalized = path.normalize(realResolved);
+  const insideProject =
+    normalized.startsWith(realProjectRoot + path.sep) || normalized === realProjectRoot;
+  if (insideProject) return;
+  for (const root of extraRoots) {
+    if (normalized.startsWith(root + path.sep) || normalized === root) return;
   }
+  throw new AppError(
+    'VALIDATION_ERROR',
+    `Path '${resolvedPath}' is outside ${PROJECT_ROOT} and the allowed extra roots (telegram-attachments)`,
+    403,
+  );
 }
 
 function findFd(): string | null {

--- a/src/soul/seed.ts
+++ b/src/soul/seed.ts
@@ -229,6 +229,31 @@ function buildJournalEntries(
       tags: ['boundaries', 'security', 'soul-seed', 'foundation'],
       schemaVersion: 1,
     },
+    {
+      type: 'journal',
+      source: 'soul-seed:exec-wisdom',
+      content: [
+        `Exec wisdom — operator-mode unrestricted access (REV2 Temat 3.5):`,
+        `When ${ownerName} grants tier-3 elevation I have unrestricted exec — but unrestricted is not reckless.`,
+        `Memphis identity around exec:`,
+        `1. ANALYZE FIRST. Before any exec call that is not obviously read-only I call memphis_exec_analyze`,
+        `   and surface the predicted impact to ${ownerName} BEFORE running the command.`,
+        `2. ASK ON IRREVERSIBLE. If recommendation is ask-operator or side_effects is irreversible,`,
+        `   I surface the analysis and wait for explicit go. Exception: when ${ownerName}'s prompt`,
+        `   explicitly authorises destructive ops ("tak", "ruszaj", "make it work"), I proceed.`,
+        `3. DRY-RUN WHEN POSSIBLE. If dry_run_command is non-null I run the dry-run first,`,
+        `   show ${ownerName} the would-do output, then ask for confirmation before the real run.`,
+        `4. AUDIT THE INTENT. I attach ${ownerName}'s prompt as surface_intent on every memphis_exec`,
+        `   call so the audit log captures intent alongside the predicted-vs-actual outcome.`,
+        `5. RESPECT THE BUDGET. If 3 exec calls fail consecutively, the runtime refuses my next attempt.`,
+        `   That is a signal — I stop blind-retrying, re-analyse, and ask ${ownerName} for guidance`,
+        `   or pick a different approach. Calling any non-exec tool resets the counter.`,
+        `6. PROTECT VAULT + SECRETS. I never run commands touching ~/.memphis/vault/, .env*, or`,
+        `   signing-seed.bin even at tier 3 — memphis_exec_analyze refuses these automatically.`,
+      ].join(' '),
+      tags: ['boundaries', 'exec', 'wisdom', 'soul-seed', 'foundation'],
+      schemaVersion: 1,
+    },
   ];
 }
 

--- a/tests/unit/vault-pepper-invariants.test.ts
+++ b/tests/unit/vault-pepper-invariants.test.ts
@@ -49,7 +49,6 @@ describe('vault pepper single-artifact invariant', () => {
     // intentionally narrow: we want the helper functions, not every
     // env read.
     const out = execSync(
-      // eslint-disable-next-line no-restricted-syntax
       'grep -rnE ' +
         '"deriveStateEncryptionKey|decrypt_master_key_v2|encrypt_master_key_v2" ' +
         '--include="*.ts" --include="*.rs" ' +
@@ -105,7 +104,6 @@ describe('vault pepper single-artifact invariant', () => {
     // Any reference to ANOTHER artifact name in the same function body
     // is a red flag.
     const rotateBody = execSync(
-      // eslint-disable-next-line no-restricted-syntax
       'sed -n "/^export function rotateVaultStatePepper/,/^}/p" ' +
         'src/infra/storage/rust-vault-adapter.ts',
       { cwd: REPO_ROOT, encoding: 'utf8' },


### PR DESCRIPTION
Single bundled PR per `feedback_codex_bundled_hotfix.md`. Six findings from Coder B's post-merge reviews:

- #596 W1: telegram-attachments retention cron (NEW `crons/prune-telegram-attachments.sh`)
- #596 W2: `glob.ts` PROJECT_ROOT install-root anchoring (was hardcoded `~/memphis/`)
- #596 N1: `glob.ts` symlink path-traversal hardening (`fs.realpath`)
- #601 W1: `soul/seed.ts` exec-wisdom doctrine (missed by squash chain, restored)
- #601 N1: `runMemphisExec` WARN on missing surface+actorId in prod
- #593/#595 W3: `vault-pepper-invariants` 2 unused `eslint-disable` removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)