### PR TITLE
fix(ci): prefer local napi bridge in source builds

### DIFF
--- a/src/infra/storage/napi-contract.ts
+++ b/src/infra/storage/napi-contract.ts
@@ -75,22 +75,28 @@ export function platformPackageName(triple: SupportedPlatformTriple): string {
 }
 
 /**
- * Try the platform sub-package first; fall back to the in-tree bridge
- * module path. Returns the loaded bridge or null if both fail.
+ * Try the freshly built in-tree bridge first; fall back to the platform
+ * sub-package and then the same in-tree path again. Returns the loaded
+ * bridge or null if all attempts fail.
  *
- * The platform sub-package path is what S9-1 distribution targets — once
- * published via S9-3 prebuilds.yml workflow, fresh `npm install` on supported
- * platforms picks the right `.node` automatically through `optionalDependencies`.
- * The in-tree fallback covers (a) source checkouts pre-publish, (b) build-from-
- * source on unsupported platforms, (c) operator override via env var.
+ * Source checkouts run `npm ci` before `npm run build`, so the optional
+ * platform package in `node_modules` can be older than the just-built
+ * `crates/memphis-napi/index.node`. Prefer the in-tree binary to keep CI
+ * and local development on the checked-out Rust contract.
+ *
+ * The platform sub-package path remains as a fallback for installs that
+ * do not include or cannot load the in-tree bridge.
  *
  * `inTreePath` is the directory containing the legacy `index.node` (per
- * resolveRustBridgePath in install-root.ts).
+ * resolveRustBridgePath in install-root.ts), or an explicit bridge file.
  */
 export function loadPlatformAwareBridge(
   inTreePath: string,
   rawProcess: typeof process = process,
 ): BridgeModule | null {
+  const inTreeBridge = loadBridgeModule(inTreePath);
+  if (inTreeBridge) return inTreeBridge;
+
   const triple = detectPlatformTriple(rawProcess);
   if (triple !== null) {
     try {
@@ -98,11 +104,10 @@ export function loadPlatformAwareBridge(
       const platformPkg = req(platformPackageName(triple)) as BridgeModule;
       if (platformPkg) return platformPkg;
     } catch {
-      // Platform sub-package not installed (operator on a build-from-source
-      // path, or pre-publish state where sub-packages don't exist yet).
-      // Fall through to in-tree fallback.
+      // Platform sub-package not installed or not loadable.
     }
   }
+
   return loadBridgeModule(inTreePath);
 }
 

--- a/tests/unit/mcp-tools.test.ts
+++ b/tests/unit/mcp-tools.test.ts
@@ -58,7 +58,7 @@ describe('MCP tool: memphis_exec', () => {
       { ...process.env, GATEWAY_EXEC_RESTRICTED_MODE: 'false' },
     );
     expect(result.exitCode).toBe(0);
-    expect(result.stdout.trim()).toBe('ok\n1');
+    expect(result.stdout.trim().split(/\s+/)).toEqual(['ok', '1']);
   });
 
   it('blocks oversized arguments', () => {

--- a/tests/unit/napi-contract.test.ts
+++ b/tests/unit/napi-contract.test.ts
@@ -1,8 +1,13 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
   detectPlatformTriple,
   hasRequiredBridgeExports,
+  loadPlatformAwareBridge,
   platformPackageName,
   resolveBridgeContract,
   type BridgeAliasMap,
@@ -104,5 +109,31 @@ describe('platformPackageName', () => {
     expect(platformPackageName('linux-arm64-gnu')).toBe('@memphis-chains/memphis-linux-arm64-gnu');
     expect(platformPackageName('darwin-x64')).toBe('@memphis-chains/memphis-darwin-x64');
     expect(platformPackageName('darwin-arm64')).toBe('@memphis-chains/memphis-darwin-arm64');
+  });
+});
+
+describe('loadPlatformAwareBridge', () => {
+  it('prefers the checked-out in-tree bridge over an installed platform package', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'memphis-napi-contract-'));
+    const localBridge = join(dir, 'local-bridge.cjs');
+    writeFileSync(localBridge, "module.exports = { source: 'local' };\n", 'utf8');
+
+    const platformDir = join(
+      dir,
+      'node_modules',
+      '@memphis-chains',
+      'memphis-linux-x64-gnu',
+    );
+    mkdirSync(platformDir, { recursive: true });
+    writeFileSync(join(platformDir, 'index.js'), "module.exports = { source: 'platform' };\n", 'utf8');
+
+    const fakeProcess = {
+      platform: 'linux',
+      arch: 'x64',
+      report: { getReport: () => ({ header: { glibcVersionRuntime: '2.39' } }) },
+      cwd: () => dir,
+    } as unknown as typeof process;
+
+    expect(loadPlatformAwareBridge(localBridge, fakeProcess)).toMatchObject({ source: 'local' });
   });
 });


### PR DESCRIPTION
## Summary
- prefer the freshly built in-tree NAPI bridge before optional platform packages
- make the memphis_exec shell-operator test robust to platform-specific wc padding
- cover the local-bridge precedence in napi-contract unit tests

## Verification
- npm run -s build
- npm run -s typecheck
- npx vitest run tests/unit/mcp-tools.test.ts tests/unit/napi-contract.test.ts
- npx tsx -e "import { assessRustBridgeManifestStatus } from './src/infra/storage/rust-bridge-manifest.ts'; const status = assessRustBridgeManifestStatus({ RUST_CHAIN_ENABLED: 'true', RUST_CHAIN_BRIDGE_PATH: './crates/memphis-napi' }); console.log(JSON.stringify({ ok: status.ok, level: status.level, missing: status.missingRequiredExports, aliases: status.legacyAliasesUsed }, null, 2));"
- npm run -s lint (passes with existing warnings outside this diff)

Note: a local full `npm run -s test:ts` run was stopped after several minutes because this workstation run entered broad integration/runtime/voice/TUI timers and produced unrelated environment-dependent failures. GitHub PR CI is the authoritative clean check for this patch.