### PR TITLE
fix(vault): refuse `vault init` on non-empty entries without --force-reinit

### DIFF
--- a/src/infra/cli/handlers/vault.handler.ts
+++ b/src/infra/cli/handlers/vault.handler.ts
@@ -120,8 +120,56 @@ export const vaultCommandHandler: CommandHandler = {
 };
 
 async function handleVaultInit(context: CliContext): Promise<boolean> {
-  const { json } = context.args;
+  const { json, forceReinit } = context.args;
   let { passphrase, recoveryAnswer, recoveryQuestion } = context.args;
+
+  // Refuse-on-nonempty guard (2026-05-13 — root-cause prevention for
+  // the pepper desync that bit on 2026-05-11 15:57 → 16:07). Without
+  // this gate, a stray `vault init` call on an install with secrets
+  // regenerates the master-key envelope, leaving the existing
+  // `vault-entries.json` ciphertext undecryptable — exactly the
+  // failure mode that forced today's full vault reset.
+  //
+  // The vault-boundary layer (`src/security/vault-boundary.ts`)
+  // already enforces the same invariant via `MEMPHIS_VAULT_FORCE_REINIT`,
+  // but only AFTER the interactive passphrase + recovery prompts have
+  // already collected operator input. Refusing here lets us short-
+  // circuit before any prompt fires, with a clear error and a CLI-
+  // specific audit event (`vault.init.refused`) that's easy to grep.
+  // We honour either signal (`--force-reinit` flag or the env var) so
+  // the CLI surface stays consistent with the boundary's contract.
+  const rawEnv = process.env;
+  const envForceReinit = rawEnv.MEMPHIS_VAULT_FORCE_REINIT === '1' ||
+    rawEnv.MEMPHIS_VAULT_FORCE_REINIT === 'true';
+  const forceReinitAuthorised = Boolean(forceReinit) || envForceReinit;
+  const existingEntries = listVaultEntries(rawEnv);
+  if (existingEntries.length > 0 && !forceReinitAuthorised) {
+    writeSecurityAudit({
+      action: 'vault.init.refused',
+      status: 'blocked',
+      details: {
+        surface: 'cli',
+        command: 'vault init',
+        reason: 'nonempty_entries_without_force_reinit',
+        existing_entry_count: existingEntries.length,
+      },
+    });
+    throw new Error(
+      `vault init: refusing to re-initialize — ${existingEntries.length} encrypted ` +
+        `entries already exist at ${resolveVaultPath('vault-entries.json', rawEnv)}. ` +
+        `Silent re-init would regenerate the master-key envelope and leave every ` +
+        `existing entry undecryptable (this is the root cause of the 2026-05-11 ` +
+        `pepper desync incident).\n\n` +
+        `Choose one:\n` +
+        `  1. Back up ~/.memphis/ then run \`memphis vault reset --confirm\` ` +
+        `(moves state + entries into a timestamped backup dir) and re-run \`vault init\`.\n` +
+        `  2. Pass --force-reinit (or set MEMPHIS_VAULT_FORCE_REINIT=1) to wipe ` +
+        `the existing master key WITHOUT moving the entries aside. Use ONLY if you ` +
+        `intend to lose access to the current entries and have backed them up off-host.\n` +
+        `  3. If you meant to add a secret instead of initialize the vault: ` +
+        `\`memphis vault add <key>\`.`,
+    );
+  }
 
   const anyFlagProvided = Boolean(passphrase || recoveryQuestion || recoveryAnswer);
   const allFlagsProvided = Boolean(passphrase && recoveryQuestion && recoveryAnswer);
@@ -162,6 +210,14 @@ async function handleVaultInit(context: CliContext): Promise<boolean> {
     }
   }
 
