### PR TITLE
fix(runtime): repair chain reads and case tool payloads

### DIFF
--- a/src/gateway/tool-executor.ts
+++ b/src/gateway/tool-executor.ts
@@ -17,7 +17,11 @@ import type { SqliteEvolveSessionRepository } from '../infra/storage/sqlite/repo
 import type { SqliteToolPermissionRepository } from '../infra/storage/sqlite/repositories/tool-permission-repository.js';
 import { runMemphisBraveSearch } from '../mcp/tools/brave-search.js';
 import { runMemphisBuild } from '../mcp/tools/build.js';
-import { runMemphisCaseAppend, runMemphisCaseQuery } from '../mcp/tools/case-entry.js';
+import {
+  normalizeCaseAppendInput,
+  runMemphisCaseAppend,
+  runMemphisCaseQuery,
+} from '../mcp/tools/case-entry.js';
 import { runMemphisChainQuery } from '../mcp/tools/chain-query.js';
 import { runMemphisCodeRead } from '../mcp/tools/code-read.js';
 import {
@@ -580,15 +584,13 @@ function createRuntimeTools(deps: InProcessToolExecutorDeps): RuntimeToolDefinit
     buildTool({
       name: 'memphis_case_append',
       description: 'Append an entry to the case chain',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          entry: { type: 'object', description: 'Case chain entry payload' },
+      inputSchema: buildRegistryInputJsonSchema('memphis_case_append', {
+        propertyDescriptions: {
+          entry: 'Case chain entry payload. You may also pass case_type and its role fields at top level.',
         },
-        required: ['entry'],
-      },
+      }),
       validateInput(args) {
-        return { entry: requiredRecord(args, 'entry') as never };
+        return normalizeCaseAppendInput(args as never) as never;
       },
       async execute(input) {
         return runMemphisCaseAppend(

--- a/src/gateway/tool-registry.ts
+++ b/src/gateway/tool-registry.ts
@@ -457,8 +457,23 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
     description: 'Append case entry',
     inputSchema: z
       .object({
-        entry: z.object({
-          case_type: z.enum([
+        entry: z
+          .object({
+            case_type: z.enum([
+              'nominative',
+              'genitive',
+              'dative',
+              'accusative',
+              'instrumental',
+              'locative',
+              'ablative',
+              'vocative',
+            ]),
+          })
+          .passthrough()
+          .optional(),
+        case_type: z
+          .enum([
             'nominative',
             'genitive',
             'dative',
@@ -467,13 +482,34 @@ export const TOOL_REGISTRY: Record<string, ToolMeta> = {
             'locative',
             'ablative',
             'vocative',
-          ]),
-        }).passthrough(),
+          ])
+          .optional(),
+        entity: z.string().optional(),
+        action: z.string().optional(),
+        timestamp: z.string().optional(),
+        owner: z.string().optional(),
+        possessed: z.string().optional(),
+        giver: z.string().optional(),
+        recipient: z.string().optional(),
+        object: z.string().optional(),
+        subject: z.string().optional(),
+        verb: z.string().optional(),
+        actor: z.string().optional(),
+        instrument: z.string().optional(),
+        target: z.string().optional(),
+        location: z.string().optional(),
+        origin: z.string().optional(),
+        destination: z.string().optional(),
+        invoker: z.string().optional(),
+        invocation: z.string().optional(),
         approval_request_id: z.string().optional(),
+      })
+      .refine((value) => Boolean(value.entry ?? value.case_type), {
+        message: 'Provide either entry.case_type or top-level case_type',
       })
       .strict(),
     helpText:
-      'Append a case entry to the cases chain — Memphis\'s linguistic-case knowledge graph. Each entry is anchored on a Polish grammatical case (nominative/genitive/dative/accusative/instrumental/locative/ablative/vocative) plus role fields (actor, target, instrument, location, etc.) drawn from the operator\'s `entry` payload. Indexed in the SQLite case-index for relational queries via memphis_case_query. Use to record structured observations the embedding index can\'t capture relationally — e.g. "X delegated Y to Z".',
+      'Append a case entry to the cases chain — Memphis\'s linguistic-case knowledge graph. Accepts either `{entry:{case_type,...}}` or top-level `{case_type,...}`. Each entry is anchored on a Polish grammatical case (nominative/genitive/dative/accusative/instrumental/locative/ablative/vocative) plus role fields: nominative needs entity/action/timestamp; instrumental needs actor/instrument/target; accusative needs subject/verb/object; locative needs entity/location. Indexed in SQLite for memphis_case_query. Use to record structured observations the embedding index can\'t capture relationally — e.g. "X delegated Y to Z".',
     cliFlags: [],
   },
   memphis_case_query: {

--- a/src/infra/storage/chain-file-io.ts
+++ b/src/infra/storage/chain-file-io.ts
@@ -80,8 +80,11 @@ export function parseEnvelope<T>(raw: string, fnName: string): T {
  */
 export async function listBlockFiles(dir: string): Promise<string[]> {
   try {
-    const files = await readdir(dir);
-    return files.filter((f) => f.endsWith('.json')).sort();
+    const entries = await readdir(dir, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+      .map((entry) => entry.name)
+      .sort();
   } catch (error) {
     if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return [];
     throw error;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,7 +10,11 @@ import '../infra/logging/contextual.js';
 
 import { runMemphisBraveSearch } from './tools/brave-search.js';
 import { runMemphisBuild } from './tools/build.js';
-import { runMemphisCaseAppend, runMemphisCaseQuery } from './tools/case-entry.js';
+import {
+  normalizeCaseAppendInput,
+  runMemphisCaseAppend,
+  runMemphisCaseQuery,
+} from './tools/case-entry.js';
 import { runMemphisChainQuery } from './tools/chain-query.js';
 import { runMemphisCodeRead } from './tools/code-read.js';
 import {
@@ -1162,65 +1166,47 @@ export function createMemphisMcpServer(
 
   const caseAppendPolicy = getToolPolicy(permissions, 'memphis_case_append', resolvedManifest);
   if (shouldRegisterTool('memphis_case_append', caseAppendPolicy, rawEnv)) {
+    const caseTypeSchema = z.enum([
+      'nominative',
+      'genitive',
+      'dative',
+      'accusative',
+      'instrumental',
+      'locative',
+      'ablative',
+      'vocative',
+    ]);
     server.registerTool(
       'memphis_case_append',
       {
         description:
-          'Append a case entry to the cognitive knowledge graph (8 Polish grammatical cases)',
+          'Append a case entry to the cognitive knowledge graph. Accepts either {entry:{case_type,...}} or top-level {case_type,...}.',
         inputSchema: {
-          entry: z.discriminatedUnion('case_type', [
-            z.object({
-              case_type: z.literal('nominative'),
-              entity: z.string().min(1),
-              action: z.string().min(1),
-              timestamp: z.string().min(1),
-            }),
-            z.object({
-              case_type: z.literal('genitive'),
-              owner: z.string().min(1),
-              possessed: z.string().min(1),
-            }),
-            z.object({
-              case_type: z.literal('dative'),
-              giver: z.string().min(1),
-              recipient: z.string().min(1),
-              object: z.string().min(1),
-            }),
-            z.object({
-              case_type: z.literal('accusative'),
-              subject: z.string().min(1),
-              verb: z.string().min(1),
-              object: z.string().min(1),
-            }),
-            z.object({
-              case_type: z.literal('instrumental'),
-              actor: z.string().min(1),
-              instrument: z.string().min(1),
-              target: z.string().min(1),
-            }),
-            z.object({
-              case_type: z.literal('locative'),
-              entity: z.string().min(1),
-              location: z.string().min(1),
-            }),
-            z.object({
-              case_type: z.literal('ablative'),
-              entity: z.string().min(1),
-              origin: z.string().min(1),
-              destination: z.string().optional(),
-            }),
-            z.object({
-              case_type: z.literal('vocative'),
-              invoker: z.string().min(1),
-              invocation: z.string().min(1),
-              target: z.string().min(1),
-            }),
-          ]),
+          entry: z.object({ case_type: caseTypeSchema }).passthrough().optional(),
+          case_type: caseTypeSchema.optional(),
+          entity: z.string().optional(),
+          action: z.string().optional(),
+          timestamp: z.string().optional(),
+          owner: z.string().optional(),
+          possessed: z.string().optional(),
+          giver: z.string().optional(),
+          recipient: z.string().optional(),
+          object: z.string().optional(),
+          subject: z.string().optional(),
+          verb: z.string().optional(),
+          actor: z.string().optional(),
+          instrument: z.string().optional(),
+          target: z.string().optional(),
+          location: z.string().optional(),
+          origin: z.string().optional(),
+          destination: z.string().optional(),
+          invoker: z.string().optional(),
+          invocation: z.string().optional(),
           approval_request_id: z.string().optional(),
         },
       },
-      withApprovalGate('memphis_case_append', caseAppendPolicy, approvals, async ({ entry }) => {
-        const result = await runMemphisCaseAppend({ entry });
+      withApprovalGate('memphis_case_append', caseAppendPolicy, approvals, async (args) => {
+        const result = await runMemphisCaseAppend(normalizeCaseAppendInput(args as never));
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
           structuredContent: toJsonRecord(result),

--- a/src/mcp/tools/case-entry.ts
+++ b/src/mcp/tools/case-entry.ts
@@ -8,7 +8,7 @@ import type {
 
 export type MemphisCaseAppendInput = {
   entry: CaseEntry;
-};
+} | CaseEntry;
 
 export type MemphisCaseQueryInput = {
   query: CaseQuery;
@@ -30,7 +30,7 @@ export async function runMemphisCaseAppend(
   input: MemphisCaseAppendInput,
   deps: CaseAppendDeps = defaultAppendDeps,
 ): Promise<CaseAppendResult> {
-  return deps.adapter.appendCaseEntry(input.entry);
+  return deps.adapter.appendCaseEntry(normalizeCaseAppendInput(input));
 }
 
 export async function runMemphisCaseQuery(
@@ -38,4 +38,9 @@ export async function runMemphisCaseQuery(
   deps: CaseQueryDeps = defaultQueryDeps,
 ): Promise<CaseQueryResult> {
   return deps.adapter.queryCases(input.query);
+}
+
+export function normalizeCaseAppendInput(input: MemphisCaseAppendInput): CaseEntry {
+  if ('entry' in input) return input.entry;
+  return input;
 }

--- a/tests/unit/chain-file-io.test.ts
+++ b/tests/unit/chain-file-io.test.ts
@@ -1,0 +1,18 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { listBlockFiles } from '../../src/infra/storage/chain-file-io.js';
+
+describe('chain file io', () => {
+  it('lists only real json block files and skips json-named directories', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'memphis-chain-files-'));
+    writeFileSync(join(dir, '000001.json'), '{}', 'utf8');
+    mkdirSync(join(dir, '000002.json'));
+    writeFileSync(join(dir, 'note.txt'), 'ignore', 'utf8');
+
+    await expect(listBlockFiles(dir)).resolves.toEqual(['000001.json']);
+  });
+});

--- a/tests/unit/in-process-tool-executor.test.ts
+++ b/tests/unit/in-process-tool-executor.test.ts
@@ -168,6 +168,32 @@ describe('in-process tool executor', () => {
     });
   });
 
+  it('accepts top-level case_append payloads from model tool calls', async () => {
+    const adapter = {
+      appendCaseEntry: vi.fn(async () => ({ success: true, index: 3, hash: 'h', chain: 'cases' })),
+      queryCases: vi.fn(),
+    };
+    const executor = createInProcessToolExecutor({ caseAdapter: adapter as never });
+
+    await executor.execute({
+      id: 'call-case-append-top-level',
+      name: 'memphis_case_append',
+      arguments: {
+        case_type: 'nominative',
+        entity: 'profile',
+        action: 'synced',
+        timestamp: '2026-06-19T00:00:00.000Z',
+      },
+    });
+
+    expect(adapter.appendCaseEntry).toHaveBeenCalledWith({
+      case_type: 'nominative',
+      entity: 'profile',
+      action: 'synced',
+      timestamp: '2026-06-19T00:00:00.000Z',
+    });
+  });
+
   it('rejects out-of-range case query limits before Rust parsing', async () => {
     const executor = createInProcessToolExecutor();
     await expect(

--- a/tests/unit/mcp-tools-extended.test.ts
+++ b/tests/unit/mcp-tools-extended.test.ts
@@ -55,6 +55,28 @@ describe('mcp tools — case-entry', () => {
     expect(result).toMatchObject({ ok: true, index: 5 });
   });
 
+  it('accepts top-level case entry fields for model/tool-call compatibility', async () => {
+    const adapter = {
+      appendCaseEntry: vi.fn(async () => ({
+        success: true,
+        index: 6,
+        hash: 'def456',
+        chain: 'cases',
+      })),
+      queryCases: vi.fn(),
+    };
+    const entry = {
+      case_type: 'nominative' as const,
+      entity: 'profile',
+      action: 'synced',
+      timestamp: '2026-06-19T00:00:00.000Z',
+    };
+    const result = await runMemphisCaseAppend(entry, { adapter: adapter as never });
+
+    expect(adapter.appendCaseEntry).toHaveBeenCalledWith(entry);
+    expect(result).toMatchObject({ success: true, index: 6 });
+  });
+
   it('queries cases via adapter', async () => {
     const adapter = {
       appendCaseEntry: vi.fn(),

--- a/tests/unit/tool-json-schema.test.ts
+++ b/tests/unit/tool-json-schema.test.ts
@@ -48,9 +48,20 @@ describe('registry-backed JSON schemas', () => {
           ],
         },
       },
-      required: ['case_type'],
     });
-    expect(schema.required).toEqual(['entry']);
+    expect(schema.properties?.case_type).toMatchObject({
+      enum: [
+        'nominative',
+        'genitive',
+        'dative',
+        'accusative',
+        'instrumental',
+        'locative',
+        'ablative',
+        'vocative',
+      ],
+    });
+    expect(schema.required).toBeUndefined();
   });
 
   it('preserves numeric registry constraints when deriving executor schemas', () => {


### PR DESCRIPTION
## Summary

This PR addresses the runtime/tool issues surfaced from the Telegram/TUI log after the operator profile sync attempt.

- hardens chain block discovery so `*.json` directories are ignored instead of causing `EISDIR` / `Is a directory (os error 21)` during chain reads
- lets `memphis_case_append` accept both payload shapes:
  - `{ "entry": { "case_type": "nominative", ... } }`
  - `{ "case_type": "nominative", ... }`
- updates the registry-derived tool schema and MCP server schema so model-facing tool descriptions match what the runtime accepts
- adds focused regressions for top-level case append payloads and `.json` directory filtering

## Root Cause

`memphis_case_append` exposed an `entry` wrapper in some surfaces while operators/models naturally tried the top-level `case_type` shape. Separately, chain file listing trusted filename suffixes rather than filesystem type, so a JSON-named directory could be handed to `readFile`, producing `Is a directory`.

## Validation

- `npm run -s test:ts -- tests/unit/chain-file-io.test.ts tests/unit/mcp-tools-extended.test.ts tests/unit/in-process-tool-executor.test.ts tests/unit/tool-json-schema.test.ts tests/unit/tool-registry-schema.test.ts`
- `npm run -s typecheck`
- `npm run -s build`
- `npm run -s lint` (passes with existing warnings in `kartograf.handler.ts`, `napi-shutdown.ts`, and `training-proposer.ts`)
- temp runtime smoke with `MEMPHIS_DATA_DIR=$(mktemp -d) RUST_CHAIN_ENABLED=false` covering top-level `case_append`, `case_query`, two consecutive `journal` writes, and `chain_query`

## Notes

Live smoke on current `main` showed `memphis_chain_query` and `memphis_decide` now work after #608; this PR closes the remaining schema/defensive-read gap from the log.