### PR TITLE
[codex] fix nightly scoped format gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "format:changed": "./scripts/format-check-changed.sh --write",
+    "format:check:changed": "./scripts/format-check-changed.sh",
     "cli": "tsx src/infra/cli/index.ts",
     "bench:run": "tsx benchmarks/run.ts",
     "bench:run:update-baseline": "tsx benchmarks/run.ts --update-baseline",

--- a/scripts/format-check-changed.sh
+++ b/scripts/format-check-changed.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+MODE="check"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/format-check-changed.sh [--write]
+
+Checks files changed in HEAD^..HEAD with Prettier. Override the range with:
+  MEMPHIS_FORMAT_BASE_REF
+  MEMPHIS_FORMAT_HEAD_REF
+USAGE
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --write)
+      MODE="write"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+BASE_REF="${MEMPHIS_FORMAT_BASE_REF:-HEAD^}"
+HEAD_REF="${MEMPHIS_FORMAT_HEAD_REF:-HEAD}"
+PRETTIER_BIN="${MEMPHIS_PRETTIER_BIN:-prettier}"
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  echo "[FAIL] Format gate base ref is not available: ${BASE_REF}" >&2
+  exit 2
+fi
+
+if ! git rev-parse --verify --quiet "$HEAD_REF" >/dev/null; then
+  echo "[FAIL] Format gate head ref is not available: ${HEAD_REF}" >&2
+  exit 2
+fi
+
+changed_files=()
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  [[ -f "$path" ]] || continue
+
+  if git ls-files --error-unmatch -- "$path" >/dev/null 2>&1; then
+    changed_files+=("$path")
+  fi
+done < <(git diff --name-only --diff-filter=ACMR "$BASE_REF" "$HEAD_REF" --)
+
+if [[ "${#changed_files[@]}" -eq 0 ]]; then
+  echo "[PASS] No changed tracked files to format-check (${BASE_REF}..${HEAD_REF})"
+  exit 0
+fi
+
+echo "Prettier ${MODE} for ${#changed_files[@]} changed tracked file(s) (${BASE_REF}..${HEAD_REF})"
+
+if [[ "$MODE" == "write" ]]; then
+  "$PRETTIER_BIN" --write --ignore-unknown "${changed_files[@]}"
+else
+  "$PRETTIER_BIN" --check --ignore-unknown "${changed_files[@]}"
+fi

