### PR TITLE
Secure scheduler migration backup permissions

### DIFF
--- a/src/infra/cli/handlers/schedule.handler.ts
+++ b/src/infra/cli/handlers/schedule.handler.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { copyFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { CommandHandler } from './command-handler.js';
@@ -221,7 +221,11 @@ async function handleReconcile(context: CliContext): Promise<boolean> {
     backupDir = join(getSchedulerDir(), 'migration-backups', stamp);
     mkdirSync(backupDir, { recursive: true, mode: 0o700 });
     const tasksPath = getSchedulerTasksPath();
-    if (existsSync(tasksPath)) copyFileSync(tasksPath, join(backupDir, 'tasks.json'));
+    if (existsSync(tasksPath)) {
+      const backupTasksPath = join(backupDir, 'tasks.json');
+      copyFileSync(tasksPath, backupTasksPath);
+      chmodSync(backupTasksPath, 0o600);
+    }
     const crontab = readCrontab();
     writeFileSync(join(backupDir, 'crontab.txt'), crontab, { mode: 0o600 });
     const logsDir = getSchedulerLogsDir();


### PR DESCRIPTION
## What changed

After copying the pre-migration scheduler task store, explicitly set the backup copy to mode `0600`.

## Why

`copyFileSync` preserved the legacy source mode (`0664`) on this host. The timestamped migration directory itself is `0700`, so the backup was not exposed, but the file should still carry least-privilege permissions independently.

## Impact

Future `memphis schedule reconcile --apply` runs create both `tasks.json` and `crontab.txt` backups with mode `0600`.

## Validation

- repaired the existing host backup to `0600`
- TypeScript typecheck passed
- ESLint passed
- scheduler and CLI registry tests: 19/19 passed
- Prettier and `git diff --check` passed