### PR TITLE
fix(startup): structured known-fork registry replaces #603 substring matcher

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -49,6 +49,11 @@ import { EXIT_CODES, MemphisExitError } from '../infra/runtime/exit-codes.js';
 import { installShutdownHandlers } from '../infra/runtime/graceful-shutdown.js';
 import { HeartbeatWatchdog, writeBootPulse } from '../infra/runtime/heartbeat-watchdog.js';
 import { resolveInstallRoot } from '../infra/runtime/install-root.js';
+import {
+  loadKnownForks,
+  matchKnownFork,
+  parseChainIntegrityError,
+} from '../infra/runtime/known-forks.js';
 import { setLocalWorkerRuntimeStatus } from '../infra/runtime/local-worker-state.js';
 import { startReflectionLoop } from '../infra/runtime/reflection-loop.js';
 import { enforceSafeModeNoEgress, safeModeEnabled } from '../infra/runtime/safe-mode.js';
@@ -302,42 +307,55 @@ export async function bootstrap(): Promise<void> {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'chain verification failed';
-    // Block 1853 fork-marker (operator decision PR #595 Opcja A,
-    // 2026-05-12): a single test escape produced a permanent prev_hash
-    // mismatch at the system chain 1852→1853 boundary. Operator chose
-    // to keep the corruption on disk as a forensic scar rather than
-    // truncate or renumber. Startup must tolerate this specific known
-    // fork — without the tolerance, every restart of an affected
-    // install crashes here and the operator can't bring the daemon
-    // back up. The audit-write guard (PR #595) prevents NEW corruption
-    // from this class; the runtime chain-append path is unaffected.
-    // Future known forks land here too — append, don't replace.
-    const KNOWN_FORK_MARKERS = [
-      'chain \'system\' integrity check failed at block 1853',
-    ];
-    const isKnownFork = KNOWN_FORK_MARKERS.some((marker) => message.includes(marker));
-    if (isKnownFork) {
+    // Known-fork tolerance (replaces PR #603's substring KNOWN_FORK_MARKERS):
+    // parse the error into structured fields, look up an operator-
+    // configured fork in `<dataDir>/known-forks.json` /
+    // `MEMPHIS_KNOWN_FORK_MARKERS` / baseline, and mitigate iff the
+    // chain + block + (optional) hash pair all match. Unknown
+    // integrity errors still throw ERR_CORRUPTION — this isn't a
+    // blanket skip-everything bypass.
+    const parsed = parseChainIntegrityError(message);
+    const forks = parsed ? loadKnownForks(process.env) : [];
+    const match = parsed ? matchKnownFork(parsed, forks) : null;
+    if (parsed && match) {
       writeSecurityAudit({
         action: 'chain.verify.startup',
         status: 'mitigated',
         details: {
           message,
-          mitigation: 'known-fork-marker accepted per operator decision',
-          fork_markers: KNOWN_FORK_MARKERS,
+          chain: parsed.chain,
+          block: parsed.block,
+          file: parsed.file,
+          kind: parsed.kind,
+          stored_prev_hash: parsed.storedPrevHash,
+          expected_prev_hash: parsed.expectedPrevHash,
+          mitigation: 'known-fork accepted per operator decision',
+          fork_reason: match.reason,
+          fork_ref: match.ref,
+          fork_accepted_at: match.acceptedAt,
         },
       });
       const fallbackLog = createPinoLogger({ level: LOG_LEVEL.read(process.env) });
       fallbackLog.warn(
-        { event: 'chain.verify.startup.known-fork', message },
-        `chain integrity check flagged a known fork marker; ` +
-          `continuing startup per operator decision (see PR #595, ` +
-          `notes/system-chain-corruption-2026-05-12.md)`,
+        {
+          event: 'chain.verify.startup.known-fork',
+          chain: parsed.chain,
+          block: parsed.block,
+          kind: parsed.kind,
+          ref: match.ref,
+        },
+        `chain integrity check flagged a known fork at ${parsed.chain}:${parsed.block} ` +
+          `(${parsed.kind}); continuing startup per operator decision — ${match.reason}`,
       );
     } else {
       writeSecurityAudit({
         action: 'chain.verify.startup',
         status: 'error',
-        details: { message },
+        details: {
+          message,
+          parsed: parsed ?? undefined,
+          known_fork_count: forks.length,
+        },
       });
       throw new MemphisExitError(
         EXIT_CODES.ERR_CORRUPTION,

--- a/src/infra/cli/utils/doctor-v2.ts
+++ b/src/infra/cli/utils/doctor-v2.ts
@@ -57,7 +57,9 @@ import type { FirstRunPlan } from '../../../onboarding/first-run.js';
 import { probeVaultCipherCycle } from '../../../security/vault-boundary.js';
 import { loadSoulManifest } from '../../../soul/manifest.js';
 import { envSchema } from '../../config/schema.js';
+import { readRecentSecurityAuditEvents } from '../../logging/security-audit.js';
 import { resolveInstallRoot } from '../../runtime/install-root.js';
+import { loadKnownForks } from '../../runtime/known-forks.js';
 import { buildRuntimeHealthSnapshot } from '../../runtime/runtime-health.js';
 import { repairRuntimeState } from '../../runtime/runtime-repair.js';
 import { diagnoseChainHashes, rebuildChainHashes } from '../../storage/chain-adapter.js';
@@ -607,6 +609,45 @@ export async function runDoctorChecksV2(options: DoctorOptions = {}): Promise<Do
     required: true,
     detail: `${chain.checked} blocks checked, invalid=${chain.invalid}`,
     fix: 'Run memphis doctor --fix to rebuild chain hashes, or restore from backup',
+  });
+
+  // Surface known-fork mitigations from the last 200 audit events.
+  // The audit log captures every startup's `chain.verify.startup`
+  // entry; this surfaces "the chain has N tolerated forks at startup"
+  // alongside the raw integrity check so operators reading `doctor`
+  // see the mitigation history without grepping audit-log.jsonl. The
+  // check is informational (level=warn, ok=true) — known forks are
+  // accepted by operator decision, not failures.
+  const knownForks = (() => {
+    try {
+      return loadKnownForks(process.env);
+    } catch {
+      return [];
+    }
+  })();
+  const recentMitigations = readRecentSecurityAuditEvents(
+    (event) =>
+      event.action === 'chain.verify.startup' && event.status === 'mitigated',
+    20,
+    process.env,
+  );
+  const latestMitigation = recentMitigations[0];
+  checks.push({
+    id: 't1-chain-known-forks',
+    tier: 1,
+    title: 'Chain known-fork tolerance',
+    level: latestMitigation ? 'warn' : 'pass',
+    ok: true,
+    required: false,
+    detail: latestMitigation
+      ? `${knownForks.length} fork(s) configured; last startup mitigated ` +
+        `${String(latestMitigation.details?.chain ?? '?')}:` +
+        `${String(latestMitigation.details?.block ?? '?')} ` +
+        `(${String(latestMitigation.details?.kind ?? '?')})`
+      : `${knownForks.length} fork(s) configured; no mitigations in recent audit history`,
+    fix: knownForks.length === 0
+      ? undefined
+      : 'Edit <dataDir>/known-forks.json or set MEMPHIS_KNOWN_FORK_MARKERS to adjust the accepted-fork list',
   });
   checks.push({
     id: 't1-chain-memory-source',

--- a/src/infra/logging/security-audit.ts
+++ b/src/infra/logging/security-audit.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import { maybeRotateAuditLog, resolveAuditLogPath } from './audit-rotation.js';
@@ -13,6 +13,10 @@ export interface SecurityAuditEvent {
   ip?: string;
   route?: string;
   details?: Record<string, unknown>;
+}
+
+export interface PersistedSecurityAuditEvent extends SecurityAuditEvent {
+  ts: string;
 }
 
 export function writeSecurityAudit(
@@ -46,4 +50,45 @@ export function writeSecurityAudit(
       `[security-audit] failed to write event ${event.action}: ${error instanceof Error ? error.message : 'unknown_error'}\n`,
     );
   }
+}
+
+/**
+ * Read the current (un-rotated) audit log and return the most recent
+ * events matching `predicate`, newest first, up to `limit`. Returns an
+ * empty array if the audit log doesn't exist yet or every line in the
+ * file fails to parse as JSON (corrupt log).
+ *
+ * Reads only the active file, NOT the rotated archives — this is a
+ * cheap "what just happened" helper for doctor/status surfaces, not a
+ * forensic query API. Doctor-v2 uses this to count
+ * `chain.verify.startup status:mitigated` events from the most recent
+ * startup.
+ */
+export function readRecentSecurityAuditEvents(
+  predicate: (event: PersistedSecurityAuditEvent) => boolean,
+  limit: number,
+  rawEnv: NodeJS.ProcessEnv = process.env,
+): PersistedSecurityAuditEvent[] {
+  if (limit <= 0) return [];
+  const path = resolveAuditLogPath(rawEnv);
+  if (!existsSync(path)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return [];
+  }
+  const lines = raw.split('\n');
+  const matches: PersistedSecurityAuditEvent[] = [];
+  for (let i = lines.length - 1; i >= 0 && matches.length < limit; i -= 1) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    try {
+      const event = JSON.parse(line) as PersistedSecurityAuditEvent;
+      if (predicate(event)) matches.push(event);
+    } catch {
+      // skip malformed lines — caller asked for "recent valid events"
+    }
+  }
+  return matches;
 }

--- a/src/infra/runtime/known-forks.ts
+++ b/src/infra/runtime/known-forks.ts
@@ -1,0 +1,281 @@
+/**
+ * Known-fork registry for chain integrity check tolerance.
+ *
+ * Background: PR #603 (2026-05-12) added a hardcoded substring match
+ * for the block-1853 corruption that operator chose to keep as a
+ * forensic scar rather than truncate. That fix unblocked daemon
+ * restart but baked the operator's specific decision into TS source,
+ * matched too loosely (block number only — any future corruption at
+ * the same block would inherit the same tolerance), and produced
+ * unstructured audit details.
+ *
+ * This module replaces the substring matcher with a structured
+ * config-driven registry. Three configuration channels (most-specific
+ * wins):
+ *
+ *   1. `<dataDir>/known-forks.json` — operator-local config (preferred).
+ *      Each install owns its own list; not shared via source control.
+ *   2. `MEMPHIS_KNOWN_FORK_MARKERS` env — JSON-encoded array of the
+ *      same shape, for CI / test fixtures / scripted deployments.
+ *   3. A baseline fallback entry for block 1853 with `chain='system'`,
+ *      kept for backward-compat with operator's pre-existing install.
+ *      Removed once the operator config catches up (the file ships
+ *      empty by default, this is the safety net during migration).
+ *
+ * Matching: each `KnownFork` is keyed on `{chain, block}` (always
+ * required) and `{storedPrevHash, expectedPrevHash}` (optional —
+ * when present, the fork only matches if those hash fragments are
+ * literal substrings of the observed error). Hash fragments are kept
+ * as substrings, not full hashes, because the error formatter
+ * truncates via `formatHashFingerprint()` (8 chars + ellipsis + 4
+ * chars). The config can hold either the truncated form or the full
+ * hex; matching tolerates both.
+ *
+ * Replaces `KNOWN_FORK_MARKERS: string[]` from PR #603's
+ * `src/app/bootstrap.ts`.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getDataDir } from '../../config/paths.js';
+
+export type KnownForkKind =
+  | 'prev_hash_mismatch'
+  | 'stored_hash_mismatch'
+  | 'non_sequential'
+  | 'genesis_prev_hash';
+
+export interface KnownFork {
+  chain: string;
+  block: number;
+  /** Optional fingerprint of the on-disk prev_hash (matches substring). */
+  storedPrevHash?: string;
+  /** Optional fingerprint of what prev_hash SHOULD have been (matches substring). */
+  expectedPrevHash?: string;
+  /** Operator-facing reason for accepting the fork. */
+  reason: string;
+  /** ISO timestamp the decision was recorded. */
+  acceptedAt: string;
+  /** Optional PR / runbook reference. */
+  ref?: string;
+}
+
+export interface ParsedIntegrityError {
+  chain: string;
+  block: number;
+  file?: string;
+  kind: KnownForkKind;
+  storedPrevHash?: string;
+  expectedPrevHash?: string;
+}
+
+/**
+ * Baseline fallback. Encodes operator's 2026-05-12 Opcja A decision
+ * for the block-1853 system-chain fork. Kept so existing installs
+ * keep restarting without operator action; removed once
+ * `<dataDir>/known-forks.json` is provisioned.
+ */
+const BASELINE_FORKS: KnownFork[] = [
+  {
+    chain: 'system',
+    block: 1853,
+    storedPrevHash: '754a7c32',
+    expectedPrevHash: '4248ca68',
+    reason:
+      'Block 1853 prev_hash mismatch from a 2026-05-12 test escape. ' +
+      'Operator chose to keep the corruption on disk as a forensic scar ' +
+      'rather than truncate or renumber. Future appended blocks are sound.',
+    acceptedAt: '2026-05-12T00:00:00Z',
+    ref: 'PR #595 + #603, notes/system-chain-corruption-2026-05-12.md',
+  },
+];
+
+function parseKnownForkArray(raw: unknown, source: string): KnownFork[] {
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `known-forks config (${source}) must be an array of {chain, block, reason, acceptedAt, ...}`,
+    );
+  }
+  return raw.map((entry, idx) => {
+    if (typeof entry !== 'object' || entry === null) {
+      throw new Error(`known-forks[${idx}] in ${source} is not an object`);
+    }
+    const obj = entry as Record<string, unknown>;
+    if (typeof obj.chain !== 'string' || obj.chain.length === 0) {
+      throw new Error(`known-forks[${idx}].chain must be a non-empty string`);
+    }
+    if (typeof obj.block !== 'number' || !Number.isInteger(obj.block) || obj.block < 0) {
+      throw new Error(`known-forks[${idx}].block must be a non-negative integer`);
+    }
+    if (typeof obj.reason !== 'string' || obj.reason.length === 0) {
+      throw new Error(`known-forks[${idx}].reason must be a non-empty string`);
+    }
+    if (typeof obj.acceptedAt !== 'string') {
+      throw new Error(`known-forks[${idx}].acceptedAt must be an ISO timestamp string`);
+    }
+    return {
+      chain: obj.chain,
+      block: obj.block,
+      storedPrevHash: typeof obj.storedPrevHash === 'string' ? obj.storedPrevHash : undefined,
+      expectedPrevHash:
+        typeof obj.expectedPrevHash === 'string' ? obj.expectedPrevHash : undefined,
+      reason: obj.reason,
+      acceptedAt: obj.acceptedAt,
+      ref: typeof obj.ref === 'string' ? obj.ref : undefined,
+    };
+  });
+}
+
+/**
+ * Load the known-fork registry from (in order of preference):
+ *   1. `<dataDir>/known-forks.json`
+ *   2. `MEMPHIS_KNOWN_FORK_MARKERS` env (JSON-encoded array)
+ *   3. Built-in baseline (block 1853)
+ *
+ * The three sources do NOT merge — the first one that yields entries
+ * wins. This keeps operator-local config authoritative and prevents
+ * unintended baseline injection on installs that have explicitly
+ * cleared the fork list (operator's `known-forks.json` = `[]` opts
+ * out of all forks).
+ */
+export function loadKnownForks(rawEnv: NodeJS.ProcessEnv = process.env): KnownFork[] {
+  const configPath = join(getDataDir(rawEnv), 'known-forks.json');
+  if (existsSync(configPath)) {
+    const raw = readFileSync(configPath, 'utf8').trim();
+    if (raw.length === 0) {
+      return [];
+    }
+    return parseKnownForkArray(JSON.parse(raw), configPath);
+  }
+  const envRaw = rawEnv.MEMPHIS_KNOWN_FORK_MARKERS;
+  if (typeof envRaw === 'string' && envRaw.trim().length > 0) {
+    return parseKnownForkArray(JSON.parse(envRaw), 'MEMPHIS_KNOWN_FORK_MARKERS');
+  }
+  return BASELINE_FORKS;
+}
+
+/**
+ * Parse a chain-integrity error message thrown by
+ * `verifyChainIntegrity()` in `src/infra/storage/chain-adapter.ts`.
+ *
+ * The four throw sites all share a stable shape:
+ *
+ *   chain '<name>' integrity check failed at block <N> (<file>):
+ *   prev_hash <hash> ≠ previous block's hash <hash>
+ *
+ *   chain '<name>' integrity check failed at block <N> (<file>):
+ *   stored hash <hash> ≠ computed <hash>
+ *
+ *   chain '<name>' integrity check failed at block <N> (<file>):
+ *   non-sequential index after block <N>
+ *
+ *   chain '<name>' integrity check failed at genesis block <0|1> (<file>):
+ *   prev_hash <hash> ≠ expected <hash>
+ *
+ * Returns `null` if the message doesn't match the expected shape —
+ * the caller must treat that as "unknown error, re-throw".
+ */
+export function parseChainIntegrityError(message: string): ParsedIntegrityError | null {
+  const headerMatch = message.match(
+    /^chain '([^']+)' integrity check failed at (?:genesis block|block) (\d+)(?: \(([^)]+)\))?:\s*(.+)$/s,
+  );
+  if (!headerMatch) return null;
+  const [, chain, blockStr, file, rest] = headerMatch;
+  const block = Number(blockStr);
+  if (!Number.isInteger(block)) return null;
+
+  const prevHashMatch = rest.match(/^prev_hash (\S+) ≠ previous block's hash (\S+)/);
+  if (prevHashMatch) {
+    return {
+      chain,
+      block,
+      file,
+      kind: 'prev_hash_mismatch',
+      storedPrevHash: prevHashMatch[1],
+      expectedPrevHash: prevHashMatch[2],
+    };
+  }
+
+  const genesisMatch = rest.match(/^prev_hash (\S+) ≠ expected (.+?)(?:\s|$)/);
+  if (genesisMatch) {
+    return {
+      chain,
+      block,
+      file,
+      kind: 'genesis_prev_hash',
+      storedPrevHash: genesisMatch[1],
+      expectedPrevHash: genesisMatch[2],
+    };
+  }
+
+  const storedHashMatch = rest.match(/^stored hash (\S+) ≠ computed (\S+)/);
+  if (storedHashMatch) {
+    return {
+      chain,
+      block,
+      file,
+      kind: 'stored_hash_mismatch',
+      storedPrevHash: storedHashMatch[1],
+      expectedPrevHash: storedHashMatch[2],
+    };
+  }
+
+  if (/^non-sequential index/.test(rest)) {
+    return { chain, block, file, kind: 'non_sequential' };
+  }
+
+  return null;
+}
+
+/**
+ * Look up an accepted-fork entry for the parsed error. Returns the
+ * matching `KnownFork` or `null` if none of the configured entries
+ * cover this error.
+ *
+ * Matching rules:
+ *   - `chain` + `block` MUST equal the error's chain + block (this is
+ *     the primary key — block-1853-system can't accidentally cover
+ *     block-1853-journal).
+ *   - If the entry has `storedPrevHash`, the error's storedPrevHash
+ *     must contain it as a substring (tolerant of fingerprint
+ *     truncation). Same for `expectedPrevHash`.
+ *   - If the entry has neither hash field, any hash mismatch at that
+ *     `{chain, block}` pair matches (less strict, supports operators
+ *     who don't have the hashes to hand).
+ */
+export function matchKnownFork(
+  parsed: ParsedIntegrityError,
+  forks: KnownFork[],
+): KnownFork | null {
+  for (const fork of forks) {
+    if (fork.chain !== parsed.chain) continue;
+    if (fork.block !== parsed.block) continue;
+    if (
+      fork.storedPrevHash !== undefined &&
+      (parsed.storedPrevHash === undefined ||
+        !parsed.storedPrevHash.includes(fork.storedPrevHash))
+    ) {
+      continue;
+    }
+    if (
+      fork.expectedPrevHash !== undefined &&
+      (parsed.expectedPrevHash === undefined ||
+        !parsed.expectedPrevHash.includes(fork.expectedPrevHash))
+    ) {
+      continue;
+    }
+    return fork;
+  }
+  return null;
+}
+
+/**
+ * Test-only seam for resetting any module-level cache. Currently the
+ * loader is stateless (re-reads on every call), so this is a no-op,
+ * but keeping the export makes future cache addition a non-breaking
+ * change.
+ */
+export function __resetKnownForksForTests(): void {
+  // intentionally empty
+}