--- a/scripts/nightly-crystal-pass.sh
+++ b/scripts/nightly-crystal-pass.sh
@@ -89,7 +89,11 @@ run_check() {
 
   local start_ts end_ts duration_sec
   start_ts="$(date +%s)"
-  if "$@"; then
+
+  "$@"
+  local exit_code=$?
+
+  if [[ "$exit_code" -eq 0 ]]; then
     end_ts="$(date +%s)"
     duration_sec=$((end_ts - start_ts))
     record_result "PASS" "$name" "$duration_sec"
@@ -97,7 +101,6 @@ run_check() {
     return 0
   fi
 
-  local exit_code=$?
   end_ts="$(date +%s)"
   duration_sec=$((end_ts - start_ts))
   record_result "FAIL" "$name" "$duration_sec" "exit=${exit_code}"
@@ -117,10 +120,10 @@ print_text "Repo: ${ROOT_DIR}"
 print_text "Timestamp (UTC): $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
 format_failed=0
-run_check "Format check" npm run -s format:check || format_failed=1
+run_check "Format check" npm run -s format:check:changed || format_failed=1
 if [[ "$format_failed" -eq 1 && "$AUTOFIX" -eq 1 ]]; then
-  run_check "Format write (autofix)" npm run -s format
-  run_check "Format check (post-autofix)" npm run -s format:check
+  run_check "Format write (autofix)" npm run -s format:changed
+  run_check "Format check (post-autofix)" npm run -s format:check:changed
 fi
 
 lint_failed=0

--- a/tests/ops/nightly-crystal-format-gate.test.ts
+++ b/tests/ops/nightly-crystal-format-gate.test.ts
@@ -1,0 +1,167 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(thisDir, '..', '..');
+const prettierBin = path.join(repoRoot, 'node_modules', '.bin', 'prettier');
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempRepo(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'memphis-format-gate-'));
+  tempDirs.push(dir);
+  mkdirSync(path.join(dir, 'scripts'));
+  copyFileSync(
+    path.join(repoRoot, 'scripts', 'format-check-changed.sh'),
+    path.join(dir, 'scripts', 'format-check-changed.sh'),
+  );
+  chmodSync(path.join(dir, 'scripts', 'format-check-changed.sh'), 0o755);
+  run('git', ['init'], dir);
+  run('git', ['config', 'user.email', 'test@example.test'], dir);
+  run('git', ['config', 'user.name', 'Memphis Test'], dir);
+  return dir;
+}
+
+function run(command: string, args: string[], cwd: string, env: Record<string, string> = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} failed with ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+
+  return result;
+}
+
+function gitCommitAll(cwd: string, message: string) {
+  run('git', ['add', '.'], cwd);
+  run('git', ['commit', '-m', message], cwd);
+}
+
+describe('format-check-changed.sh', () => {
+  it('checks only files changed in the selected range', () => {
+    const dir = makeTempRepo();
+    writeFileSync(path.join(dir, 'legacy.js'), 'const legacy={a:1}\n');
+    gitCommitAll(dir, 'legacy debt');
+
+    writeFileSync(path.join(dir, 'changed.js'), 'const changed = { a: 1 };\n');
+    gitCommitAll(dir, 'formatted change');
+
+    const result = spawnSync('./scripts/format-check-changed.sh', [], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: { ...process.env, MEMPHIS_PRETTIER_BIN: prettierBin },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('1 changed tracked file');
+    expect(result.stdout + result.stderr).not.toContain('legacy.js');
+  });
+
+  it('fails when a changed tracked file is not formatted', () => {
+    const dir = makeTempRepo();
+    writeFileSync(path.join(dir, 'legacy.js'), 'const legacy = { a: 1 };\n');
+    gitCommitAll(dir, 'base');
+
+    writeFileSync(path.join(dir, 'changed.js'), 'const changed={a:1}\n');
+    gitCommitAll(dir, 'unformatted change');
+
+    const result = spawnSync('./scripts/format-check-changed.sh', [], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: { ...process.env, MEMPHIS_PRETTIER_BIN: prettierBin },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain('changed.js');
+  });
+
+  it('passes when the selected range has no changed files to check', () => {
+    const dir = makeTempRepo();
+    writeFileSync(path.join(dir, 'tracked.js'), 'const tracked = { a: 1 };\n');
+    gitCommitAll(dir, 'base');
+
+    const head = run('git', ['rev-parse', 'HEAD'], dir).stdout.trim();
+    const result = spawnSync('./scripts/format-check-changed.sh', [], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        MEMPHIS_FORMAT_BASE_REF: head,
+        MEMPHIS_FORMAT_HEAD_REF: head,
+        MEMPHIS_PRETTIER_BIN: prettierBin,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('[PASS] No changed tracked files');
+  });
+});
+
+describe('nightly-crystal-pass.sh', () => {
+  it('reports the real failing command exit code in JSON output', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'memphis-nightly-exit-'));
+    tempDirs.push(dir);
+    mkdirSync(path.join(dir, 'scripts'));
+    copyFileSync(
+      path.join(repoRoot, 'scripts', 'nightly-crystal-pass.sh'),
+      path.join(dir, 'scripts', 'nightly-crystal-pass.sh'),
+    );
+    chmodSync(path.join(dir, 'scripts', 'nightly-crystal-pass.sh'), 0o755);
+    writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify(
+        {
+          type: 'module',
+          scripts: {
+            'format:check:changed': 'node -e "process.exit(7)"',
+            'format:changed': 'node -e "process.exit(0)"',
+            lint: 'node -e "process.exit(0)"',
+            typecheck: 'node -e "process.exit(0)"',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = spawnSync(
+      './scripts/nightly-crystal-pass.sh',
+      ['--json', '--skip-tests', '--skip-build', '--skip-bench', '--skip-security'],
+      { cwd: dir, encoding: 'utf8', env: process.env },
+    );
+
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout) as {
+      ok: boolean;
+      results: Array<{ name: string; status: string; info?: string }>;
+    };
+    const formatCheck = parsed.results.find((entry) => entry.name === 'Format check');
+
+    expect(parsed.ok).toBe(false);
+    expect(formatCheck).toMatchObject({ status: 'FAIL', info: 'exit=7' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a changed-file Prettier gate for nightly checks with base/head env overrides
- switch nightly Crystal format checks and autofix to the scoped formatter
- preserve the real failed command exit code in nightly JSON reports
- cover the scoped gate and exit-code reporting with focused Vitest coverage

## Root Cause
`nightly-crystal` used the repo-wide `format:check`, so historical Prettier debt could fail the nightly even when the latest change was clean. Its `run_check()` also captured `$?` after the failure branch had already normalized the result, which could report misleading `exit=0` for failed commands.

## Validation
- `npx vitest run tests/ops/nightly-crystal-format-gate.test.ts`
- `npm run -s format:check:changed`
- `npm run -s typecheck`
- `npm run -s ops:nightly-crystal:json -- --skip-tests --skip-build --skip-bench`

Note: lint emits existing `process.env` warnings only; no lint errors.