### PR TITLE
[codex] fix nightly shallow format range

### DIFF
--- a/.github/workflows/nightly-crystal.yml
+++ b/.github/workflows/nightly-crystal.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/tests/ops/nightly-crystal-format-gate.test.ts
+++ b/tests/ops/nightly-crystal-format-gate.test.ts
@@ -1,12 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import {
-  chmodSync,
-  copyFileSync,
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
## Summary
- fetch two commits in the nightly-crystal checkout so the scoped formatter can resolve `HEAD^..HEAD`
- format the new nightly format-gate test file so the scoped gate passes on the merged squash commit

## Root Cause
The scoped format gate defaults to `HEAD^..HEAD`, but the manual nightly workflow used the default `actions/checkout` depth of 1. On a fresh runner that makes `HEAD^` unavailable, so the nightly format check failed with `exit=2` even though the code change was otherwise valid.

## Validation
- `npm run -s format:check:changed`
- `npx vitest run tests/ops/nightly-crystal-format-gate.test.ts`
- commit hook lint passed with existing warnings only