+  // Thread the operator's `--force-reinit` decision into the boundary
+  // via the existing env contract so vault-boundary's own refuse-guard
+  // sees the same authorisation we just accepted at the CLI surface.
+  // Without this, `--force-reinit` would pass the CLI gate but the
+  // boundary would still throw `VaultAlreadyInitializedError`.
+  const initEnv = forceReinitAuthorised
+    ? { ...rawEnv, MEMPHIS_VAULT_FORCE_REINIT: '1' }
+    : rawEnv;
   const vault = initializeVault(
     {
       passphrase: passphrase!,
@@ -169,8 +225,22 @@ async function handleVaultInit(context: CliContext): Promise<boolean> {
       recovery_answer: recoveryAnswer!,
     },
     { surface: 'cli', command: 'vault init' },
-    process.env,
+    initEnv,
   );
+
+  if (forceReinitAuthorised && existingEntries.length > 0) {
+    writeSecurityAudit({
+      action: 'vault.init.force_reinit',
+      status: 'allowed',
+      details: {
+        surface: 'cli',
+        command: 'vault init',
+        reason: 'operator_authorised_force_reinit',
+        overwritten_entry_count: existingEntries.length,
+        authorised_via: forceReinit ? 'flag' : 'env',
+      },
+    });
+  }
 
   print({ ok: true, vault }, json);
   return true;

--- a/src/infra/cli/parser.ts
+++ b/src/infra/cli/parser.ts
@@ -131,6 +131,11 @@ export function parseCommand(argv: string[]): CliArgs {
     nonInteractive: hasBooleanFlag(flags, '--non-interactive'),
     profile: readFlagValue(flags, '--profile') as CliArgs['profile'],
     force: hasBooleanFlag(flags, '--force'),
+    // `--force-reinit` is the explicit opt-in for `vault init`'s
+    // refuse-on-nonempty guard. Kept distinct from `--force` so an
+    // unrelated handler accepting `--force` cannot transitively
+    // re-authorise a vault wipe — see CliArgs.forceReinit docstring.
+    forceReinit: hasBooleanFlag(flags, '--force-reinit'),
     noVault: hasBooleanFlag(flags, '--no-vault'),
     fix: hasBooleanFlag(flags, '--fix'),
     deep: hasBooleanFlag(flags, '--deep'),

--- a/src/infra/cli/types.ts
+++ b/src/infra/cli/types.ts
@@ -59,6 +59,20 @@ export type CliArgs = {
     | 'build-only'
     | 'custom';
   force: boolean;
+  /**
+   * Opt-in override for `vault init`'s refuse-on-nonempty guard
+   * (2026-05-13 — root-cause fix for the pepper desync that bit on
+   * 2026-05-11 15:57 → 16:07). Without this flag, `vault init` refuses
+   * to overwrite an existing non-empty `vault-entries.json` because
+   * silent re-init regenerates the master key envelope while the old
+   * ciphertext stays on disk, leaving every entry undecryptable.
+   *
+   * Set this flag deliberately when you really do want to wipe state
+   * (after backing up `~/.memphis/`). Distinct from the generic
+   * `--force` so a stray `--force` somewhere else can't accidentally
+   * authorise a vault wipe.
+   */
+  forceReinit?: boolean;
   fix?: boolean;
   deep?: boolean;
   postInstall?: boolean;

--- a/tests/cli/vault-init-refuse-nonempty.test.ts
+++ b/tests/cli/vault-init-refuse-nonempty.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Refuse-on-nonempty guard for `memphis vault init`.
+ *
+ * Root-cause fix for the pepper desync that bit on 2026-05-11
+ * 15:57 → 16:07 and forced operator's full vault reset on
+ * 2026-05-13. The boundary (`src/security/vault-boundary.ts`) had
+ * the invariant via `MEMPHIS_VAULT_FORCE_REINIT`, but only refused
+ * AFTER interactive prompts had collected operator input. The CLI
+ * guard short-circuits before any prompt fires so a stray
+ * `vault init` on a populated vault can't silently regenerate the
+ * master-key envelope while the existing entries stay on disk.
+ *
+ * Four branches verified here:
+ *   1. greenfield (no entries file at all)            → init succeeds
+ *   2. empty entries file `[]`                         → init succeeds
+ *   3. non-empty, no override                          → init refuses
+ *   4. non-empty + `--force-reinit`                    → init succeeds
+ *
+ * The boundary's env-var path (`MEMPHIS_VAULT_FORCE_REINIT=1`) is the
+ * legacy / scriptable alias and is verified separately by
+ * `tests/unit/vault-boundary.test.ts`. We test the flag path here
+ * because it is the CLI-discoverable shape operators reach for.
+ */
+import { mkdtempSync, existsSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runCli, runCliResult } from '../helpers/cli.js';
+
+const PASSPHRASE = 'test-passphrase-123';
+const RECOVERY_Q = 'Color of the test fixture?';
+const RECOVERY_A = 'magenta';
+
+function envFor(dataDir: string): NodeJS.ProcessEnv {
+  return {
+    HOME: dataDir,
+    MEMPHIS_DATA_DIR: dataDir,
+    MEMPHIS_VAULT_ENTRIES_PATH: join(dataDir, 'vault-entries.json'),
+    MEMPHIS_VAULT_PEPPER: 'test-pepper-0123456789abcdef',
+  };
+}
+
+function initArgs(extra: string[] = []): string[] {
+  return [
+    'vault',
+    'init',
+    '--passphrase',
+    PASSPHRASE,
+    '--recovery-question',
+    RECOVERY_Q,
+    '--recovery-answer',
+    RECOVERY_A,
+    '--json',
+    ...extra,
+  ];
+}
+
+describe('CLI vault init refuse-on-nonempty', () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'memphis-vault-init-guard-'));
+  });
+
+  afterEach(() => {
+    if (existsSync(dataDir)) {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('succeeds on a greenfield install (no entries file present)', async () => {
+    // No vault-entries.json at all. Should be allowed.
+    const out = JSON.parse(await runCli(initArgs(), { env: envFor(dataDir) }));
+    expect(out.ok).toBe(true);
+    expect(out.vault).toBeDefined();
+  }, 30_000);
+
+  it('succeeds when entries file exists but is the empty array `[]`', async () => {
+    // Matches the existing `tests/cli/vault.test.ts` setup: empty `[]` is
+    // the "no entries yet" sentinel after a `vault reset` or a fresh
+    // touch — must remain allowed.
+    writeFileSync(join(dataDir, 'vault-entries.json'), '[]', 'utf8');
+    const out = JSON.parse(await runCli(initArgs(), { env: envFor(dataDir) }));
+    expect(out.ok).toBe(true);
+  }, 30_000);
+
+  it('refuses when entries file has secrets and no override is passed', async () => {
+    // Simulate the bug shape: vault-entries.json already populated by a
+    // prior `vault add` (or restored from backup). A stray `vault init`
+    // here is the exact event that produced 2026-05-11's pepper desync.
+    const fakeEntries = [
+      {
+        key: 'minimax_api_key',
+        encrypted: 'base64-ciphertext',
+        iv: 'base64-iv',
+        createdAt: new Date().toISOString(),
+        fingerprint: 'fp-1',
+      },
+    ];
+    writeFileSync(
+      join(dataDir, 'vault-entries.json'),
+      JSON.stringify(fakeEntries),
+      'utf8',
+    );
+
+    const result = await runCliResult(initArgs(), { env: envFor(dataDir) });
+    expect(result.status).not.toBe(0);
+    const combined = `${result.stdout}\n${result.stderr}`;
+    expect(combined).toMatch(/refusing to re-initialize/i);
+    expect(combined).toMatch(/--force-reinit/);
+    expect(combined).toMatch(/1 encrypted entries/);
+
+    // The pre-existing entries file must NOT have been mutated — the
+    // refusal must short-circuit BEFORE any vault write happens.
+    const onDisk = readFileSync(join(dataDir, 'vault-entries.json'), 'utf8');
+    expect(JSON.parse(onDisk)).toEqual(fakeEntries);
+    expect(existsSync(join(dataDir, 'vault-state.json'))).toBe(false);
+  }, 30_000);
+
+  it('proceeds when --force-reinit is passed explicitly', async () => {
+    // Operator opted in. The flag is the discoverable shape; the
+    // env-var bypass (MEMPHIS_VAULT_FORCE_REINIT=1) is tested at the
+    // boundary layer. Either is sufficient.
+    const fakeEntries = [
+      {
+        key: 'minimax_api_key',
+        encrypted: 'base64-ciphertext',
+        iv: 'base64-iv',
+        createdAt: new Date().toISOString(),
+        fingerprint: 'fp-1',
+      },
+    ];
+    writeFileSync(
+      join(dataDir, 'vault-entries.json'),
+      JSON.stringify(fakeEntries),
+      'utf8',
+    );
+
+    const out = JSON.parse(
+      await runCli(initArgs(['--force-reinit']), { env: envFor(dataDir) }),
+    );
+    expect(out.ok).toBe(true);
+    expect(out.vault).toBeDefined();
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Root-cause prevention for the pepper desync that bit on 2026-05-11 15:57 → 16:07 and forced operator's full vault reset on 2026-05-13. Refuses `memphis vault init` at the CLI surface when `vault-entries.json` already holds secrets, unless operator passes `--force-reinit` (or sets the existing `MEMPHIS_VAULT_FORCE_REINIT=1`).

The vault-boundary layer already enforces this invariant via the env var (added 2026-05-02), but only AFTER interactive passphrase + recovery prompts have collected input. The CLI guard short-circuits BEFORE any prompt fires, with a clear error message and a CLI-specific audit event (`vault.init.refused`) for easier forensics.

## What changes

- `src/infra/cli/types.ts` — adds `forceReinit?: boolean` to `CliArgs` with explanatory docstring (intentionally distinct from generic `--force`)
- `src/infra/cli/parser.ts` — parses `--force-reinit`
- `src/infra/cli/handlers/vault.handler.ts:handleVaultInit` — refuse path + threaded env into `initializeVault` so the boundary sees the same authorisation; emits `vault.init.refused` (blocked) and `vault.init.force_reinit` (allowed, with `authorised_via: 'flag' | 'env'` provenance)

Error message guides operators to the three legitimate paths: backup + `vault reset --confirm` + re-init, or `--force-reinit` opt-in, or `vault add` if they meant to add a secret instead.

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – (CLI-side guard; boundary already enforces in TS) |
| NAPI | – |
| TS host | ✅ `src/infra/cli/handlers/vault.handler.ts` |
| CLI | ✅ `src/infra/cli/parser.ts`, `src/infra/cli/types.ts` |
| Tauri | – |
| doctor/status | – (audit log captures both refused + force_reinit; doctor reading the log surfaces the history) |
| tests | ✅ `tests/cli/vault-init-refuse-nonempty.test.ts` |

## Tests

`tests/cli/vault-init-refuse-nonempty.test.ts` — 4 branches:

1. Greenfield (no entries file) → init succeeds
2. Empty entries file `[]` → init succeeds (parity with existing `vault.test.ts` fixture shape)
3. Non-empty without override → init refuses, exit code != 0, error mentions `--force-reinit`, on-disk entries unchanged, no `vault-state.json` written
4. Non-empty + `--force-reinit` → init succeeds (operator opted-in)

Env-var bypass (`MEMPHIS_VAULT_FORCE_REINIT=1`) continues to be tested at the boundary layer; this PR focuses on the CLI-discoverable flag path.

## Test plan

- [ ] CI green on `tests/cli/vault-init-refuse-nonempty.test.ts`
- [ ] CI green on existing `tests/cli/vault.test.ts` (no regression on the `[]` empty-array fixture)
- [ ] Local smoke: `memphis vault init` on operator's freshly-reset install hits the guard if entries grow back (cannot run today — operator's vault is freshly-initialized so the test fires only on the SECOND init attempt)
- [ ] Audit log shows `vault.init.refused` with `existing_entry_count` on guard fire

## Refs

- `feedback_pepper_desync_twice_same_day.md` — no longer phantom CLOSED; silent-reinit flavor IS real
- `src/security/vault-boundary.ts:202-220` — existing boundary guard (this PR is the CLI-side peer)
- `src/infra/storage/rust-vault-adapter.ts:558` — existing rotation-side guard
- `docs/operator/FORCE-FLAGS.md` — operator-facing doc for force-flag contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)