### PR TITLE
fix(ci): migrate retired macOS Intel runner

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -38,7 +38,7 @@ jobs:
             runner: ubuntu-24.04-arm
             cargo_target: aarch64-unknown-linux-gnu
           - triple: darwin-x64
-            runner: macos-13
+            runner: macos-15-intel
             cargo_target: x86_64-apple-darwin
           - triple: darwin-arm64
             runner: macos-14


### PR DESCRIPTION
## What changed

- replace the retired `macos-13` hosted runner with `macos-15-intel` for the `darwin-x64` N-API prebuild

## Root cause

GitHub retired the `macos-13` runner image on 2025-12-04. The v1.11.0 Intel macOS prebuild therefore remained queued indefinitely and left the release commit at 4/5.

## Impact

Future tag and manual prebuild runs can build and publish the supported `x86_64-apple-darwin` package again.

## Validation

- `npx vitest run tests/ops/napi-subpackage-contract.test.ts` — 31/31 passed
- `npm run lint` — passed
- `git diff --check` — passed