### PR TITLE
Fix daily briefing recursion

### DIFF
--- a/crons/daily-9am-briefing.sh
+++ b/crons/daily-9am-briefing.sh
@@ -1,8 +1,39 @@
 #!/usr/bin/env bash
 # schedule: 0 9 * * *
+#
+# Memphis daily 09:00 briefing entry point.
+# The report implementation lives in morning-report.sh; this wrapper adds
+# overlap protection and a bounded runtime for cron execution.
+
 set -euo pipefail
 
-#!/usr/bin/env bash
-# Memphis daily 9:00 briefing — weather + world news + filesystem state
-set -uo pipefail
-exec /home/memphis/memphis/crons/daily-9am-briefing.sh
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SELF_PATH="$SCRIPT_DIR/$(basename -- "${BASH_SOURCE[0]}")"
+readonly REPORT_SCRIPT="${MEMPHIS_DAILY_BRIEFING_TARGET:-$SCRIPT_DIR/morning-report.sh}"
+readonly TIMEOUT_SECONDS="${MEMPHIS_DAILY_BRIEFING_TIMEOUT_SECONDS:-180}"
+readonly LOCK_DIR="${MEMPHIS_HOME:-$HOME/.memphis}/locks"
+readonly LOCK_FILE="$LOCK_DIR/daily-9am-briefing.lock"
+
+if ! [[ "$TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || [ "$TIMEOUT_SECONDS" -gt 3600 ]; then
+  echo "daily briefing: timeout must be an integer between 1 and 3600 seconds" >&2
+  exit 2
+fi
+
+if [ "$(realpath -m -- "$REPORT_SCRIPT")" = "$(realpath -m -- "$SELF_PATH")" ]; then
+  echo "daily briefing: refusing recursive self-execution" >&2
+  exit 2
+fi
+
+if [ ! -f "$REPORT_SCRIPT" ]; then
+  echo "daily briefing: report script not found: $REPORT_SCRIPT" >&2
+  exit 2
+fi
+
+mkdir -p "$LOCK_DIR"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  echo "daily briefing: another run is already active; skipping" >&2
+  exit 0
+fi
+
+exec timeout --signal=TERM --kill-after=10s "$TIMEOUT_SECONDS" bash "$REPORT_SCRIPT"

--- a/tests/unit/cron-script-safety.test.ts
+++ b/tests/unit/cron-script-safety.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const CRONS_DIR = join(process.cwd(), 'crons');
+
+describe('cron script safety', () => {
+  it('does not directly exec a cron script into itself', () => {
+    const violations = readdirSync(CRONS_DIR)
+      .filter((name) => name.endsWith('.sh'))
+      .filter((name) => {
+        const source = readFileSync(join(CRONS_DIR, name), 'utf8');
+        const executableLines = source
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => line && !line.startsWith('#'));
+        return executableLines.some(
+          (line) =>
+            line.startsWith('exec ') &&
+            (line.includes(`/crons/${name}`) || line.includes(`./${basename(name)}`)),
+        );
+      });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('guards the daily briefing against overlap, recursion, and unbounded execution', () => {
+    const source = readFileSync(join(CRONS_DIR, 'daily-9am-briefing.sh'), 'utf8');
+
+    expect(source).toContain('refusing recursive self-execution');
+    expect(source).toContain('flock -n');
+    expect(source).toContain('timeout --signal=TERM --kill-after=10s');
+    expect(source).toContain('morning-report.sh');
+  });
+});


### PR DESCRIPTION
## What changed

- replaces the self-recursive `daily-9am-briefing.sh` body with a bounded wrapper around the existing `morning-report.sh`
- refuses recursive self-targeting
- uses a non-blocking `flock` to prevent overlapping daily runs
- applies a configurable timeout with a hard upper bound
- adds a regression test that scans cron scripts for direct self-exec loops and asserts the daily wrapper safeguards

## Root cause

The tracked cron entry executed its own absolute path with `exec`. Every 09:00 invocation therefore looped forever, and cron accumulated another busy process tree each day.

## Operator impact

The six stale process trees observed from July 19–24 are no longer present. The active user crontab still points at this repository path, so the next scheduled run will use the fixed wrapper.

## Validation

- `bash -n crons/daily-9am-briefing.sh crons/morning-report.sh`
- recursive target smoke: rejected with exit 2
- controlled target smoke: completed successfully
- `npx vitest run tests/unit/cron-script-safety.test.ts` — 2/2 passed
- changed-file Prettier and ESLint
- `npm run -s typecheck`
- `npm run -s deadcode:check`
- `git diff --check`
- `memphis tui --check-only --json` — ok

The repository pre-commit hook took an unusually long time in full `eslint .`; it completed while being interrupted and produced commit `d9d761b`. All scoped checks above completed independently.