--- a/tests/unit/known-forks.test.ts
+++ b/tests/unit/known-forks.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Known-fork registry — loader, parser, matcher.
+ *
+ * Replaces the substring `KNOWN_FORK_MARKERS.some()` matcher from PR
+ * #603 with structured `{chain, block, prev_hash, expected_prev_hash}`
+ * matching. The bootstrap catch site at `src/app/bootstrap.ts` calls
+ * `parseChainIntegrityError()` → `loadKnownForks()` → `matchKnownFork()`
+ * — this file covers all three.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  loadKnownForks,
+  matchKnownFork,
+  parseChainIntegrityError,
+  type KnownFork,
+} from '../../src/infra/runtime/known-forks.js';
+
+describe('parseChainIntegrityError', () => {
+  it('parses prev_hash mismatch (operator block-1853 shape)', () => {
+    const message =
+      `chain 'system' integrity check failed at block 1853 (001853.json): ` +
+      `prev_hash 754a7c32…9d1b ≠ previous block's hash 4248ca68…cd62`;
+    const parsed = parseChainIntegrityError(message);
+    expect(parsed).toEqual({
+      chain: 'system',
+      block: 1853,
+      file: '001853.json',
+      kind: 'prev_hash_mismatch',
+      storedPrevHash: '754a7c32…9d1b',
+      expectedPrevHash: '4248ca68…cd62',
+    });
+  });
+
+  it('parses stored hash mismatch', () => {
+    const parsed = parseChainIntegrityError(
+      `chain 'journal' integrity check failed at block 42 (000042.json): ` +
+        `stored hash aaaa1111…bbbb ≠ computed cccc2222…dddd`,
+    );
+    expect(parsed).toMatchObject({
+      chain: 'journal',
+      block: 42,
+      kind: 'stored_hash_mismatch',
+      storedPrevHash: 'aaaa1111…bbbb',
+      expectedPrevHash: 'cccc2222…dddd',
+    });
+  });
+
+  it('parses non-sequential index', () => {
+    const parsed = parseChainIntegrityError(
+      `chain 'case' integrity check failed at block 99 (000099.json): ` +
+        `non-sequential index after block 50`,
+    );
+    expect(parsed).toMatchObject({ chain: 'case', block: 99, kind: 'non_sequential' });
+  });
+
+  it('parses genesis prev_hash mismatch', () => {
+    const parsed = parseChainIntegrityError(
+      `chain 'system' integrity check failed at genesis block 0 (000000.json): ` +
+        `prev_hash abc123…0000 ≠ expected GENESIS_PREV_HASH`,
+    );
+    expect(parsed).toMatchObject({
+      chain: 'system',
+      block: 0,
+      kind: 'genesis_prev_hash',
+      storedPrevHash: 'abc123…0000',
+    });
+  });
+
+  it('returns null for unrelated errors', () => {
+    expect(parseChainIntegrityError('totally unrelated error')).toBeNull();
+    expect(parseChainIntegrityError('chain integrity check')).toBeNull();
+  });
+});
+
+describe('matchKnownFork', () => {
+  const fork: KnownFork = {
+    chain: 'system',
+    block: 1853,
+    storedPrevHash: '754a7c32',
+    expectedPrevHash: '4248ca68',
+    reason: 'test fork',
+    acceptedAt: '2026-05-12T00:00:00Z',
+  };
+
+  it('matches on chain + block + both hash substrings', () => {
+    const parsed = {
+      chain: 'system' as const,
+      block: 1853,
+      kind: 'prev_hash_mismatch' as const,
+      storedPrevHash: '754a7c32…9d1b',
+      expectedPrevHash: '4248ca68…cd62',
+    };
+    expect(matchKnownFork(parsed, [fork])).toEqual(fork);
+  });
+
+  it('rejects wrong chain', () => {
+    const parsed = {
+      chain: 'journal' as const,
+      block: 1853,
+      kind: 'prev_hash_mismatch' as const,
+      storedPrevHash: '754a7c32…9d1b',
+      expectedPrevHash: '4248ca68…cd62',
+    };
+    expect(matchKnownFork(parsed, [fork])).toBeNull();
+  });
+
+  it('rejects wrong block', () => {
+    const parsed = {
+      chain: 'system' as const,
+      block: 1854,
+      kind: 'prev_hash_mismatch' as const,
+      storedPrevHash: '754a7c32…9d1b',
+      expectedPrevHash: '4248ca68…cd62',
+    };
+    expect(matchKnownFork(parsed, [fork])).toBeNull();
+  });
+
+  it('rejects wrong storedPrevHash', () => {
+    // This is the regression the PR #603 critique called out: matching
+    // on block number alone is too loose — any new corruption at block
+    // 1853 would inherit the same tolerance. The structured matcher
+    // rejects a different stored hash.
+    const parsed = {
+      chain: 'system' as const,
+      block: 1853,
+      kind: 'prev_hash_mismatch' as const,
+      storedPrevHash: 'ffffffff…0000',
+      expectedPrevHash: '4248ca68…cd62',
+    };
+    expect(matchKnownFork(parsed, [fork])).toBeNull();
+  });
+
+  it('matches when fork omits hash fields (chain+block only)', () => {
+    const looseFork: KnownFork = {
+      chain: 'system',
+      block: 1853,
+      reason: 'loose match',
+      acceptedAt: '2026-05-12T00:00:00Z',
+    };
+    const parsed = {
+      chain: 'system' as const,
+      block: 1853,
+      kind: 'prev_hash_mismatch' as const,
+      storedPrevHash: 'anything',
+      expectedPrevHash: 'else',
+    };
+    expect(matchKnownFork(parsed, [looseFork])).toEqual(looseFork);
+  });
+
+  it('returns null on empty fork list', () => {
+    const parsed = {
+      chain: 'system' as const,
+      block: 1853,
+      kind: 'prev_hash_mismatch' as const,
+    };
+    expect(matchKnownFork(parsed, [])).toBeNull();
+  });
+});
+
+describe('loadKnownForks', () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'memphis-known-forks-'));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('returns the baseline block-1853 fork when no config is present', () => {
+    const forks = loadKnownForks({ MEMPHIS_DATA_DIR: dataDir });
+    expect(forks).toHaveLength(1);
+    expect(forks[0]).toMatchObject({ chain: 'system', block: 1853 });
+  });
+
+  it('reads known-forks.json when present', () => {
+    writeFileSync(
+      join(dataDir, 'known-forks.json'),
+      JSON.stringify([
+        {
+          chain: 'system',
+          block: 9999,
+          reason: 'fixture',
+          acceptedAt: '2026-01-01T00:00:00Z',
+        },
+      ]),
+    );
+    const forks = loadKnownForks({ MEMPHIS_DATA_DIR: dataDir });
+    expect(forks).toHaveLength(1);
+    expect(forks[0]).toMatchObject({ chain: 'system', block: 9999, reason: 'fixture' });
+  });
+
+  it('honours empty known-forks.json as "no forks accepted"', () => {
+    // Operator who explicitly clears the fork list opts OUT of the
+    // baseline. The empty file is the canonical way to do that
+    // without setting an env var.
+    writeFileSync(join(dataDir, 'known-forks.json'), '[]');
+    const forks = loadKnownForks({ MEMPHIS_DATA_DIR: dataDir });
+    expect(forks).toEqual([]);
+  });
+
+  it('reads MEMPHIS_KNOWN_FORK_MARKERS env var when no file present', () => {
+    const env: NodeJS.ProcessEnv = {
+      MEMPHIS_DATA_DIR: dataDir,
+      MEMPHIS_KNOWN_FORK_MARKERS: JSON.stringify([
+        {
+          chain: 'journal',
+          block: 7,
+          reason: 'env fixture',
+          acceptedAt: '2026-01-01T00:00:00Z',
+        },
+      ]),
+    };
+    const forks = loadKnownForks(env);
+    expect(forks).toHaveLength(1);
+    expect(forks[0]).toMatchObject({ chain: 'journal', block: 7 });
+  });
+
+  it('file takes precedence over env var', () => {
+    writeFileSync(
+      join(dataDir, 'known-forks.json'),
+      JSON.stringify([
+        {
+          chain: 'system',
+          block: 1,
+          reason: 'file wins',
+          acceptedAt: '2026-01-01T00:00:00Z',
+        },
+      ]),
+    );
+    const env: NodeJS.ProcessEnv = {
+      MEMPHIS_DATA_DIR: dataDir,
+      MEMPHIS_KNOWN_FORK_MARKERS: JSON.stringify([
+        {
+          chain: 'journal',
+          block: 99,
+          reason: 'env loses',
+          acceptedAt: '2026-01-01T00:00:00Z',
+        },
+      ]),
+    };
+    const forks = loadKnownForks(env);
+    expect(forks).toHaveLength(1);
+    expect(forks[0].reason).toBe('file wins');
+  });
+
+  it('throws on malformed entries (missing required fields)', () => {
+    writeFileSync(
+      join(dataDir, 'known-forks.json'),
+      JSON.stringify([{ chain: 'system' }]), // missing block + reason + acceptedAt
+    );
+    expect(() => loadKnownForks({ MEMPHIS_DATA_DIR: dataDir })).toThrow(/block must be/);
+  });
+});

