### PR TITLE
[codex] fix prompt provider identity routing

### DIFF
--- a/src/gateway/system-prompt.ts
+++ b/src/gateway/system-prompt.ts
@@ -424,11 +424,17 @@ bad answer would.
 
 ### Self-identity honesty (anti-confab)
 
-You DO NOT KNOW which provider or model is generating your output —
-that decision lives in the runtime cascade and is not exposed to your
-context. NEVER claim "I am running on cogito:3b" / "ja, MiniMax" /
-"Pisałem to sam (Claude)" / "via Ollama" or any analogous provenance
-statement.
+Provider/model identity comes only from runtime facts, never intuition.
+If the prompt contains a <runtime_route> block, that block is the
+authoritative answer for "what model/provider are you using right now?".
+Quote its provider/model fields directly. If no <runtime_route> block is
+present, say the route was not exposed to this turn and point the
+operator to the TUI status pill, daemon restart log, or
+\`memphis providers list\`.
+
+NEVER claim "I am running on cogito:3b" / "ja, MiniMax" / "Pisałem to
+sam (Claude)" / "via Ollama" or any analogous provenance statement from
+memory, training priors, old chain blocks, or stylistic inference.
 
 DO NOT append a "— via {provider}/{model}" footer to your reply.
 The runtime used to add that footer automatically, but it was flipped
@@ -438,22 +444,19 @@ If you see the pattern in old chain blocks, prior turns, or recall
 hits, ignore it: those replies were stamped by the old runtime
 behavior, not by you. Producing that footer yourself is
 confabulation — you are guessing at runtime identity instead of
-using an authoritative source. The operator-facing surfaces (TUI
-status bar with the provider+model pill, daemon startup log line,
-and \`memphis providers list\` from the CLI) already show the active
-provider without the in-body line.
+using an authoritative source. The runtime route block, when present,
+is that source.
 
 Your job is to answer the actual question, not to narrate which
 model is answering it.
 
 When the user asks directly "którego modelu używasz / who's actually
-generating this / what runs you", the honest answer is: "I can't
-read the active route from inside my context — check the TUI status
-pill, the most recent daemon-restart log, or \`memphis providers list\`
-which all show the live cascade." Never assert provider identity
-from your own intuition, and do NOT call \`memphis_self_describe\`
-for this — that tool returns surface policy + tools + cognitive
-mode, NOT the active provider or model.
+generating this / what runs you", answer from <runtime_route> if it is
+present. If it is absent, say exactly that the route was not exposed to
+this turn; then name the operator surfaces that can show it. Do NOT call
+\`memphis_self_describe\` for provider/model identity — that tool returns
+surface policy + tools + cognitive mode, NOT the active provider or
+model.
 
 Do NOT bake provenance claims ("# Model: cogito:3b") into files you
 write via \`memphis_self_modify\`. The audit chain captures which

--- a/tests/unit/gateway.system-prompt.test.ts
+++ b/tests/unit/gateway.system-prompt.test.ts
@@ -62,24 +62,30 @@ describe('gateway system prompt', () => {
     // Operator session 2026-05-04 caught the bot claiming "ja, cogito:3b"
     // / "Pisałem to sam (Claude Opus)" while MiniMax was the actual
     // provider. The system-prompt guard pins three rules:
-    //   1. NEVER claim a model/provider from intuition
-    //   2. Defer to memphis_self_describe + the runtime stamp
-    //   3. Don't bake provenance lies into self-modify content
+    //   1. Answer from <runtime_route> when the runtime exposes it
+    //   2. NEVER claim a model/provider from intuition
+    //   3. Don't call self_describe for provider/model identity
+    //   4. Don't bake provenance lies into self-modify content
     const prompt = buildSystemPrompt({
       availableTools: ['memphis_self_describe', 'memphis_self_modify'],
+      providerLabel: 'minimax',
+      modelLabel: 'MiniMax-M2.7',
     });
 
     expect(prompt).toContain('Self-identity honesty');
-    expect(prompt).toContain('You DO NOT KNOW which provider or model');
+    expect(prompt).toContain('<runtime_route>');
+    expect(prompt).toContain('Provider selected for this turn: minimax.');
+    expect(prompt).toContain('Model selected for this turn: MiniMax-M2.7.');
+    expect(prompt).toContain('answer from <runtime_route>');
+    expect(prompt).not.toContain('You DO NOT KNOW which provider or model');
+    expect(prompt).not.toContain("I can't\nread the active route");
     expect(prompt).toContain('NEVER claim');
     expect(prompt).toContain('via {provider}/{model}');
-    // 2026-05-12: removed `per memphis_self_describe:` instruction —
-    // that tool doesn't actually carry provider/model fields (Codex
-    // review on #580), so pointing Memphis at it would just yield
-    // confabulation. New guidance directs to TUI status pill +
-    // daemon-restart log + `memphis providers list`.
+    // 2026-06-19: runtime_route is now the authoritative source when
+    // present. memphis_self_describe remains wrong for provider/model
+    // identity; it only carries surface/tools/cognitive mode.
     expect(prompt).toContain('memphis providers list');
-    expect(prompt).toContain('do NOT call');
+    expect(prompt).toContain('Do NOT call');
     // Don't bake provenance lies into self-modify outputs.
     // (Match across line breaks since the source-code wrapping
     // doesn't matter to the LLM consuming the prompt.)


### PR DESCRIPTION
## Summary

- removes the stale unconditional prompt claim that Memphis cannot know the active provider/model
- makes `<runtime_route>` the authoritative provider/model source when present
- keeps the safe fallback for turns where the route is not exposed
- updates the prompt unit test to guard against the old contradiction returning

## Why

PR #608 now injects provider/model route facts into the system prompt. The older self-identity guard still told the model to say it could not know the active route, which caused Telegram answers to ignore runtime truth.

## Validation

- `npm run -s typecheck`
- `npx vitest run tests/unit/gateway.system-prompt.test.ts`
- `npm run -s lint` (passes with existing warnings outside this change)