--- a/tests/unit/security-audit-read.test.ts
+++ b/tests/unit/security-audit-read.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `readRecentSecurityAuditEvents` — used by `memphis doctor` to surface
+ * known-fork mitigations from the audit log. Verifies the reader
+ * returns events newest-first, applies the predicate, and tolerates a
+ * missing or partly-corrupt log file.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  readRecentSecurityAuditEvents,
+  writeSecurityAudit,
+} from '../../src/infra/logging/security-audit.js';
+
+describe('readRecentSecurityAuditEvents', () => {
+  let dataDir: string;
+  let auditPath: string;
+  let envOverride: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'memphis-audit-read-'));
+    auditPath = join(dataDir, 'audit-log.jsonl');
+    envOverride = {
+      MEMPHIS_DATA_DIR: dataDir,
+      MEMPHIS_SECURITY_AUDIT_LOG_PATH: auditPath,
+      MEMPHIS_TEST_ALLOW_AUDIT_WRITE: '1',
+    };
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('returns empty when audit log is missing', () => {
+    const events = readRecentSecurityAuditEvents(() => true, 10, envOverride);
+    expect(events).toEqual([]);
+  });
+
+  it('returns events newest-first up to the limit', () => {
+    writeSecurityAudit({ action: 'a.one', status: 'allowed' }, envOverride);
+    writeSecurityAudit({ action: 'a.two', status: 'allowed' }, envOverride);
+    writeSecurityAudit({ action: 'a.three', status: 'allowed' }, envOverride);
+
+    const events = readRecentSecurityAuditEvents(() => true, 2, envOverride);
+    expect(events).toHaveLength(2);
+    expect(events[0].action).toBe('a.three');
+    expect(events[1].action).toBe('a.two');
+  });
+
+  it('applies the predicate filter', () => {
+    writeSecurityAudit({ action: 'irrelevant.one', status: 'allowed' }, envOverride);
+    writeSecurityAudit(
+      {
+        action: 'chain.verify.startup',
+        status: 'mitigated',
+        details: { chain: 'system', block: 1853 },
+      },
+      envOverride,
+    );
+    writeSecurityAudit({ action: 'irrelevant.two', status: 'allowed' }, envOverride);
+
+    const events = readRecentSecurityAuditEvents(
+      (e) => e.action === 'chain.verify.startup' && e.status === 'mitigated',
+      10,
+      envOverride,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].details).toMatchObject({ chain: 'system', block: 1853 });
+  });
+
+  it('skips malformed lines without throwing', () => {
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(
+      auditPath,
+      '{"ts":"2026-01-01T00:00:00Z","action":"good.one","status":"allowed"}\n' +
+        'this line is not json at all\n' +
+        '{"ts":"2026-01-02T00:00:00Z","action":"good.two","status":"allowed"}\n',
+    );
+    const events = readRecentSecurityAuditEvents(() => true, 10, envOverride);
+    // Order is newest-first: good.two before good.one (line 3 read before line 1).
+    expect(events.map((e) => e.action)).toEqual(['good.two', 'good.one']);
+  });
+
+  it('returns empty when limit is zero or negative', () => {
+    writeSecurityAudit({ action: 'a.one', status: 'allowed' }, envOverride);
+    expect(readRecentSecurityAuditEvents(() => true, 0, envOverride)).toEqual([]);
+    expect(readRecentSecurityAuditEvents(() => true, -1, envOverride)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces PR #603's hardcoded `KNOWN_FORK_MARKERS: string[]` / `.some(message.includes(marker))` substring matcher with a structured config-driven registry. Addresses 6 of 7 items from the #603 follow-on critique; the seventh (Rust-side `verify_with_known_forks` + structured `IntegrityError`) is deferred — the integrity check is implemented in TS (`src/infra/storage/chain-adapter.ts`, not Rust), so the catch-and-classify pattern is the right shape for now.

## What changes

### Replaces the substring matcher with structured fields
- `src/infra/runtime/known-forks.ts` (NEW) — `parseChainIntegrityError()` (regex parser for the 4 throw shapes), `loadKnownForks()` (file → env → baseline), `matchKnownFork()` (chain + block + optional hash substring match)
- `src/app/bootstrap.ts` — catch site now parses, loads, matches, and emits structured audit details

### Config-driven (no more TS source edits per install)
- `<dataDir>/known-forks.json` (preferred) — operator-local, not in source control
- `MEMPHIS_KNOWN_FORK_MARKERS` env — JSON-encoded array, for CI / scripted installs
- Built-in baseline for block 1853 — backward-compat with existing installs

Empty `known-forks.json` (literal `[]`) opts the install OUT of all forks including the baseline.

### Doctor surfacing
- New `t1-chain-known-forks` check reads recent audit events and reports `N fork(s) configured; last startup mitigated <chain>:<block> (<kind>)`. No more grepping audit-log.jsonl for the mitigation history.

### Structured audit details
- `chain.verify.startup status:mitigated` now emits `{chain, block, file, kind, stored_prev_hash, expected_prev_hash, mitigation, fork_reason, fork_ref, fork_accepted_at}` instead of stuffing the whole error string into `details.message`.

### Reusable audit reader
- `readRecentSecurityAuditEvents()` in `src/infra/logging/security-audit.ts` — predicate-based newest-first read of the current (un-rotated) audit log. Doctor is the first consumer; future surfaces can reuse.

## Mapping to #603 critique

| # | Critique point | Status |
|---|---|---|
| a | Tests for KNOWN_FORK_MARKERS branch | ✅ 17 unit tests for parser/matcher/loader + 5 for audit reader |
| b | Rust-side accepted_forks manifest + structured IntegrityError | ⏭️ Deferred — integrity check is TS-side, not Rust. Tracked as follow-up. |
| c | Tighter matcher (pin to prev_hash pair) | ✅ Structured `{storedPrevHash, expectedPrevHash}` match — new corruption at block 1853 with different hashes no longer inherits tolerance |
| d | doctor surfaces mitigation status | ✅ `t1-chain-known-forks` |
| e | Config (env or file), not source-baked | ✅ `<dataDir>/known-forks.json` + `MEMPHIS_KNOWN_FORK_MARKERS` env |
| f | Audit details structured | ✅ 9 structured fields |
| - | Reusable audit reader | ✅ `readRecentSecurityAuditEvents` for future surfaces |

## Cross-Layer Grid

| Layer | Status |
|---|---|
| Rust core | – (integrity check is TS-side at `chain-adapter.ts:543-608`) |
| NAPI | – |
| TS host | ✅ `src/app/bootstrap.ts`, `src/infra/runtime/known-forks.ts`, `src/infra/logging/security-audit.ts` |
| CLI | ✅ `src/infra/cli/utils/doctor-v2.ts` (`t1-chain-known-forks` check) |
| Tauri | – |
| doctor/status | ✅ |
| tests | ✅ `tests/unit/known-forks.test.ts` (17), `tests/unit/security-audit-read.test.ts` (5) |

## Tests

22 new tests (all green locally). Covers:
- Parser: 4 throw shapes + null on unrelated errors
- Matcher: chain mismatch / block mismatch / hash mismatch / loose match / empty list
- Loader: greenfield / file present / empty-array opt-out / env var / file > env precedence / malformed throws
- Audit reader: missing log / newest-first / predicate / malformed-line skip / zero-limit

No regression in existing `tests/unit/chain-adapter*` (5 cases passing).

## Test plan

- [ ] CI green on new tests
- [ ] CI green on existing `tests/unit/chain-adapter*` (no regression)
- [ ] Operator smoke: after merge, `memphis doctor --json | jq '.checks[] | select(.id=="t1-chain-known-forks")'` shows expected detail
- [ ] Audit log shape: trigger a known fork on operator's install → `tail ~/.memphis/audit-log.jsonl | grep chain.verify.startup` shows the new structured `{chain, block, kind, ...}` fields, not just `message`

## Refs

- PR #603 (the substring matcher this replaces)
- `notes/system-chain-corruption-2026-05-12.md` (operator's Opcja A decision — encoded as baseline fork)
- `feedback_codex_review_judgment.md` — Rust-side deferral is a judgment call given the check lives in TS

🤖 Generated with [Claude Code](https://claude.com/claude-code)